### PR TITLE
Fix github action of release-note from master to 5.2.0

### DIFF
--- a/.github/workflows/release-note.yml
+++ b/.github/workflows/release-note.yml
@@ -15,6 +15,6 @@ jobs:
 
     steps:
       - name: release note
-        uses: toolmantim/release-drafter@master
+        uses: toolmantim/release-drafter@v5.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
fix github action of release-note from master to 5.2.0 to avoid release-note@master issues.