### PR TITLE
Fix memory leak and optimize memory usage

### DIFF
--- a/src/main/java/io/streamnative/kop/utils/MessageRecordUtils.java
+++ b/src/main/java/io/streamnative/kop/utils/MessageRecordUtils.java
@@ -193,6 +193,7 @@ public final class MessageRecordUtils {
 
         messageMetaBuilder.recycle();
         msgMetadata.recycle();
+        batchedMessageMetadataAndPayload.release();
 
         return buf;
     }
@@ -266,8 +267,10 @@ public final class MessageRecordUtils {
 
                         SingleMessageMetadata singleMessageMetadata = singleMessageMetadataBuilder.build();
 
+                        // TODO: optimize this to avoid memory copy
                         byte[] data = new byte[singleMessagePayload.readableBytes()];
                         singleMessagePayload.readBytes(data);
+                        singleMessagePayload.release();
                         Header[] headers = getHeadersFromMetadata(singleMessageMetadata.getPropertiesList());
 
                         builder.appendWithOffset(
@@ -279,6 +282,7 @@ public final class MessageRecordUtils {
                         singleMessageMetadataBuilder.recycle();
                     }
                 } else {
+                    // TODO: optimize this to avoid memory copy
                     byte[] data = new byte[payload.readableBytes()];
                     payload.readBytes(data);
                     Header[] headers = getHeadersFromMetadata(msgMetadata.getPropertiesList());
@@ -290,6 +294,9 @@ public final class MessageRecordUtils {
                         data,
                         headers);
                 }
+
+                payload.release();
+                entry.release();
             }
             return builder.build();
         } catch (IOException ioe){

--- a/src/main/java/org/apache/kafka/common/requests/ResponseUtils.java
+++ b/src/main/java/org/apache/kafka/common/requests/ResponseUtils.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import java.nio.ByteBuffer;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.protocol.types.Struct;
+
+/**
+ * Provide util classes to access protected fields in kafka structures.
+ */
+@Slf4j
+public class ResponseUtils {
+
+    /**
+     * Serialize a kafka response into a byte buf.
+     * @param version
+     * @param responseHeader
+     * @param response
+     * @return
+     */
+    public static ByteBuf serializeResponse(short version,
+                                            ResponseHeader responseHeader,
+                                            AbstractResponse response) {
+        return serialize(
+            responseHeader.toStruct(),
+            response.toStruct(version)
+        );
+    }
+
+    public static ByteBuf serialize(Struct headerStruct, Struct bodyStruct) {
+        int size = headerStruct.sizeOf() + bodyStruct.sizeOf();
+        ByteBuf buf = PooledByteBufAllocator.DEFAULT.buffer(size, size);
+        buf.writerIndex(buf.readerIndex() + size);
+        ByteBuffer buffer = buf.nioBuffer();
+        headerStruct.writeTo(buffer);
+        bodyStruct.writeTo(buffer);
+        buffer.rewind();
+        return buf;
+    }
+
+}


### PR DESCRIPTION
*Motivation*

There is a memory leak in MessageRecordUtils.

*Modifications*

- Fix the memory leak in MessageRecordUtils
- Avoid memory allocation when serializing the response
- Optimize the reference counting for kafka request holding the payload reference