### PR TITLE
[Issue #303] handle OffsetCommitRequest retentionTime field convert properly

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -939,8 +939,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         // commit from kafka
 
         long offsetRetention;
-        if (apiVersion <= 1 ||
-                request.retentionTime() == OffsetCommitRequest.DEFAULT_RETENTION_TIME) {
+        if (apiVersion <= 1 || request.retentionTime() == OffsetCommitRequest.DEFAULT_RETENTION_TIME) {
             offsetRetention = configOffsetsRetentionMs;
         } else {
             offsetRetention = request.retentionTime();
@@ -952,7 +951,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
 
         // > expire timestamp is computed differently for v1 and v2.
         // >  - If v1 and no explicit commit timestamp is provided we use default expiration timestamp.
-        // >  - If v1 and explicit commit timestamp is provided we calculate retention from that explicit commit timestamp
+        // >  - If v1 and explicit commit timestamp is provided we calculate retention from
+        // >    that explicit commit timestamp
         // >  - If v2 we use the default expiration timestamp
         // commit from kafka
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -23,6 +23,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.kafka.common.protocol.CommonFields.THROTTLE_TIME_MS;
 import static org.apache.kafka.common.requests.CreateTopicsRequest.TopicDetails;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import io.netty.channel.ChannelHandlerContext;
@@ -32,6 +33,7 @@ import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupMetadata.Group
 import io.streamnative.pulsar.handlers.kop.format.EntryFormatter;
 import io.streamnative.pulsar.handlers.kop.format.EntryFormatterFactory;
 import io.streamnative.pulsar.handlers.kop.offset.OffsetAndMetadata;
+import io.streamnative.pulsar.handlers.kop.offset.OffsetMetadata;
 import io.streamnative.pulsar.handlers.kop.security.SaslAuthenticator;
 import io.streamnative.pulsar.handlers.kop.utils.CoreUtils;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
@@ -118,6 +120,7 @@ import org.apache.kafka.common.requests.SaslAuthenticateResponse;
 import org.apache.kafka.common.requests.SaslHandshakeResponse;
 import org.apache.kafka.common.requests.SyncGroupRequest;
 import org.apache.kafka.common.requests.SyncGroupResponse;
+import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfigurationUtils;
@@ -924,34 +927,108 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
 //                ));
     }
 
+    @VisibleForTesting
+    Map<TopicPartition, OffsetAndMetadata> convertOffsetCommitRequestRetentionMs(OffsetCommitRequest request,
+                                                                                 short apiVersion,
+                                                                                 long currentTimeStamp,
+                                                                                 long configOffsetsRetentionMs) {
+
+        // commit from kafka
+        // > for version 1 and beyond store offsets in offset manager
+        // > compute the retention time based on the request version:
+        // commit from kafka
+
+        long offsetRetention;
+        if (apiVersion <= 1 ||
+                request.retentionTime() == OffsetCommitRequest.DEFAULT_RETENTION_TIME) {
+            offsetRetention = configOffsetsRetentionMs;
+        } else {
+            offsetRetention = request.retentionTime();
+        }
+
+        // commit from kafka
+        // > commit timestamp is always set to now.
+        // > "default" expiration timestamp is now + retention (and retention may be overridden if v2)
+
+        // > expire timestamp is computed differently for v1 and v2.
+        // >  - If v1 and no explicit commit timestamp is provided we use default expiration timestamp.
+        // >  - If v1 and explicit commit timestamp is provided we calculate retention from that explicit commit timestamp
+        // >  - If v2 we use the default expiration timestamp
+        // commit from kafka
+
+        long defaultExpireTimestamp = offsetRetention + currentTimeStamp;
+
+
+        long finalOffsetRetention = offsetRetention;
+        return CoreUtils.mapValue(request.offsetData(), (partitionData) -> {
+
+            String metadata;
+            if (partitionData.metadata == null) {
+                metadata = OffsetMetadata.NO_METADATA;
+            } else {
+                metadata = partitionData.metadata;
+            }
+
+            long expireTimeStamp;
+            if (partitionData.timestamp == OffsetCommitRequest.DEFAULT_TIMESTAMP) {
+                expireTimeStamp = defaultExpireTimestamp;
+            } else {
+                expireTimeStamp = finalOffsetRetention + partitionData.timestamp;
+            }
+
+            return OffsetAndMetadata.apply(
+                    partitionData.offset,
+                    metadata,
+                    currentTimeStamp,
+                    expireTimeStamp);
+        });
+
+    }
+
     protected void handleOffsetCommitRequest(KafkaHeaderAndRequest offsetCommit,
                                              CompletableFuture<AbstractResponse> resultFuture) {
         checkArgument(offsetCommit.getRequest() instanceof OffsetCommitRequest);
         checkState(groupCoordinator != null,
-            "Group Coordinator not started");
+                "Group Coordinator not started");
 
         OffsetCommitRequest request = (OffsetCommitRequest) offsetCommit.getRequest();
 
+        // TODO not process nonExistingTopic at this time.
         Map<TopicPartition, Errors> nonExistingTopic = nonExistingTopicErrors(request);
 
-        groupCoordinator.handleCommitOffsets(
-            request.groupId(),
-            request.memberId(),
-            request.generationId(),
-            CoreUtils.mapValue(
-                request.offsetData().entrySet().stream()
-                    .filter(entry -> !nonExistingTopic.containsKey(entry.getKey()))
-                    .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue())),
-                (partitionData) ->
-                    OffsetAndMetadata.apply(partitionData.offset, partitionData.metadata, partitionData.timestamp)
-            )
-        ).thenAccept(offsetCommitResult -> {
-            if (nonExistingTopic != null) {
+        Map<TopicPartition, OffsetCommitRequest.PartitionData> authorizedTopic = request.offsetData();
+        if (authorizedTopic.isEmpty()) {
+            Map<TopicPartition, Errors> offsetCommitResult = new HashMap<>();
+            if (!nonExistingTopic.isEmpty()) {
                 offsetCommitResult.putAll(nonExistingTopic);
             }
+
             OffsetCommitResponse response = new OffsetCommitResponse(offsetCommitResult);
             resultFuture.complete(response);
-        });
+
+        } else {
+            Map<TopicPartition, OffsetAndMetadata> convertedPartitionData =
+                    convertOffsetCommitRequestRetentionMs(
+                            request,
+                            offsetCommit.getHeader().apiVersion(),
+                            Time.SYSTEM.milliseconds(),
+                            groupCoordinator.offsetConfig().offsetsRetentionMs()
+                    );
+
+            groupCoordinator.handleCommitOffsets(
+                    request.groupId(),
+                    request.memberId(),
+                    request.generationId(),
+                    convertedPartitionData
+            ).thenAccept(offsetCommitResult -> {
+                if (!nonExistingTopic.isEmpty()) {
+                    offsetCommitResult.putAll(nonExistingTopic);
+                }
+                OffsetCommitResponse response = new OffsetCommitResponse(offsetCommitResult);
+                resultFuture.complete(response);
+            });
+
+        }
     }
 
     protected void handleFetchRequest(KafkaHeaderAndRequest fetch,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinator.java
@@ -218,6 +218,14 @@ public class GroupCoordinator {
         return groupManager;
     }
 
+    public GroupConfig groupConfig() {
+        return groupConfig;
+    }
+
+    public OffsetConfig offsetConfig() {
+        return groupManager.offsetConfig();
+    }
+
     public CompletableFuture<JoinGroupResult> handleJoinGroup(
         String groupId,
         String memberId,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
@@ -341,6 +341,10 @@ public class GroupMetadataManager {
         );
     }
 
+    public OffsetConfig offsetConfig() {
+        return offsetConfig;
+    }
+
     // return true iff group is owned and the group doesn't exist
     public boolean groupNotExists(String groupId) {
         return inLock(

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndTestBase.java
@@ -40,6 +40,7 @@ import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
 /**
@@ -58,6 +59,7 @@ public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
         super.internalSetup();
     }
 
+    @AfterClass
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -42,13 +42,13 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import lombok.Cleanup;
@@ -69,8 +69,8 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.AbstractResponse;
 import org.apache.kafka.common.requests.ApiVersionsRequest;
 import org.apache.kafka.common.requests.ApiVersionsResponse;
-import org.apache.kafka.common.requests.OffsetCommitRequest;
 import org.apache.kafka.common.requests.MetadataResponse.PartitionMetadata;
+import org.apache.kafka.common.requests.OffsetCommitRequest;
 import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.requests.ResponseHeader;
 import org.apache.kafka.common.serialization.IntegerSerializer;
@@ -518,7 +518,8 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
 
 
         // convert
-        Map<TopicPartition, OffsetAndMetadata> converted = handler.convertOffsetCommitRequestRetentionMs(offsetCommitRequest,
+        Map<TopicPartition, OffsetAndMetadata> converted =
+                handler.convertOffsetCommitRequestRetentionMs(offsetCommitRequest,
                 builder.latestAllowedVersion(),
                 currentTime,
                 configRetentionMs);
@@ -553,7 +554,8 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
 
 
         // convert
-        Map<TopicPartition, OffsetAndMetadata> converted = handler.convertOffsetCommitRequestRetentionMs(offsetCommitRequest,
+        Map<TopicPartition, OffsetAndMetadata> converted =
+                handler.convertOffsetCommitRequestRetentionMs(offsetCommitRequest,
                 builder.latestAllowedVersion(),
                 currentTime,
                 offsetsConfigRetentionMs);
@@ -585,8 +587,10 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
                 .setRetentionTime(OffsetCommitRequest.DEFAULT_RETENTION_TIME);
         OffsetCommitRequest offsetCommitRequest = builder.build();
 
-        RequestHeader header = new RequestHeader(ApiKeys.OFFSET_COMMIT, offsetCommitRequest.version(), "", 0);
-        KafkaHeaderAndRequest headerAndRequest = new KafkaHeaderAndRequest(header, offsetCommitRequest, PulsarByteBufAllocator.DEFAULT.heapBuffer(), null);
+        RequestHeader header = new RequestHeader(ApiKeys.OFFSET_COMMIT, offsetCommitRequest.version(),
+                "", 0);
+        KafkaHeaderAndRequest headerAndRequest = new KafkaHeaderAndRequest(header,
+                offsetCommitRequest, PulsarByteBufAllocator.DEFAULT.heapBuffer(), null);
 
         // handle request
         CompletableFuture<AbstractResponse> future = new CompletableFuture<>();
@@ -604,10 +608,12 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
         Assert.assertNotNull(offsetAndMetadata);
 
         // trigger clean expire offset logic
-        Map<TopicPartition, OffsetAndMetadata> removeExpiredOffsets = metadata.removeExpiredOffsets(Time.SYSTEM.milliseconds());
+        Map<TopicPartition, OffsetAndMetadata> removeExpiredOffsets =
+                metadata.removeExpiredOffsets(Time.SYSTEM.milliseconds());
 
         // there is only one offset just saved. it should not being removed.
-        Assert.assertTrue(removeExpiredOffsets.isEmpty(),"expect no expired offset. but " + removeExpiredOffsets + " expired.");
+        Assert.assertTrue(removeExpiredOffsets.isEmpty(),
+                "expect no expired offset. but " + removeExpiredOffsets + " expired.");
 
         metadata = groupMetadataManager.getGroup(group).get();
         offsetAndMetadata = metadata.offset(topicPartition).get();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -150,7 +150,7 @@ public abstract class KopProtocolHandlerTestBase {
         kafkaConfig.setAuthenticationEnabled(false);
         kafkaConfig.setAuthorizationEnabled(false);
         kafkaConfig.setAllowAutoTopicCreation(true);
-        kafkaConfig.setAllowAutoTopicCreationType("non-partitioned");
+        kafkaConfig.setAllowAutoTopicCreationType("partitioned");
         kafkaConfig.setBrokerDeleteInactiveTopicsEnabled(false);
 
         kafkaConfig.setKafkaMetadataTenant(tenant);


### PR DESCRIPTION
When `KafkaConsumer` send OffsetCommitRequest,
the field `retentionTime` is always set to -1,
and kafka server convert the retentionTime according to server config.

this patch add convert logic the same as kafka server
to avoid kop expire the wrong commit offset in
`GroupMetadataManager.cleanupGroupMetadata` logic.

test in `KafkaRequestHandlerTest.testOffsetCommitRequestRetentionMs`