### PR TITLE
Support listener with no hostname, e.g. SSL://:9093

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -480,7 +480,7 @@ public class KafkaProtocolHandler implements ProtocolHandler {
 
     // listener either in format: type://:port, e.g.: "SSL://:9093",
     // or in format: type://hostname:port, e.g.: "SSL://hostname:9093",
-    // Ror the 1st format, need to fill it with `advertisedAddress` for hostname.
+    // For the 1st format, need to fill it with `advertisedAddress` for hostname.
     // For the 2nd format, need to check the hostname is the same as `advertisedAddress`.
     public static String checkAndFillUpListeners(String listeners, String advertisedAddress) {
         String[] parts = listeners.split(LISTENER_DEL);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -179,7 +179,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         this.executor = pulsarService.getExecutor();
         this.admin = pulsarService.getAdminClient();
         this.tlsEnabled = tlsEnabled;
-        this.localListeners = KafkaProtocolHandler.getListeners(kafkaConfig);
+        this.localListeners = KafkaProtocolHandler.getListenersFromConfig(kafkaConfig);
         this.plaintextPort = getListenerPort(localListeners, PLAINTEXT);
         this.sslPort = getListenerPort(localListeners, SSL);
         this.namespace = NamespaceName.get(


### PR DESCRIPTION
Support listener either in format: type://:port, e.g.: "SSL://:9093", or in format: type://hostname:port, e.g.: "SSL://hostname:9093",
For the 1st format, need to fill it with advertisedAddress for hostname.
For the 2nd format, need to check the hostname is the same as advertisedAddress.