### PR TITLE
Add advertised listeners as the listeners exposed to client

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,8 @@ The following table lists all KoP configurations.
 |Name|Description|Default|
 |---|---|---|
 |messagingProtocols|  Messaging protocols available for being loaded by Pulsar Broker |kafka|
-|listeners| Listener properties for the Kafka service (The host should follow the  `advertisedAddress`.) |PLAINTEXT://localhost:9092,SSL://localhost:9093|
+|kafkaListeners|Comma-separated list of URIs we will listen on and the listener names.<br>e.g. PLAINTEXT://localhost:9092,SSL://localhost:9093.<br>If hostname is not set, bind to the default interface.||
+|listeners|Deprecated - use `kafkaListeners` instead. ||
 |kafkaTenant| The default tenant of Kafka's topics |public|
 |kafkaNamespace| The default namespace of Kafka's topics |default|
 |kafkaMetadataTenant| Tenant used for storing Kafka metadata topics |public|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,7 @@ The following table lists all KoP configurations.
 |---|---|---|
 |messagingProtocols|  Messaging protocols available for being loaded by Pulsar Broker |kafka|
 |kafkaListeners|Comma-separated list of URIs we will listen on and the listener names.<br>e.g. PLAINTEXT://localhost:9092,SSL://localhost:9093.<br>If hostname is not set, bind to the default interface.||
