### PR TITLE
Clean log and return highWaterMark if active transactions not exist

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -1449,7 +1449,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                         TopicName topicName = TopicName.get(fullPartitionName);
                         long firstOffset = transactionCoordinator.removeActivePidOffset(
                                 topicName, txnMarkerEntry.producerId());
-                        long lastStableOffset = transactionCoordinator.getLastStableOffset(topicName);
+                        long lastStableOffset = transactionCoordinator.getLastStableOffset(topicName, offset);
 
                         if (txnMarkerEntry.transactionResult().equals(TransactionResult.ABORT)) {
                             transactionCoordinator.addAbortedIndex(AbortedIndexEntry.builder()

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -26,7 +26,6 @@ import io.streamnative.pulsar.handlers.kop.utils.MessageIdUtils;
 import io.streamnative.pulsar.handlers.kop.utils.ZooKeeperUtils;
 
 import java.util.Date;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,7 +40,6 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntriesCallback;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
-import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.NonDurableCursorImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.commons.lang3.tuple.Pair;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -317,7 +317,7 @@ public class TransactionCoordinator {
 
     public long getLastStableOffset(TopicName topicName, long highWaterMark) {
         NavigableMap<Long, Long> map = activeOffsetPidMap.getOrDefault(topicName, null);
-        if (map == null || map.size() == 0) {
+        if (map == null || map.isEmpty()) {
             return highWaterMark;
         }
         return map.firstKey();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -315,15 +315,10 @@ public class TransactionCoordinator {
         return offset;
     }
 
-    public long getLastStableOffset(TopicName topicName) {
+    public long getLastStableOffset(TopicName topicName, long highWaterMark) {
         NavigableMap<Long, Long> map = activeOffsetPidMap.getOrDefault(topicName, null);
-        if (map == null) {
-            log.warn("[activeOffsetPidMap] size: {} the topic {} map is null last",
-                    activeOffsetPidMap.size(), topicName);
-            return Long.MAX_VALUE;
-        }
-        if (map.size() == 0) {
-            return Long.MAX_VALUE;
+        if (map == null || map.size() == 0) {
+            return highWaterMark;
         }
         return map.firstKey();
     }


### PR DESCRIPTION
1. remove log if the active transaction map is empty.
2. return the `highWaterMark` if there is no active transaction.