### PR TITLE
add produce message validation

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -1786,7 +1786,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             || (data.getWebServiceUrlTls() != null && data.getWebServiceUrlTls().contains(hostAndPort));
     }
 
-    static MemoryRecords validateRecords(short version, TopicPartition topicPartition, MemoryRecords records) {
+    private static MemoryRecords validateRecords(short version, TopicPartition topicPartition, MemoryRecords records) {
         if (version >= 3) {
             Iterator<MutableRecordBatch> iterator = records.batches().iterator();
             if (!iterator.hasNext()) {


### PR DESCRIPTION
### Motivation
KOP receives Kafka messages produced by all kinds of Kafka Producer, and packed into pulsar entry and stored in bookkeeper without validation. If Kafka producer produced a broker message to KOP, the consumer will parse failed and may cause consumer failed.

### Changes
1. Add message validation in KOP `handleProduce` stage. If it validate failed, return error to Kafka Producer and request resend to ensure valid message stored in bookkeeper. 