+|kafkaAdvertisedListeners|Listeners to publish to ZooKeeper for clients to use.<br>The format is the same as `kafkaListeners`.||
 |listeners|Deprecated - use `kafkaListeners` instead. ||
 |kafkaTenant| The default tenant of Kafka's topics |public|
 |kafkaNamespace| The default namespace of Kafka's topics |default|

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/EndPoint.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/EndPoint.java
@@ -30,6 +30,7 @@ import org.apache.kafka.common.security.auth.SecurityProtocol;
  */
 public class EndPoint {
 
+    private static final String END_POINT_SEPARATOR = ",";
     private static final String REGEX = "^(.*)://\\[?([0-9a-zA-Z\\-%._:]*)\\]?:(-?[0-9]+)";
     private static final Pattern PATTERN = Pattern.compile(REGEX);
 
@@ -67,7 +68,7 @@ public class EndPoint {
 
     public static Map<SecurityProtocol, EndPoint> parseListeners(final String listeners) {
         final Map<SecurityProtocol, EndPoint> endPointMap = new HashMap<>();
-        for (String listener : listeners.split(",")) {
+        for (String listener : listeners.split(END_POINT_SEPARATOR)) {
             final EndPoint endPoint = new EndPoint(listener);
             if (endPointMap.containsKey(endPoint.securityProtocol)) {
                 throw new IllegalStateException(
@@ -77,5 +78,25 @@ public class EndPoint {
             }
         }
         return endPointMap;
+    }
+
+    public static EndPoint getPlainTextEndPoint(final String listeners) {
+        for (String listener : listeners.split(END_POINT_SEPARATOR)) {
+            if (listener.startsWith(SecurityProtocol.PLAINTEXT.name())
+                    || listener.startsWith(SecurityProtocol.SASL_PLAINTEXT.name())) {
+                return new EndPoint(listener);
+            }
+        }
+        throw new IllegalStateException(listeners + " has no plain text endpoint");
+    }
+
+    public static EndPoint getSslEndPoint(final String listeners) {
+        for (String listener : listeners.split(END_POINT_SEPARATOR)) {
+            if (listener.startsWith(SecurityProtocol.SSL.name())
+                    || listener.startsWith(SecurityProtocol.SASL_SSL.name())) {
+                return new EndPoint(listener);
+            }
+        }
+        throw new IllegalStateException(listeners + " has no ssl endpoint");
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/EndPoint.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/EndPoint.java
@@ -18,6 +18,8 @@ import static com.google.common.base.Preconditions.checkState;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.Getter;
@@ -61,5 +63,19 @@ public class EndPoint {
 
     public InetSocketAddress getInetAddress() {
         return new InetSocketAddress(hostname, port);
+    }
+
+    public static Map<SecurityProtocol, EndPoint> parseListeners(final String listeners) {
+        final Map<SecurityProtocol, EndPoint> endPointMap = new HashMap<>();
+        for (String listener : listeners.split(",")) {
+            final EndPoint endPoint = new EndPoint(listener);
+            if (endPointMap.containsKey(endPoint.securityProtocol)) {
+                throw new IllegalStateException(
+                        listeners + " has multiple listeners whose protocol is " + endPoint.securityProtocol);
+            } else {
+                endPointMap.put(endPoint.securityProtocol, endPoint);
+            }
+        }
+        return endPointMap;
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/EndPoint.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/EndPoint.java
@@ -35,6 +35,8 @@ public class EndPoint {
     private static final Pattern PATTERN = Pattern.compile(REGEX);
 
     @Getter
+    private final String originalListener;
+    @Getter
     private final SecurityProtocol securityProtocol;
     @Getter
     private final String hostname;
@@ -42,6 +44,7 @@ public class EndPoint {
     private final int port;
 
     public EndPoint(final String listener) {
+        this.originalListener = listener;
         final String errorMessage = "listener '" + listener + "' is invalid";
         final Matcher matcher = PATTERN.matcher(listener);
         checkState(matcher.find(), errorMessage);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/EndPoint.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/EndPoint.java
@@ -16,6 +16,7 @@ package io.streamnative.pulsar.handlers.kop;
 import static com.google.common.base.Preconditions.checkState;
 
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -55,10 +56,10 @@ public class EndPoint {
             this.hostname = originalHostname;
         }
         this.port = Integer.parseInt(matcher.group(3));
-        checkState(port >= 0 && port < 65535, errorMessage + ": port " + port + " is invalid");
+        checkState(port >= 0 && port <= 65535, errorMessage + ": port " + port + " is invalid");
     }
 
-    public String getConnectionString() {
-        return hostname + ":" + port;
+    public InetSocketAddress getInetAddress() {
+        return new InetSocketAddress(hostname, port);
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/EndPoint.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/EndPoint.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.Getter;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+
+/**
+ * The endpoint that KoP binds.
+ */
+public class EndPoint {
+
+    private static final String REGEX = "^(.*)://\\[?([0-9a-zA-Z\\-%._:]*)\\]?:(-?[0-9]+)";
+    private static final Pattern PATTERN = Pattern.compile(REGEX);
+
+    @Getter
+    private final SecurityProtocol securityProtocol;
+    @Getter
+    private final String hostname;
+    @Getter
+    private final int port;
+
+    public EndPoint(final String listener) {
+        final String errorMessage = "listener '" + listener + "' is invalid";
+        final Matcher matcher = PATTERN.matcher(listener);
+        checkState(matcher.find(), errorMessage);
+        checkState(matcher.groupCount() == 3, errorMessage);
+
+        this.securityProtocol = SecurityProtocol.forName(matcher.group(1));
+        final String originalHostname = matcher.group(2);
+        if (originalHostname.isEmpty()) {
+            try {
+                this.hostname = InetAddress.getLocalHost().getCanonicalHostName();
+            } catch (UnknownHostException e) {
+                throw new IllegalStateException("hostname is empty and localhost is unknown: " + e.getMessage());
+            }
+        } else {
+            this.hostname = originalHostname;
+        }
+        this.port = Integer.parseInt(matcher.group(3));
+        checkState(port >= 0 && port < 65535, errorMessage + ": port " + port + " is invalid");
+    }
+
+    public String getConnectionString() {
+        return hostname + ":" + port;
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
@@ -42,17 +42,21 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
     @Getter
     private final boolean enableTls;
     @Getter
+    private final EndPoint advertisedEndPoint;
+    @Getter
     private final SslContextFactory sslContextFactory;
 
     public KafkaChannelInitializer(PulsarService pulsarService,
                                    KafkaServiceConfiguration kafkaConfig,
                                    GroupCoordinator groupCoordinator,
-                                   boolean enableTLS) {
+                                   boolean enableTLS,
+                                   EndPoint advertisedEndPoint) {
         super();
         this.pulsarService = pulsarService;
         this.kafkaConfig = kafkaConfig;
         this.groupCoordinator = groupCoordinator;
         this.enableTls = enableTLS;
+        this.advertisedEndPoint = advertisedEndPoint;
 
         if (enableTls) {
             sslContextFactory = SSLUtils.createSslContextFactory(kafkaConfig);
@@ -70,7 +74,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
         ch.pipeline().addLast("frameDecoder",
             new LengthFieldBasedFrameDecoder(MAX_FRAME_LENGTH, 0, 4, 0, 4));
         ch.pipeline().addLast("handler",
-            new KafkaRequestHandler(pulsarService, kafkaConfig, groupCoordinator, enableTls));
+            new KafkaRequestHandler(pulsarService, kafkaConfig, groupCoordinator, enableTls, advertisedEndPoint));
     }
 
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
@@ -47,7 +47,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
     public KafkaChannelInitializer(PulsarService pulsarService,
                                    KafkaServiceConfiguration kafkaConfig,
                                    GroupCoordinator groupCoordinator,
-                                   boolean enableTLS) throws Exception {
+                                   boolean enableTLS) {
         super();
         this.pulsarService = pulsarService;
         this.kafkaConfig = kafkaConfig;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -229,11 +229,11 @@ public class KafkaProtocolHandler implements ProtocolHandler {
     // This method is called after initialize
     @Override
     public String getProtocolDataToAdvertise() {
-        String listeners = getListenersFromConfig(kafkaConfig);
-        if (log.isDebugEnabled()) {
-            log.debug("Get configured listeners {}", listeners);
+        if (kafkaConfig.getKafkaAdvertisedListeners() != null) {
+            return kafkaConfig.getKafkaAdvertisedListeners();
+        } else {
+            return kafkaConfig.getListeners();
         }
-        return listeners;
     }
 
     @Override

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -225,7 +225,7 @@ public class KafkaProtocolHandler implements ProtocolHandler {
     // This method is called after initialize
     @Override
     public String getProtocolDataToAdvertise() {
-        return getListenersFromConfig(kafkaConfig);
+        return getKafkaAdvertisedListeners(kafkaConfig);
     }
 
     @Override
@@ -383,8 +383,7 @@ public class KafkaProtocolHandler implements ProtocolHandler {
         }
     }
 
-    // getLocalListeners from config, if not exists in config, set it as PLAINTEXT://advertisedAddress:9092
-    public static @NonNull String getListenersFromConfig(KafkaServiceConfiguration kafkaConfig) {
+    public static @NonNull String getKafkaAdvertisedListeners(KafkaServiceConfiguration kafkaConfig) {
         if (kafkaConfig.getKafkaAdvertisedListeners() != null) {
             return kafkaConfig.getKafkaAdvertisedListeners();
         } else {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -276,9 +276,8 @@ public class KafkaProtocolHandler implements ProtocolHandler {
             ImmutableMap.Builder<InetSocketAddress, ChannelInitializer<SocketChannel>> builder =
                 ImmutableMap.<InetSocketAddress, ChannelInitializer<SocketChannel>>builder();
 
-            for (String listener: kafkaConfig.getListeners().split(",")) {
-                final EndPoint endPoint = new EndPoint(listener);
-                switch (endPoint.getSecurityProtocol()) {
+            EndPoint.parseListeners(kafkaConfig.getListeners()).forEach((protocol, endPoint) -> {
+                switch (protocol) {
                     case PLAINTEXT:
                     case SASL_PLAINTEXT:
                         builder.put(endPoint.getInetAddress(), new KafkaChannelInitializer(
@@ -290,7 +289,7 @@ public class KafkaProtocolHandler implements ProtocolHandler {
                                 brokerService.getPulsar(), kafkaConfig, groupCoordinator, true));
                         break;
                 }
-            }
+            });
 
             return builder.build();
         } catch (Exception e){

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -15,9 +15,6 @@ package io.streamnative.pulsar.handlers.kop;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static io.streamnative.pulsar.handlers.kop.KafkaProtocolHandler.ListenerType.PLAINTEXT;
-import static io.streamnative.pulsar.handlers.kop.KafkaProtocolHandler.ListenerType.SSL;
-import static io.streamnative.pulsar.handlers.kop.KafkaProtocolHandler.getListenerPort;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.kafka.common.protocol.CommonFields.THROTTLE_TIME_MS;
 import static org.apache.kafka.common.requests.CreateTopicsRequest.TopicDetails;
@@ -155,8 +152,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     private final Boolean tlsEnabled;
     private final EndPoint advertisedEndPoint;
     private final String advertisedListeners;
-    private final int plaintextPort;
-    private final int sslPort;
     private final int defaultNumPartitions;
     public final int maxReadEntriesNum;
     @Getter
@@ -185,8 +180,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         this.tlsEnabled = tlsEnabled;
         this.advertisedEndPoint = advertisedEndPoint;
         this.advertisedListeners = KafkaProtocolHandler.getListenersFromConfig(kafkaConfig);
-        this.plaintextPort = getListenerPort(advertisedListeners, PLAINTEXT);
-        this.sslPort = getListenerPort(advertisedListeners, SSL);
         this.topicManager = new KafkaTopicManager(this);
         this.defaultNumPartitions = kafkaConfig.getDefaultNumPartitions();
         this.maxReadEntriesNum = kafkaConfig.getMaxReadEntriesNum();
@@ -1400,14 +1393,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                     );
             });
         return returnFuture;
-    }
-
-    private boolean isOffsetTopic(String topic) {
-        String offsetsTopic = kafkaConfig.getKafkaMetadataTenant() + "/"
-            + kafkaConfig.getKafkaMetadataNamespace()
-            + "/" + Topic.GROUP_METADATA_TOPIC_NAME;
-
-        return topic.contains(offsetsTopic);
     }
 
     private CompletableFuture<PartitionMetadata> findBroker(TopicName topic) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -179,7 +179,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         this.adminManager = new AdminManager(admin);
         this.tlsEnabled = tlsEnabled;
         this.advertisedEndPoint = advertisedEndPoint;
-        this.advertisedListeners = KafkaProtocolHandler.getListenersFromConfig(kafkaConfig);
+        this.advertisedListeners = KafkaProtocolHandler.getKafkaAdvertisedListeners(kafkaConfig);
         this.topicManager = new KafkaTopicManager(this);
         this.defaultNumPartitions = kafkaConfig.getDefaultNumPartitions();
         this.maxReadEntriesNum = kafkaConfig.getMaxReadEntriesNum();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -156,6 +156,13 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
         return (kafkaListeners != null) ? kafkaListeners : listeners;
     }
 
+    @FieldContext(
+        category = CATEGORY_KOP,
+        doc = "Listeners to publish to ZooKeeper for clients to use.\n"
+                + "The format is the same as `kafkaListeners`.\n"
+    )
+    private String kafkaAdvertisedListeners;
+
     // Kafka SSL configs
     @FieldContext(
         category = CATEGORY_KOP_SSL,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -137,13 +137,26 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
     )
     private long offsetsRetentionCheckIntervalMs = OffsetConfig.DefaultOffsetsRetentionCheckIntervalMs;
 
+    @Deprecated
     @FieldContext(
         category = CATEGORY_KOP,
-        doc = "ListenersProp for Kafka service(host should follow the advertisedAddress). "
+        doc = "Comma-separated list of URIs we will listen on and the listener names."
               + "e.g. PLAINTEXT://localhost:9092,SSL://localhost:9093. "
               + "If not set, kop will use PLAINTEXT://advertisedAddress:9092"
     )
     private String listeners;
+
+    @FieldContext(
+        category = CATEGORY_KOP,
+        doc = "Comma-separated list of URIs we will listen on and the listener names."
+                + "e.g. PLAINTEXT://localhost:9092,SSL://localhost:9093. "
+                + "If not set, kop will use PLAINTEXT://advertisedAddress:9092"
+    )
+    private String kafkaListeners;
+
+    public String getListeners() {
+        return (kafkaListeners != null) ? kafkaListeners : listeners;
+    }
 
     // Kafka SSL configs
     @FieldContext(

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -140,17 +140,15 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
     @Deprecated
     @FieldContext(
         category = CATEGORY_KOP,
-        doc = "Comma-separated list of URIs we will listen on and the listener names."
-              + "e.g. PLAINTEXT://localhost:9092,SSL://localhost:9093. "
-              + "If not set, kop will use PLAINTEXT://advertisedAddress:9092"
+        doc = "Use `kafkaListeners` instead"
     )
     private String listeners;
 
     @FieldContext(
         category = CATEGORY_KOP,
-        doc = "Comma-separated list of URIs we will listen on and the listener names."
-                + "e.g. PLAINTEXT://localhost:9092,SSL://localhost:9093. "
-                + "If not set, kop will use PLAINTEXT://advertisedAddress:9092"
+        doc = "Comma-separated list of URIs we will listen on and the listener names.\n"
+                + "e.g. PLAINTEXT://localhost:9092,SSL://localhost:9093.\n"
+                + "If hostname is not set, bind to the default interface."
     )
     private String kafkaListeners;
 

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/EndPointTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/EndPointTest.java
@@ -122,4 +122,11 @@ public class EndPointTest {
             assertTrue(e.getMessage().contains("has no ssl endpoint"));
         }
     }
+
+    @Test
+    public void testOriginalUrl() throws Exception {
+        final EndPoint endPoint = new EndPoint("PLAINTEXT://:9092");
+        assertEquals(endPoint.getHostname(), InetAddress.getLocalHost().getCanonicalHostName());
+        assertEquals(endPoint.getOriginalListener(), "PLAINTEXT://:9092");
+    }
 }

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/EndPointTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/EndPointTest.java
@@ -53,9 +53,9 @@ public class EndPointTest {
             assertTrue(e.getMessage().contains("No enum constant"));
         }
         try {
-            new EndPoint("PLAINTEXT://localhost:123456");
+            new EndPoint("PLAINTEXT://localhost:65536");
         } catch (IllegalStateException e) {
-            assertTrue(e.getMessage().contains("port 123456 is invalid"));
+            assertTrue(e.getMessage().contains("port 65536 is invalid"));
         }
         try {
             new EndPoint("PLAINTEXT://localhost:-1");

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/EndPointTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/EndPointTest.java
@@ -99,4 +99,27 @@ public class EndPointTest {
             assertTrue(e.getMessage().contains(" has multiple listeners whose protocol is SSL"));
         }
     }
+
+    @Test
+    public void testGetEndPoint() {
+        String listeners = "PLAINTEXT://:9092,SSL://:9093,SASL_SSL://:9094,SASL_PLAINTEXT:9095";
+        assertEquals(EndPoint.getPlainTextEndPoint(listeners).getPort(), 9092);
+        assertEquals(EndPoint.getSslEndPoint(listeners).getPort(), 9093);
+        listeners = "SASL_PLAINTEXT://:9095,SASL_SSL://:9094,SSL://:9093,PLAINTEXT:9092";
+        assertEquals(EndPoint.getPlainTextEndPoint(listeners).getPort(), 9095);
+        assertEquals(EndPoint.getSslEndPoint(listeners).getPort(), 9094);
+
+        try {
+            EndPoint.getPlainTextEndPoint("SSL://:9093");
+            fail();
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage().contains("has no plain text endpoint"));
+        }
+
+        try {
+            EndPoint.getSslEndPoint("PLAINTEXT://:9092");
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage().contains("has no ssl endpoint"));
+        }
+    }
 }

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/EndPointTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/EndPointTest.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.net.InetAddress;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for EndPoint.
+ */
+public class EndPointTest {
+
+    @Test
+    public void testValidListener() throws Exception {
+        EndPoint endPoint = new EndPoint("PLAINTEXT://192.168.0.1:9092");
+        assertEquals(endPoint.getSecurityProtocol(), SecurityProtocol.PLAINTEXT);
+        assertEquals(endPoint.getHostname(), "192.168.0.1");
+        assertEquals(endPoint.getPort(), 9092);
+
+        final String localhost = InetAddress.getLocalHost().getCanonicalHostName();
+        endPoint = new EndPoint("SSL://:9094");
+        assertEquals(endPoint.getSecurityProtocol(), SecurityProtocol.SSL);
+        assertEquals(endPoint.getHostname(), localhost);
+        assertEquals(endPoint.getPort(), 9094);
+    }
+
+    @Test
+    public void testInvalidListener() throws Exception {
+        try {
+            new EndPoint("hello world");
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage().contains("listener 'hello world' is invalid"));
+            e.getMessage();
+        }
+        try {
+            new EndPoint("pulsar://localhost:6650");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("No enum constant"));
+        }
+        try {
+            new EndPoint("PLAINTEXT://localhost:123456");
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage().contains("port 123456 is invalid"));
+        }
+        try {
+            new EndPoint("PLAINTEXT://localhost:-1");
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage().contains("port -1 is invalid"));
+        }
+    }
+
+}

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
@@ -16,7 +16,6 @@ package io.streamnative.pulsar.handlers.kop;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.fail;
 
 import io.streamnative.pulsar.handlers.kop.utils.ConfigurationUtils;
 import java.io.File;
@@ -29,7 +28,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.api.DigestType;
 
 import org.apache.pulsar.broker.ServiceConfiguration;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 /**
@@ -136,102 +134,6 @@ public class KafkaServiceConfigurationTest {
 
         assertEquals(kafkaServiceConfig.getAdvertisedAddress(), advertisedAddress1);
         assertEquals(serviceConfiguration.getAdvertisedAddress(), advertisedAddress2);
-    }
-
-    @Test
-    public void testKopListeners() throws Exception {
-        KafkaServiceConfiguration config = new KafkaServiceConfiguration();
-        String advertisedAddress = "127.0.0.1";
-        config.setAdvertisedAddress(advertisedAddress);
-
-        // fail for advertisedAddress not match
-        try {
-            String inputListener = "PLAINTEXT://hello:9092";
-            verifyGetListenersFromConfig(config, inputListener, inputListener);
-            fail("Should throw exception for advertisedAddress not match");
-        } catch (Exception e) {
-            // expected
-            log.info("exception: " + e);
-        }
-
-        // success match
-        try {
-            String inputListener = "PLAINTEXT://" + advertisedAddress + ":9092";
-            verifyGetListenersFromConfig(config, inputListener, inputListener);
-        } catch (Exception e) {
-            fail("Should success and equals " + e);
-        }
-
-        // success match both no hostname
-        try {
-            String inputListener = "PLAINTEXT://:9092" + ",SSL://:9093";
-            String outputListener = "PLAINTEXT://" + advertisedAddress + ":9092"
-                                    + ",SSL://" + advertisedAddress + ":9093";
-            verifyGetListenersFromConfig(config, inputListener, outputListener);
-        } catch (Exception e) {
-            fail("Should success and equals " + e);
-        }
-
-        // success match ssl no hostname
-        try {
-            String inputListener = "PLAINTEXT://" + advertisedAddress + ":9092" + ",SSL://:9093";
-            String outputListener = "PLAINTEXT://" + advertisedAddress + ":9092"
-                                    + ",SSL://" + advertisedAddress + ":9093";
-            verifyGetListenersFromConfig(config, inputListener, outputListener);
-        } catch (Exception e) {
-            fail("Should success and equals " + e);
-        }
-
-        // fail for ssl hostname not match
-        try {
-            String inputListener = "PLAINTEXT://" + advertisedAddress + ":9092" + ",SSL://" + "hello" + ":9093";
-            String outputListener = "PLAINTEXT://" + advertisedAddress + ":9092"
-                                    + ",SSL://" + advertisedAddress + ":9093";
-            verifyGetListenersFromConfig(config, inputListener, outputListener);
-            fail("Should throw exception for ssl advertisedAddress not match");
-        } catch (Exception e) {
-            // expected
-            log.info("exception: " + e);
-        }
-
-        // fail for no port
-        try {
-            String inputListener = "PLAINTEXT://" + advertisedAddress;
-            verifyGetListenersFromConfig(config, inputListener, inputListener);
-            fail("Should throw exception for no port");
-        } catch (Exception e) {
-            // expected
-            log.info("exception: " + e);
-        }
-
-        // fail for wrong port
-        try {
-            String inputListener = "PLAINTEXT://" + advertisedAddress + ":65537";
-            verifyGetListenersFromConfig(config, inputListener, inputListener);
-            fail("Should throw exception for wrong port");
-        } catch (Exception e) {
-            // expected
-            log.info("exception: " + e);
-        }
-
-        // fail for wrong port
-        try {
-            String inputListener = "PLAINTEXT://" + advertisedAddress + ":wrongPort";
-            verifyGetListenersFromConfig(config, inputListener, inputListener);
-            fail("Should throw exception for wrong port");
-        } catch (Exception e) {
-            // expected
-            log.info("exception: " + e);
-        }
-    }
-
-    private static void verifyGetListenersFromConfig(KafkaServiceConfiguration config,
-                                                     String inputListener,
-                                                     String outputListener) {
-
-        config.setListeners(inputListener);
-        log.info("inputListener: {}, outputListener: {}", inputListener, outputListener);
-        Assert.assertEquals(KafkaProtocolHandler.getListenersFromConfig(config), outputListener);
     }
 
 }

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
@@ -57,6 +57,16 @@ public class KafkaServiceConfigurationTest {
     }
 
     @Test
+    public void testKafkaListeners() {
+        KafkaServiceConfiguration configuration = new KafkaServiceConfiguration();
+        configuration.setListeners("PLAINTEXT://localhost:9092");
+        assertEquals(configuration.getListeners(), "PLAINTEXT://localhost:9092");
+        // kafkaListeners has higher priority than listeners
+        configuration.setKafkaListeners("PLAINTEXT://localhost:9093");
+        assertEquals(configuration.getListeners(), "PLAINTEXT://localhost:9093");
+    }
+
+    @Test
     public void testConfigurationUtilsStream() throws Exception {
         File testConfigFile = new File("tmp." + System.currentTimeMillis() + ".properties");
         if (testConfigFile.exists()) {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
@@ -13,7 +13,6 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
-import static io.streamnative.pulsar.handlers.kop.KafkaProtocolHandler.PLAINTEXT_PREFIX;
 import static org.apache.kafka.common.internals.Topic.GROUP_METADATA_TOPIC_NAME;
 import static org.apache.pulsar.common.naming.TopicName.PARTITIONED_TOPIC_SUFFIX;
 import static org.testng.Assert.assertEquals;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
@@ -138,7 +138,8 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
             pulsar,
             (KafkaServiceConfiguration) conf,
             groupCoordinator,
-            false);
+            false,
+            getPlainEndPoint());
         ChannelHandlerContext mockCtx = mock(ChannelHandlerContext.class);
         Channel mockChannel = mock(Channel.class);
         doReturn(mockChannel).when(mockCtx).channel();
@@ -613,7 +614,8 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
 
         // verify all served by same broker : localhost:port
         assertEquals(metadataResponse.brokers().size(), 1);
-        assertEquals(metadataResponse.brokers().iterator().next().host(), "localhost");
+        // NOTE: the listener's hostname is "localhost", but the advertised listener's hostname is "127.0.0.1"
+        assertEquals(metadataResponse.brokers().iterator().next().host(), "127.0.0.1");
 
         // check metadata response
         Collection<TopicMetadata> topicMetadatas = metadataResponse.topicMetadata();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaIntegrationTest.java
@@ -26,8 +26,6 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
-import static io.streamnative.pulsar.handlers.kop.KafkaProtocolHandler.PLAINTEXT_PREFIX;
-import static io.streamnative.pulsar.handlers.kop.KafkaProtocolHandler.SSL_PREFIX;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -149,7 +149,8 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
             pulsar,
             (KafkaServiceConfiguration) conf,
             groupCoordinator,
-            false);
+            false,
+            getPlainEndPoint());
     }
 
     @AfterMethod

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
@@ -64,7 +64,8 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
             pulsar,
             (KafkaServiceConfiguration) conf,
             groupCoordinator,
-            false);
+            false,
+            getPlainEndPoint());
 
         ChannelHandlerContext mockCtx = mock(ChannelHandlerContext.class);
         Channel mockChannel = mock(Channel.class);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -135,6 +135,10 @@ public abstract class KopProtocolHandlerTestBase {
         resetConfig();
     }
 
+    protected EndPoint getPlainEndPoint() {
+        return new EndPoint(PLAINTEXT_PREFIX + "127.0.0.1:" + kafkaBrokerPort);
+    }
+
     protected void resetConfig() {
         KafkaServiceConfiguration kafkaConfig = new KafkaServiceConfiguration();
         addBrokerEntryMetadataInterceptors(kafkaConfig);
@@ -162,9 +166,12 @@ public abstract class KopProtocolHandlerTestBase {
         // kafka related settings.
         kafkaConfig.setEnableGroupCoordinator(true);
         kafkaConfig.setOffsetsTopicNumPartitions(1);
-        kafkaConfig.setListeners(
-            PLAINTEXT_PREFIX + "localhost:" + kafkaBrokerPort + ","
-                + SSL_PREFIX + "localhost:" + kafkaBrokerPortTls);
+        kafkaConfig.setKafkaListeners(
+                PLAINTEXT_PREFIX + "localhost:" + kafkaBrokerPort + ","
+                        + SSL_PREFIX + "localhost:" + kafkaBrokerPortTls);
+        kafkaConfig.setKafkaAdvertisedListeners(
+                PLAINTEXT_PREFIX + "127.0.0.1:" + kafkaBrokerPort + ","
+                        + SSL_PREFIX + "127.0.0.1:" + kafkaBrokerPortTls);
         kafkaConfig.setEntryFormat(entryFormat);
 
         // set protocol related config

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -13,8 +13,6 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
-import static io.streamnative.pulsar.handlers.kop.KafkaProtocolHandler.PLAINTEXT_PREFIX;
-import static io.streamnative.pulsar.handlers.kop.KafkaProtocolHandler.SSL_PREFIX;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
@@ -61,6 +59,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.pulsar.broker.BookKeeperClientFactory;
@@ -124,6 +123,9 @@ public abstract class KopProtocolHandlerTestBase {
     protected String restConnect;
 
     private final String entryFormat;
+
+    protected static final String PLAINTEXT_PREFIX = SecurityProtocol.PLAINTEXT.name() + "://";
+    protected static final String SSL_PREFIX = SecurityProtocol.SSL.name() + "://";
 
     public KopProtocolHandlerTestBase() {
         this.entryFormat = "pulsar";


### PR DESCRIPTION
Fixes #315 

The original `listeners` config's semantics is wrong that it mixed the `listeners` and `advertised.listeners` semantics of Kafka. So this PR adds a `kafkaAdvertisedListeners` as the listeners exposed to client, and only use `listeners` as the bind address. To avoid conflict with other protocol handlers, mark `listeners` as deprecated and use `kafkaListeners` instead.

For convenience, this PR adds an `EndPoint` class to do the listener url parse work, which can be applied to both `kafkaListeners` and `kafkaAdvertisedListeners`. It also handles `SASL_XXX` protocols which were not handled before. And the related tests are added.

The existed `KafkaApisTest#testBrokerHandleTopicMetadataRequest` could verify the `kafkaAdvertisedListeners` because the tests' `kafkaAdvertisedListeners` is `127.0.0.1:<port>` while `kafkaListeners` is `localhost:<port>`.