### PR TITLE
change default offsets topic number partitions to 8

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -38,7 +38,7 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
     private static final int GroupInitialRebalanceDelayMs = 3000;
     // offset configuration
     private static final int OffsetsRetentionMinutes = 7 * 24 * 60;
-    public static final int DefaultOffsetsTopicNumPartitions = 1;
+    public static final int DefaultOffsetsTopicNumPartitions = 8;
 
     @Category
     private static final String CATEGORY_KOP = "Kafka on Pulsar";

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
@@ -58,6 +58,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.common.util.MathUtils;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.protocol.Errors;
@@ -847,7 +848,8 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         // group is not owned
         assertFalse(groupMetadataManager.groupNotExists(groupId));
 
-        groupMetadataManager.addPartitionOwnership(groupPartitionId);
+        int tmpGroupPartitionId = MathUtils.signSafeMod(groupId.hashCode(), offsetConfig.offsetsTopicNumPartitions());
+        groupMetadataManager.addPartitionOwnership(tmpGroupPartitionId);
         // group is owned but does not exist yet
         assertTrue(groupMetadataManager.groupNotExists(groupId));
 


### PR DESCRIPTION
### Motivation
For `DefaultOffsetsTopicNumPartitions` in code is set to `1`, however the document setting is `8` . `DefaultOffsetsTopicNumPartitions` should be greater than `1` to improve the throughput.

### Modification
1. Sync with documentation and set to `8`