### PR TITLE
remove redundance reference to get rid of native memory leak when getting a lot of requests.

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -1033,8 +1033,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             });
         }
 
-        MessageFetchContext fetchContext = MessageFetchContext.get(this, fetch);
-        fetchContext.handleFetch(resultFuture);
+        MessageFetchContext fetchContext = MessageFetchContext.get(this);
+        fetchContext.handleFetch(resultFuture, fetch);
     }
 
     protected void handleJoinGroupRequest(KafkaHeaderAndRequest joinGroup,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -58,14 +58,11 @@ import org.apache.kafka.common.requests.FetchResponse.PartitionData;
 public final class MessageFetchContext {
 
     private KafkaRequestHandler requestHandler;
-    private KafkaHeaderAndRequest fetchRequest;
 
     // recycler and get for this object
-    public static MessageFetchContext get(KafkaRequestHandler requestHandler,
-                                          KafkaHeaderAndRequest fetchRequest) {
+    public static MessageFetchContext get(KafkaRequestHandler requestHandler) {
         MessageFetchContext context = RECYCLER.get();
         context.requestHandler = requestHandler;
-        context.fetchRequest = fetchRequest;
         return context;
     }
 
@@ -83,13 +80,14 @@ public final class MessageFetchContext {
 
     public void recycle() {
         requestHandler = null;
-        fetchRequest = null;
         recyclerHandle.recycle(this);
     }
 
 
     // handle request
-    public CompletableFuture<AbstractResponse> handleFetch(CompletableFuture<AbstractResponse> fetchResponse) {
+    public CompletableFuture<AbstractResponse> handleFetch(
+            CompletableFuture<AbstractResponse> fetchResponse,
+            KafkaHeaderAndRequest fetchRequest) {
         LinkedHashMap<TopicPartition, PartitionData<MemoryRecords>> responseData = new LinkedHashMap<>();
 
         // Map of partition and related tcm.


### PR DESCRIPTION
KafkaHeaderAndRequest contains native memory references. When getting a lot of requests from kafka client, for example 10 million per seconds, those redundance references will stop gc collection and memory get increased.
It would be tricky to provide unit test for this patch and this pr seems to be a minor change, so I didn't write test case for it.