### PR TITLE
Set controller to broker itself when metadata request is processed

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -454,6 +454,9 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
 
         // 2. After get all topics, for each topic, get the service Broker for it, and add to response
         AtomicInteger topicsCompleted = new AtomicInteger(0);
+        // Each Pulsar broker can manage metadata like controller in Kafka, Kafka's AdminClient needs to find a
+        // controller node for metadata management. So here we return the broker itself as a controller.
+        final int controllerId = newSelfNode().id();
         pulsarTopicsFuture.whenComplete((pulsarTopics, e) -> {
             if (e != null) {
                 log.warn("[{}] Request {}: Exception fetching metadata, will return null Response",
@@ -463,7 +466,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                     new MetadataResponse(
                         allNodes,
                         clusterName,
-                        MetadataResponse.NO_CONTROLLER_ID,
+                        controllerId,
                         Collections.emptyList());
                 resultFuture.complete(finalResponse);
                 return;
@@ -478,7 +481,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                     new MetadataResponse(
                         allNodes,
                         clusterName,
-                        MetadataResponse.NO_CONTROLLER_ID,
+                        controllerId,
                         allTopicMetadata);
                 resultFuture.complete(finalResponse);
                 return;
@@ -541,7 +544,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                         new MetadataResponse(
                                             allNodes,
                                             clusterName,
-                                            MetadataResponse.NO_CONTROLLER_ID,
+                                            controllerId,
                                             allTopicMetadata);
                                     resultFuture.complete(finalResponse);
                                 }


### PR DESCRIPTION
KoP needs no controller id because it's used for metadata operations in Kafka. So it simply sets controller id field to -1 when metadata request is processed.

However, before a Kafka's `AdminClient` send a metadata related request like `CreateTopics`, it sent a metadata request and try to get a valid controller broker from the controller id field of metadata response. If the controller id is invalid, the `AdminClient` will send metadata request infinitely.

Since each broker can manage metadata, this PR change metadata response's controller id to the self node's controller id, which is generated by a hash function.

In addition, this PR adds a test to verify Kafka's `AdminClient` won't stuck at the `CreateTopics` method which is not supported currently.