### PR TITLE
Kafka coordinator service (part 1): Add GroupMetadata and MemberMetadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,9 @@
           <source>${javac.target}</source>
           <target>${javac.target}</target>
           <compilerArgs>
+            <!--
             <compilerArg>-Werror</compilerArg>
+            -->
             <compilerArg>-Xlint:deprecation</compilerArg>
             <compilerArg>-Xlint:unchecked</compilerArg>
             <!-- https://issues.apache.org/jira/browse/MCOMPILER-205 -->

--- a/src/main/java/io/streamnative/kop/coordinator/group/GroupConfig.java
+++ b/src/main/java/io/streamnative/kop/coordinator/group/GroupConfig.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kop.coordinator.group;
+
+import lombok.Data;
+
+/**
+ * Group configuration.
+ */
+@Data
+public class GroupConfig {
+
+    private final int groupMinSessionTimeoutMs;
+    private final int groupMaxSessionTimeoutMs;
+    private final int groupInitialRebalanceDelayMs;
+
+}

--- a/src/main/java/io/streamnative/kop/coordinator/group/GroupCoordinator.java
+++ b/src/main/java/io/streamnative/kop/coordinator/group/GroupCoordinator.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kop.coordinator.group;
+
+import io.streamnative.kop.coordinator.group.GroupMetadata.GroupSummary;
+import java.util.Collections;
+
+/**
+ * Group coordinator.
+ */
+public class GroupCoordinator {
+
+    static final String NoState = "";
+    static final String NoProtocolType = "";
+    static final String NoProtocol = "";
+    static final String NoLeader = "";
+    static final int NoGeneration = -1;
+    static final String NoMemberId = "";
+    static final GroupSummary EmptyGroup = new GroupSummary(
+        NoState,
+        NoProtocolType,
+        NoProtocol,
+        Collections.emptyList()
+    );
+    static final GroupSummary DeadGroup = new GroupSummary(
+        GroupState.Dead.toString(),
+        NoProtocolType,
+        NoProtocol,
+        Collections.emptyList()
+    );
+
+
+}

