### PR TITLE
Fix message disorder

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -597,9 +597,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             PendingProduceQueue queue =
                     pendingProduceQueueMap.computeIfAbsent(topicPartition, ignored -> new PendingProduceQueue());
             queue.add(pendingProduce);
-            pendingProduce.whenComplete(() -> {
-                queue.getAndRemoveCompletedProduces().forEach(PendingProduce::publishMessages);
-            });
+            pendingProduce.whenComplete(queue::sendCompletedProduces);
         }
 
         CompletableFuture.allOf(responsesFutures.values().toArray(new CompletableFuture<?>[responsesSize]))

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessagePublishContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessagePublishContext.java
@@ -13,25 +13,12 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
-import static io.streamnative.pulsar.handlers.kop.utils.MessageRecordUtils.messageToByteBuf;
-import static io.streamnative.pulsar.handlers.kop.utils.MessageRecordUtils.recordToEntry;
-import static io.streamnative.pulsar.handlers.kop.utils.MessageRecordUtils.recordsToByteBuf;
-
-import com.google.common.collect.Lists;
-import io.netty.buffer.ByteBuf;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
 import io.streamnative.pulsar.handlers.kop.utils.MessageIdUtils;
-import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.record.MemoryRecords;
-import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.Topic.PublishContext;
 
