### PR TITLE
#135 fix IllegalArgumentException for  KafkaConsumer#offsetsForTimes

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -149,6 +149,7 @@ import org.apache.pulsar.zookeeper.ZooKeeperCache.Deserializer;
 @Slf4j
 @Getter
 public class KafkaRequestHandler extends KafkaCommandDecoder {
+    public static final long DEFAULT_TIMESTAMP = 0L;
 
     private final PulsarService pulsarService;
     private final KafkaServiceConfiguration kafkaConfig;
@@ -696,7 +697,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 } else {
                     partitionData.complete(new ListOffsetResponse.PartitionData(
                             Errors.NONE,
-                            RecordBatch.NO_TIMESTAMP,
+                            DEFAULT_TIMESTAMP,
                             MessageIdUtils
                                     .getOffset(position.getLedgerId(), entryId == -1 ? 0 : entryId)));
                 }
@@ -717,7 +718,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 } else {
                     partitionData.complete(new ListOffsetResponse.PartitionData(
                             Errors.NONE,
-                            RecordBatch.NO_TIMESTAMP,
+                            DEFAULT_TIMESTAMP,
                             MessageIdUtils.getOffset(position.getLedgerId(), position.getEntryId())));
                 }
 
@@ -766,7 +767,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                         } else {
                             partitionData.complete(new ListOffsetResponse.PartitionData(
                                     Errors.NONE,
-                                    RecordBatch.NO_TIMESTAMP,
+                                    0,
                                     MessageIdUtils.getOffset(finalPosition.getLedgerId(), finalPosition.getEntryId())));
                         }
                     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -767,7 +767,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                         } else {
                             partitionData.complete(new ListOffsetResponse.PartitionData(
                                     Errors.NONE,
-                                    0,
+                                    DEFAULT_TIMESTAMP,
                                     MessageIdUtils.getOffset(finalPosition.getLedgerId(), finalPosition.getEntryId())));
                         }
                     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
@@ -13,7 +13,6 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
-import static org.apache.kafka.common.record.RecordBatch.NO_TIMESTAMP;
 import static org.apache.pulsar.common.naming.TopicName.PARTITIONED_TOPIC_SUFFIX;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -283,7 +282,7 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
         ListOffsetResponse listOffsetResponse = (ListOffsetResponse) response;
         assertEquals(listOffsetResponse.responseData().get(tp).error, Errors.NONE);
         assertEquals(listOffsetResponse.responseData().get(tp).offset, Long.valueOf(limitOffset));
-        assertEquals(listOffsetResponse.responseData().get(tp).timestamp, Long.valueOf(NO_TIMESTAMP));
+        assertEquals(listOffsetResponse.responseData().get(tp).timestamp, Long.valueOf(0));
     }
 
     // these 2 test cases test Read Commit / UnCommit.
@@ -352,7 +351,7 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
         ListOffsetResponse listOffsetResponse = (ListOffsetResponse) response;
         assertEquals(listOffsetResponse.responseData().get(tp).error, Errors.NONE);
         assertEquals(listOffsetResponse.responseData().get(tp).offset, Long.valueOf(limitOffset));
-        assertEquals(listOffsetResponse.responseData().get(tp).timestamp, Long.valueOf(NO_TIMESTAMP));
+        assertEquals(listOffsetResponse.responseData().get(tp).timestamp, Long.valueOf(0));
     }
 
     /// Add test for FetchRequest


### PR DESCRIPTION
 Fix IllegalArgumentException for  KafkaConsumer#offsetsForTimes under kafka versions of 2.1.0 , 2.2.0 and 2.3.0
