### PR TITLE
Fix group coordinator's metadata never expired

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -328,7 +328,7 @@ public class KafkaProtocolHandler implements ProtocolHandler {
 
     public void startGroupCoordinator() throws Exception {
         if (this.groupCoordinator != null) {
-            this.groupCoordinator.startup(false);
+            this.groupCoordinator.startup(true);
         } else {
             log.error("Failed to start group coordinator. Need init it first.");
         }


### PR DESCRIPTION
The `GroupCoordinator`'s startup method accepts a boolean param `enableMetadataExpiration`, which will be passed to `GroupMetadataManager#startup`. If it's true, the group metadata manager will clean up group metadata cache periodically.

However `enableMetadataExpiration` is false now. It should only be set false in tests. 