@@ -44,7 +31,6 @@ public final class MessagePublishContext implements PublishContext {
     private CompletableFuture<Long> offsetFuture;
     private Topic topic;
     private long startTimeNs;
-    public static final boolean MESSAGE_BATCHED = true;
 
     /**
      * Executed from managed ledger thread when the message is persisted.
@@ -99,82 +85,5 @@ public final class MessagePublishContext implements PublishContext {
         topic = null;
         startTimeNs = -1;
         recyclerHandle.recycle(this);
-    }
-
-
-    // publish Kafka records to pulsar topic, handle callback in MessagePublishContext.
-    public static void publishMessages(MemoryRecords records,
-                                       Topic topic,
-                                       CompletableFuture<PartitionResponse> future,
-                                       ScheduledExecutorService executor) {
-
-        // get records size.
-        AtomicInteger size = new AtomicInteger(0);
-        records.records().forEach(record -> size.incrementAndGet());
-        int rec = size.get();
-
-        if (log.isDebugEnabled()) {
-            log.debug("publishMessages for topic partition: {} , records size is {} ", topic.getName(), size.get());
-        }
-
-        if (MESSAGE_BATCHED) {
-            CompletableFuture<Long> offsetFuture = new CompletableFuture<>();
-
-//            ByteBuf headerAndPayload = recordsToByteBuf(records, rec);
-            CompletableFuture<ByteBuf> transFuture = new CompletableFuture<>();
-            //put queue
-            executor.submit(() -> {
-                recordsToByteBuf(records, rec, transFuture);
-            });
-
-            transFuture.whenComplete((headerAndPayload, ex) -> {
-                if (ex != null) {
-                    log.error("record to bytebuf error: ", ex);
-                } else {
-                    topic.publishMessage(
-                            headerAndPayload,
-                            MessagePublishContext.get(
-                                    offsetFuture, topic, System.nanoTime()));
-                }
-            });
-
-//            topic.publishMessage(
-//                headerAndPayload,
-//                MessagePublishContext.get(
-//                    offsetFuture, topic, System.nanoTime()));
-
-            offsetFuture.whenComplete((offset, ex) -> {
-                if (ex != null) {
-                    log.error("publishMessages for topic partition: {} failed when write.",
-                        topic.getName(), ex);
-                    future.complete(new PartitionResponse(Errors.KAFKA_STORAGE_ERROR));
-                } else {
-                    future.complete(new PartitionResponse(Errors.NONE));
-                }
-            });
-        } else {
-            List<CompletableFuture<Long>> futures = Collections
-                .synchronizedList(Lists.newArrayListWithExpectedSize(size.get()));
-
-            records.records().forEach(record -> {
-                CompletableFuture<Long> offsetFuture = new CompletableFuture<>();
-                futures.add(offsetFuture);
-                ByteBuf headerAndPayload = messageToByteBuf(recordToEntry(record));
-                topic.publishMessage(
-                    headerAndPayload,
-                    MessagePublishContext.get(
-                        offsetFuture, topic, System.nanoTime()));
-            });
-
-            CompletableFuture.allOf(futures.toArray(new CompletableFuture<?>[rec])).whenComplete((ignore, ex) -> {
-                if (ex != null) {
-                    log.error("publishMessages for topic partition: {} failed when write.",
-                        topic.getName(), ex);
-                    future.complete(new PartitionResponse(Errors.KAFKA_STORAGE_ERROR));
-                } else {
-                    future.complete(new PartitionResponse(Errors.NONE));
-                }
-            });
-        }
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/PendingProduce.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/PendingProduce.java
@@ -1,0 +1,130 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import io.netty.buffer.ByteBuf;
+import io.streamnative.pulsar.handlers.kop.utils.MessageRecordUtils;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.Record;
+import org.apache.kafka.common.requests.ProduceResponse.PartitionResponse;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+
+/**
+ * Pending context related to the produce task.
+ */
+@Slf4j
+public class PendingProduce {
+
+    private final CompletableFuture<PartitionResponse> responseFuture;
+    private final KafkaTopicManager topicManager;
+    private final String partitionName;
+    private final int numMessages;
+    private final CompletableFuture<PersistentTopic> topicFuture;
+    private final CompletableFuture<ByteBuf> byteBufFuture;
+    private CompletableFuture<Long> offsetFuture;
+
+    public PendingProduce(CompletableFuture<PartitionResponse> responseFuture,
+                          KafkaTopicManager topicManager,
+                          String partitionName,
+                          MemoryRecords memoryRecords,
+                          ExecutorService executor) {
+        this.responseFuture = responseFuture;
+        this.topicManager = topicManager;
+        this.partitionName = partitionName;
+        this.numMessages = parseNumMessages(memoryRecords);
+
+        this.topicFuture = topicManager.getTopic(partitionName).exceptionally(e -> {
+            log.error("Failed to getTopic for partition '{}': {}", partitionName, e);
+            return null;
+        });
+        this.byteBufFuture = new CompletableFuture<>();
+        this.byteBufFuture.exceptionally(e -> {
+            log.error("Failed to compute ByteBuf for partition '{}': {}", partitionName, e);
+            return null;
+        });
+        executor.execute(() -> {
+            ByteBuf byteBuf = MessageRecordUtils.recordsToByteBuf(memoryRecords, this.numMessages);
+            this.byteBufFuture.complete(byteBuf);
+        });
+        this.offsetFuture = new CompletableFuture<>();
+    }
+
+    public boolean ready() {
+        return topicFuture.isDone() && byteBufFuture.isDone();
+    }
+
+    public void whenComplete(Runnable runnable) {
+        CompletableFuture.allOf(topicFuture, byteBufFuture).whenComplete((ignored, e) -> {
+            if (e == null) {
+                runnable.run();
+            } else {
+                // The error logs have already been printed, so we needn't log error again.
+                if (topicFuture.isCompletedExceptionally()) {
+                    responseFuture.complete(new PartitionResponse(Errors.LEADER_NOT_AVAILABLE));
+                } else if (byteBufFuture.isCompletedExceptionally()) {
+                    responseFuture.complete(new PartitionResponse(Errors.CORRUPT_MESSAGE));
+                } else {
+                    responseFuture.completeExceptionally(e);
+                }
+            }
+        });
+    }
+
+    public void publishMessages() {
+        if (!ready()) {
+            throw new RuntimeException("Try to send while PendingProduce is not ready");
+        }
+        PersistentTopic persistentTopic;
+        ByteBuf byteBuf;
+        try {
+            persistentTopic = topicFuture.get();
+            byteBuf = byteBufFuture.get();
+        } catch (InterruptedException | ExecutionException e) {
+            // It shouldn't fail because we've already checked ready() before.
+            throw new RuntimeException(e);
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("publishMessages for topic partition: {}, records size is {}", partitionName, numMessages);
+        }
+        topicManager.registerProducerInPersistentTopic(partitionName, persistentTopic);
+        // collect metrics
+        topicManager.getReferenceProducer(partitionName).getTopic()
+                .incrementPublishCount(numMessages, byteBuf.readableBytes());
+        persistentTopic.publishMessage(byteBuf,
+                MessagePublishContext.get(offsetFuture, persistentTopic, System.nanoTime()));
+        offsetFuture.whenComplete((offset, e) -> {
+            if (e == null) {
+                responseFuture.complete(new PartitionResponse(Errors.NONE, offset, -1L, -1L));
+            } else {
+                log.error("publishMessages for topic partition: {} failed when write.", partitionName, e);
+                responseFuture.complete(new PartitionResponse(Errors.KAFKA_STORAGE_ERROR));
+            }
+            byteBuf.release();
+        });
+    }
+
+    private static int parseNumMessages(MemoryRecords records) {
+        int n = 0;
+        for (Record ignored : records.records()) {
+            n++;
+        }
+        return n;
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/PendingProduceQueue.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/PendingProduceQueue.java
@@ -13,9 +13,7 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
-import java.util.ArrayList;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.Queue;
 
 /**
@@ -25,17 +23,15 @@ public class PendingProduceQueue {
 
     private final Queue<PendingProduce> queue = new LinkedList<>();
 
-    public synchronized List<PendingProduce> getAndRemoveCompletedProduces() {
-        List<PendingProduce> completedProduces = new ArrayList<>();
+    public synchronized void sendCompletedProduces() {
         while (!queue.isEmpty()) {
             PendingProduce pendingProduce = queue.peek();
             if (!pendingProduce.ready()) {
                 break;
             }
-            completedProduces.add(pendingProduce);
             queue.remove();
+            pendingProduce.publishMessages();
         }
-        return completedProduces;
     }
 
     public synchronized void add(PendingProduce pendingProduce) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/PendingProduceQueue.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/PendingProduceQueue.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
+/**
+ * Queue of PendingProduce instances.
+ */
+public class PendingProduceQueue {
+
+    private final Queue<PendingProduce> queue = new LinkedList<>();
+
+    public synchronized List<PendingProduce> getAndRemoveCompletedProduces() {
+        List<PendingProduce> completedProduces = new ArrayList<>();
+        while (!queue.isEmpty()) {
+            PendingProduce pendingProduce = queue.peek();
+            if (!pendingProduce.ready()) {
+                break;
+            }
+            completedProduces.add(pendingProduce);
+            queue.remove();
+        }
+        return completedProduces;
+    }
+
+    public synchronized void add(PendingProduce pendingProduce) {
+        queue.add(pendingProduce);
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaMessageOrderTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaMessageOrderTest.java
@@ -17,19 +17,35 @@ package io.streamnative.pulsar.handlers.kop;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+
+import io.streamnative.pulsar.handlers.kop.utils.MessageIdUtils;
+
+import java.time.Duration;
 import java.util.Base64;
-import java.util.List;
-import java.util.concurrent.Future;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.TenantInfo;
@@ -86,7 +102,7 @@ public class KafkaMessageOrderTest extends KopProtocolHandlerTestBase {
     }
 
     @Test(timeOut = 20000)
-    public void testKafkaProducePulsarConsumeMessageOrder() throws Exception {
+    public void testKafkaProduceMessageOrder() throws Exception {
         String topicName = "kopKafkaProducePulsarConsumeMessageOrder";
         String pulsarTopicName = "persistent://public/default/" + topicName;
 
@@ -96,48 +112,45 @@ public class KafkaMessageOrderTest extends KopProtocolHandlerTestBase {
         @Cleanup
         Consumer<byte[]> consumer = pulsarClient.newConsumer()
             .topic(pulsarTopicName)
-            .subscriptionName("test_k_producer_k_pconsumer_order_sub")
+            .subscriptionName("testKafkaProduce-PulsarConsume")
             .subscribe();
+
+        final Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getKafkaBrokerPort());
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.BATCH_SIZE_CONFIG, 256); // avoid all messages are in a single batch
 
         // 1. produce message with Kafka producer.
         @Cleanup
-        KProducer kProducer = new KProducer(topicName, false, getKafkaBrokerPort());
+        KafkaProducer<Integer, String> producer = new KafkaProducer<>(props);
 
         int totalMsgs = 10;
         String messageStrPrefix = "Message_Kop_KafkaProducePulsarConsumeOrder_";
 
-        List<Future<RecordMetadata>> futures = Lists.newArrayListWithExpectedSize(totalMsgs);
-
-        // send in sync mode
+        Map<Long, Set<Long>> ledgerToEntrySet = new ConcurrentHashMap<>();
         for (int i = 0; i < totalMsgs; i++) {
-            String messageStr = messageStrPrefix + i;
-            ProducerRecord record = new ProducerRecord<>(
-                topicName,
-                i,
-                messageStr);
-
-            futures.add(kProducer.getProducer().send(record));
-
-            if (log.isDebugEnabled()) {
-                log.debug("Kafka Producer Sent message: ({}, {})", i, messageStr);
-            }
+            final int index = i;
+            producer.send(new ProducerRecord<>(topicName, i, messageStrPrefix + i), (recordMetadata, e) -> {
+                assertNull(e);
+                MessageIdImpl id = (MessageIdImpl) MessageIdUtils.getMessageId(recordMetadata.offset());
+                log.info("Success write message {} to {} ({}, {})", index, recordMetadata.offset(),
+                        id.getLedgerId(), id.getEntryId());
+                ledgerToEntrySet.computeIfAbsent(id.getLedgerId(), key -> Collections.synchronizedSet(new HashSet<>()))
+                        .add(id.getEntryId());
+            });
         }
 
-        retryStrategically((test) ->
-                !futures.stream().anyMatch(future -> !future.isDone()),
-            5,
-            200);
-
-        // 2. Consume messages use Pulsar client Consumer. verify content and key and headers
+        // 2. Consume messages use Pulsar client Consumer.
         Message<byte[]> msg = null;
         for (int i = 0; i < totalMsgs; i++) {
-            msg = consumer.receive(100, TimeUnit.MILLISECONDS);
+            msg = consumer.receive(1000, TimeUnit.MILLISECONDS);
             assertNotNull(msg);
             Integer key = kafkaIntDeserialize(Base64.getDecoder().decode(msg.getKey()));
             assertEquals(messageStrPrefix + key.toString(), new String(msg.getValue()));
 
             if (log.isDebugEnabled()) {
-                log.info("Pulsar consumer get i: {} message: {}, key: {}",
+                log.debug("Pulsar consumer get i: {} message: {}, key: {}",
                     i,
                     new String(msg.getData()),
                     kafkaIntDeserialize(Base64.getDecoder().decode(msg.getKey())).toString());
@@ -150,6 +163,28 @@ public class KafkaMessageOrderTest extends KopProtocolHandlerTestBase {
         // verify have received all messages
         msg = consumer.receive(100, TimeUnit.MILLISECONDS);
         assertNull(msg);
+
+        final AtomicInteger numEntries = new AtomicInteger(0);
+        ledgerToEntrySet.forEach((ledgerId, entrySet) -> numEntries.set(numEntries.get() + entrySet.size()));
+        log.info("Successfully write {} entries of {} messages to bookie", numEntries.get(), totalMsgs);
+        assertTrue(numEntries.get() > 1 && numEntries.get() < totalMsgs);
+
+        // 3. Consume messages use Kafka consumer.
+        @Cleanup
+        KConsumer kConsumer = new KConsumer(topicName, getKafkaBrokerPort(), "testKafkaProduce-KafkaConsume");
+        kConsumer.getConsumer().subscribe(Collections.singleton(topicName));
+        for (int i = 0; i < totalMsgs; ) {
+            ConsumerRecords<Integer, String> records = kConsumer.getConsumer().poll(Duration.ofSeconds(1));
+            if (log.isDebugEnabled()) {
+                for (ConsumerRecord<Integer, String> record : records) {
+                    log.debug("Kafka consumer get i: {} message: {}, key: {}", i, record.value(), record.key());
+                    assertEquals(record.key().intValue(), i);
+                    i++;
+                }
+            } else {
+                i += records.count();
+            }
+        }
     }
 
 


### PR DESCRIPTION
Fixes [#247](https://github.com/streamnative/kop/issues/247)

The original implementation of message publishing cannot guarantee that a topic partition's pending writes are completed in order. This PR is to fix the issue by refactoring the handler for Produce requests.

The basic steps of handling a single partition's produce request are:
1. Get `PersistentTopic` from topic manager;
2. Convert Kafka's `MemoryRecords` to Pulsar's `ByteBuf`;
3. Call `PersistentTopic#publishMessages` to write `ByteBuf` to BK asynchronously.

This PR adds a `PendingProduce` class to compose pending step 1 and 2 to a `CompletableFuture`, then add the `PendingProduce` object to a queue (`PendingProduceQueue`) which is associated with the partition name in a map named `pendingProduceQueueMap`. When the step 1 and 2 are completed, the queue will try to remove all ready `PendingProduce` objects in the head and call `PersistentTopic#publishMessages`. We use `synchronized` keyword to make the remove operation thread safe.

Therefore, the first two steps can be executed in parallel, but the third step is executed in order.

In addition, this PR fixes the current message order test by using different batch size. In the original test, all messages are batched to a single batch, so the disorder never happens because there's only one batch.