### PR TITLE
Fix NPE if kafkaAdvertisedListeners was not set

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -36,7 +36,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.internals.Topic;
 import org.apache.kafka.common.record.CompressionType;
@@ -225,7 +224,7 @@ public class KafkaProtocolHandler implements ProtocolHandler {
     // This method is called after initialize
     @Override
     public String getProtocolDataToAdvertise() {
-        return getKafkaAdvertisedListeners(kafkaConfig);
+        return kafkaConfig.getKafkaAdvertisedListeners();
     }
 
     @Override
@@ -380,17 +379,6 @@ public class KafkaProtocolHandler implements ProtocolHandler {
             FutureUtil.waitForAll(lists).get();
         } else {
             log.info("Current broker: {} does not own any of the offset topic partitions", currentBroker);
-        }
-    }
-
-    public static @NonNull String getKafkaAdvertisedListeners(KafkaServiceConfiguration kafkaConfig) {
-        if (kafkaConfig.getKafkaAdvertisedListeners() != null) {
-            return kafkaConfig.getKafkaAdvertisedListeners();
-        } else {
-            if (kafkaConfig.getListeners() == null) {
-                throw new IllegalStateException("listeners or kafkaListeners is required");
-            }
-            return kafkaConfig.getListeners();
         }
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -179,7 +179,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         this.adminManager = new AdminManager(admin);
         this.tlsEnabled = tlsEnabled;
         this.advertisedEndPoint = advertisedEndPoint;
-        this.advertisedListeners = KafkaProtocolHandler.getKafkaAdvertisedListeners(kafkaConfig);
+        this.advertisedListeners = kafkaConfig.getKafkaAdvertisedListeners();
         this.topicManager = new KafkaTopicManager(this);
         this.defaultNumPartitions = kafkaConfig.getDefaultNumPartitions();
         this.maxReadEntriesNum = kafkaConfig.getMaxReadEntriesNum();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -18,6 +18,7 @@ import io.streamnative.pulsar.handlers.kop.coordinator.group.OffsetConfig;
 import java.util.HashSet;
 import java.util.Set;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.Setter;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.pulsar.broker.ServiceConfiguration;
@@ -162,6 +163,17 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
                 + "The format is the same as `kafkaListeners`.\n"
     )
     private String kafkaAdvertisedListeners;
+
+    public @NonNull String getKafkaAdvertisedListeners() {
+        if (kafkaAdvertisedListeners != null) {
+            return kafkaAdvertisedListeners;
+        } else {
+            if (getListeners() == null) {
+                throw new IllegalStateException("listeners or kafkaListeners is required");
+            }
+            return getListeners();
+        }
+    }
 
     // Kafka SSL configs
     @FieldContext(

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
@@ -94,6 +94,13 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
     KafkaRequestHandler kafkaRequestHandler;
     SocketAddress serviceAddress;
 
+    @Override
+    protected void resetConfig() {
+        super.resetConfig();
+        this.conf.setKafkaAdvertisedListeners(PLAINTEXT_PREFIX + "127.0.0.1:" + kafkaBrokerPort + ","
+                + SSL_PREFIX + "127.0.0.1:" + kafkaBrokerPortTls);
+    }
+
     @BeforeMethod
     @Override
     protected void setup() throws Exception {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaIntegrationTest.java
@@ -162,13 +162,12 @@ public class KafkaIntegrationTest extends KopProtocolHandlerTestBase {
         // - set pulsar advertized address to host IP
         // - use the `host.testcontainers.internal` address exposed by testcontainers
         final String ip = getSiteLocalAddress();
-        System.out.println("exposing Pulsar broker on " + ip);
-        conf.setAdvertisedAddress(ip);
+        System.out.println("Bind Pulsar broker/KoP on " + ip);
         ((KafkaServiceConfiguration) conf).setListeners(
                 PLAINTEXT_PREFIX + ip + ":" + kafkaBrokerPort + ","
                         + SSL_PREFIX + ip + ":" + kafkaBrokerPortTls);
-        conf.setKafkaAdvertisedListeners(
-                PLAINTEXT_PREFIX + ip + ":" + kafkaBrokerPort + "," + SSL_PREFIX + ip + ":" + kafkaBrokerPortTls);
+        conf.setKafkaAdvertisedListeners(PLAINTEXT_PREFIX + "127.0.0.1:" + kafkaBrokerPort
+                + "," + SSL_PREFIX + "127.0.0.1:" + kafkaBrokerPortTls);
         super.internalSetup();
 
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaIntegrationTest.java
@@ -167,6 +167,8 @@ public class KafkaIntegrationTest extends KopProtocolHandlerTestBase {
         ((KafkaServiceConfiguration) conf).setListeners(
                 PLAINTEXT_PREFIX + ip + ":" + kafkaBrokerPort + ","
                         + SSL_PREFIX + ip + ":" + kafkaBrokerPortTls);
+        conf.setKafkaAdvertisedListeners(
+                PLAINTEXT_PREFIX + ip + ":" + kafkaBrokerPort + "," + SSL_PREFIX + ip + ":" + kafkaBrokerPortTls);
         super.internalSetup();
 
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -171,9 +171,6 @@ public abstract class KopProtocolHandlerTestBase {
         kafkaConfig.setKafkaListeners(
                 PLAINTEXT_PREFIX + "localhost:" + kafkaBrokerPort + ","
                         + SSL_PREFIX + "localhost:" + kafkaBrokerPortTls);
-        kafkaConfig.setKafkaAdvertisedListeners(
-                PLAINTEXT_PREFIX + "127.0.0.1:" + kafkaBrokerPort + ","
-                        + SSL_PREFIX + "127.0.0.1:" + kafkaBrokerPortTls);
         kafkaConfig.setEntryFormat(entryFormat);
 
         // set protocol related config


### PR DESCRIPTION
If `kafkaAdvertisedListeners` that was introduced from #317 was not set, the KoP would fail to start. It's because in `KafkaProtocolHandler#start` we use `kafkaConfig.getKafkaAdvertisedListeners()` to get the configured `kafkaAdvertisedListeners` which is null. But we need to call `KafkaProtocolHandler#getKafkaAdvertisedListeners` to get the `kafkaListeners`/`listeners` if `kafkaAdvertisedListeners` is null.

This PR overwrites the `KafkaServiceConfiguration#getKafkaAdvertisedListeners` to fix this issue.

This issue was not exposed because the `kafkaAdvertisedListeners` has been set in `KopProtocolHandlerTestBase#resetConfig` before. So this PR removes the default config and only set it in `KafkaApisTest` for verification of the `kafkaAdvertisedListeners`.