### PR TITLE
fix advertised address config issue for standalone

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -195,6 +195,11 @@ public class KafkaProtocolHandler implements ProtocolHandler {
         } else {
             // when loaded with PulsarService as NAR, `conf` will be type of ServiceConfiguration
             kafkaConfig = ConfigurationUtils.create(conf.getProperties(), KafkaServiceConfiguration.class);
+
+            // some of the configs value in conf.properties may not updated.
+            // So need to get latest value from conf itself
+            kafkaConfig.setAdvertisedAddress(conf.getAdvertisedAddress());
+            kafkaConfig.setBindAddress(conf.getBindAddress());
         }
         this.bindAddress = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(kafkaConfig.getBindAddress());
     }


### PR DESCRIPTION
In Pulsar standalone mode, If advertisedAddress not set, it is hard coded as "localhost":
```
        if (this.getAdvertisedAddress() != null) {
            // Use advertised address from command line
            config.setAdvertisedAddress(this.getAdvertisedAddress());
            zkServers = this.getAdvertisedAddress();
        } else if (isBlank(config.getAdvertisedAddress())) {
            // Use advertised address as local hostname
            config.setAdvertisedAddress("localhost");
        } else {
            // Use advertised address from config file
        }
```

And in KoP, if host address  not set in listeners, it will use advertised address to do the config.
Then the value read from conf.properties is outdated. This PR update it with right value.