### PR TITLE
[BUGFIX] join operation could not be finished and proceed group rebalance

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinator.java
@@ -1192,7 +1192,7 @@ public class GroupCoordinator {
                 maybePrepareRebalance(group);
                 break;
             case PreparingRebalance:
-                // joinPurgatory.checkAndComplete(GroupKey(group.groupId))
+                joinPurgatory.checkAndComplete(new GroupKey(group.groupId()));
                 break;
             default:
                 break;


### PR DESCRIPTION
This pull request fixes a group state transition problem when running group rebalance. When we constantly start and stop a consumer task to consume a topic using the same groupid, we found that our client program may occasionally hold for about 30 seconds and then receive a log
```
Group coordinator XXX (id: YYY rack: null) is unavailable or invalid, will attempt rediscovery
```
After that, the client program returns to normal.

```java
// GroupCoordinator.java
private void removeMemberAndUpdateGroup(GroupMetadata group,
                                            MemberMetadata member) {
    group.remove(member.memberId());
    switch (group.currentState()) {
        case Dead:
        case Empty:
            break;
        case Stable:
        case CompletingRebalance:
            maybePrepareRebalance(group);
            break;
        case PreparingRebalance:
            // joinPurgatory.checkAndComplete(GroupKey(group.groupId));
            break;
        default:
            break;
    }
}
```
We can see from the above code snippet that when group current state is equal to `PreparingRebalance`, the group state can not  be naturally coverted to `CompletingRebalance` through `joinPurgatory.checkAndComplete` method. Therefore it may hang until this request times out.  And then the client program reports the above log and re-send join request which triggering a new round of rebalance.