### PR TITLE
[WIP] Add Kafka version coverage tests

### DIFF
--- a/integrations/build.sh
+++ b/integrations/build.sh
@@ -20,11 +20,24 @@ VERSION=$(${INTR_HOME}/scripts/dev/get-project-version.py)
 TAG=${VERSION%"-SNAPSHOT"}
 IMAGE_NAME_PREFIX="kop-test-"
 
-for img_dir in `ls -d ${INTR_HOME}/integrations/*/ | grep -v dev`; do
-    BASE_NAME=$(basename ${img_dir})
-    cd ${img_dir}
-    IMAGE="streamnative/${IMAGE_NAME_PREFIX}${BASE_NAME}:${TAG}"
+build_image() {
+    IMAGE=$1
     echo "Building test image : ${IMAGE}"
     docker build . -t ${IMAGE}
     echo "Successfully built test image : ${IMAGE}"
+}
+
+for img_dir in `ls -d ${INTR_HOME}/integrations/*/ | grep -v dev`; do
+    BASE_NAME=$(basename ${img_dir})
+    cd ${img_dir}
+    if [[ $BASE_NAME == "kafka-client" ]]; then
+        VERSIONS=(1.0.0 1.1.0 2.0.0 2.1.0 2.2.0 2.3.0 2.4.0 2.5.0 2.6.0)
+        for VERSION in ${VERSIONS[@]}; do
+            sed -i '' "s/<kafka\.version>.*<\/kafka\.version>/<kafka.version>$VERSION<\/kafka.version>/" pom.xml
+            build_image "streamnative/${IMAGE_NAME_PREFIX}${BASE_NAME}-${VERSION}:${TAG}"
+            sed -i '' "s/<kafka\.version>.*<\/kafka\.version>/<kafka.version>2.6.0<\/kafka.version>/" pom.xml
+        done
+    else
+        build_image "streamnative/${IMAGE_NAME_PREFIX}${BASE_NAME}:${TAG}"
+    fi
 done

--- a/integrations/kafka-client/Dockerfile
+++ b/integrations/kafka-client/Dockerfile
@@ -11,6 +11,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 FROM maven:3.6.3-openjdk-8 AS build
 WORKDIR /app
 COPY pom.xml .

