### PR TITLE
change pulsar dependency jars to provided scope to reduce nar package size

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,30 +106,35 @@
       <groupId>org.apache.pulsar</groupId>
       <artifactId>pulsar-broker</artifactId>
       <version>${pulsar.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.pulsar</groupId>
       <artifactId>pulsar-broker-common</artifactId>
       <version>${pulsar.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.pulsar</groupId>
       <artifactId>pulsar-client-original</artifactId>
       <version>${pulsar.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.pulsar</groupId>
       <artifactId>pulsar-client-admin-original</artifactId>
       <version>${pulsar.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.pulsar</groupId>
       <artifactId>testmocks</artifactId>
       <version>${pulsar.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
### Motivation
KOP put pulsar dependency jar into nar package, which lead the nar size up to 130MB. However, the kop nar run with pulsar broker, the pulsar dependency is no need to be packed into KOP nar package.

### Changes
1. change pulsar dependency jar scope to provided in pom.xml