### PR TITLE
fix can not consume all message if topics has > 1000 partitions

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -303,7 +303,6 @@ public final class MessageFetchContext {
                             fetch.getHeader(), entriesRead.get(), allSize);
                     }
 
-                    AtomicBoolean allPartitionsNoEntry = new AtomicBoolean(true);
                     responseValues.entrySet().forEach(responseEntries -> {
                         final PartitionData partitionData;
                         TopicPartition kafkaPartition = responseEntries.getKey();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -305,7 +304,7 @@ public final class MessageFetchContext {
                     }
 
                     AtomicBoolean allPartitionsNoEntry = new AtomicBoolean(true);
-                    responseValues.entrySet().parallelStream().forEach(responseEntries -> {
+                    responseValues.entrySet().forEach(responseEntries -> {
                         final PartitionData partitionData;
                         TopicPartition kafkaPartition = responseEntries.getKey();
                         List<Entry> entries = responseEntries.getValue();
@@ -334,8 +333,6 @@ public final class MessageFetchContext {
                                 null,
                                 MemoryRecords.EMPTY);
                         } else {
-                            allPartitionsNoEntry.set(false);
-
                             ManagedLedgerImpl managedLedger = (ManagedLedgerImpl) cursors
                                     .get(kafkaPartition).getLeft().getManagedLedger();
                             long highWatermark = MessageIdUtils.getHighWatermark(managedLedger);
@@ -368,29 +365,13 @@ public final class MessageFetchContext {
                         responseData.put(kafkaPartition, partitionData);
                     });
 
-                    if (allPartitionsNoEntry.get()) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("Request {}: All partitions for request read 0 entry",
-                                fetch.getHeader());
-                        }
-
-                        requestHandler.getPulsarService().getExecutor().schedule(() -> {
-                            resultFuture.complete(
-                                new FetchResponse(Errors.NONE,
+                    resultFuture.complete(
+                            new FetchResponse(
+                                    Errors.NONE,
                                     responseData,
                                     ((Integer) THROTTLE_TIME_MS.defaultValue),
                                     ((FetchRequest) fetch.getRequest()).metadata().sessionId()));
-                            this.recycle();
-                        }, waitTime, TimeUnit.MILLISECONDS);
-                    } else {
-                        resultFuture.complete(
-                            new FetchResponse(
-                                Errors.NONE,
-                                responseData,
-                                ((Integer) THROTTLE_TIME_MS.defaultValue),
-                                ((FetchRequest) fetch.getRequest()).metadata().sessionId()));
-                        this.recycle();
-                    }
+                    this.recycle();
                 } else {
                     if (log.isDebugEnabled()) {
                         log.debug("Request {}: Read time or size not reach, do another round of read before return.",

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;


### PR DESCRIPTION
fixes #353

1, `responseData` is `LinkedHashMap`, which implementation is not synchronized, therefore `responseValues` should not parallel.
2, `getExecutor schedule` may not process so fast for lots of partitions.