### PR TITLE
Bump version to 2.8.0-SNAPSHOT

### DIFF
--- a/kafka-impl/pom.xml
+++ b/kafka-impl/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.streamnative.pulsar.handlers</groupId>
     <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
-    <version>2.7.0</version>
+    <version>2.8.0-SNAPSHOT</version>
   </parent>
 
   <groupId>io.streamnative.pulsar.handlers</groupId>

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/InternalProducer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/InternalProducer.java
@@ -13,11 +13,13 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.service.Producer;
 import org.apache.pulsar.broker.service.ServerCnx;
 import org.apache.pulsar.broker.service.Topic;
+import org.apache.pulsar.common.api.proto.PulsarApi;
 
 /**
  * InternalServerCnx, this only used to construct internalProducer / internalConsumer.
@@ -31,7 +33,8 @@ public class InternalProducer extends Producer {
     public InternalProducer(Topic topic, ServerCnx cnx,
                             long producerId, String producerName) {
         super(topic, cnx, producerId, producerName, null,
-            false, null, null, 0, false);
+                false, null, null, 0, false,
+                PulsarApi.ProducerAccessMode.Shared, Optional.empty());
         this.serverCnx = cnx;
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
@@ -159,7 +159,7 @@ public class KafkaTopicManager {
         }
 
         // this will register and add USAGE_COUNT_UPDATER.
-        persistentTopic.addProducer(producer);
+        persistentTopic.addProducer(producer, new CompletableFuture<>());
         return producer;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <log4j2.version>2.13.3</log4j2.version>
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
-    <pulsar.version>2.7.0</pulsar.version>
+    <pulsar.version>2.8.0-rc-202012200040</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testcontainers.version>1.12.5</testcontainers.version>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
   <groupId>io.streamnative.pulsar.handlers</groupId>
   <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
-  <version>2.7.0</version>
+  <version>2.8.0-SNAPSHOT</version>
   <name>StreamNative :: Pulsar Protocol Handler :: KoP Parent</name>
   <description>Parent for Kafka on Pulsar implemented using Pulsar Protocol Handler.</description>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.streamnative.pulsar.handlers</groupId>
     <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
-    <version>2.7.0</version>
+    <version>2.8.0-SNAPSHOT</version>
   </parent>
 
   <groupId>io.streamnative.pulsar.handlers</groupId>


### PR DESCRIPTION
This PR bumps project version to 2.8.0-SNAPSHOT. Also it bumps pulsar version to 2.8.0-rc-202012200040 so that we can make use of some latest features.