### PR TITLE
Add tests to verify KoP with Confluent Schema Registry

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -30,6 +30,10 @@
   <name>StreamNative :: Pulsar Protocol Handler :: KoP Tests</name>
   <description>Tests for Kafka on Pulsar</description>
 
+  <properties>
+    <schema.registry.version>5.0.0</schema.registry.version>
+  </properties>
+
   <!-- include the dependencies -->
   <dependencies>
     <dependency>
@@ -52,6 +56,33 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.confluent</groupId>
+      <artifactId>kafka-schema-registry</artifactId>
+      <version>${schema.registry.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.glassfish.jersey.core</groupId>
+          <artifactId>jersey-common</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>io.confluent</groupId>
+      <artifactId>kafka-avro-serializer</artifactId>
+      <version>${schema.registry.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <build>
@@ -78,4 +109,10 @@
     </plugins>
   </build>
 
+  <repositories>
+    <repository>
+      <id>io-confluent</id>
+      <url>https://packages.confluent.io/maven/</url>
+    </repository>
+  </repositories>
 </project>

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -221,6 +221,8 @@ public abstract class KopProtocolHandlerTestBase {
             admin.topics().createPartitionedTopic(KAFKASTORE_TOPIC, 1);
             final Properties props = new Properties();
             props.put(SchemaRegistryConfig.PORT_CONFIG, Integer.toString(getKafkaSchemaRegistryPort()));
+            // Increase the kafkastore.timeout.ms (default: 500) to avoid test failure in CI
+            props.put(SchemaRegistryConfig.KAFKASTORE_TIMEOUT_CONFIG, 3000);
             // NOTE: KoP doesn't support kafkastore.connection.url
             props.put(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG,
                     "PLAINTEXT://localhost:" + getKafkaBrokerPort());

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -22,6 +22,9 @@ import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
+import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
+import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
+import io.confluent.kafka.schemaregistry.rest.SchemaRegistryRestApplication;
 import io.streamnative.pulsar.handlers.kop.utils.MetadataUtils;
 
 import java.io.Closeable;
@@ -73,6 +76,7 @@ import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.MockZooKeeper;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.ACL;
+import org.eclipse.jetty.server.Server;
 
 /**
  * Unit test to test KoP handler.
@@ -96,6 +100,8 @@ public abstract class KopProtocolHandlerTestBase {
     protected int kafkaBrokerPort = PortManager.nextFreePort();
     @Getter
     protected int kafkaBrokerPortTls = PortManager.nextFreePort();
+    @Getter
+    protected int kafkaSchemaRegistryPort = PortManager.nextFreePort();
 
     protected MockZooKeeper mockZooKeeper;
     protected NonClosableMockBookKeeper mockBookKeeper;
@@ -107,6 +113,13 @@ public abstract class KopProtocolHandlerTestBase {
 
     private SameThreadOrderedSafeExecutor sameThreadOrderedSafeExecutor;
     private ExecutorService bkExecutor;
+
+    // Fields about Confluent Schema Registry
+    protected boolean enableSchemaRegistry = false;
+    private static final String KAFKASTORE_TOPIC = SchemaRegistryConfig.DEFAULT_KAFKASTORE_TOPIC;
+    protected SchemaRegistryRestApplication restApp;
+    protected Server restServer;
+    protected String restConnect;
 
     public KopProtocolHandlerTestBase() {
         resetConfig();
@@ -203,12 +216,36 @@ public abstract class KopProtocolHandlerTestBase {
         createAdmin();
 
         MetadataUtils.createKafkaMetadataIfMissing(admin, this.conf);
+
+        if (enableSchemaRegistry) {
+            admin.topics().createPartitionedTopic(KAFKASTORE_TOPIC, 1);
+            final Properties props = new Properties();
+            props.put(SchemaRegistryConfig.PORT_CONFIG, Integer.toString(getKafkaSchemaRegistryPort()));
+            // NOTE: KoP doesn't support kafkastore.connection.url
+            props.put(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG,
+                    "PLAINTEXT://localhost:" + getKafkaBrokerPort());
+            props.put(SchemaRegistryConfig.KAFKASTORE_TOPIC_CONFIG, KAFKASTORE_TOPIC);
+            props.put(SchemaRegistryConfig.COMPATIBILITY_CONFIG, AvroCompatibilityLevel.NONE.name);
+            props.put(SchemaRegistryConfig.MASTER_ELIGIBILITY, true);
+
+            restApp = new SchemaRegistryRestApplication(props);
+            restServer = restApp.createServer();
+            restServer.start();
+            restConnect = restServer.getURI().toString();
+            if (restConnect.endsWith("/")) {
+                restConnect = restConnect.substring(0, restConnect.length() - 1);
+            }
+        }
     }
 
     protected final void internalCleanup() throws Exception {
         try {
             // if init fails, some of these could be null, and if so would throw
             // an NPE in shutdown, obscuring the real error
+            if (restServer != null) {
+                restServer.stop();
+                restServer.join();
+            }
             if (admin != null) {
                 admin.close();
             }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryTest.java
@@ -19,6 +19,9 @@ import static org.testng.Assert.fail;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Properties;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
@@ -35,10 +38,6 @@ import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import java.time.Duration;
-import java.util.Collections;
-import java.util.Properties;
 
 /**
  * Test for KoP with Confluent Schema Registry.
@@ -63,9 +62,8 @@ public class SchemaRegistryTest extends KopProtocolHandlerTestBase {
     }
 
     private IndexedRecord createAvroRecord() {
-        String userSchema= "{\"namespace\": \"example.avro\", \"type\": \"record\", " +
-                "\"name\": \"User\"," +
-                "\"fields\": [{\"name\": \"name\", \"type\": \"string\"}]}";
+        String userSchema = "{\"namespace\": \"example.avro\", \"type\": \"record\", "
+                + "\"name\": \"User\", \"fields\": [{\"name\": \"name\", \"type\": \"string\"}]}";
         Schema.Parser parser = new Schema.Parser();
         Schema schema = parser.parse(userSchema);
         GenericRecord avroRecord = new GenericData.Record(schema);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryTest.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Properties;
+
+/**
+ * Test for KoP with Confluent Schema Registry.
+ */
+@Slf4j
+public class SchemaRegistryTest extends KopProtocolHandlerTestBase {
+
+    private String bootstrapServers;
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.enableSchemaRegistry = true;
+        this.internalSetup();
+        bootstrapServers = "localhost:" + getKafkaBrokerPort();
+    }
+
+    @BeforeMethod
+    @Override
+    protected void cleanup() throws Exception {
+        this.internalCleanup();
+    }
+
+    private IndexedRecord createAvroRecord() {
+        String userSchema= "{\"namespace\": \"example.avro\", \"type\": \"record\", " +
+                "\"name\": \"User\"," +
+                "\"fields\": [{\"name\": \"name\", \"type\": \"string\"}]}";
+        Schema.Parser parser = new Schema.Parser();
+        Schema schema = parser.parse(userSchema);
+        GenericRecord avroRecord = new GenericData.Record(schema);
+        avroRecord.put("name", "testUser");
+        return avroRecord;
+    }
+
+    private KafkaProducer<Integer, Object> createAvroProducer() {
+        Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class);
+        props.put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, restConnect);
+        return new KafkaProducer<>(props);
+    }
+
+    private KafkaConsumer<Integer, Object> createAvroConsumer() {
+        Properties props = new Properties();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "avroGroup");
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class);
+        props.put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, restConnect);
+        return new KafkaConsumer<>(props);
+    }
+
+    @Test(timeOut = 40000)
+    public void testAvroProduceAndConsume() throws Exception {
+        String topic = "SchemaRegistryTest-testAvroProduceAndConsume";
+        IndexedRecord avroRecord = createAvroRecord();
+        Object[] objects = new Object[]{ avroRecord, true, 130, 345L, 1.23f, 2.34d, "abc", "def".getBytes() };
+        @Cleanup
+        KafkaProducer<Integer, Object> producer = createAvroProducer();
+        for (int i = 0; i < objects.length; i++) {
+            final Object object = objects[i];
+            producer.send(new ProducerRecord<>(topic, i, object), (metadata, e) -> {
+                if (e != null) {
+                    log.error("Failed to send {}: {}", object, e.getMessage());
+                    fail("Failed to send " + object + ": " + e.getMessage());
+                }
+                log.info("Success send {} to {}-partition-{}@{}",
+                        object, metadata.topic(), metadata.partition(), metadata.offset());
+            });
+        }
+
+        @Cleanup
+        KafkaConsumer<Integer, Object> consumer = createAvroConsumer();
+        consumer.subscribe(Collections.singleton(topic));
+        int i = 0;
+        while (i < objects.length) {
+            for (ConsumerRecord<Integer, Object> record : consumer.poll(Duration.ofSeconds(3))) {
+                assertEquals(record.key().intValue(), i);
+                assertEquals(record.value(), objects[i]);
+                i++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR add a unit test to verify that when KoP is running with Confluent Schema Registry, Kafka Client with `KafkaAvroSerializer` or `KafkaAvroDeserializer` works well with different message types. The timeout is a little longer than other tests because it takes some time to start the schema registry service.