### PR TITLE
[ENHANCEMENT] perf tuning in decode phrase

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaEntryFormatter.java
@@ -13,21 +13,20 @@
  */
 package io.streamnative.pulsar.handlers.kop.format;
 
+import static org.apache.kafka.common.record.Records.MAGIC_OFFSET;
+import static org.apache.kafka.common.record.Records.OFFSET_OFFSET;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.streamnative.pulsar.handlers.kop.utils.ByteBufUtils;
 import io.streamnative.pulsar.handlers.kop.utils.MessageIdUtils;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.protocol.Commands;
-
-import java.nio.ByteBuffer;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static org.apache.kafka.common.record.Records.MAGIC_OFFSET;
-import static org.apache.kafka.common.record.Records.OFFSET_OFFSET;
 
 /**
  * The entry formatter that uses Kafka's format.
@@ -59,7 +58,6 @@ public class KafkaEntryFormatter implements EntryFormatter {
             records.buffer().putLong(p + OFFSET_OFFSET, startOffset);
             records.buffer().put(p + MAGIC_OFFSET, magic);
 
-            entry.release();
             return records;
         }).collect(Collectors.toList());
 
@@ -73,6 +71,7 @@ public class KafkaEntryFormatter implements EntryFormatter {
         batchedBuffer.flip();
 
         MemoryRecords batchedMemoryRecords = MemoryRecords.readableRecords(batchedBuffer);
+        entries.forEach(Entry::release);
         return batchedMemoryRecords;
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaEntryFormatter.java
@@ -17,17 +17,17 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.streamnative.pulsar.handlers.kop.utils.ByteBufUtils;
 import io.streamnative.pulsar.handlers.kop.utils.MessageIdUtils;
-import java.nio.ByteBuffer;
-import java.util.List;
-
 import org.apache.bookkeeper.mledger.Entry;
-import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.MemoryRecords;
-import org.apache.kafka.common.record.MemoryRecordsBuilder;
-import org.apache.kafka.common.record.Record;
-import org.apache.kafka.common.record.TimestampType;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.protocol.Commands;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.kafka.common.record.Records.MAGIC_OFFSET;
+import static org.apache.kafka.common.record.Records.OFFSET_OFFSET;
 
 /**
  * The entry formatter that uses Kafka's format.
@@ -47,30 +47,33 @@ public class KafkaEntryFormatter implements EntryFormatter {
 
     @Override
     public MemoryRecords decode(List<Entry> entries, byte magic) {
-        int size = 0;
-        for (Entry entry : entries) {
-            size += entry.getLength();
-        }
         // TODO The memory records should maintain multiple batches, one entry present one batch,
         //  this is necessary, because one entry only belongs to one transaction.
-        final MemoryRecordsBuilder builder = MemoryRecords.builder(
-                ByteBuffer.allocate(size),
-                magic,
-                CompressionType.NONE,
-                TimestampType.CREATE_TIME,
-                MessageIdUtils.peekBaseOffsetFromEntry(entries.get(0)));
-        entries.forEach(entry -> {
+        List<MemoryRecords> orderedRecord = entries.stream().parallel().map(entry -> {
             long startOffset = MessageIdUtils.peekBaseOffsetFromEntry(entry);
             final ByteBuf byteBuf = entry.getDataBuffer();
             Commands.skipMessageMetadata(byteBuf);
             final MemoryRecords records = MemoryRecords.readableRecords(ByteBufUtils.getNioBuffer(byteBuf));
-            for (Record record : records.records()) {
-                builder.appendWithOffset(startOffset, record);
-                startOffset++;
-            }
+
+            int p = records.buffer().position();
+            records.buffer().putLong(p + OFFSET_OFFSET, startOffset);
+            records.buffer().put(p + MAGIC_OFFSET, magic);
+
             entry.release();
-        });
-        return builder.build();
+            return records;
+        }).collect(Collectors.toList());
+
+        // Concatenate multiple batch into one single MemoryRecords object
+        // In this mode, batch and entry have a one-to-one correspondence
+        int totalSize = orderedRecord.stream().mapToInt(MemoryRecords::sizeInBytes).sum();
+        ByteBuffer batchedBuffer = ByteBuffer.allocate(totalSize);
+        for (MemoryRecords records : orderedRecord) {
+            batchedBuffer.put(records.buffer());
+        }
+        batchedBuffer.flip();
+
+        MemoryRecords batchedMemoryRecords = MemoryRecords.readableRecords(batchedBuffer);
+        return batchedMemoryRecords;
     }
 
     private static MessageMetadata getMessageMetadataWithNumberMessages(int numMessages) {


### PR DESCRIPTION
### Motivation
The decode method in `KafkaEntryFormatter` is time-consuming among which the process of constructing `MemoryRecordsBuilder` takes the highest proportion of time. 

### Designing
Therefore our aims are:
1. overwrites `BaseOffset` field in byte buffer directly to avoid time-consuming iteration which is mainly used for assigning offsets
2. concatenates multiple record batches into one `MemoryRecords` object to better simulate kafka's behavior

### Modifications
- remove the iteration of continuously appending records in the `MemoryRecordsBuilder`
- change to one-to-one correspondence between batch and entry