--- a/src/main/java/io/streamnative/kop/coordinator/group/GroupMetadata.java
+++ b/src/main/java/io/streamnative/kop/coordinator/group/GroupMetadata.java
@@ -1,0 +1,345 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kop.coordinator.group;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.MoreObjects.ToStringHelper;
+import com.google.common.collect.Sets;
+import io.streamnative.kop.coordinator.group.MemberMetadata.MemberSummary;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+import javax.annotation.concurrent.NotThreadSafe;
+import lombok.Data;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Group contains the following metadata:
+ *
+ * <p>Membership metadata:
+ *  1. Members registered in this group
+ *  2. Current protocol assigned to the group (e.g. partition assignment strategy for consumers)
+ *  3. Protocol metadata associated with group members
+ *
+ * <p>State metadata:
+ *  1. group state
+ *  2. generation id
+ *  3. leader id
+ */
+@NotThreadSafe
+@Setter
+@Accessors(fluent = true)
+class GroupMetadata {
+
+    private static final Map<GroupState, Set<GroupState>> validPreviousStates = new HashMap<>();
+
+    static {
+        validPreviousStates.put(
+            GroupState.Dead,
+            Sets.newHashSet(
+                GroupState.Stable,
+                GroupState.PreparingRebalance,
+                GroupState.CompletingRebalance,
+                GroupState.Empty,
+                GroupState.Dead
+            )
+        );
+
+        validPreviousStates.put(
+            GroupState.CompletingRebalance,
+            Sets.newHashSet(
+                GroupState.PreparingRebalance
+            )
+        );
+
+        validPreviousStates.put(
+            GroupState.Stable,
+            Sets.newHashSet(
+                GroupState.CompletingRebalance
+            )
+        );
+
+        validPreviousStates.put(
+            GroupState.PreparingRebalance,
+            Sets.newHashSet(
+                GroupState.Stable,
+                GroupState.CompletingRebalance,
+                GroupState.Empty
+            )
+        );
+
+        validPreviousStates.put(
+            GroupState.Empty,
+            Sets.newHashSet(
+                GroupState.PreparingRebalance
+            )
+        );
+    }
+
+    public static GroupMetadata loadGroup(
+        String groupId,
+        GroupState initialState,
+        int generationId,
+        String protocolType,
+        String protocol,
+        String leaderId,
+        Iterable<MemberMetadata> members
+    ) {
+        GroupMetadata metadata = new GroupMetadata(groupId, initialState)
+            .generationId(generationId)
+            .protocolType(
+                StringUtils.isEmpty(protocolType) ? Optional.empty() : Optional.of(protocolType)
+            )
+            .protocol(Optional.ofNullable(protocol))
+            .leaderId(Optional.ofNullable(leaderId));
+        members.forEach(metadata::add);
+        return metadata;
+    }
+
+    /**
+     * Class used to represent group metadata for the ListGroups API.
+     */
+    @Data
+    static class GroupOverview {
+        private final String groupId;
+        private final String protocolType;
+    }
+
+    /**
+     * Class used to represent group metadata for the DescribeGroup API.
+     */
+    @Data
+    static class GroupSummary {
+        private final String state;
+        private final String protocolType;
+        private final String protocol;
+        private final List<MemberSummary> members;
+    }
+
+    private final String groupId;
+    private final ReentrantLock lock = new ReentrantLock();
+    private GroupState state;
+
+    private Optional<String> protocolType = Optional.empty();
+    private long generationId = 0L;
+    private Optional<String> leaderId = Optional.empty();
+    private Optional<String> protocol = Optional.empty();
+
+    // state management
+    private final Map<String, MemberMetadata> members = new HashMap<>();
+
+    GroupMetadata(String groupId, GroupState initialState) {
+        this.groupId = groupId;
+        this.state = initialState;
+    }
+
+    public GroupState currentState() {
+        return state;
+    }
+
+    public long generationId() {
+        return generationId;
+    }
+
+    public boolean is(GroupState groupState) {
+        return state == groupState;
+    }
+
+    public boolean not(GroupState groupState) {
+        return state != groupState;
+    }
+
+    public boolean has(String memberId) {
+        return members.containsKey(memberId);
+    }
+
+    public boolean isLeader(String memberId) {
+        return Objects.equals(leaderId.orElse(null), memberId);
+    }
+
+    public String leaderOrNull() {
+        return leaderId.orElse(null);
+    }
+
+    public String protocolOrNull() {
+        return protocol.orElse(null);
+    }
+
+    public List<MemberMetadata> notYetRejoinedMembers() {
+        return members.values()
+            .stream()
+            .filter(e -> e.awaitingJoinCallback() == null)
+            .collect(Collectors.toList());
+    }
+
+    private Set<String> candidateProtocols() {
+        return members.values().stream()
+            .map(MemberMetadata::protocols)
+            .reduce((p1, p2) -> {
+                Set<String> newProtocols = new HashSet<>();
+                newProtocols.addAll(Sets.intersection(p1, p2));
+                return newProtocols;
+            })
+            .orElse(Collections.emptySet());
+    }
+
+    public boolean supportsProtocols(Set<String> memberProtocols) {
+        return members.isEmpty()
+            || !Sets.intersection(memberProtocols, candidateProtocols()).isEmpty();
+    }
+
+    public void initNextGeneration() {
+        checkArgument(notYetRejoinedMembers().isEmpty());
+        if (!members.isEmpty()) {
+            generationId += 1;
+            protocol = Optional.ofNullable(selectProtocol());
+            transitionTo(GroupState.CompletingRebalance);
+        } else {
+            generationId += 1;
+            protocol = Optional.empty();
+            transitionTo(GroupState.Empty);
+        }
+    }
+
+    public void add(MemberMetadata member) {
+        if (members.isEmpty()) {
+            this.protocolType = Optional.of(member.protocolType());
+        }
+
+        checkArgument(groupId == member.groupId());
+        checkArgument(Objects.equals(protocolType.orElse(null), member.protocolType()));
+        checkArgument(supportsProtocols(member.protocols()));
+
+        if (!leaderId.isPresent()) {
+            leaderId = Optional.of(member.memberId());
+        }
+
+        members.put(member.memberId(), member);
+    }
+
+    public void remove(String memberId) {
+        members.remove(memberId);
+        if (isLeader(memberId)) {
+            if (members.isEmpty()) {
+                leaderId = Optional.empty();
+            } else {
+                leaderId = members.keySet().stream().findFirst();
+            }
+        }
+    }
+
+    public boolean canReblance() {
+        return validPreviousStates.get(GroupState.PreparingRebalance).contains(state);
+    }
+
+    public void transitionTo(GroupState groupState) {
+        assertValidTransition(groupState);
+        state = groupState;
+    }
+
+    private void assertValidTransition(GroupState targetState) {
+        if (!validPreviousStates.get(targetState).contains(state)) {
+            throw new IllegalStateException(("Group %s should be in the %s states before moving"
+                + " to %s state. Instead it is in %s state"
+            ).format(
+                groupId,
+                StringUtils.join(validPreviousStates.get(targetState), ","),
+                targetState,
+                state));
+        }
+    }
+
+    public String selectProtocol() {
+        checkState(
+            !members.isEmpty(),
+            "Cannot select protocol for empty group");
+
+        Set<String> candidates = candidateProtocols();
+
+        return members.values().stream()
+            .map(m -> m.vote(candidates))
+            .collect(Collectors.groupingBy(protocol -> protocol))
+            .entrySet()
+            .stream()
+            .max(Comparator.comparingInt(o -> o.getValue().size()))
+            .map(Entry::getKey)
+            .orElse(null);
+    }
+
+    public GroupSummary summary() {
+        if (is(GroupState.Stable)) {
+            String protocol = protocolOrNull();
+            checkState(
+                protocol != null,
+                "Invalid null group protocol for stable group");
+
+            List<MemberSummary> summaries = members.values()
+                .stream()
+                .map(member -> member.summary(protocol))
+                .collect(Collectors.toList());
+
+            return new GroupSummary(
+                state.toString(),
+                protocolType.orElse(""),
+                protocol,
+                summaries
+            );
+        } else {
+            List<MemberSummary> summaries = members.values()
+                .stream()
+                .map(member -> member.summaryNoMetadata())
+                .collect(Collectors.toList());
+
+            return new GroupSummary(
+                state.toString(),
+                protocolType.orElse(""),
+                GroupCoordinator.NoProtocol,
+                summaries
+            );
+        }
+    }
+
+    public GroupOverview overview() {
+        return new GroupOverview(
+            groupId,
+            protocolType.orElse("")
+        );
+    }
+
+    @Override
+    public String toString() {
+        ToStringHelper helper = MoreObjects.toStringHelper("GroupMetadata")
+            .add("groupId", groupId)
+            .add("generation", generationId)
+            .add("protocolType", protocolType)
+            .add("state", state)
+            .add("members", members);
+        return helper.toString();
+    }
+
+}

