### PR TITLE
Upgrade pulsar with LightProto support

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/InternalProducer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/InternalProducer.java
@@ -19,7 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.service.Producer;
 import org.apache.pulsar.broker.service.ServerCnx;
 import org.apache.pulsar.broker.service.Topic;
-import org.apache.pulsar.common.api.proto.PulsarApi;
+import org.apache.pulsar.common.api.proto.ProducerAccessMode;
 
 /**
  * InternalServerCnx, this only used to construct internalProducer / internalConsumer.
@@ -34,7 +34,7 @@ public class InternalProducer extends Producer {
                             long producerId, String producerName) {
         super(topic, cnx, producerId, producerName, null,
                 false, null, null, 0, false,
-                PulsarApi.ProducerAccessMode.Shared, Optional.empty());
+                ProducerAccessMode.Shared, Optional.empty());
         this.serverCnx = cnx;
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -455,7 +455,7 @@ public final class MessageFetchContext {
 
                         readFuture.completeExceptionally(e);
                     }
-                }, null);
+                }, null, PositionImpl.latest);
 
             readFutures.putIfAbsent(cursorOffsetPair.getKey(), readFuture);
         });

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaEntryFormatter.java
@@ -26,7 +26,7 @@ import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.MemoryRecordsBuilder;
 import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.record.TimestampType;
-import org.apache.pulsar.common.api.proto.PulsarApi;
+import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.protocol.Commands;
 
 /**
@@ -73,17 +73,16 @@ public class KafkaEntryFormatter implements EntryFormatter {
         return builder.build();
     }
 
-    private static PulsarApi.MessageMetadata getMessageMetadataWithNumberMessages(int numMessages) {
-        final PulsarApi.MessageMetadata.Builder builder = PulsarApi.MessageMetadata.newBuilder();
-        builder.addProperties(PulsarApi.KeyValue.newBuilder()
+    private static MessageMetadata getMessageMetadataWithNumberMessages(int numMessages) {
+        final MessageMetadata metadata = new MessageMetadata();
+        metadata.addProperty()
                 .setKey("entry.format")
-                .setValue(EntryFormatterFactory.EntryFormat.KAFKA.name().toLowerCase())
-                .build());
-        builder.setProducerName("");
-        builder.setSequenceId(0L);
-        builder.setPublishTime(System.currentTimeMillis());
-        builder.setNumMessagesInBatch(numMessages);
-        return builder.build();
+                .setValue(EntryFormatterFactory.EntryFormat.KAFKA.name().toLowerCase());
+        metadata.setProducerName("");
+        metadata.setSequenceId(0L);
+        metadata.setPublishTime(System.currentTimeMillis());
+        metadata.setNumMessagesInBatch(numMessages);
+        return metadata;
     }
 
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/PulsarEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/PulsarEntryFormatter.java
@@ -121,7 +121,6 @@ public class PulsarEntryFormatter implements EntryFormatter {
             // each entry is a batched message
             ByteBuf metadataAndPayload = entry.getDataBuffer();
 
-            // Uncompress the payload if necessary
             Commands.skipBrokerEntryMetadataIfExist(metadataAndPayload);
             MessageMetadata msgMetadata = Commands.parseMessageMetadata(metadataAndPayload);
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/PulsarEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/PulsarEntryFormatter.java
@@ -122,10 +122,12 @@ public class PulsarEntryFormatter implements EntryFormatter {
             ByteBuf metadataAndPayload = entry.getDataBuffer();
 
             // Uncompress the payload if necessary
+            Commands.skipBrokerEntryMetadataIfExist(metadataAndPayload);
             MessageMetadata msgMetadata = Commands.parseMessageMetadata(metadataAndPayload);
 
-            if (msgMetadata.getMarkerType() == MarkerType.TXN_COMMIT_VALUE
-                    || msgMetadata.getMarkerType() == MarkerType.TXN_ABORT_VALUE) {
+            if (msgMetadata.hasMarkerType()
+                    && (msgMetadata.getMarkerType() == MarkerType.TXN_COMMIT_VALUE
+                    || msgMetadata.getMarkerType() == MarkerType.TXN_ABORT_VALUE)) {
                 MemoryRecords memoryRecords = MemoryRecords.withEndTransactionMarker(
                         baseOffset,
                         msgMetadata.getPublishTime(),

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ByteBufUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ByteBufUtils.java
@@ -18,7 +18,9 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import io.netty.buffer.ByteBuf;
 import java.nio.ByteBuffer;
 import java.util.Base64;
-import org.apache.pulsar.common.api.proto.PulsarApi;
+
+import org.apache.pulsar.common.api.proto.MessageMetadata;
+import org.apache.pulsar.common.api.proto.SingleMessageMetadata;
 
 
 /**
@@ -26,9 +28,9 @@ import org.apache.pulsar.common.api.proto.PulsarApi;
  */
 public class ByteBufUtils {
 
-    public static ByteBuffer getKeyByteBuffer(PulsarApi.SingleMessageMetadata messageMetadata) {
+    public static ByteBuffer getKeyByteBuffer(SingleMessageMetadata messageMetadata) {
         if (messageMetadata.hasOrderingKey()) {
-            return messageMetadata.getOrderingKey().asReadOnlyByteBuffer();
+            return ByteBuffer.wrap(messageMetadata.getOrderingKey()).asReadOnlyBuffer();
         }
 
         String key = messageMetadata.getPartitionKey();
@@ -40,9 +42,9 @@ public class ByteBufUtils {
         }
     }
 
-    public static ByteBuffer getKeyByteBuffer(PulsarApi.MessageMetadata messageMetadata) {
+    public static ByteBuffer getKeyByteBuffer(MessageMetadata messageMetadata) {
         if (messageMetadata.hasOrderingKey()) {
-            return messageMetadata.getOrderingKey().asReadOnlyByteBuffer();
+            return ByteBuffer.wrap(messageMetadata.getOrderingKey()).asReadOnlyBuffer();
         }
 
         String key = messageMetadata.getPartitionKey();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ByteBufUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ByteBufUtils.java
@@ -33,12 +33,16 @@ public class ByteBufUtils {
             return ByteBuffer.wrap(messageMetadata.getOrderingKey()).asReadOnlyBuffer();
         }
 
-        String key = messageMetadata.getPartitionKey();
-        if (messageMetadata.hasPartitionKeyB64Encoded()) {
-            return ByteBuffer.wrap(Base64.getDecoder().decode(key));
+        if (messageMetadata.hasPartitionKey()) {
+            final String key = messageMetadata.getPartitionKey();
+            if (messageMetadata.hasPartitionKeyB64Encoded()) {
+                return ByteBuffer.wrap(Base64.getDecoder().decode(key)).asReadOnlyBuffer();
+            } else {
+                // for Base64 not encoded string, convert to UTF_8 chars
+                return ByteBuffer.wrap(key.getBytes(UTF_8));
+            }
         } else {
-            // for Base64 not encoded string, convert to UTF_8 chars
-            return ByteBuffer.wrap(key.getBytes(UTF_8));
+            return ByteBuffer.allocate(0);
         }
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/OffsetSearchPredicate.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/OffsetSearchPredicate.java
@@ -14,7 +14,7 @@
 package io.streamnative.pulsar.handlers.kop.utils;
 
 import org.apache.bookkeeper.mledger.Entry;
-import org.apache.pulsar.common.api.proto.PulsarApi;
+import org.apache.pulsar.common.api.proto.BrokerEntryMetadata;
 import org.apache.pulsar.common.protocol.Commands;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
@@ -34,7 +34,7 @@ public class OffsetSearchPredicate implements com.google.common.base.Predicate<E
     @Override
     public boolean apply(@Nullable Entry entry) {
         try {
-            PulsarApi.BrokerEntryMetadata brokerEntryMetadata =
+            BrokerEntryMetadata brokerEntryMetadata =
                     Commands.parseBrokerEntryMetadataIfExist(entry.getDataBuffer());
             return brokerEntryMetadata.getIndex() < indexToSearch;
         } catch (Exception e) {

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/OffsetFinderTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/OffsetFinderTest.java
@@ -36,9 +36,8 @@ import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
 import org.apache.pulsar.broker.service.persistent.PersistentMessageExpiryMonitor;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
-import org.apache.pulsar.common.api.proto.PulsarApi;
+import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.protocol.ByteBufPair;
-import org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream;
 import org.testng.annotations.Test;
 
 /**
@@ -47,11 +46,10 @@ import org.testng.annotations.Test;
 public class OffsetFinderTest extends MockedBookKeeperTestCase {
 
     public static byte[] createMessageWrittenToLedger(String msg) throws Exception {
-        PulsarApi.MessageMetadata.Builder messageMetadataBuilder = PulsarApi.MessageMetadata.newBuilder();
-        messageMetadataBuilder.setPublishTime(System.currentTimeMillis());
-        messageMetadataBuilder.setProducerName("createMessageWrittenToLedger");
-        messageMetadataBuilder.setSequenceId(1);
-        PulsarApi.MessageMetadata messageMetadata = messageMetadataBuilder.build();
+        final MessageMetadata messageMetadata = new MessageMetadata();
+        messageMetadata.setPublishTime(System.currentTimeMillis());
+        messageMetadata.setProducerName("createMessageWrittenToLedger");
+        messageMetadata.setSequenceId(1);
         ByteBuf data = UnpooledByteBufAllocator.DEFAULT.heapBuffer().writeBytes(msg.getBytes());
 
         int msgMetadataSize = messageMetadata.getSerializedSize();
@@ -59,9 +57,8 @@ public class OffsetFinderTest extends MockedBookKeeperTestCase {
         int totalSize = 4 + msgMetadataSize + payloadSize;
 
         ByteBuf headers = PulsarByteBufAllocator.DEFAULT.heapBuffer(totalSize, totalSize);
-        ByteBufCodedOutputStream outStream = ByteBufCodedOutputStream.get(headers);
         headers.writeInt(msgMetadataSize);
-        messageMetadata.writeTo(outStream);
+        messageMetadata.writeTo(headers);
         ByteBuf headersAndPayload = ByteBufPair.coalesce(ByteBufPair.get(headers, data));
         byte[] byteMessage = headersAndPayload.nioBuffer().array();
         headersAndPayload.release();

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <log4j2.version>2.13.3</log4j2.version>
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
-    <pulsar.version>2.8.0-rc-202101052233</pulsar.version>
+    <pulsar.version>2.8.0-rc-202101192246</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testcontainers.version>1.12.5</testcontainers.version>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <log4j2.version>2.13.3</log4j2.version>
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
-    <pulsar.version>2.8.0-SNAPSHOT</pulsar.version>
+    <pulsar.version>2.8.0-rc-202101252233</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testcontainers.version>1.12.5</testcontainers.version>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <log4j2.version>2.13.3</log4j2.version>
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
-    <pulsar.version>2.8.0-rc-202101192246</pulsar.version>
+    <pulsar.version>2.8.0-SNAPSHOT</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testcontainers.version>1.12.5</testcontainers.version>

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/EntryPublishTimePulsarFormatTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/EntryPublishTimePulsarFormatTest.java
@@ -34,7 +34,7 @@ public class EntryPublishTimePulsarFormatTest extends EntryPublishTimeTest {
     private static final Logger log = LoggerFactory.getLogger(EntryPublishTimePulsarFormatTest.class);
 
 
-    public EntryPublishTimePulsarFormatTest(String format) {
+    public EntryPublishTimePulsarFormatTest() {
         super("pulsar");
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -71,6 +71,7 @@ import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.compaction.Compactor;
+import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.apache.pulsar.zookeeper.ZooKeeperClientFactory;
 import org.apache.pulsar.zookeeper.ZookeeperClientFactoryImpl;
 import org.apache.zookeeper.CreateMode;
@@ -326,6 +327,7 @@ public abstract class KopProtocolHandlerTestBase {
         // Override default providers with mocked ones
         doReturn(mockZooKeeperClientFactory).when(pulsar).getZooKeeperClientFactory();
         doReturn(mockBookKeeperClientFactory).when(pulsar).newBookKeeperClientFactory();
+        doReturn(new ZKMetadataStore(mockZooKeeper)).when(pulsar).createLocalMetadataStore();
 
         Supplier<NamespaceService> namespaceServiceSupplier = () -> spy(new NamespaceService(pulsar));
         doReturn(namespaceServiceSupplier).when(pulsar).getNamespaceServiceProvider();


### PR DESCRIPTION
Fixes https://github.com/streamnative/kop/issues/336

Besides applying the LightProto generated new package name and some new APIs, this PR also fixes the tests error caused by https://github.com/apache/pulsar/pull/9240, which introduces a new method `PulsarService#createLocalMetadataStore`.

And some tests are affected by the wrong parse of entry data after the pulsar update, this PR fixes the test failures.