### PR TITLE
Cursor read more entries one time when fetching message

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,7 @@ The following table lists all KoP configurations.
 |kafkaNamespace| The default namespace of Kafka's topics |default|
 |kafkaMetadataTenant| Tenant used for storing Kafka metadata topics |public|
 |kafkaMetadataNamespace| Namespace used for storing Kafka metadata topics  |__kafka|
+|maxReadEntriesNum| Maximum number of entries that are read from cursor once per time  |5|
 |enableGroupCoordinator|  Flag used to enable the group coordinator  |true|
 |groupMinSessionTimeoutMs| The minimum allowed session timeout for registered consumers<br>Shorter timeouts result in quicker failure detection while require more frequent consumer heart beating, which can overwhelm broker resources.  |6000|
 |groupMaxSessionTimeoutMs| The maximum allowed session timeout for registered consumers. <br>Longer timeouts give consumers more time to process messages between heartbeats while require longer time to detect failures. |300000|

--- a/kafka-impl/conf/kop.conf
+++ b/kafka-impl/conf/kop.conf
@@ -68,6 +68,9 @@ offsetsRetentionCheckIntervalMs=600000
 # Number of partitions for the offsets topic
 offsetsTopicNumPartitions=8
 
+# the number of reading entries from bookie
+readEntriesNum=10
+
 ### --- KoP SSL configs--- ###
 
 # Kafka ssl configuration map with: SSL_PROTOCOL_CONFIG = ssl.protocol

--- a/kafka-impl/conf/kop.conf
+++ b/kafka-impl/conf/kop.conf
@@ -69,7 +69,7 @@ offsetsRetentionCheckIntervalMs=600000
 offsetsTopicNumPartitions=8
 
 # the number of reading entries from bookie
-readEntriesNum=10
+readEntriesNum=5
 
 ### --- KoP SSL configs--- ###
 

--- a/kafka-impl/conf/kop.conf
+++ b/kafka-impl/conf/kop.conf
@@ -68,8 +68,8 @@ offsetsRetentionCheckIntervalMs=600000
 # Number of partitions for the offsets topic
 offsetsTopicNumPartitions=8
 
-# maximum number of entries that are read from cursor once per time
-readEntriesNum=5
+# Maximum number of entries that are read from cursor once per time
+maxReadEntriesNum=5
 
 ### --- KoP SSL configs--- ###
 

--- a/kafka-impl/conf/kop.conf
+++ b/kafka-impl/conf/kop.conf
@@ -68,7 +68,7 @@ offsetsRetentionCheckIntervalMs=600000
 # Number of partitions for the offsets topic
 offsetsTopicNumPartitions=8
 
-# the number of reading entries from bookie
+# maximum number of entries that are read from cursor once per time
 readEntriesNum=5
 
 ### --- KoP SSL configs--- ###

--- a/kafka-impl/conf/kop_standalone.conf
+++ b/kafka-impl/conf/kop_standalone.conf
@@ -68,6 +68,9 @@ offsetsRetentionCheckIntervalMs=600000
 # Number of partitions for the offsets topic
 offsetsTopicNumPartitions=8
 
+# the number of reading entries from bookie
+readEntriesNum=1
+
 ### --- KoP SSL configs--- ###
 
 # Kafka ssl configuration map with: SSL_PROTOCOL_CONFIG = ssl.protocol

--- a/kafka-impl/conf/kop_standalone.conf
+++ b/kafka-impl/conf/kop_standalone.conf
@@ -68,8 +68,8 @@ offsetsRetentionCheckIntervalMs=600000
 # Number of partitions for the offsets topic
 offsetsTopicNumPartitions=8
 
-# maximum number of entries that are read from cursor once per time
-readEntriesNum=1
+# Maximum number of entries that are read from cursor once per time
+maxReadEntriesNum=1
 
 ### --- KoP SSL configs--- ###
 

--- a/kafka-impl/conf/kop_standalone.conf
+++ b/kafka-impl/conf/kop_standalone.conf
@@ -68,7 +68,7 @@ offsetsRetentionCheckIntervalMs=600000
 # Number of partitions for the offsets topic
 offsetsTopicNumPartitions=8
 
-# the number of reading entries from bookie
+# maximum number of entries that are read from cursor once per time
 readEntriesNum=1
 
 ### --- KoP SSL configs--- ###

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -167,7 +167,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     private String authRole;
     private AuthenticationState authState;
     private final int defaultNumPartitions;
