### PR TITLE
Fix wrong offset in send callback

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessagePublishContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessagePublishContext.java
@@ -54,7 +54,8 @@ public final class MessagePublishContext implements PublishContext {
 
             topic.recordAddLatency(System.nanoTime() - startTimeNs, TimeUnit.MICROSECONDS);
 
-            offsetFuture.complete(MessageIdUtils.getCurrentOffset(managedLedger));
+            final long baseOffset = MessageIdUtils.getCurrentOffset(managedLedger) - (numberOfMessages - 1);
+            offsetFuture.complete(baseOffset);
         }
 
         recycle();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessagePublishContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessagePublishContext.java
@@ -54,6 +54,9 @@ public final class MessagePublishContext implements PublishContext {
 
             topic.recordAddLatency(System.nanoTime() - startTimeNs, TimeUnit.MICROSECONDS);
 
+            // In asynchronously send mode, there's a possibility that some messages' offsets are larger than the actual
+            // offsets. For example, two messages are sent concurrently, if the 1st message is completed while the 2nd
+            // message is already persisted, `MessageIdUtils.getCurrentOffset` will return the 2nd message's offset.
             final long baseOffset = MessageIdUtils.getCurrentOffset(managedLedger) - (numberOfMessages - 1);
             offsetFuture.complete(baseOffset);
         }


### PR DESCRIPTION
This PR is a partial fix of https://github.com/streamnative/kop/issues/332.

Before this PR, the `MessagePublishContext` completed with the current offset, which is the latest offset. Then `PartitionResponse` will be filled with the offset. However, Kafka producer treat the `PartitionResponse`'s offset as the base offset.

For example, before this PR, when Kafka producer sends a batch with 3 single messages to a new topic, the offsets in send callback will be `(2, 3, 4)` before this PR. After this PR, the offsets in send callback will be `(0, 1, 2)`.