### PR TITLE
Bump pulsar to 2.7.0

### DIFF
--- a/kafka-impl/pom.xml
+++ b/kafka-impl/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.streamnative.pulsar.handlers</groupId>
     <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
-    <version>2.6.2-SNAPSHOT</version>
+    <version>2.7.0</version>
   </parent>
 
   <groupId>io.streamnative.pulsar.handlers</groupId>

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaBrokerStarter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaBrokerStarter.java
@@ -36,6 +36,7 @@ import java.util.Date;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.util.ReflectionUtils;
 import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.discover.BookieServiceInfo;
 import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.replication.AutoRecoveryMain;
 import org.apache.bookkeeper.stats.StatsProvider;
@@ -130,7 +131,8 @@ public class KafkaBrokerStarter {
             if (starterArguments.runBookie) {
                 checkNotNull(bookieConfig, "No ServerConfiguration for Bookie");
                 checkNotNull(bookieStatsProvider, "No Stats Provider for Bookie");
-                bookieServer = new BookieServer(bookieConfig, bookieStatsProvider.getStatsLogger(""));
+                bookieServer = new BookieServer(
+                        bookieConfig, bookieStatsProvider.getStatsLogger(""), BookieServiceInfo.NO_INFO);
             } else {
                 bookieServer = null;
             }

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
   <groupId>io.streamnative.pulsar.handlers</groupId>
   <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
-  <version>2.6.2-SNAPSHOT</version>
+  <version>2.7.0</version>
   <name>StreamNative :: Pulsar Protocol Handler :: KoP Parent</name>
   <description>Parent for Kafka on Pulsar implemented using Pulsar Protocol Handler.</description>
 
@@ -47,7 +47,7 @@
     <log4j2.version>2.13.3</log4j2.version>
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
-    <pulsar.version>2.6.2.0</pulsar.version>
+    <pulsar.version>2.7.0</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testcontainers.version>1.12.5</testcontainers.version>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.streamnative.pulsar.handlers</groupId>
     <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
-    <version>2.6.2-SNAPSHOT</version>
+    <version>2.7.0</version>
   </parent>
 
   <groupId>io.streamnative.pulsar.handlers</groupId>


### PR DESCRIPTION
Bump pulsar to 2.7.0. Since BookKeeper API has changed, the KoP will be incompatible with Pulsar 2.6.x after this PR.