-    public static int readEntriesNum;
+    public final int readEntriesNum;
 
     public KafkaRequestHandler(PulsarService pulsarService,
                                KafkaServiceConfiguration kafkaConfig,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -167,7 +167,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     private String authRole;
     private AuthenticationState authState;
     private final int defaultNumPartitions;
-    public final int readEntriesNum;
+    public final int maxReadEntriesNum;
 
     public KafkaRequestHandler(PulsarService pulsarService,
                                KafkaServiceConfiguration kafkaConfig,
@@ -186,7 +186,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         this.sslPort = getListenerPort(localListeners, SSL);
         this.topicManager = new KafkaTopicManager(this);
         this.defaultNumPartitions = kafkaConfig.getDefaultNumPartitions();
-        this.readEntriesNum = kafkaConfig.getReadEntriesNum();
+        this.maxReadEntriesNum = kafkaConfig.getMaxReadEntriesNum();
     }
 
     @Override

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -167,6 +167,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     private String authRole;
     private AuthenticationState authState;
     private final int defaultNumPartitions;
+    public static int readEntriesNum;
 
     public KafkaRequestHandler(PulsarService pulsarService,
                                KafkaServiceConfiguration kafkaConfig,
@@ -185,6 +186,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         this.sslPort = getListenerPort(localListeners, SSL);
         this.topicManager = new KafkaTopicManager(this);
         this.defaultNumPartitions = kafkaConfig.getDefaultNumPartitions();
+        this.readEntriesNum = kafkaConfig.getReadEntriesNum();
     }
 
     @Override

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -245,8 +245,8 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
 
     @FieldContext(
             category = CATEGORY_KOP,
-            doc = "the number of reading entries from bookie"
+            doc = "maximum number of entries that are read from cursor once per time"
     )
-    private int readEntriesNum = 5;
+    private int maxReadEntriesNum = 5;
 
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -243,4 +243,10 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
     )
     private Set<String> saslAllowedMechanisms = new HashSet<String>();
 
+    @FieldContext(
+            category = CATEGORY_KOP,
+            doc = "the number of reading entries from bookie"
+    )
+    private int readEntriesNum = 10;
+
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -245,7 +245,7 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
 
     @FieldContext(
             category = CATEGORY_KOP,
-            doc = "maximum number of entries that are read from cursor once per time"
+            doc = "Maximum number of entries that are read from cursor once per time"
     )
     private int maxReadEntriesNum = 5;
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -247,6 +247,6 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
             category = CATEGORY_KOP,
             doc = "the number of reading entries from bookie"
     )
-    private int readEntriesNum = 10;
+    private int readEntriesNum = 5;
 
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -364,7 +364,7 @@ public final class MessageFetchContext {
             CompletableFuture<List<Entry>> readFuture = new CompletableFuture<>();
             cursor = cursorOffsetPair.getValue().getLeft();
             long currentOffset = cursorOffsetPair.getValue().getRight();
-            int readeEntryNum = KafkaRequestHandler.readEntriesNum;
+            int readeEntryNum = requestHandler.getReadEntriesNum();
 
             // read readeEntryNum size entry.
             cursor.asyncReadEntries(readeEntryNum,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -389,7 +389,8 @@ public final class MessageFetchContext {
                                     long nextOffset = MessageIdUtils
                                             .getOffset(nextPosition.getLedgerId(), nextPosition.getEntryId());
 
-                                    // put next offset in to passed in cursors map. and add back to TCM when all read complete.
+                                    // put next offset in to passed in cursors map.
+                                    // and add back to TCM when all read complete.
                                     cursors.put(cursorOffsetPair.getKey(), Pair.of(cursor, nextOffset));
 
                                     if (log.isDebugEnabled()) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -364,7 +364,7 @@ public final class MessageFetchContext {
             CompletableFuture<List<Entry>> readFuture = new CompletableFuture<>();
             cursor = cursorOffsetPair.getValue().getLeft();
             long currentOffset = cursorOffsetPair.getValue().getRight();
-            int readeEntryNum = requestHandler.getReadEntriesNum();
+            int readeEntryNum = requestHandler.getMaxReadEntriesNum();
 
             // read readeEntryNum size entry.
             cursor.asyncReadEntries(readeEntryNum,

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
@@ -49,6 +49,14 @@ public class KafkaServiceConfigurationTest {
     }
 
     @Test
+    public void testReadEntriesNum() {
+        int readEntriesNum = 60;
+        KafkaServiceConfiguration configuration = new KafkaServiceConfiguration();
+        configuration.setReadEntriesNum(readEntriesNum);
+        assertEquals(60, configuration.getReadEntriesNum());
+    }
+
+    @Test
     public void testConfigurationUtilsStream() throws Exception {
         File testConfigFile = new File("tmp." + System.currentTimeMillis() + ".properties");
         if (testConfigFile.exists()) {

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
@@ -49,11 +49,11 @@ public class KafkaServiceConfigurationTest {
     }
 
     @Test
-    public void testReadEntriesNum() {
+    public void testMaxReadEntriesNum() {
         int readEntriesNum = 60;
         KafkaServiceConfiguration configuration = new KafkaServiceConfiguration();
-        configuration.setReadEntriesNum(readEntriesNum);
-        assertEquals(60, configuration.getReadEntriesNum());
+        configuration.setMaxReadEntriesNum(readEntriesNum);
+        assertEquals(60, configuration.getMaxReadEntriesNum());
     }
 
     @Test

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
@@ -498,7 +498,7 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
 
         int messagesPerPartition = 9;
         int maxResponseBytes = 800;
-        int maxPartitionBytes = 190;
+        int maxPartitionBytes = 900;
 
         List<TopicPartition> topicPartitions = createTopics(topicName, numberTopics, numberPartitions);
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
@@ -498,7 +498,7 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
 
         int messagesPerPartition = 9;
         int maxResponseBytes = 800;
-        int maxPartitionBytes = 900;
+        int maxPartitionBytes = 190;
 
         List<TopicPartition> topicPartitions = createTopics(topicName, numberTopics, numberPartitions);
 


### PR DESCRIPTION
feature related to https://github.com/streamnative/kop/issues/212, it could improve the consuming speed at least 30%.