### PR TITLE
Perform authentication before processing other requests

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -163,9 +163,7 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
             } else {
                 if (!hasAuthenticated(kafkaHeaderAndRequest)) {
                     authenticate(kafkaHeaderAndRequest, responseFuture);
-                    if (!hasAuthenticated(kafkaHeaderAndRequest)) {
-                        return;
-                    }
+                    return;
                 }
                 switch (kafkaHeaderAndRequest.getHeader().apiKey()) {
                     case API_VERSIONS:

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -167,7 +167,9 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         this.clusterName = kafkaConfig.getClusterName();
         this.executor = pulsarService.getExecutor();
         this.admin = pulsarService.getAdminClient();
-        this.authenticator = (pulsarService.getBrokerService().isAuthenticationEnabled())
+        final boolean authenticationEnabled = pulsarService.getBrokerService().isAuthenticationEnabled()
+                && !kafkaConfig.getSaslAllowedMechanisms().isEmpty();
+        this.authenticator = authenticationEnabled
                 ? new SaslAuthenticator(pulsarService, kafkaConfig.getSaslAllowedMechanisms())
                 : null;
         this.tlsEnabled = tlsEnabled;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -144,11 +144,11 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     private final KafkaServiceConfiguration kafkaConfig;
     private final KafkaTopicManager topicManager;
     private final GroupCoordinator groupCoordinator;
-    private final SaslAuthenticator authenticator;
 
     private final String clusterName;
     private final ScheduledExecutorService executor;
     private final PulsarAdmin admin;
+    private final SaslAuthenticator authenticator;
     private final Boolean tlsEnabled;
     private final String localListeners;
     private final int plaintextPort;
@@ -164,12 +164,12 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         this.pulsarService = pulsarService;
         this.kafkaConfig = kafkaConfig;
         this.groupCoordinator = groupCoordinator;
-        this.authenticator = (pulsarService.getBrokerService().isAuthenticationEnabled())
-                ? new SaslAuthenticator(pulsarService.getBrokerService(), kafkaConfig.getSaslAllowedMechanisms())
-                : null;
         this.clusterName = kafkaConfig.getClusterName();
         this.executor = pulsarService.getExecutor();
         this.admin = pulsarService.getAdminClient();
+        this.authenticator = (pulsarService.getBrokerService().isAuthenticationEnabled())
+                ? new SaslAuthenticator(pulsarService, kafkaConfig.getSaslAllowedMechanisms())
+                : null;
         this.tlsEnabled = tlsEnabled;
         this.localListeners = KafkaProtocolHandler.getListenersFromConfig(kafkaConfig);
         this.plaintextPort = getListenerPort(localListeners, PLAINTEXT);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
@@ -2,9 +2,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
@@ -200,7 +200,7 @@ public class SaslAuthenticator {
         authRole = authState.getAuthRole();
 
         // TODO: we need to let KafkaRequestHandler do the authorization works. Here we just check the permissions
-        //  of the namespace, which is the namespace.
+        //  of the namespace, which is the namespace. See https://github.com/streamnative/kop/issues/236
         final String namespace = saslAuth.getUsername();
         try {
             Map<String, Set<AuthAction>> permissions = admin.namespaces().getPermissions(namespace);
@@ -243,7 +243,7 @@ public class SaslAuthenticator {
 
         final String mechanism = request.mechanism();
         if (mechanism != null && !mechanism.equals("PLAIN")) {
-            // TODO: support more mechanisms
+            // TODO: support more mechanisms, see https://github.com/streamnative/kop/issues/235
             AuthenticationException e = new AuthenticationException("KoP only support PLAIN mechanism");
             responseFuture.complete(request.getErrorResponse(e));
             throw e;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
@@ -109,7 +109,7 @@ public class SaslAuthenticator {
                 handleKafkaRequest(header, request, response);
                 break;
             case AUTHENTICATE:
-                handleSaslToken(header, request, response);
+                handleAuthenticate(header, request, response);
                 break;
             default:
                 break;
@@ -156,9 +156,9 @@ public class SaslAuthenticator {
         }
     }
 
-    private void handleSaslToken(RequestHeader header,
-                                 AbstractRequest request,
-                                 CompletableFuture<AbstractResponse> responseFuture) throws AuthenticationException {
+    private void handleAuthenticate(RequestHeader header,
+                                    AbstractRequest request,
+                                    CompletableFuture<AbstractResponse> responseFuture) throws AuthenticationException {
         ApiKeys apiKey = header.apiKey();
         short version = header.apiVersion();
         if (apiKey != ApiKeys.SASL_AUTHENTICATE) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
@@ -174,6 +174,7 @@ public class SaslAuthenticator {
             throw e;
         }
 
+        responseFuture.complete(new SaslAuthenticateResponse(Errors.NONE, ""));
         authData = AuthData.of(saslAuth.getAuthData().getBytes(UTF_8));
         setState(State.COMPLETE);
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
@@ -1,0 +1,222 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.security;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import io.streamnative.pulsar.handlers.kop.SaslAuth;
+import io.streamnative.pulsar.handlers.kop.utils.SaslUtils;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import javax.naming.AuthenticationException;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.AbstractRequest;
+import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.requests.ApiVersionsRequest;
+import org.apache.kafka.common.requests.ApiVersionsResponse;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.requests.SaslAuthenticateRequest;
+import org.apache.kafka.common.requests.SaslAuthenticateResponse;
+import org.apache.kafka.common.requests.SaslHandshakeRequest;
+import org.apache.kafka.common.requests.SaslHandshakeResponse;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.pulsar.broker.authentication.AuthenticationProvider;
+import org.apache.pulsar.broker.service.BrokerService;
+import org.apache.pulsar.common.api.AuthData;
+
+/**
+ * The SASL authenticator.
+ */
+@Slf4j
+public class SaslAuthenticator {
+
+    private enum State {
+        HANDSHAKE_OR_VERSIONS_REQUEST,
+        HANDSHAKE_REQUEST,
+        AUTHENTICATE,
+        COMPLETE
+    }
+
+    /**
+     * The exception to indicate that the authenticator's state is illegal when processing some requests.
+     */
+    public static class IllegalStateException extends AuthenticationException {
+
+        public IllegalStateException(String msg, State actualState, State expectedState) {
+            super(msg + " actual state: " + actualState + " expected state: " + expectedState);
+        }
+    }
+
+    /**
+     * The exception to indicate that the client provided mechanism is not supported.
+     */
+    public static class UnsupportedSaslMechanismException extends AuthenticationException {
+
+        public UnsupportedSaslMechanismException(String mechanism) {
+            super("SASL mechanism '" + mechanism + "' requested by client is not supported");
+        }
+    }
+
+    private final BrokerService brokerService;
+    private final Set<String> allowedMechanisms;
+    private State state = State.HANDSHAKE_OR_VERSIONS_REQUEST;
+    private AuthData authData = null;
+
+    public SaslAuthenticator(BrokerService brokerService, Set<String> allowedMechanisms) {
+        this.brokerService = brokerService;
+        this.allowedMechanisms = allowedMechanisms;
+    }
+
+    public void authenticate(RequestHeader header,
+                             AbstractRequest request,
+                             CompletableFuture<AbstractResponse> response) throws AuthenticationException {
+        switch (state) {
+            case HANDSHAKE_OR_VERSIONS_REQUEST:
+            case HANDSHAKE_REQUEST:
+                handleKafkaRequest(header, request, response);
+                break;
+            case AUTHENTICATE:
+                handleSaslToken(header, request, response);
+                break;
+            default:
+                break;
+        }
+    }
+
+    public boolean complete() {
+        return state == State.COMPLETE;
+    }
+
+    public AuthData getAuthData() {
+        return complete() ? authData : null;
+    }
+
+    public void reset() {
+        state = State.HANDSHAKE_OR_VERSIONS_REQUEST;
+        authData = null;
+    }
+
+    private void setState(State state) {
+        this.state = state;
+        if (log.isDebugEnabled()) {
+            log.debug("Set SaslAuthenticator's state to {}", state);
+        }
+    }
+
+    private void handleKafkaRequest(RequestHeader header,
+                                    AbstractRequest request,
+                                    CompletableFuture<AbstractResponse> responseFuture) throws AuthenticationException {
+        ApiKeys apiKey = header.apiKey();
+        if (apiKey == ApiKeys.API_VERSIONS) {
+            handleApiVersionsRequest((ApiVersionsRequest) request, responseFuture);
+        } else if (apiKey == ApiKeys.SASL_HANDSHAKE) {
+            // If SaslHandshakeRequest version is v0, a series of SASL client and server tokens corresponding to the
+            // mechanism are sent as opaque packets without wrapping the messages with Kafka protocol headers.
+            // However, KoP always parses the header before a request is processed. Therefore, SaslHandshakeRequest v0
+            // shouldn't be supported, we need to send error response to client during handshake.
+            if (header.apiVersion() < 1) {
+                AuthenticationException e = new AuthenticationException("KoP doesn't support SaslHandshake v0");
+                responseFuture.complete(request.getErrorResponse(e));
+                throw e;
+            }
+            handleHandshakeRequest((SaslHandshakeRequest) request, responseFuture);
+        } else {
+            throw new AuthenticationException("Unexpected Kafka request of type " + apiKey + " during SASL handshake");
+        }
+    }
+
+    private void handleSaslToken(RequestHeader header,
+                                 AbstractRequest request,
+                                 CompletableFuture<AbstractResponse> responseFuture) throws AuthenticationException {
+        ApiKeys apiKey = header.apiKey();
+        short version = header.apiVersion();
+        if (apiKey != ApiKeys.SASL_AUTHENTICATE) {
+            AuthenticationException e = new AuthenticationException(
+                    "Unexpected Kafka request of type " + apiKey + " during SASL authentication");
+            responseFuture.complete(request.getErrorResponse(e));
+            throw e;
+        }
+        if (!apiKey.isVersionSupported(version)) {
+            throw new AuthenticationException("Version " + version + " is not supported for apiKey " + apiKey);
+        }
+
+        SaslAuthenticateRequest saslAuthenticateRequest = (SaslAuthenticateRequest) request;
+        SaslAuth saslAuth = null;
+        try {
+            saslAuth = SaslUtils.parseSaslAuthBytes(Utils.toArray(saslAuthenticateRequest.saslAuthBytes()));
+        } catch (IOException e) {
+            responseFuture.complete(new SaslAuthenticateResponse(Errors.SASL_AUTHENTICATION_FAILED, e.getMessage()));
+            return;
+        }
+        AuthenticationProvider authenticationProvider =
+                brokerService.getAuthenticationService().getAuthenticationProvider(saslAuth.getAuthMethod());
+        if (authenticationProvider == null) {
+            AuthenticationException e = new AuthenticationException(
+                    "No AuthenticationProvider found for method " + saslAuth.getAuthMethod());
+            responseFuture.complete(request.getErrorResponse(e));
+            throw e;
+        }
+
+        authData = AuthData.of(saslAuth.getAuthData().getBytes(UTF_8));
+        setState(State.COMPLETE);
+    }
+
+    private void handleApiVersionsRequest(ApiVersionsRequest request,
+                                          CompletableFuture<AbstractResponse> responseFuture)
+            throws AuthenticationException {
+        if (state != State.HANDSHAKE_OR_VERSIONS_REQUEST) {
+            throw new IllegalStateException(
+                    "Receive ApiVersions request", state, State.HANDSHAKE_OR_VERSIONS_REQUEST);
+        }
+        if (request.hasUnsupportedRequestVersion()) {
+            responseFuture.complete(request.getErrorResponse(0, Errors.UNSUPPORTED_VERSION.exception()));
+        } else {
+            responseFuture.complete(ApiVersionsResponse.defaultApiVersionsResponse());
+            // Handshake request must be followed by the ApiVersions request
+            setState(State.HANDSHAKE_REQUEST);
+        }
+    }
+
+    private void handleHandshakeRequest(SaslHandshakeRequest request,
+                                        CompletableFuture<AbstractResponse> responseFuture)
+            throws AuthenticationException {
+
+        final String mechanism = request.mechanism();
+        if (mechanism != null && !mechanism.equals("PLAIN")) {
+            // TODO: support more mechanisms
+            AuthenticationException e = new AuthenticationException("KoP only support PLAIN mechanism");
+            responseFuture.complete(request.getErrorResponse(e));
+            throw e;
+        }
+        if (allowedMechanisms.contains(mechanism)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Using SASL mechanism '{}' provided by client", mechanism);
+            }
+            responseFuture.complete(new SaslHandshakeResponse(Errors.NONE, allowedMechanisms));
+            setState(State.AUTHENTICATE);
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("SASL mechanism '{}' requested by client is not supported", mechanism);
+            }
+            responseFuture.complete(new SaslHandshakeResponse(Errors.UNSUPPORTED_SASL_MECHANISM, allowedMechanisms));
+            throw new UnsupportedSaslMechanismException(mechanism);
+        }
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/package-info.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.security;


### PR DESCRIPTION
Fixes #208 

This PR ports Kafka's `SaslServerAuthenticator` into KoP with some limits:

- Don't handle authentication corner cases for the Kafka Client 0.9.0.x, it's too troublesome and KoP doesn't support Kafka Client 0.9.0.x now.
-  Don't handle `SaslHandshakeRequest` v0 because this request has no header that it takes a lot of efforts to refactor current code and test.
- Keep the old authentication way, i.e. user pass a `username` field to represent the namespace and a `data` field to represent the token, then Pulsar broker will use JWT authentication to do the actual authentication. See `docs/security.md` for details.
- Add a unit test to cover the case that client doesn't configure authentication.

More works to do:
- Currently it just does a simple check for permissions in the authentication step. The authorization should be performed before each request is processed.
- The authenticator exposes a getter for `AuthenticationState`, the `isExpired` method should be called to check if the token is expired and trigger the reconnection for clients.