### PR TITLE
Bump pulsar to 2.8.0-rc-202102252222

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaService.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaService.java
@@ -116,8 +116,9 @@ public class KafkaService extends PulsarService {
 
             BookKeeperClientFactory bkClientFactory = newBookKeeperClientFactory();
             setBkClientFactory(bkClientFactory);
-            setManagedLedgerClientFactory(
-                new ManagedLedgerClientFactory(kafkaConfig, getZkClient(), bkClientFactory));
+            final ManagedLedgerClientFactory managedLedgerClientFactory = new ManagedLedgerClientFactory();
+            managedLedgerClientFactory.initialize(kafkaConfig, getZkClient(), bkClientFactory);
+            setManagedLedgerClientFactory(managedLedgerClientFactory);
             setBrokerService(new BrokerService(this));
 
             // Start load management service (even if load balancing is disabled)
@@ -157,6 +158,7 @@ public class KafkaService extends PulsarService {
                 new ServletHolder(
                     new PrometheusMetricsServlet(
                         this,
+                        false,
                         kafkaConfig.isExposeTopicLevelMetricsInPrometheus(),
                         kafkaConfig.isExposeConsumerLevelMetricsInPrometheus())),
                 false, attributeMap);

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <log4j2.version>2.13.3</log4j2.version>
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
-    <pulsar.version>2.8.0-rc-202101252233</pulsar.version>
+    <pulsar.version>2.8.0-rc-202102252222</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testcontainers.version>1.15.1</testcontainers.version>

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CommitOffsetBacklogTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CommitOffsetBacklogTest.java
@@ -97,14 +97,14 @@ public class CommitOffsetBacklogTest extends KopProtocolHandlerTestBase {
         final AtomicLong backlog = new AtomicLong(0);
         retryStrategically(
             ((test) -> {
-                backlog.set(persistentTopic.getStats(true).backlogSize);
+                backlog.set(persistentTopic.getStats(true, true).backlogSize);
                 return backlog.get() == expected;
             }),
             5,
             200);
 
         if (log.isDebugEnabled()) {
-            TopicStats topicStats = persistentTopic.getStats(true);
+            TopicStats topicStats = persistentTopic.getStats(true, true);
             log.info(" dump topicStats for topic : {}, storageSize: {}, backlogSize: {}, expected: {}",
                 persistentTopic.getName(),
                 topicStats.storageSize, topicStats.backlogSize, expected);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
@@ -687,8 +687,11 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
         int numberTopics = 5;
         int numberPartitions = 6;
 
-        List<TopicPartition> topicPartitions = createTopics(topicName, numberTopics, numberPartitions);
         List<String> kafkaTopics = getCreatedTopics(topicName, numberTopics);
+        for (String topic : kafkaTopics) {
+            admin.topics().createPartitionedTopic(topic, numberPartitions);
+        }
+
         KafkaHeaderAndRequest metadataRequest = createTopicMetadataRequest(kafkaTopics);
         CompletableFuture<AbstractResponse> responseFuture = new CompletableFuture<>();
         kafkaRequestHandler.handleTopicMetadataRequest(metadataRequest, responseFuture);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
@@ -239,7 +239,7 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
         PersistentTopic persistentTopic = (PersistentTopic)
                 pulsar.getBrokerService().getTopicReference(pulsarPartitionName).get();
 
-        long backlogSize = persistentTopic.getStats(true).backlogSize;
+        long backlogSize = persistentTopic.getStats(true, true).backlogSize;
         verifyBacklogAndNumCursor(persistentTopic, backlogSize, 3);
 
         // simulate a read complete;
@@ -271,14 +271,14 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
         AtomicInteger cursorCount = new AtomicInteger(0);
         retryStrategically(
             ((test) -> {
-                backlog.set(persistentTopic.getStats(true).backlogSize);
+                backlog.set(persistentTopic.getStats(true, true).backlogSize);
                 return backlog.get() == expectedBacklog;
             }),
             5,
             200);
 
         if (log.isDebugEnabled()) {
-            TopicStats topicStats = persistentTopic.getStats(true);
+            TopicStats topicStats = persistentTopic.getStats(true, true);
             log.info(" dump topicStats for topic : {}, storageSize: {}, backlogSize: {}, expected: {}",
                 persistentTopic.getName(),
                 topicStats.storageSize, topicStats.backlogSize, expectedBacklog);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -328,6 +328,7 @@ public abstract class KopProtocolHandlerTestBase {
         doReturn(mockZooKeeperClientFactory).when(pulsar).getZooKeeperClientFactory();
         doReturn(mockBookKeeperClientFactory).when(pulsar).newBookKeeperClientFactory();
         doReturn(new ZKMetadataStore(mockZooKeeper)).when(pulsar).createLocalMetadataStore();
+        doReturn(new ZKMetadataStore(mockZooKeeper)).when(pulsar).createConfigurationMetadataStore();
 
         Supplier<NamespaceService> namespaceServiceSupplier = () -> spy(new NamespaceService(pulsar));
         doReturn(namespaceServiceSupplier).when(pulsar).getNamespaceServiceProvider();


### PR DESCRIPTION
This version update is convenient for tests in real environment since there's no binary download url for original pulsar `2.8.0-rc-202101252233`.

This PR fixes the API incompatibility problems that are introduced by https://github.com/apache/pulsar/pull/9397 and https://github.com/apache/pulsar/pull/9302.

Another significant change between these two versions is https://github.com/apache/pulsar/pull/9338, which introduced metadata-store API for cluster resources. This PR fixed the test failure caused by it as well. Since KoP `tests` module only uses one `MockZooKeeper` to manage z-nodes, see `KopProtocolHandlerTestBase#createMockZooKeeper`, the mocked `createConfigurationMetadataStore` method returns `mockedZooKeeper` here instead of a `mockedZooKeeperGlobal` like what Pulsar did in `MockedPulsarServiceBaseTest`.

Besides, there's a test bug in `testBrokerHandleTopicMetadataRequest` that was not exposed by the previous Pulsar. This PR fixes it.