### PR TITLE
auto split  if batch size > 4096

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatter.java
@@ -14,26 +14,38 @@
 package io.streamnative.pulsar.handlers.kop.format;
 
 import io.netty.buffer.ByteBuf;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.MemoryRecordsBuilder;
 import org.apache.kafka.common.record.MutableRecordBatch;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.common.utils.ByteBufferOutputStream;
 
 
 /**
  * The formatter for conversion between Kafka records and Bookie entries.
  */
 public interface EntryFormatter {
+    int MAX_BATCH_MESSAGE_NUM = 4096;
+    int DEFAULT_FETCH_BUFFER_SIZE = 1024 * 1024;
+    int MAX_RECORDS_BUFFER_SIZE = 100 * 1024 * 1024;
 
     /**
      * Encode Kafka records to a ByteBuf.
      *
      * @param records messages with Kafka's format
-     * @param numMessages the number of messages
      * @return the ByteBuf of an entry that is to be written to Bookie
      */
-    ByteBuf encode(final MemoryRecords records, final int numMessages);
+    ByteBuf encode(final MemoryRecords records);
 
     /**
      * Decode a stream of entries to Kafka records.
@@ -49,7 +61,7 @@ public interface EntryFormatter {
      * Get the number of messages from MemoryRecords.
      * Since MemoryRecords doesn't provide a way to get the number of messages. We need to iterate over the whole
      * MemoryRecords object. So we use a helper method to get the number of messages that can be passed to
-     * {@link EntryFormatter#encode(MemoryRecords, int)} and metrics related methods as well.
+     * {@link EntryFormatter#encode(MemoryRecords)} and metrics related methods as well.
      *
      * @param records messages with Kafka's format
      * @return the number of messages
@@ -60,5 +72,58 @@ public interface EntryFormatter {
             numMessages += (batch.lastOffset() - batch.baseOffset() + 1);
         }
         return numMessages;
+    }
+
+    /**
+     * Split large batch records.
+     *
+     * @param records messages with Kafka's format
+     * @param numMessages the number of messages
+     * @return the list of split records
+     */
+    static List<MemoryRecords> splitLargeBatchRecords(MemoryRecords records, int numMessages) {
+        List<MemoryRecords> splitResultList = new ArrayList<>();
+        if (numMessages < MAX_BATCH_MESSAGE_NUM){
+            splitResultList.add(records);
+        } else {
+            Map<Integer, MemoryRecordsBuilder> recordsHashMap = new HashMap<>();
+            int splitTotalNum = numMessages / MAX_BATCH_MESSAGE_NUM;
+            for (int i = 0; i <= splitTotalNum; i++) {
+                recordsHashMap.put(i, null);
+            }
+            final AtomicInteger splitCounter = new AtomicInteger(1);
+            records.records().forEach(record -> {
+                int recordsNum = splitCounter.getAndIncrement();
+                int chunkIndex = recordsNum / MAX_BATCH_MESSAGE_NUM;
+                if (recordsHashMap.get(chunkIndex) == null) {
+                    try (ByteBufferOutputStream outputStream = new ByteBufferOutputStream(DEFAULT_FETCH_BUFFER_SIZE)) {
+                        MemoryRecordsBuilder builder = new MemoryRecordsBuilder(
+                                outputStream, RecordBatch.CURRENT_MAGIC_VALUE,
+                                org.apache.kafka.common.record.CompressionType.NONE,
+                                TimestampType.CREATE_TIME,
+                                record.offset(),
+                                RecordBatch.NO_TIMESTAMP,
+                                RecordBatch.NO_PRODUCER_ID,
+                                RecordBatch.NO_PRODUCER_EPOCH,
+                                RecordBatch.NO_SEQUENCE,
+                                false, false,
+                                RecordBatch.NO_PARTITION_LEADER_EPOCH,
+                                MAX_RECORDS_BUFFER_SIZE);
+                        builder.append(record);
+                        recordsHashMap.put(chunkIndex, builder);
+                    } catch (IOException ioe){
+                        throw new UncheckedIOException(ioe);
+                    } catch (Exception e){
+                        throw e;
+                    }
+                } else {
+                    recordsHashMap.get(chunkIndex).append(record);
+                }
+            });
+            recordsHashMap.forEach((key, value) -> {
+                splitResultList.add(value.build());
+            });
+        }
+        return splitResultList;
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaEntryFormatter.java
@@ -35,7 +35,7 @@ public class KafkaEntryFormatter implements EntryFormatter {
     private final KafkaEntryFormatterHeader header = new KafkaEntryFormatterHeader();
 
     @Override
-    public ByteBuf encode(MemoryRecords records, int numMessages) {
+    public ByteBuf encode(MemoryRecords records) {
         return Commands.serializeMetadataAndPayload(
                 Commands.ChecksumType.None,
                 header.getMessageMetadata(),

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/PulsarEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/PulsarEntryFormatter.java
@@ -16,12 +16,12 @@ package io.streamnative.pulsar.handlers.kop.format;
 import static com.google.common.base.Preconditions.checkState;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import com.google.common.collect.Lists;
 import io.netty.buffer.ByteBuf;
 import io.streamnative.pulsar.handlers.kop.utils.ByteBufUtils;
 import io.streamnative.pulsar.handlers.kop.utils.MessageIdUtils;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
@@ -61,7 +61,7 @@ public class PulsarEntryFormatter implements EntryFormatter {
     private static final int MAX_MESSAGE_BATCH_SIZE_BYTES = 128 * 1024;
 
     @Override
-    public ByteBuf encode(final MemoryRecords records, final int numMessages) {
+    public ByteBuf encode(final MemoryRecords records) {
         long currentBatchSizeBytes = 0;
         int numMessagesInBatch = 0;
 
@@ -71,7 +71,7 @@ public class PulsarEntryFormatter implements EntryFormatter {
 
         ByteBuf batchedMessageMetadataAndPayload = PulsarByteBufAllocator.DEFAULT
                 .buffer(Math.min(INITIAL_BATCH_BUFFER_SIZE, MAX_MESSAGE_BATCH_SIZE_BYTES));
-        List<MessageImpl<byte[]>> messages = Lists.newArrayListWithExpectedSize(numMessages);
+        List<MessageImpl<byte[]>> messages = new ArrayList<>();
         MessageMetadata.Builder messageMetaBuilder = MessageMetadata.newBuilder();
 
         StreamSupport.stream(records.records().spliterator(), true).forEachOrdered(record -> {

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EncodePerformanceTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EncodePerformanceTest.java
@@ -55,21 +55,21 @@ public class EncodePerformanceTest {
 
         long t1 = System.currentTimeMillis();
         for (int i = 0; i < repeatTimes; i++) {
-            pulsarFormatter.encode(records, NUM_MESSAGES).release();
+            pulsarFormatter.encode(records).release();
         }
         long t2 = System.currentTimeMillis();
         System.out.println("PulsarEntryFormatter encode time: " + (t2 - t1) + " ms");
 
         t1 = System.currentTimeMillis();
         for (int i = 0; i < repeatTimes; i++) {
-            kafkaFormatter.encode(records, NUM_MESSAGES).release();
+            kafkaFormatter.encode(records).release();
         }
         t2 = System.currentTimeMillis();
         System.out.println("KafkaEntryFormatter encode time: " + (t2 - t1) + " ms");
 
         t1 = System.currentTimeMillis();
         for (int i = 0; i < repeatTimes; i++) {
-            noHeaderKafkaFormatter.encode(records, NUM_MESSAGES).release();
+            noHeaderKafkaFormatter.encode(records).release();
         }
         t2 = System.currentTimeMillis();
         System.out.println("NoHeaderKafkaEntryFormatter encode time: " + (t2 - t1) + " ms");

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/NoHeaderKafkaEntryFormatter.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/NoHeaderKafkaEntryFormatter.java
@@ -25,7 +25,7 @@ import org.apache.kafka.common.record.MemoryRecords;
 public class NoHeaderKafkaEntryFormatter implements EntryFormatter {
 
     @Override
-    public ByteBuf encode(MemoryRecords records, int numMessages) {
+    public ByteBuf encode(MemoryRecords records) {
         // The difference from KafkaEntryFormatter is here we don't add the header
         return Unpooled.wrappedBuffer(records.buffer());
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaLargeBatchTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaLargeBatchTest.java
@@ -1,0 +1,197 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import com.google.common.collect.Sets;
+
+import io.streamnative.pulsar.handlers.kop.utils.MessageIdUtils;
+
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.RetentionPolicies;
+import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Unit test for Different kafka produce messages.
+ */
+@Slf4j
+public class KafkaLargeBatchTest extends KopProtocolHandlerTestBase {
+
+    @DataProvider(name = "batchSizeList")
+    public static Object[][] batchSizeList() {
+        // batches associated with following batch.size config, for 2000,4000,8000 or 16000 messages in a batch.
+        return new Object[][] { { 100000 }, { 200000 }, { 400000 }, { 800000 } };
+    }
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        log.info("success internal setup");
+
+        if (!admin.clusters().getClusters().contains(configClusterName)) {
+            // so that clients can test short names
+            admin.clusters().createCluster(configClusterName,
+                    new ClusterData("http://127.0.0.1:" + brokerWebservicePort));
+        } else {
+            admin.clusters().updateCluster(configClusterName,
+                    new ClusterData("http://127.0.0.1:" + brokerWebservicePort));
+        }
+
+        if (!admin.tenants().getTenants().contains("public")) {
+            admin.tenants().createTenant("public",
+                    new TenantInfo(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
+        } else {
+            admin.tenants().updateTenant("public",
+                    new TenantInfo(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test")));
+        }
+        if (!admin.namespaces().getNamespaces("public").contains("public/default")) {
+            admin.namespaces().createNamespace("public/default");
+            admin.namespaces().setNamespaceReplicationClusters("public/default", Sets.newHashSet("test"));
+            admin.namespaces().setRetention("public/default",
+                    new RetentionPolicies(60, 1000));
+        }
+        if (!admin.namespaces().getNamespaces("public").contains("public/__kafka")) {
+            admin.namespaces().createNamespace("public/__kafka");
+            admin.namespaces().setNamespaceReplicationClusters("public/__kafka", Sets.newHashSet("test"));
+            admin.namespaces().setRetention("public/__kafka",
+                    new RetentionPolicies(-1, -1));
+        }
+    }
+
+    @AfterMethod
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test(timeOut = 20000, dataProvider = "batchSizeList")
+    public void testKafkaProduceMessageForLargeBatch(int batchSize) throws Exception {
+        String topicName = "kopKafkaProducePulsarConsumeForLargeBatch";
+        String pulsarTopicName = "persistent://public/default/" + topicName;
+
+        // create partitioned topic with 1 partition.
+        pulsar.getAdminClient().topics().createPartitionedTopic(topicName, 1);
+
+        @Cleanup
+        Consumer<byte[]> consumer = pulsarClient.newConsumer()
+                .topic(pulsarTopicName)
+                .subscriptionName("testKafkaProduce-PulsarConsume")
+                .subscribe();
+
+        final Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getKafkaBrokerPort());
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.BATCH_SIZE_CONFIG, batchSize);
+
+        // 1. produce message with Kafka producer.
+        @Cleanup
+        KafkaProducer<Integer, String> producer = new KafkaProducer<>(props);
+
+        // each batch has 2000,4000,8000 or 16000 messages
+        int totalMsgs = 20000;
+        String messageStrPrefix = "Message_Kop_KafkaProducePulsarConsumeForLargeBatch_";
+
+        Map<Long, Set<Long>> ledgerToEntrySet = new ConcurrentHashMap<>();
+        for (int i = 0; i < totalMsgs; i++) {
+            final int index = i;
+            producer.send(new ProducerRecord<>(topicName, i, messageStrPrefix + i), (recordMetadata, e) -> {
+                assertNull(e);
+                MessageIdImpl id = (MessageIdImpl) MessageIdUtils.getMessageId(recordMetadata.offset());
+                log.info("Success write message {} to {} ({}, {})", index, recordMetadata.offset(),
+                        id.getLedgerId(), id.getEntryId());
+                ledgerToEntrySet.computeIfAbsent(id.getLedgerId(), key -> Collections.synchronizedSet(new HashSet<>()))
+                        .add(id.getEntryId());
+            });
+        }
+
+        // 2. Consume messages use Pulsar client Consumer.
+        Message<byte[]> msg = null;
+        for (int i = 0; i < totalMsgs; i++) {
+            msg = consumer.receive(1000, TimeUnit.MILLISECONDS);
+            assertNotNull(msg);
+            Integer key = kafkaIntDeserialize(Base64.getDecoder().decode(msg.getKey()));
+            assertEquals(messageStrPrefix + key.toString(), new String(msg.getValue()));
+
+            if (log.isDebugEnabled()) {
+                log.debug("Pulsar consumer get i: {} message: {}, key: {}",
+                        i,
+                        new String(msg.getData()),
+                        kafkaIntDeserialize(Base64.getDecoder().decode(msg.getKey())).toString());
+            }
+            assertEquals(i, key.intValue());
+
+            consumer.acknowledge(msg);
+        }
+
+        // verify have received all messages
+        msg = consumer.receive(1000, TimeUnit.MILLISECONDS);
+        assertNull(msg);
+
+        final AtomicInteger numEntries = new AtomicInteger(0);
+        ledgerToEntrySet.forEach((ledgerId, entrySet) -> numEntries.set(numEntries.get() + entrySet.size()));
+        log.info("Successfully write {} entries of {} messages to bookie", numEntries.get(), totalMsgs);
+        assertTrue(numEntries.get() > 1 && numEntries.get() < totalMsgs);
+
+        // 3. Consume messages use Kafka consumer.
+        @Cleanup
+        KConsumer kConsumer = new KConsumer(topicName, getKafkaBrokerPort(), "testKafkaProduce-KafkaConsume");
+        kConsumer.getConsumer().subscribe(Collections.singleton(topicName));
+        for (int i = 0; i < totalMsgs; ) {
+            ConsumerRecords<Integer, String> records = kConsumer.getConsumer().poll(Duration.ofSeconds(1));
+            if (log.isDebugEnabled()) {
+                for (ConsumerRecord<Integer, String> record : records) {
+                    log.debug("Kafka consumer get i: {} message: {}, key: {}", i, record.value(), record.key());
+                    assertEquals(record.key().intValue(), i);
+                    i++;
+                }
+            } else {
+                i += records.count();
+            }
+        }
+    }
+}


### PR DESCRIPTION
fixes #218

there is a 4096 batch size limit due to `MessageIdUtils` design for offset, this PR intends to auto split for size > 4096, we can use it before the offset refactor finished.