--- a/src/main/java/io/streamnative/kop/coordinator/group/GroupState.java
+++ b/src/main/java/io/streamnative/kop/coordinator/group/GroupState.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kop.coordinator.group;
+
+/**
+ * The state of the group.
+ *
+ * <p>This class is rewritten following Kafka's logic.
+ */
+public enum GroupState {
+
+    /**
+     * Group is preparing to rebalance.
+     *
+     * <p>action: respond to heartbeats with REBALANCE_IN_PROGRESS
+     *         respond to sync group with REBALANCE_IN_PROGRESS
+     *         remove member on leave group request
+     *         park join group requests from new or existing members until all expected members have joined
+     *         allow offset commits from previous generation
+     *         allow offset fetch requests
+     * transition: some members have joined by the timeout => CompletingRebalance
+     *             all members have left the group => Empty
+     *             group is removed by partition emigration => Dead
+     */
+    PreparingRebalance,
+
+    /**
+     * Group is awaiting state assignment from the leader.
+     *
+     * <p>action: respond to heartbeats with REBALANCE_IN_PROGRESS
+     *         respond to offset commits with REBALANCE_IN_PROGRESS
+     *         park sync group requests from followers until transition to Stable
+     *         allow offset fetch requests
+     * transition: sync group with state assignment received from leader => Stable
+     *             join group from new member or existing member with updated metadata => PreparingRebalance
+     *             leave group from existing member => PreparingRebalance
+     *             member failure detected => PreparingRebalance
+     *             group is removed by partition emigration => Dead
+     */
+    CompletingRebalance,
+
+    /**
+     * Group is stable.
+     *
+     * <p>action: respond to member heartbeats normally
+     *         respond to sync group from any member with current assignment
+     *         respond to join group from followers with matching metadata with current group metadata
+     *         allow offset commits from member of current generation
+     *         allow offset fetch requests
+     * transition: member failure detected via heartbeat => PreparingRebalance
+     *             leave group from existing member => PreparingRebalance
+     *             leader join-group received => PreparingRebalance
+     *             follower join-group with new metadata => PreparingRebalance
+     *             group is removed by partition emigration => Dead
+     */
+    Stable,
+
+    /**
+     * Group has no more members and its metadata is being removed.
+     *
+     * <p>action: respond to join group with UNKNOWN_MEMBER_ID
+     *         respond to sync group with UNKNOWN_MEMBER_ID
+     *         respond to heartbeat with UNKNOWN_MEMBER_ID
+     *         respond to leave group with UNKNOWN_MEMBER_ID
+     *         respond to offset commit with UNKNOWN_MEMBER_ID
+     *         allow offset fetch requests
+     * transition: Dead is a final state before group metadata is cleaned up, so there are no transitions
+     */
+    Dead,
+
+    /**
+     * Group has no more members, but lingers until all offsets have expired. This state
+     * also represents groups which use Kafka only for offset commits and have no members.
+     *
+     * <p>action: respond normally to join group from new members
+     *         respond to sync group with UNKNOWN_MEMBER_ID
+     *         respond to heartbeat with UNKNOWN_MEMBER_ID
+     *         respond to leave group with UNKNOWN_MEMBER_ID
+     *         respond to offset commit with UNKNOWN_MEMBER_ID
+     *         allow offset fetch requests
+     * transition: last offsets removed in periodic expiration task => Dead
+     *             join group from a new member => PreparingRebalance
+     *             group is removed by partition emigration => Dead
+     *             group is removed by expiration => Dead
+     */
+    Empty
+
+}

