### PR TITLE
Bump pulsar to 2.7.0.8-rc-202102191415

### DIFF
--- a/kafka-impl/pom.xml
+++ b/kafka-impl/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.streamnative.pulsar.handlers</groupId>
     <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
-    <version>2.7.0.7</version>
+    <version>2.7.0.8-rc-202102191415</version>
   </parent>
 
   <groupId>io.streamnative.pulsar.handlers</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
   <groupId>io.streamnative.pulsar.handlers</groupId>
   <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
-  <version>2.7.0.7</version>
+  <version>2.7.0.8-rc-202102191415</version>
   <name>StreamNative :: Pulsar Protocol Handler :: KoP Parent</name>
   <description>Parent for Kafka on Pulsar implemented using Pulsar Protocol Handler.</description>
 
@@ -47,7 +47,7 @@
     <log4j2.version>2.13.3</log4j2.version>
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
-    <pulsar.version>2.7.0.7</pulsar.version>
+    <pulsar.version>2.7.0.8-rc-202102191415</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testcontainers.version>1.15.1</testcontainers.version>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.streamnative.pulsar.handlers</groupId>
     <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
-    <version>2.7.0.7</version>
+    <version>2.7.0.8-rc-202102191415</version>
   </parent>
 
   <groupId>io.streamnative.pulsar.handlers</groupId>

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CommitOffsetBacklogTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CommitOffsetBacklogTest.java
@@ -97,14 +97,14 @@ public class CommitOffsetBacklogTest extends KopProtocolHandlerTestBase {
         final AtomicLong backlog = new AtomicLong(0);
         retryStrategically(
             ((test) -> {
-                backlog.set(persistentTopic.getStats(true).backlogSize);
+                backlog.set(persistentTopic.getStats(true, true).backlogSize);
                 return backlog.get() == expected;
             }),
             5,
             200);
 
         if (log.isDebugEnabled()) {
-            TopicStats topicStats = persistentTopic.getStats(true);
+            TopicStats topicStats = persistentTopic.getStats(true, true);
             log.info(" dump topicStats for topic : {}, storageSize: {}, backlogSize: {}, expected: {}",
                 persistentTopic.getName(),
                 topicStats.storageSize, topicStats.backlogSize, expected);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
@@ -256,7 +256,7 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
         ManagedCursor cursor2 = cursorPair2.getLeft();
         ManagedCursor cursor3 = cursorPair3.getLeft();
 
-        long backlogSize = persistentTopic.getStats(true).backlogSize;
+        long backlogSize = persistentTopic.getStats(true, true).backlogSize;
         verifyBacklogAndNumCursor(persistentTopic, backlogSize, 3);
 
         // simulate a read complete;
@@ -288,14 +288,14 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
         AtomicInteger cursorCount = new AtomicInteger(0);
         retryStrategically(
             ((test) -> {
-                backlog.set(persistentTopic.getStats(true).backlogSize);
+                backlog.set(persistentTopic.getStats(true, true).backlogSize);
                 return backlog.get() == expectedBacklog;
             }),
             5,
             200);
 
         if (log.isDebugEnabled()) {
-            TopicStats topicStats = persistentTopic.getStats(true);
+            TopicStats topicStats = persistentTopic.getStats(true, true);
             log.info(" dump topicStats for topic : {}, storageSize: {}, backlogSize: {}, expected: {}",
                 persistentTopic.getName(),
                 topicStats.storageSize, topicStats.backlogSize, expectedBacklog);


### PR DESCRIPTION
Besides bumping pulsar version, this PR also fixes the compile error caused by new `PersistentTopic#getStats` API.