### PR TITLE
Fix event time handling in FetchContext

### DIFF
--- a/conf/kop_standalone.conf
+++ b/conf/kop_standalone.conf
@@ -19,7 +19,7 @@ enableGroupCoordinator=true
 
 messagingProtocols=kafka
 
-listeners=PLAINTEXT://localhost:9092,SSL://localhost:9093
+listeners=PLAINTEXT://localhost:9092
 ### --- General broker settings --- ###
 
 # Zookeeper quorum connection string


### PR DESCRIPTION
In pulsar cpp client, the default event time is set as minus value and caused error when use kafka consumer to consume message produced by pulsar cpp/cgo client. 
In this change, if we checked the event time is not set, using publish time to set it.