### PR TITLE
Fix topic auto created when using Kafka AdminClient to get metadata

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -417,7 +417,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                         .collect(Collectors.toList());
                                     pulsarTopics.put(topic, pulsarTopicNames);
                                 } else {
-                                    if (kafkaConfig.isAllowAutoTopicCreation()) {
+                                    if (kafkaConfig.isAllowAutoTopicCreation()
+                                            && metadataRequest.allowAutoTopicCreation()) {
                                         if (log.isDebugEnabled()) {
                                             log.debug("[{}] Request {}: Topic {} has single partition, "
                                                     + "auto create partitioned topic",
@@ -432,8 +433,11 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                         pulsarTopics.put(topic, pulsarTopicNames);
 
                                     } else {
-                                        log.error("[{}] Request {}: Topic {} has single partition, "
-                                                        + "Not allow to auto create partitioned topic",
+                                        // NOTE: Currently no matter topic is a non-partitioned topic or topic doesn't
+                                        // exist, the queried partitions from broker are both 0.
+                                        // See https://github.com/apache/pulsar/issues/8813 for details.
+                                        log.error("[{}] Request {}: Topic {} doesn't exist and it's not allowed to"
+                                                        + "auto create partitioned topic",
                                                 ctx.channel(), metadataHar.getHeader(), topic);
                                         // not allow to auto create topic, return unknown topic
                                         allTopicMetadata.add(


### PR DESCRIPTION
Fixes [#273](https://github.com/streamnative/kop/issues/273)

When KoP handles metadata requests, it only checks the config `allowAutoTopicCreation` but not the same field in the metadata request. Then it causes that `AdminClient#describeTopics` returns a success result even if the topics don't exist and topics will be created automatically.

So this PR adds the check for metadata request's `allowAutoTopicCreation` field and the test for `AdminClient#describeTopics`.