### PR TITLE
Fix flaky testCreateInvalidTopics

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -61,6 +61,7 @@ import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
@@ -356,7 +357,8 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
             fail("create a invalid topic should fail");
         } catch (Exception e) {
             log.info("Failed to create topics: {} caused by {}", topicToNumPartitions, e.getCause());
-            assertTrue(e.getCause() instanceof TimeoutException);
+            final Throwable cause = e.getCause();
+            assertTrue(cause instanceof TimeoutException || cause instanceof UnknownServerException);
         }
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -355,7 +355,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
             createTopicsByKafkaAdmin(kafkaAdmin, topicToNumPartitions);
             fail("create a invalid topic should fail");
         } catch (Exception e) {
-            log.info("Failed to create topics: {}", topicToNumPartitions);
+            log.info("Failed to create topics: {} caused by {}", topicToNumPartitions, e.getCause());
             assertTrue(e.getCause() instanceof TimeoutException);
         }
     }


### PR DESCRIPTION
The `testCreateInvalidTopics` sometimes failed in CI environment, like

```
Error:  testCreateInvalidTopics(io.streamnative.pulsar.handlers.kop.KafkaRequestHandlerTest)  Time elapsed: 5.022 s  <<< FAILURE!
java.lang.AssertionError: expected [true] but found [false]
	at org.testng.Assert.fail(Assert.java:96)
	at org.testng.Assert.failNotEquals(Assert.java:776)
	at org.testng.Assert.assertTrue(Assert.java:44)
	at org.testng.Assert.assertTrue(Assert.java:54)
	at io.streamnative.pulsar.handlers.kop.KafkaRequestHandlerTest.testCreateInvalidTopics(KafkaRequestHandlerTest.java:359)
```

However here we only use `assertTrue` to check the cause type of the `ExecutionException` but not printed it. So this PR adds error logs for debugging.

Normally it should returns a `TimeoutException`. However, the `KafkaAdmin` could also generate an `UnknownServerException` sometimes, whose error message is just what the server's response is. Here's a sample output of a CI failure:

> Failed to create topics: {xxx/testCreateInvalidTopics-0=1} caused by org.apache.kafka.common.errors.UnknownServerException: Invalid short topic name 'xxx/testCreateInvalidTopics-0', it should be in the format of <tenant>/<namespace>/<topic> or <topic>

The exception message is from `KopTopic#expandToFullName` that is thrown in `AdminManager#createTopicsAsync`.

So this PR looses the check of exception type to make the test pass.