--- a/integrations/kafka-client/Dockerfile
+++ b/integrations/kafka-client/Dockerfile
@@ -1,0 +1,23 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+FROM maven:3.6.3-openjdk-8 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn clean package
+
+FROM openjdk:8-jre
+WORKDIR /app
+COPY --from=build /app/target/*jar-with-dependencies.jar /app/kafka-client.jar
+CMD exec java -cp /app/kafka-client.jar Main

--- a/integrations/kafka-client/pom.xml
+++ b/integrations/kafka-client/pom.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/integrations/kafka-client/pom.xml
+++ b/integrations/kafka-client/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.example</groupId>
+  <artifactId>kafka-client</artifactId>
+  <version>1.0</version>
+
+  <properties>
+    <kafka.version>2.6.0</kafka.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>${kafka.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.30</version>
+      <scope>runtime</scope>
+    </dependency>
+
+    <!-- This dependency is required for kafka-clients 2.6.0 -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.10.5</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <encoding>UTF-8</encoding>
+          <showDeprecation>true</showDeprecation>
+          <showWarnings>true</showWarnings>
+          <optimize>true</optimize>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+        </configuration>
+        <executions>
+          <execution>
+            <id>make-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <includes>
+          <include>*.properties</include>
+        </includes>
+      </resource>
+    </resources>
+  </build>
+
+</project>

--- a/integrations/kafka-client/src/main/java/Main.java
+++ b/integrations/kafka-client/src/main/java/Main.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class Main {
+    public static void main(String[] args) {
+        Map<String, String> map = System.getenv();
+        final String broker = map.getOrDefault("KOP_BROKER", "localhost:9092");
+        final String topic = map.getOrDefault("KOP_TOPIC", "kafka-client");
+        final int limit = Integer.parseInt(map.getOrDefault("KOP_LIMIT", "10"));
+        final boolean shouldProduce = Boolean.parseBoolean(map.getOrDefault("KOP_PRODUCE", "false"));
+        final boolean shouldConsume = Boolean.parseBoolean(map.getOrDefault("KOP_CONSUME", "false"));
+        final String stringSerializer = "org.apache.kafka.common.serialization.StringSerializer";
+        final String stringDeserializer = "org.apache.kafka.common.serialization.StringDeserializer";
+        final String group = "Subscription";
+
+        if (shouldProduce) {
+            System.out.println("starting to produce");
+
+            final Properties props = new Properties();
+            props.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, broker);
+            props.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, stringSerializer);
+            props.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, stringSerializer);
+
+            final KafkaProducer<String, String> producer = new KafkaProducer<>(props);
+
+            AtomicInteger numMessagesSent = new AtomicInteger(0);
+            for (int i = 0; i < limit; i++) {
+                producer.send(new ProducerRecord<>(topic, "hello from kafka-client"),
+                        (recordMetadata, e) -> {
+                            if (e == null) {
+                                System.out.println("Send to " + recordMetadata);
+                                numMessagesSent.incrementAndGet();
+                            } else {
+                                System.out.println("Failed to send: " + e.getMessage());
+                            }
+                        });
+            }
+
+            producer.flush();
+            producer.close();
+            if (numMessagesSent.get() == limit) {
+                System.out.println("produced all messages successfully");
+            }
+        }
+
+        if (shouldConsume) {
+            System.out.println("starting to consume");
+
+            final Properties props = new Properties();
+            props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, broker);
+            props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, group);
+            props.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, stringDeserializer);
+            props.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, stringDeserializer);
+            props.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+            final KafkaConsumer<String, String> consumer = new KafkaConsumer<>(props);
+            consumer.subscribe(Collections.singleton(topic));
+
+            int i = 0;
+            while (i < limit) {
+                ConsumerRecords<String, String> records = consumer.poll(3000);
+                for (ConsumerRecord<String, String> record : records) {
+                    System.out.println("Receive " + record);
+                }
+                i += records.count();
+            }
+
+            consumer.close();
+            System.out.println("consumed all messages successfully");
+        }
+
+        System.out.println("exiting normally");
+    }
+}

--- a/integrations/kafka-client/src/main/resources/simplelogger.properties
+++ b/integrations/kafka-client/src/main/resources/simplelogger.properties
@@ -1,21 +1,17 @@
 #
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
+
 org.slf4j.simpleLogger.defaultLogLevel=info
 org.slf4j.simpleLogger.showDateTime=true
 org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS

--- a/integrations/kafka-client/src/main/resources/simplelogger.properties
+++ b/integrations/kafka-client/src/main/resources/simplelogger.properties
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+org.slf4j.simpleLogger.defaultLogLevel=info
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS

--- a/integrations/publish.sh
+++ b/integrations/publish.sh
@@ -36,11 +36,22 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-for img_dir in `ls -d ${INTR_HOME}/integrations/*/ | grep -v dev`; do
-    BASE_NAME=$(basename ${img_dir})
-    IMAGE="streamnative/${IMAGE_NAME_PREFIX}${BASE_NAME}:${TAG}"
-    IMAGE_LATEST="streamnative/${IMAGE_NAME_PREFIX}${BASE_NAME}:latest"
+push_image() {
+    IMAGE="streamnative/${IMAGE_NAME_PREFIX}$1:${TAG}"
+    IMAGE_LATEST="streamnative/${IMAGE_NAME_PREFIX}$1:latest"
     docker tag ${IMAGE} ${IMAGE_LATEST}
     docker push ${IMAGE_LATEST}
     docker push ${IMAGE}
+}
+
+for img_dir in `ls -d ${INTR_HOME}/integrations/*/ | grep -v dev`; do
+    BASE_NAME=$(basename ${img_dir})
+    if [[ $BASE_NAME == "kafka-client" ]]; then
+        KAFKA_VERSIONS=(1.0.0 1.1.0 2.0.0 2.1.0 2.2.0 2.3.0 2.4.0 2.5.0 2.6.0)
+        for KAFKA_VERSION in ${KAFKA_VERSIONS[@]}; do
+            push_image "${BASE_NAME}-${KAFKA_VERSION}"
+        done
+    else
+        push_image $BASE_NAME
+    fi
 done

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaIntegrationTest.java
@@ -88,6 +88,15 @@ public class KafkaIntegrationTest extends KopProtocolHandlerTestBase {
                 // consumer is broken, see integrations/README.md
                 {"node-kafka-node", Optional.empty(), true, false},
                 {"node-rdkafka", Optional.empty(), true, true},
+                {"kafka-client-1.0.0", Optional.empty(), true, true},
+                {"kafka-client-1.1.0", Optional.empty(), true, true},
+                {"kafka-client-2.0.0", Optional.empty(), true, true},
+                {"kafka-client-2.1.0", Optional.empty(), true, true},
+                {"kafka-client-2.2.0", Optional.empty(), true, true},
+                {"kafka-client-2.3.0", Optional.empty(), true, true},
+                {"kafka-client-2.4.0", Optional.empty(), true, true},
+                {"kafka-client-2.5.0", Optional.empty(), true, true},
+                {"kafka-client-2.6.0", Optional.empty(), true, true},
         };
     }
 


### PR DESCRIPTION
Master issue: #138 

Use one code to build multiple docker images for Kafka client version 1.x.0 and 2.y.0.

Kafka client 0.11.0.0 could also pass the `simpleProduceAndConsume` tests but from the log we can see the 0.11.0.0 consumer cannot commit offsets. Therefore it's treated as not supported by KoP.

In additions, the current integration tests cannot be run locally (at least with MacOS) because the advertised address was set to localhost. I fix this problem by replacing it with a site local address.

----

Currently, it has some problems with Kafka client tests. When the container of Kafka client exits, it doesn't print `ExitCode: 0` so exceptions would be thrown from:

https://github.com/streamnative/kop/blob/41f274ccd629c2e18edd33ccecb50c70ee593257/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaIntegrationTest.java#L204

On the other hand, it seems to have a race condition in https://github.com/streamnative/kop/blob/41f274ccd629c2e18edd33ccecb50c70ee593257/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaIntegrationTest.java#L192-L193. The race condition applies in current integration tests. 