### PR TITLE
Support CreateTopics request

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
@@ -72,7 +72,13 @@ class AdminManager {
             final CompletableFuture<ApiError> errorFuture = new CompletableFuture<>();
             futureMap.put(topic, errorFuture);
 
-            KopTopic kopTopic = new KopTopic(topic);
+            KopTopic kopTopic;
+            try {
+                kopTopic = new KopTopic(topic);
+            } catch (RuntimeException e) {
+                errorFuture.complete(ApiError.fromThrowable(e));
+                return;
+            }
             admin.topics().createPartitionedTopicAsync(kopTopic.getFullName(), detail.numPartitions)
                     .whenComplete((ignored, e) -> {
                         if (e == null) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
@@ -1,0 +1,105 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import static io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperationKey.TopicKey;
+import static org.apache.kafka.common.requests.CreateTopicsRequest.TopicDetails;
+
+import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperation;
+import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperationPurgatory;
+import io.streamnative.pulsar.handlers.kop.utils.timer.SystemTimer;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.ApiError;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+
+@Slf4j
+class AdminManager {
+
+    private final DelayedOperationPurgatory<DelayedOperation> topicPurgatory =
+            DelayedOperationPurgatory.<DelayedOperation>builder()
+                    .purgatoryName("topic")
+                    .timeoutTimer(SystemTimer.builder().executorName("topic").build())
+                    .build();
+
+    private final PulsarAdmin admin;
+
+    AdminManager(PulsarAdmin admin) {
+        this.admin = admin;
+    }
+
+    CompletableFuture<Map<String, ApiError>> createTopicsAsync(Map<String, TopicDetails> createInfo, int timeoutMs) {
+        final Map<String, CompletableFuture<ApiError>> futureMap = new ConcurrentHashMap<>();
+        final AtomicInteger numTopics = new AtomicInteger(futureMap.size());
+        final CompletableFuture<Map<String, ApiError>> resultFuture = new CompletableFuture<>();
+
+        Runnable complete = () -> {
+            // prevent `futureMap` from being modified by createPartitionedTopicAsync()'s callback
+            numTopics.set(0);
+            // complete the pending futures with timeout error
+            futureMap.values().forEach(future -> {
+                if (!future.isDone()) {
+                    future.complete(new ApiError(Errors.REQUEST_TIMED_OUT, null));
+                }
+            });
+            resultFuture.complete(futureMap.entrySet().stream().collect(Collectors.toMap(
+                    Map.Entry::getKey,
+                    entry -> entry.getValue().getNow(ApiError.NONE)
+            )));
+        };
+
+        createInfo.forEach((topic, detail) -> {
+            final CompletableFuture<ApiError> errorFuture = new CompletableFuture<>();
+            futureMap.put(topic, errorFuture);
+
+            admin.topics().createPartitionedTopicAsync(topic, detail.numPartitions).whenComplete((ignored, e) -> {
+                if (e == null) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Successfully create topic '{}'", topic);
+                    }
+                } else {
+                    log.error("Failed to create topic '{}': {}", topic, e);
+                }
+
+                int restNumTopics = numTopics.decrementAndGet();
+                if (restNumTopics < 0) {
+                    return;
+                }
+                errorFuture.complete((e == null) ? ApiError.NONE : ApiError.fromThrowable(e));
+                if (restNumTopics == 0) {
+                    complete.run();
+                }
+            });
+        });
+
+        if (timeoutMs <= 0) {
+            complete.run();
+        } else {
+            List<Object> delayedCreateKeys =
+                    createInfo.keySet().stream().map(TopicKey::new).collect(Collectors.toList());
+            DelayedCreateTopics delayedCreate = new DelayedCreateTopics(timeoutMs, numTopics, complete);
+            topicPurgatory.tryCompleteElseWatch(delayedCreate, delayedCreateKeys);
+        }
+
+        return resultFuture;
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/DelayedCreateTopics.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/DelayedCreateTopics.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperation;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A delayed create topic operation that is stored in the topic purgatory.
+ */
+class DelayedCreateTopics extends DelayedOperation {
+
+    private final AtomicInteger numTopics;
+    private final Runnable callback;
+
+    DelayedCreateTopics(long delayMs, AtomicInteger numTopics, Runnable callback) {
+        super(delayMs, Optional.empty());
+        this.numTopics = numTopics;
+        this.callback = callback;
+    }
+
+    @Override
+    public void onExpiration() {
+        callback.run();
+    }
+
+    @Override
+    public void onComplete() {
+        callback.run();
+    }
+
+    @Override
+    public boolean tryComplete() {
+        if (numTopics.get() <= 0) {
+            forceComplete();
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -229,6 +229,9 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
                     case SASL_AUTHENTICATE:
                         handleSaslAuthenticate(kafkaHeaderAndRequest, responseFuture);
                         break;
+                    case CREATE_TOPICS:
+                        handleCreateTopics(kafkaHeaderAndRequest, responseFuture);
+                        break;
                     default:
                         handleError(kafkaHeaderAndRequest, responseFuture);
                 }
@@ -359,6 +362,9 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
 
     protected abstract void
     handleSaslHandshake(KafkaHeaderAndRequest kafkaHeaderAndRequest, CompletableFuture<AbstractResponse> response);
+
+    protected abstract void
+    handleCreateTopics(KafkaHeaderAndRequest kafkaHeaderAndRequest, CompletableFuture<AbstractResponse> response);
 
     static class KafkaHeaderAndRequest implements Closeable {
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -321,7 +321,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
         for (Map.Entry<String, Integer> entry : topicToNumPartitions.entrySet()) {
             final String topic = entry.getKey();
             final int numPartitions = entry.getValue();
-            assertEquals(admin.topics().getPartitionedTopicMetadata(topic).partitions, numPartitions);
+            assertEquals(this.admin.topics().getPartitionedTopicMetadata(topic).partitions, numPartitions);
         }
     }
 


### PR DESCRIPTION
Master issue: #241 

This PR add support for Kafka `CreateTopics` request so that topics can be created by Kafka's `AdminClient`. Related tests are added to verify 

The `validateOnly` field introduced from `CreateTopics` request v1 is not processed. The `validateOnly` field only checks the topics can be created as specified but not creates anything. It's not a important feature currently so leave it as a future task.