### PR TITLE
Fix offset in send callback may be wrong

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessagePublishContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessagePublishContext.java
@@ -61,6 +61,8 @@ public final class MessagePublishContext implements PublishContext {
             if (offset < 0) {
                 if (offset != -1L) {
                     log.error("offset was changed to {} (< 0) but no exception was thrown", offset);
+                } else {
+                    log.error("There's no valid BrokerEntryData in entry ({}, {})", ledgerId, entryId);
                 }
                 offset = MessageIdUtils.getCurrentOffset(managedLedger);
             }


### PR DESCRIPTION
Fixes #332 

The offset in send callback was calculated with the index of `AppendIndexMetadataInterceptor` when `MessagePublishContext#completed` was invoked. However, the index of `AppendIndexMetadataInterceptor` was updated every time a message was sent while `PublishContext#completed` was called every time a message's send was done. So the interceptor's index may be overwritten by a newer message's offset.

This PR fixes this issue by implementing the new method `PublishContext#setMetadataFromEntryData` that was introduced in https://github.com/apache/pulsar/pull/9257.