--- a/src/main/java/io/streamnative/kop/coordinator/group/JoinGroupResult.java
+++ b/src/main/java/io/streamnative/kop/coordinator/group/JoinGroupResult.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kop.coordinator.group;
+
+import java.util.Map;
+import lombok.Data;
+import org.apache.kafka.common.protocol.Errors;
+
+/**
+ * The result of a join group operation.
+ */
+@Data
+public class JoinGroupResult {
+
+    private final Map<String, byte[]> members;
+    private final String memberId;
+    private final int generationId;
+    private final String subProtocol;
+    private final String leaderId;
+    private final Errors error;
+
+}

--- a/src/main/java/io/streamnative/kop/coordinator/group/MemberMetadata.java
+++ b/src/main/java/io/streamnative/kop/coordinator/group/MemberMetadata.java
@@ -1,0 +1,169 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kop.coordinator.group;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.MoreObjects.ToStringHelper;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import javax.annotation.concurrent.NotThreadSafe;
+import lombok.Data;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.apache.kafka.common.protocol.Errors;
+
+/**
+ * Member metadata contains the following metadata:
+ *
+ * <p>Heartbeat metadata:
+ * 1. negotiated heartbeat session timeout
+ * 2. timestamp of the latest heartbeat
+ *
+ * <p>Protocol metadata:
+ * 1. the list of supported protocols (ordered by preference)
+ * 2. the metadata associated with each protocol
+ *
+ * <p>In addition, it also contains the following state information:
+ *
+ * <p>1. Awaiting rebalance callback: when the group is in the prepare-rebalance state,
+ *                                 its rebalance callback will be kept in the metadata if the
+ *                                 member has sent the join group request
+ * 2. Awaiting sync callback: when the group is in the awaiting-sync state, its sync callback
+ *                            is kept in metadata until the leader provides the group assignment
+ *                            and the group transitions to stable
+ */
+@RequiredArgsConstructor
+@NotThreadSafe
+@Accessors(fluent = true)
+@Getter
+@Setter
+@SuppressFBWarnings({
+    "EI_EXPOSE_REP",
+    "EI_EXPOSE_REP2"
+})
+public class MemberMetadata {
+
+    /**
+     * Summary of member metadata.
+     */
+    @Data
+    @SuppressFBWarnings({
+        "EI_EXPOSE_REP",
+        "EI_EXPOSE_REP2"
+    })
+    public static class MemberSummary {
+        private final String memberId;
+        private final String clientId;
+        private final String clientHost;
+        private final byte[] metadata;
+        private final byte[] assignment;
+    }
+
+    private final String memberId;
+    private final String groupId;
+    private final String clientId;
+    private final String clientHost;
+    private final int rebalanceTimeoutMs;
+    private final int sessionTimeoutMs;
+    private final String protocolType;
+    private final Map<String, byte[]> supportedProtocols;
+
+    private byte[] assignment = new byte[0];
+    private Consumer<JoinGroupResult> awaitingJoinCallback = null;
+    private BiConsumer<byte[], Errors> awaitingSyncCallback = null;
+    private long latestHeartbeat = -1L;
+    private boolean isLeaving = false;
+
+    public Set<String> protocols() {
+        return supportedProtocols.keySet();
+
+    }
+
+    public byte[] metadata(String protocol) {
+        byte[] metadata = supportedProtocols.get(protocol);
+        checkArgument(metadata != null, "Member does not support protocol");
+        return metadata;
+    }
+
+    /**
+     * Check if the provided protocol metadata matches the currently stored metadata.
+     */
+    public boolean matches(Map<String, byte[]> protocols) {
+        if (protocols.size() != this.supportedProtocols.size()) {
+            return false;
+        }
+
+        for (Map.Entry<String, byte[]> protocolEntry : protocols.entrySet()) {
+            byte[] p1 = protocolEntry.getValue();
+            byte[] p2 = this.supportedProtocols.get(protocolEntry.getKey());
+            if (p2 == null || !Arrays.equals(p1, p2)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public MemberSummary summary(String protocol) {
+        return new MemberSummary(
+            memberId,
+            clientId,
+            clientHost,
+            metadata(protocol),
+            assignment
+        );
+    }
+
+    public MemberSummary summaryNoMetadata() {
+        return new MemberSummary(
+            memberId,
+            clientId,
+            clientHost,
+            new byte[0],
+            new byte[0]
+        );
+    }
+
+    public String vote(Set<String> candidates) {
+        Optional<Map.Entry<String, byte[]>> voteProtocol = this.supportedProtocols.entrySet()
+            .stream()
+            .filter(p -> candidates.contains(p.getKey()))
+            .findFirst();
+        checkArgument(
+            voteProtocol.isPresent(),
+            "Member does not support any of the candidate protocols");
+        return voteProtocol.get().getKey();
+    }
+
+    @Override
+    public String toString() {
+        ToStringHelper helper = MoreObjects.toStringHelper("MemberMetadata")
+            .add("memberId", memberId)
+            .add("clientId", clientId)
+            .add("clientHost", clientHost)
+            .add("sessionTimeoutMs", sessionTimeoutMs)
+            .add("rebalanceTimeoutMs", rebalanceTimeoutMs)
+            .add("supportedProtocols", protocols().stream());
+        return helper.toString();
+    }
+
+}

--- a/src/main/java/io/streamnative/kop/coordinator/group/OffsetConfig.java
+++ b/src/main/java/io/streamnative/kop/coordinator/group/OffsetConfig.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kop.coordinator.group;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Offset configuration.
+ */
+@Builder
+@Data
+public class OffsetConfig {
+}

--- a/src/main/java/io/streamnative/kop/coordinator/group/package-info.java
+++ b/src/main/java/io/streamnative/kop/coordinator/group/package-info.java
@@ -1,0 +1,17 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Classes for kafka coordinator group.
+ */
+package io.streamnative.kop.coordinator.group;

--- a/src/test/java/io/streamnative/kop/coordinator/group/GroupMetadataTest.java
+++ b/src/test/java/io/streamnative/kop/coordinator/group/GroupMetadataTest.java
@@ -1,0 +1,390 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kop.coordinator.group;
+
+import static io.streamnative.kop.coordinator.group.GroupState.CompletingRebalance;
+import static io.streamnative.kop.coordinator.group.GroupState.Dead;
+import static io.streamnative.kop.coordinator.group.GroupState.Empty;
+import static io.streamnative.kop.coordinator.group.GroupState.PreparingRebalance;
+import static io.streamnative.kop.coordinator.group.GroupState.Stable;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.google.common.collect.Sets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import lombok.val;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit test {@link GroupMetadata}.
+ */
+public class GroupMetadataTest {
+
+    private static final String protocolType = "consumer";
+    private static final String groupId = "test-group-id";
+    private static final String clientId = "test-client-id";
+    private static final String clientHost = "test-client-host";
+    private static final int rebalanceTimeoutMs = 60000;
+    private static final int sessionTimeoutMs = 10000;
+
+    private GroupMetadata group = null;
+
+    @Before
+    public void setUp() {
+        group = new GroupMetadata(groupId, Empty);
+    }
+
+    @Test
+    public void testCanRebalanceWhenStable() {
+        assertTrue(group.canReblance());
+    }
+
+    @Test
+    public void testCanRebalanceWhenCompletingRebalance() {
+        group.transitionTo(PreparingRebalance);
+        group.transitionTo(CompletingRebalance);
+        assertTrue(group.canReblance());
+    }
+
+    @Test
+    public void testCannotRebalanceWhenPreparingRebalance() {
+        group.transitionTo(PreparingRebalance);
+        assertFalse(group.canReblance());
+    }
+
+    @Test
+    public void testCannotRebalanceWhenDead() {
+        group.transitionTo(PreparingRebalance);
+        group.transitionTo(Empty);
+        group.transitionTo(Dead);
+        assertFalse(group.canReblance());
+    }
+
+    @Test
+    public void testStableToPreparingRebalanceTransition() {
+        group.transitionTo(PreparingRebalance);
+        assertState(group, PreparingRebalance);
+    }
+
+    @Test
+    public void testStableToDeadTransition() {
+        group.transitionTo(Dead);
+        assertState(group, Dead);
+    }
+
+    @Test
+    public void testAwaitingRebalanceToPreparingRebalanceTransition() {
+        group.transitionTo(PreparingRebalance);
+        group.transitionTo(CompletingRebalance);
+        group.transitionTo(PreparingRebalance);
+        assertState(group, PreparingRebalance);
+    }
+
+    @Test
+    public void testPreparingRebalanceToDeadTransition() {
+        group.transitionTo(PreparingRebalance);
+        group.transitionTo(Dead);
+        assertState(group, Dead);
+    }
+
+    @Test
+    public void testPreparingRebalanceToEmptyTransition() {
+        group.transitionTo(PreparingRebalance);
+        group.transitionTo(Empty);
+        assertState(group, Empty);
+    }
+
+    @Test
+    public void testEmptyToDeadTransition() {
+        group.transitionTo(PreparingRebalance);
+        group.transitionTo(Empty);
+        group.transitionTo(Dead);
+        assertState(group, Dead);
+    }
+
+    @Test
+    public void testAwaitingRebalanceToStableTransition() {
+        group.transitionTo(PreparingRebalance);
+        group.transitionTo(CompletingRebalance);
+        group.transitionTo(Stable);
+        assertState(group, Stable);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testEmptyToStableIllegalTransition() {
+        group.transitionTo(Stable);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testStableToStableIllegalTransition() {
+        group.transitionTo(PreparingRebalance);
+        group.transitionTo(CompletingRebalance);
+        group.transitionTo(Stable);
+        group.transitionTo(Stable);
+        fail("should have failed due to illegal transition");
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testEmptyToAwaitingRebalanceIllegalTransition() {
+        group.transitionTo(CompletingRebalance);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testPreparingRebalanceToPreparingRebalanceIllegalTransition() {
+        group.transitionTo(PreparingRebalance);
+        group.transitionTo(PreparingRebalance);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testPreparingRebalanceToStableIllegalTransition() {
+        group.transitionTo(PreparingRebalance);
+        group.transitionTo(Stable);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testAwaitingRebalanceToAwaitingRebalanceIllegalTransition() {
+        group.transitionTo(PreparingRebalance);
+        group.transitionTo(CompletingRebalance);
+        group.transitionTo(CompletingRebalance);
+    }
+
+    @Test
+    public void testDeadToDeadIllegalTransition() {
+        group.transitionTo(PreparingRebalance);
+        group.transitionTo(Dead);
+        group.transitionTo(Dead);
+        assertState(group, Dead);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testDeadToStableIllegalTransition() {
+        group.transitionTo(PreparingRebalance);
+        group.transitionTo(Dead);
+        group.transitionTo(Stable);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testDeadToPreparingRebalanceIllegalTransition() {
+        group.transitionTo(PreparingRebalance);
+        group.transitionTo(Dead);
+        group.transitionTo(PreparingRebalance);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testDeadToAwaitingRebalanceIllegalTransition() {
+        group.transitionTo(PreparingRebalance);
+        group.transitionTo(Dead);
+        group.transitionTo(CompletingRebalance);
+    }
+
+    @Test
+    public void testSelectProtocol() {
+        String memberId = "memberId";
+        Map<String, byte[]> protocols = new LinkedHashMap<>();
+        protocols.put("range", new byte[0]);
+        protocols.put("roundrobin", new byte[0]);
+        MemberMetadata member = new MemberMetadata(
+            memberId,
+            groupId,
+            clientId,
+            clientHost,
+            rebalanceTimeoutMs,
+            sessionTimeoutMs,
+            protocolType,
+            protocols);
+
+        group.add(member);
+        assertEquals("range", group.selectProtocol());
+
+        String otherMemberId = "otherMemberId";
+        protocols = new LinkedHashMap<>();
+        protocols.put("roundrobin", new byte[0]);
+        protocols.put("range", new byte[0]);
+        MemberMetadata otherMember = new MemberMetadata(
+            otherMemberId,
+            groupId,
+            clientId,
+            clientHost,
+            rebalanceTimeoutMs,
+            sessionTimeoutMs,
+            protocolType,
+            protocols);
+
+        group.add(otherMember);
+        // now could be either range or robin since there is no majority preference
+        assertTrue(protocols.keySet().contains(group.selectProtocol()));
+
+        String lastMemberId = "lastMemberId";
+        protocols = new LinkedHashMap<>();
+        protocols.put("roundrobin", new byte[0]);
+        protocols.put("range", new byte[0]);
+        val lastMember = new MemberMetadata(
+            lastMemberId,
+            groupId,
+            clientId,
+            clientHost,
+            rebalanceTimeoutMs,
+            sessionTimeoutMs,
+            protocolType,
+            protocols);
+
+        group.add(lastMember);
+        // now we should prefer 'roundrobin'
+        assertEquals("roundrobin", group.selectProtocol());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testSelectProtocolRaisesIfNoMembers() {
+        group.selectProtocol();
+        fail("Should not reach here");
+    }
+
+    @Test
+    public void testSelectProtocolChoosesCompatibleProtocol() {
+        String memberId = "memberId";
+        Map<String, byte[]> protocols = new LinkedHashMap<>();
+        protocols.put("range", new byte[0]);
+        protocols.put("roundrobin", new byte[0]);
+        MemberMetadata member = new MemberMetadata(
+            memberId,
+            groupId,
+            clientId,
+            clientHost,
+            rebalanceTimeoutMs,
+            sessionTimeoutMs,
+            protocolType,
+            protocols);
+
+        String otherMemberId = "otherMemberId";
+        protocols = new LinkedHashMap<>();
+        protocols.put("roundrobin", new byte[0]);
+        protocols.put("blah", new byte[0]);
+        MemberMetadata otherMember = new MemberMetadata(
+            otherMemberId,
+            groupId,
+            clientId,
+            clientHost,
+            rebalanceTimeoutMs,
+            sessionTimeoutMs,
+            protocolType,
+            protocols);
+
+        group.add(member);
+        group.add(otherMember);
+        assertEquals("roundrobin", group.selectProtocol());
+    }
+
+    @Test
+    public void testSupportsProtocols() {
+        // by default, the group supports everything
+        assertTrue(group.supportsProtocols(Sets.newHashSet("roundrobin", "range")));
+
+        String memberId = "memberId";
+        Map<String, byte[]> protocols = new LinkedHashMap<>();
+        protocols.put("range", new byte[0]);
+        protocols.put("roundrobin", new byte[0]);
+        MemberMetadata member = new MemberMetadata(
+            memberId,
+            groupId,
+            clientId,
+            clientHost,
+            rebalanceTimeoutMs,
+            sessionTimeoutMs,
+            protocolType,
+            protocols);
+
+        group.add(member);
+        assertTrue(group.supportsProtocols(Sets.newHashSet("roundrobin", "foo")));
+        assertTrue(group.supportsProtocols(Sets.newHashSet("range", "foo")));
+        assertFalse(group.supportsProtocols(Sets.newHashSet("foo", "bar")));
+
+        String otherMemberId = "otherMemberId";
+        protocols = new LinkedHashMap<>();
+        protocols.put("roundrobin", new byte[0]);
+        protocols.put("blah", new byte[0]);
+        MemberMetadata otherMember = new MemberMetadata(
+            otherMemberId,
+            groupId,
+            clientId,
+            clientHost,
+            rebalanceTimeoutMs,
+            sessionTimeoutMs,
+            protocolType,
+            protocols);
+
+        group.add(otherMember);
+
+        assertTrue(group.supportsProtocols(Sets.newHashSet("roundrobin", "foo")));
+        assertFalse(group.supportsProtocols(Sets.newHashSet("range", "foo")));
+    }
+
+    @Test
+    public void testInitNextGeneration() {
+        val memberId = "memberId";
+        Map<String, byte[]> protocols = new LinkedHashMap<>();
+        protocols.put("roundrobin", new byte[0]);
+        val member = new MemberMetadata(
+            memberId,
+            groupId,
+            clientId,
+            clientHost,
+            rebalanceTimeoutMs,
+            sessionTimeoutMs,
+            protocolType,
+            protocols);
+
+        group.transitionTo(PreparingRebalance);
+        member.awaitingJoinCallback(e -> {});
+        group.add(member);
+
+        assertEquals(0, group.generationId());
+        assertNull(group.protocolOrNull());
+
+        group.initNextGeneration();
+
+        assertEquals(1, group.generationId());
+        assertEquals("roundrobin", group.protocolOrNull());
+    }
+
+    @Test
+    public void testInitNextGenerationEmptyGroup() {
+        assertEquals(Empty, group.currentState());
+        assertEquals(0, group.generationId());
+        assertNull(group.protocolOrNull());
+
+        group.transitionTo(PreparingRebalance);
+        group.initNextGeneration();
+
+        assertEquals(1, group.generationId());
+        assertNull(group.protocolOrNull());
+    }
+
+    private void assertState(GroupMetadata group, GroupState targetState) {
+        Set<GroupState> states = Sets.newHashSet(
+            Stable, PreparingRebalance, CompletingRebalance, Dead
+        );
+        Set<GroupState> otherStates = Sets.newHashSet(states);
+        otherStates.remove(targetState);
+        otherStates.forEach(otherState -> assertFalse(group.is(otherState)));
+        assertTrue(group.is(targetState));
+    }
+
+
+}

--- a/src/test/java/io/streamnative/kop/coordinator/group/MemberMetadataTest.java
+++ b/src/test/java/io/streamnative/kop/coordinator/group/MemberMetadataTest.java
@@ -1,0 +1,126 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kop.coordinator.group;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.google.common.collect.Sets;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Test;
+import org.testng.collections.Maps;
+
+/**
+ * Unit test of {@link MemberMetadata}.
+ */
+public class MemberMetadataTest {
+
+    private static final String groupId = "test-group-id";
+    private static final String clientId = "test-client-id";
+    private static final String clientHost = "test-client-host";
+    private static final String memberId = "test-member-id";
+    private static final String protocolType = "consumer";
+    private static final int rebalanceTimeoutMs = 60000;
+    private static final int sessionTimemoutMs = 10000;
+
+    private static MemberMetadata newMember(Map<String, byte[]> protocols) {
+        return new MemberMetadata(
+            memberId,
+            groupId,
+            clientId,
+            clientHost,
+            rebalanceTimeoutMs,
+            sessionTimemoutMs,
+            protocolType,
+            protocols
+        );
+    }
+
+    @Test
+    public void testMatchesSupportedProtocols() {
+        Map<String, byte[]> protocols = Maps.newHashMap();
+        protocols.put("range", new byte[0]);
+
+        MemberMetadata member = newMember(protocols);
+
+        assertTrue(member.matches(protocols));
+
+        protocols = new HashMap<>();
+        protocols.put("range", new byte[] { 0 });
+        assertFalse(member.matches(protocols));
+
+        protocols = new HashMap<>();
+        protocols.put("roundrobin", new byte[0]);
+        assertFalse(member.matches(protocols));
+
+        protocols = new HashMap<>();
+        protocols.put("range", new byte[0]);
+        protocols.put("roundrobin", new byte[0]);
+        assertFalse(member.matches(protocols));
+    }
+
+    @Test
+    public void testVoteForPreferredProtocol() {
+        Map<String, byte[]> protocols = new LinkedHashMap<>();
+        protocols.put("range", new byte[0]);
+        protocols.put("roundrobin", new byte[0]);
+
+        MemberMetadata member = newMember(protocols);
+        assertEquals("range", member.vote(Sets.newHashSet("range", "roundrobin")));
+        assertEquals("roundrobin", member.vote(Sets.newHashSet("blah", "roundrobin")));
+    }
+
+    @Test
+    public void testMetadata() {
+        Map<String, byte[]> protocols = new LinkedHashMap<>();
+        protocols.put("range", new byte[] { 0xf });
+        protocols.put("roundrobin", new byte[] { 0xe });
+
+        MemberMetadata memberMetadata = newMember(protocols);
+        assertArrayEquals(
+            new byte[] { 0xf },
+            memberMetadata.metadata("range"));
+        assertArrayEquals(
+            new byte[] { 0xe },
+            memberMetadata.metadata("roundrobin"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMetadataRaisesOnUnsupportedProtocol() {
+        Map<String, byte[]> protocols = new LinkedHashMap<>();
+        protocols.put("range", new byte[0]);
+        protocols.put("roundrobin", new byte[0]);
+
+        MemberMetadata member = newMember(protocols);
+        member.metadata("blah");
+        fail("Should not reach here");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testVoteRaisesOnUnsupportedProtocols() {
+        Map<String, byte[]> protocols = new LinkedHashMap<>();
+        protocols.put("range", new byte[0]);
+        protocols.put("roundrobin", new byte[0]);
+
+        MemberMetadata member = newMember(protocols);
+        member.vote(Sets.newHashSet("blah"));
+        fail("Should not reach here");
+    }
+
+}


### PR DESCRIPTION
*Motivation*

Master Issue: #4 

Import Kafka coordinator implementation. This is the first part to introduce
GroupMetadata and MemberMetadata.