### PR TITLE
use kafkaTenant and kafkaNamespace when OffsetAcker create consumer

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -316,6 +316,7 @@ public class KafkaProtocolHandler implements ProtocolHandler {
             (PulsarClientImpl) (service.pulsar().getClient()),
             groupConfig,
             offsetConfig,
+            kafkaConfig,
             SystemTimer.builder()
                 .executorName("group-coordinator-timer")
                 .build(),

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinator.java
@@ -25,6 +25,7 @@ import static org.apache.kafka.common.record.RecordBatch.NO_PRODUCER_ID;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupMetadata.GroupOverview;
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupMetadata.GroupSummary;
 import io.streamnative.pulsar.handlers.kop.offset.OffsetAndMetadata;
@@ -83,6 +84,8 @@ public class GroupCoordinator {
         PulsarClientImpl pulsarClient,
         GroupConfig groupConfig,
         OffsetConfig offsetConfig,
+        KafkaServiceConfiguration kafkaServiceConfiguration,
+
         Timer timer,
         Time time
     ) {
@@ -116,7 +119,7 @@ public class GroupCoordinator {
                 .timeoutTimer(timer)
                 .build();
 
-        OffsetAcker offsetAcker = new OffsetAcker(pulsarClient);
+        OffsetAcker offsetAcker = new OffsetAcker(pulsarClient, kafkaServiceConfiguration);
         return new GroupCoordinator(
             groupConfig,
             metadataManager,


### PR DESCRIPTION
fix #186 
use `kafkaTenant` and `kafkaNamespace` set in broker.conf instead of `public` and `default` for `OffsetAcker ` when create consumer 