### PR TITLE
fix issue #252 bundle unload bug

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -25,7 +25,7 @@ jobs:
       run: mvn clean install -DskipTests
 
     - name: tests module
-      run: mvn test -DfailIfNoTests=false '-Dtest=!KafkaIntegration*Test,!DistributedClusterTest' -pl tests
+      run: mvn test -DfailIfNoTests=false '-Dtest=!KafkaIntegration*Test' -pl tests
 
     - name: package surefire artifacts
       if: failure()

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -169,9 +169,8 @@ public class KafkaProtocolHandler implements ProtocolHandler {
                                 }
                                 groupCoordinator.handleGroupEmigration(name.getPartitionIndex());
                             }
-                            // remove cache when unload
-                            KafkaTopicManager.removeTopicManagerCache(name.toString());
-                            KopBrokerLookupManager.removeTopicManagerCache(name.toString());
+                            // deReference topic when unload
+                            KafkaTopicManager.deReference(name.toString());
                         }
                     } else {
                         log.error("Failed to get owned topic list for "

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -23,6 +23,7 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.socket.SocketChannel;
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupConfig;
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupCoordinator;
+import io.streamnative.pulsar.handlers.kop.coordinator.group.OffsetAcker;
 import io.streamnative.pulsar.handlers.kop.coordinator.group.OffsetConfig;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionConfig;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
@@ -117,7 +118,6 @@ public class KafkaProtocolHandler implements ProtocolHandler {
                                         name, service.pulsar().getBrokerServiceUrl());
                                 }
                                 groupCoordinator.handleGroupImmigration(name.getPartitionIndex());
-                                continue;
                             }
                             KafkaTopicManager.removeTopicManagerCache(name.toString());
                             KopBrokerLookupManager.removeTopicManagerCache(name.toString());
@@ -169,7 +169,6 @@ public class KafkaProtocolHandler implements ProtocolHandler {
                                         name, service.pulsar().getBrokerServiceUrl());
                                 }
                                 groupCoordinator.handleGroupEmigration(name.getPartitionIndex());
-                                continue;
                             }
                             // deReference topic when unload
                             KopBrokerLookupManager.removeTopicManagerCache(name.toString());
@@ -354,6 +353,7 @@ public class KafkaProtocolHandler implements ProtocolHandler {
         KafkaTopicManager.getConsumerTopicManagers().clear();
         KafkaTopicManager.getReferences().clear();
         KafkaTopicManager.getTopics().clear();
+        OffsetAcker.CONSUMERS.clear();
         statsProvider.stop();
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -170,6 +170,7 @@ public class KafkaProtocolHandler implements ProtocolHandler {
                                 groupCoordinator.handleGroupEmigration(name.getPartitionIndex());
                             }
                             // deReference topic when unload
+                            KopBrokerLookupManager.removeTopicManagerCache(name.toString());
                             KafkaTopicManager.deReference(name.toString());
                         }
                     } else {
@@ -348,6 +349,9 @@ public class KafkaProtocolHandler implements ProtocolHandler {
         }
         KafkaTopicManager.LOOKUP_CACHE.clear();
         KopBrokerLookupManager.clear();
+        KafkaTopicManager.getConsumerTopicManagers().clear();
+        KafkaTopicManager.getReferences().clear();
+        KafkaTopicManager.getTopics().clear();
         statsProvider.stop();
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -117,6 +117,7 @@ public class KafkaProtocolHandler implements ProtocolHandler {
                                         name, service.pulsar().getBrokerServiceUrl());
                                 }
                                 groupCoordinator.handleGroupImmigration(name.getPartitionIndex());
+                                continue;
                             }
                             KafkaTopicManager.removeTopicManagerCache(name.toString());
                             KopBrokerLookupManager.removeTopicManagerCache(name.toString());
@@ -168,6 +169,7 @@ public class KafkaProtocolHandler implements ProtocolHandler {
                                         name, service.pulsar().getBrokerServiceUrl());
                                 }
                                 groupCoordinator.handleGroupEmigration(name.getPartitionIndex());
+                                continue;
                             }
                             // deReference topic when unload
                             KopBrokerLookupManager.removeTopicManagerCache(name.toString());

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
@@ -59,9 +59,11 @@ public class KafkaTopicManager {
         consumerTopicManagers = new ConcurrentHashMap<>();
 
     // cache for topics: <topicName, persistentTopic>, for removing producer
+    @Getter
     private static final ConcurrentHashMap<String, CompletableFuture<PersistentTopic>>
         topics = new ConcurrentHashMap<>();
     // cache for references in PersistentTopic: <topicName, producer>
+    @Getter
     private static final ConcurrentHashMap<String, Producer>
         references = new ConcurrentHashMap<>();
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
@@ -375,6 +375,8 @@ public class KafkaTopicManager {
                 persistentTopic.removeProducer(producer);
             }
             topics.remove(topicName);
+
+            OffsetAcker.removeOffsetAcker(topicName);
         } catch (Exception e) {
             log.error("Failed to close reference for individual topic {}. exception:", topicName, e);
         }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
@@ -55,12 +55,15 @@ public class KafkaTopicManager {
 
     // consumerTopicManagers for consumers cache.
     @Getter
-    private final ConcurrentHashMap<String, CompletableFuture<KafkaTopicConsumerManager>> consumerTopicManagers;
+    private static final ConcurrentHashMap<String, CompletableFuture<KafkaTopicConsumerManager>>
+        consumerTopicManagers = new ConcurrentHashMap<>();
 
     // cache for topics: <topicName, persistentTopic>, for removing producer
-    private final ConcurrentHashMap<String, CompletableFuture<PersistentTopic>> topics;
+    private static final ConcurrentHashMap<String, CompletableFuture<PersistentTopic>>
+        topics = new ConcurrentHashMap<>();
     // cache for references in PersistentTopic: <topicName, producer>
-    private final ConcurrentHashMap<String, Producer> references;
+    private static final ConcurrentHashMap<String, Producer>
+        references = new ConcurrentHashMap<>();
 
     private InternalServerCnx internalServerCnx;
 
@@ -89,10 +92,6 @@ public class KafkaTopicManager {
         this.pulsarService = kafkaRequestHandler.getPulsarService();
         this.brokerService = pulsarService.getBrokerService();
         this.internalServerCnx = new InternalServerCnx(requestHandler);
-
-        consumerTopicManagers = new ConcurrentHashMap<>();
-        topics = new ConcurrentHashMap<>();
-        references = new ConcurrentHashMap<>();
 
         this.rwLock = new ReentrantReadWriteLock();
         this.closed = false;
@@ -357,7 +356,7 @@ public class KafkaTopicManager {
         return references.get(topicName);
     }
 
-    public void deReference(String topicName) {
+    public static void deReference(String topicName) {
         try {
             removeTopicManagerCache(topicName);
 
@@ -376,8 +375,7 @@ public class KafkaTopicManager {
             }
             topics.remove(topicName);
         } catch (Exception e) {
-            log.error("[{}] Failed to close reference for individual topic {}. exception:",
-                requestHandler.ctx.channel(), topicName, e);
+            log.error("Failed to close reference for individual topic {}. exception:", topicName, e);
         }
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
@@ -363,17 +363,16 @@ public class KafkaTopicManager {
             removeTopicManagerCache(topicName);
 
             if (consumerTopicManagers.containsKey(topicName)) {
-                CompletableFuture<KafkaTopicConsumerManager> manager = consumerTopicManagers.get(topicName);
-                manager.get().close();
-                consumerTopicManagers.remove(topicName);
+                consumerTopicManagers.remove(topicName).get().close();
             }
 
             if (!topics.containsKey(topicName)) {
                 return;
             }
             PersistentTopic persistentTopic = topics.get(topicName).get();
-            if (persistentTopic != null) {
-                persistentTopic.removeProducer(references.get(topicName));
+            Producer producer = references.get(topicName);
+            if (persistentTopic != null && producer != null) {
+                persistentTopic.removeProducer(producer);
             }
             topics.remove(topicName);
         } catch (Exception e) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -123,7 +123,7 @@ public final class MessageFetchContext {
                                 tcm = pair.getValue().get();
                                 if (tcm == null) {
                                     // remove null future cache from consumerTopicManagers
-                                    requestHandler.getTopicManager().getConsumerTopicManagers()
+                                    KafkaTopicManager.getConsumerTopicManagers()
                                             .remove(KopTopic.toString(pair.getKey()));
                                     throw new NullPointerException("topic not owned, and return null TCM in fetch.");
                                 }
@@ -239,7 +239,7 @@ public final class MessageFetchContext {
                                                 "cursor.readEntry fail. deleteCursor");
                                     } else {
                                         // remove null future cache from consumerTopicManagers
-                                        requestHandler.getTopicManager().getConsumerTopicManagers()
+                                        KafkaTopicManager.getConsumerTopicManagers()
                                                 .remove(KopTopic.toString(kafkaTopic));
                                         log.warn("Cursor deleted while TCM close.");
                                     }
@@ -329,8 +329,8 @@ public final class MessageFetchContext {
                                     cm.add(pair.getRight(), pair);
                                 } else {
                                     // remove null future cache from consumerTopicManagers
-                                    requestHandler.getTopicManager().getConsumerTopicManagers()
-                                            .remove(KopTopic.toString(kafkaPartition));
+                                    KafkaTopicManager.getConsumerTopicManagers()
+                                        .remove(KopTopic.toString(kafkaPartition));
                                     log.warn("Cursor deleted while TCM close, failed to add cursor back to TCM.");
                                 }
                             });

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/OffsetAcker.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/OffsetAcker.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 
+import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
@@ -45,7 +46,7 @@ import org.apache.pulsar.client.impl.PulsarClientImpl;
 @Slf4j
 public class OffsetAcker implements Closeable {
 
-    private static final Map<TopicPartition, CompletableFuture<Consumer<byte[]>>> EMPTY_CONSUMERS = new HashMap<>();
+    private static final Map<String, CompletableFuture<Consumer<byte[]>>> EMPTY_CONSUMERS = new HashMap<>();
 
     private final ConsumerBuilder<byte[]> consumerBuilder;
     private final BrokerService brokerService;
@@ -57,8 +58,8 @@ public class OffsetAcker implements Closeable {
     //     value is the created future of consumer.
     // The consumer, whose subscription is the group id, is used for acknowledging message id cumulatively.
     // This behavior is equivalent to committing offsets in Kafka.
-    private final Map<String, Map<TopicPartition, CompletableFuture<Consumer<byte[]>>>>
-            consumers = new ConcurrentHashMap<>();
+    public static final Map<String, Map<String, CompletableFuture<Consumer<byte[]>>>>
+            CONSUMERS = new ConcurrentHashMap<>();
 
     public OffsetAcker(PulsarClientImpl pulsarClient) {
         this.consumerBuilder = pulsarClient.newConsumer()
@@ -138,8 +139,8 @@ public class OffsetAcker implements Closeable {
 
     public void close(Set<String> groupIds) {
         for (String groupId : groupIds) {
-            final Map<TopicPartition, CompletableFuture<Consumer<byte[]>>>
-                    consumersToRemove = consumers.remove(groupId);
+            final Map<String, CompletableFuture<Consumer<byte[]>>>
+                    consumersToRemove = CONSUMERS.remove(groupId);
             if (consumersToRemove == null) {
                 continue;
             }
@@ -151,9 +152,7 @@ public class OffsetAcker implements Closeable {
                 }
                 final Consumer<byte[]> consumer = consumerFuture.getNow(null);
                 if (consumer != null) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Try to close consumer of [group={}] [topic={}]", groupId, topicPartition.toString());
-                    }
+                    log.debug("Try to close consumer of [group={}] [topic={}]", groupId, topicPartition);
                     consumer.closeAsync();
                 }
             });
@@ -162,35 +161,41 @@ public class OffsetAcker implements Closeable {
 
     @Override
     public void close() {
-        log.info("close OffsetAcker with {} groupIds", consumers.size());
-        close(consumers.keySet());
+        log.info("close OffsetAcker with {} groupIds", CONSUMERS.size());
+        close(CONSUMERS.keySet());
     }
 
     @NonNull
     public CompletableFuture<Consumer<byte[]>> getOrCreateConsumer(String groupId, TopicPartition topicPartition) {
-        Map<TopicPartition, CompletableFuture<Consumer<byte[]>>> group = consumers
+        Map<String, CompletableFuture<Consumer<byte[]>>> group = CONSUMERS
             .computeIfAbsent(groupId, gid -> new ConcurrentHashMap<>());
+        KopTopic kopTopic = new KopTopic(topicPartition.topic());
+        String topicName = kopTopic.getPartitionName((topicPartition.partition()));
         return group.computeIfAbsent(
-            topicPartition,
-            partition -> createConsumer(groupId, partition));
+            topicName,
+            name -> createConsumer(groupId, name));
     }
 
     @NonNull
-    private CompletableFuture<Consumer<byte[]>> createConsumer(String groupId, TopicPartition topicPartition) {
-        KopTopic kopTopic = new KopTopic(topicPartition.topic());
+    private CompletableFuture<Consumer<byte[]>> createConsumer(String groupId, String topicName) {
         return consumerBuilder.clone()
-                .topic(kopTopic.getPartitionName(topicPartition.partition()))
+                .topic(topicName)
                 .subscriptionName(groupId)
                 .subscribeAsync();
     }
 
     public CompletableFuture<Consumer<byte[]>> getConsumer(String groupId, TopicPartition topicPartition) {
-        return consumers.getOrDefault(groupId, EMPTY_CONSUMERS).get(topicPartition);
+        KopTopic kopTopic = new KopTopic(topicPartition.topic());
+        String topicName = kopTopic.getPartitionName((topicPartition.partition()));
+        return CONSUMERS.getOrDefault(groupId, EMPTY_CONSUMERS).get(topicName);
     }
 
     public void removeConsumer(String groupId, TopicPartition topicPartition) {
+        KopTopic kopTopic = new KopTopic(topicPartition.topic());
+        String topicName = kopTopic.getPartitionName((topicPartition.partition()));
+
         final CompletableFuture<Consumer<byte[]>> consumerFuture =
-                consumers.getOrDefault(groupId, EMPTY_CONSUMERS).remove(topicPartition);
+                CONSUMERS.getOrDefault(groupId, EMPTY_CONSUMERS).remove(topicName);
         if (consumerFuture != null) {
             consumerFuture.whenComplete((consumer, e) -> {
                 if (e == null) {
@@ -201,5 +206,19 @@ public class OffsetAcker implements Closeable {
                 }
             });
         }
+    }
+
+    public static void removeOffsetAcker(String topicName) {
+        CONSUMERS.forEach((groupId, group) -> {
+            CompletableFuture<Consumer<byte[]> > consumerCompletableFuture = group.remove(topicName);
+            if (consumerCompletableFuture != null) {
+                consumerCompletableFuture.thenApply(Consumer::closeAsync).whenCompleteAsync((ignore, t) -> {
+                    if (t != null) {
+                        log.error("Failed to close offsetAcker consumer when remove partition {}.",
+                            topicName);
+                    }
+                });
+            }
+        });
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/OffsetAcker.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/OffsetAcker.java
@@ -25,7 +25,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 
-import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
@@ -91,9 +91,6 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
         kConfig.setAllowAutoTopicCreation(true);
         kConfig.setAllowAutoTopicCreationType("partitioned");
         kConfig.setBrokerDeleteInactiveTopicsEnabled(false);
-        kConfig.setLoadBalancerEnabled(false);
-        kConfig.setLoadBalancerSheddingEnabled(false);
-        kConfig.setLoadBalancerAutoBundleSplitEnabled(false);
 
         // set protocol related config
         URL testHandlerUrl = this.getClass().getClassLoader().getResource("test-protocol-handler.nar");

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
@@ -92,6 +92,9 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
         kConfig.setAllowAutoTopicCreationType("partitioned");
         kConfig.setBrokerDeleteInactiveTopicsEnabled(false);
         kConfig.setLoadBalancerEnabled(false);
+        kConfig.setLoadBalancerSheddingEnabled(false);
+        kConfig.setLoadBalancerAutoBundleSplitEnabled(false);
+        kConfig.setMessagingProtocols(Sets.newHashSet("kafka"));
 
         // set protocol related config
         URL testHandlerUrl = this.getClass().getClassLoader().getResource("test-protocol-handler.nar");

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
@@ -31,7 +31,6 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import lombok.Cleanup;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -298,19 +297,14 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
         // 1. produce message with Kafka producer.
         int totalMsgs = 50;
         String messageStrPrefix = "Message_Kop_KafkaProduceKafkaConsume_" + partitionNumber + "_";
-        @Cleanup
         KProducer kProducer = new KProducer(kafkaTopicName, false, getKafkaBrokerPort(), true);
         kafkaPublishMessage(kProducer, totalMsgs, messageStrPrefix);
 
         // 2. create 4 kafka consumer from different consumer groups.
         //    consume data and commit offsets for 4 consumer group.
-        @Cleanup
         KConsumer kConsumer1 = new KConsumer(kafkaTopicName, getKafkaBrokerPort(), "consumer-group-1");
-        @Cleanup
         KConsumer kConsumer2 = new KConsumer(kafkaTopicName, getKafkaBrokerPort(), "consumer-group-2");
-        @Cleanup
         KConsumer kConsumer3 = new KConsumer(kafkaTopicName, getKafkaBrokerPort(), "consumer-group-3");
-        @Cleanup
         KConsumer kConsumer4 = new KConsumer(kafkaTopicName, getKafkaBrokerPort(), "consumer-group-4");
 
         List<TopicPartition> topicPartitions = IntStream.range(0, partitionNumber)
@@ -421,15 +415,12 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
         // 2. produce consume message with Kafka producer.
         int totalMsgs = 50;
         String messageStrPrefix = "Message_" + kafkaTopicName + "_";
-        @Cleanup
         KProducer kProducer = new KProducer(kafkaTopicName, false, getKafkaBrokerPort(), true);
         kafkaPublishMessage(kProducer, totalMsgs, messageStrPrefix);
 
         List<TopicPartition> topicPartitions = IntStream.range(0, partitionNumber)
             .mapToObj(i -> new TopicPartition(kafkaTopicName, i)).collect(Collectors.toList());
-        @Cleanup
         KConsumer kConsumer1 = new KConsumer(kafkaTopicName, getKafkaBrokerPort(), "consumer-group-1");
-        @Cleanup
         KConsumer kConsumer2 = new KConsumer(kafkaTopicName, getKafkaBrokerPort(), "consumer-group-2");
         log.info("Partition size: {}, will consume and commitOffset for 2 consumers",
             topicPartitions.size());
@@ -470,15 +461,12 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
         // 2. produce consume message with Kafka producer.
         int totalMsgs = 50;
         String messageStrPrefix = "Message_" + kafkaTopicName + "_";
-        @Cleanup
         KProducer kProducer = new KProducer(kafkaTopicName, false, getKafkaBrokerPort(), true);
         kafkaPublishMessage(kProducer, totalMsgs, messageStrPrefix);
 
         List<TopicPartition> topicPartitions = IntStream.range(0, partitionNumber)
             .mapToObj(i -> new TopicPartition(kafkaTopicName, i)).collect(Collectors.toList());
-        @Cleanup
         KConsumer kConsumer1 = new KConsumer(kafkaTopicName, getKafkaBrokerPort(), "consumer-group-1");
-        @Cleanup
         KConsumer kConsumer2 = new KConsumer(kafkaTopicName, getKafkaBrokerPort(), "consumer-group-2");
         log.info("Partition size: {}, will consume and commitOffset for 2 consumers",
             topicPartitions.size());

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
@@ -351,6 +351,7 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
         log.info("Unload offset namespace, this will trigger another reload. After reload verify offset.");
         pulsarService1.getAdminClient().namespaces().unload(offsetNs);
 
+        /*
         // verify offset be kept and no more records could read.
         ConsumerRecords<Integer, String> records = kConsumer1.getConsumer().poll(Duration.ofMillis(200));
         assertTrue(records.isEmpty());
@@ -360,6 +361,7 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
         assertTrue(records.isEmpty());
         records = kConsumer4.getConsumer().poll(Duration.ofMillis(200));
         assertTrue(records.isEmpty());
+        */
 
         // 5. another round publish and consume after ns unload.
         kafkaPublishMessage(kProducer, totalMsgs, messageStrPrefix);
@@ -382,6 +384,7 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
         log.info("Unload offset namespace, this will trigger another reload");
         pulsarService1.getAdminClient().namespaces().unload(offsetNs);
 
+        /*
         // verify offset be kept and no more records could read.
         records = kConsumer1.getConsumer().poll(Duration.ofMillis(200));
         assertTrue(records.isEmpty());
@@ -391,6 +394,7 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
         assertTrue(records.isEmpty());
         records = kConsumer4.getConsumer().poll(Duration.ofMillis(200));
         assertTrue(records.isEmpty());
+        */
 
         kProducer.close();
         kConsumer1.close();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
@@ -16,7 +16,6 @@ package io.streamnative.pulsar.handlers.kop;
 import static org.apache.kafka.common.internals.Topic.GROUP_METADATA_TOPIC_NAME;
 import static org.apache.pulsar.common.naming.TopicName.PARTITIONED_TOPIC_SUFFIX;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
@@ -194,7 +194,7 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
     }
 
 
-    @AfterMethod
+    @AfterMethod(timeOut = 30000)
     @Override
     public void cleanup() throws Exception {
         log.info("--- Shutting down ---");
@@ -388,6 +388,12 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
         assertTrue(records.isEmpty());
         records = kConsumer4.getConsumer().poll(Duration.ofMillis(200));
         assertTrue(records.isEmpty());
+
+        kProducer.close();
+        kConsumer1.close();
+        kConsumer2.close();
+        kConsumer3.close();
+        kConsumer4.close();
     }
 
     // Unit test for unload / reload user topic bundle, verify it works well.
@@ -436,6 +442,10 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
         kafkaPublishMessage(kProducer, totalMsgs, messageStrPrefix);
         kafkaConsumeCommitMessage(kConsumer1, totalMsgs, messageStrPrefix, topicPartitions);
         kafkaConsumeCommitMessage(kConsumer2, totalMsgs, messageStrPrefix, topicPartitions);
+
+        kProducer.close();
+        kConsumer1.close();
+        kConsumer2.close();
     }
 
     @Test(timeOut = 30000)
@@ -482,5 +492,9 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
         kafkaPublishMessage(kProducer, totalMsgs, messageStrPrefix);
         kafkaConsumeCommitMessage(kConsumer1, totalMsgs, messageStrPrefix, topicPartitions);
         kafkaConsumeCommitMessage(kConsumer2, totalMsgs, messageStrPrefix, topicPartitions);
+
+        kProducer.close();
+        kConsumer1.close();
+        kConsumer2.close();
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
@@ -94,7 +94,6 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
         kConfig.setLoadBalancerEnabled(false);
         kConfig.setLoadBalancerSheddingEnabled(false);
         kConfig.setLoadBalancerAutoBundleSplitEnabled(false);
-        kConfig.setMessagingProtocols(Sets.newHashSet("kafka"));
 
         // set protocol related config
         URL testHandlerUrl = this.getClass().getClassLoader().getResource("test-protocol-handler.nar");

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
@@ -91,6 +91,7 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
         kConfig.setAllowAutoTopicCreation(true);
         kConfig.setAllowAutoTopicCreationType("partitioned");
         kConfig.setBrokerDeleteInactiveTopicsEnabled(false);
+        kConfig.setLoadBalancerEnabled(false);
 
         // set protocol related config
         URL testHandlerUrl = this.getClass().getClassLoader().getResource("test-protocol-handler.nar");

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
@@ -15,6 +15,7 @@ package io.streamnative.pulsar.handlers.kop;
 
 import static org.apache.kafka.common.internals.Topic.GROUP_METADATA_TOPIC_NAME;
 import static org.apache.pulsar.common.naming.TopicName.PARTITIONED_TOPIC_SUFFIX;
+import static org.junit.Assert.assertTrue;
 import static org.testng.Assert.assertEquals;
 
 import com.google.common.collect.Lists;
@@ -350,7 +351,6 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
         log.info("Unload offset namespace, this will trigger another reload. After reload verify offset.");
         pulsarService1.getAdminClient().namespaces().unload(offsetNs);
 
-        /*
         // verify offset be kept and no more records could read.
         ConsumerRecords<Integer, String> records = kConsumer1.getConsumer().poll(Duration.ofMillis(200));
         assertTrue(records.isEmpty());
@@ -360,7 +360,6 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
         assertTrue(records.isEmpty());
         records = kConsumer4.getConsumer().poll(Duration.ofMillis(200));
         assertTrue(records.isEmpty());
-        */
 
         // 5. another round publish and consume after ns unload.
         kafkaPublishMessage(kProducer, totalMsgs, messageStrPrefix);
@@ -383,7 +382,6 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
         log.info("Unload offset namespace, this will trigger another reload");
         pulsarService1.getAdminClient().namespaces().unload(offsetNs);
 
-        /*
         // verify offset be kept and no more records could read.
         records = kConsumer1.getConsumer().poll(Duration.ofMillis(200));
         assertTrue(records.isEmpty());
@@ -393,7 +391,6 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
         assertTrue(records.isEmpty());
         records = kConsumer4.getConsumer().poll(Duration.ofMillis(200));
         assertTrue(records.isEmpty());
-        */
 
         kProducer.close();
         kConsumer1.close();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -463,11 +463,11 @@ public abstract class KopProtocolHandlerTestBase {
             props.put(ProducerConfig.CLIENT_ID_CONFIG, "DemoKafkaOnPulsarProducer");
             props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySer);
             props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSer);
-            props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 1000);
+            props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 30000);
 
             if (retry) {
                 props.put(ProducerConfig.RETRIES_CONFIG, 3);
-                props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1);
+                props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 3);
             }
 
             if (null != username && null != password) {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -338,6 +338,7 @@ public abstract class KopProtocolHandlerTestBase {
         doReturn(mockBookKeeperClientFactory).when(pulsar).newBookKeeperClientFactory();
         doReturn(new ZKMetadataStore(mockZooKeeper)).when(pulsar).createLocalMetadataStore();
         doReturn(new ZKMetadataStore(mockZooKeeper)).when(pulsar).createConfigurationMetadataStore();
+        doReturn(mockZooKeeper).when(pulsar).getZkClient();
 
         Supplier<NamespaceService> namespaceServiceSupplier = () -> spy(new NamespaceService(pulsar));
         doReturn(namespaceServiceSupplier).when(pulsar).getNamespaceServiceProvider();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -463,11 +463,11 @@ public abstract class KopProtocolHandlerTestBase {
             props.put(ProducerConfig.CLIENT_ID_CONFIG, "DemoKafkaOnPulsarProducer");
             props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySer);
             props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSer);
-            props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 30000);
+            props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 10000);
 
             if (retry) {
                 props.put(ProducerConfig.RETRIES_CONFIG, 3);
-                props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 3);
+                props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1);
             }
 
             if (null != username && null != password) {


### PR DESCRIPTION
Fix #252 

### Motivation
When bundle unload triggered, the `consumerTopicManagers` cache won't be evicted and it will return the old `KafkaTopicConsumerManager` instance in the next fetch request handle. However, after bundle unload, the producer/consumer/managedLedger of topics in related bundle will be closed. If we use old  `KafkaTopicConsumerManager` instance to read messages, it will return `managedLedger has been closed` exception.

### Changes
1. Change `consumerTopicManagers`, `topics`, `references` map to static attribute ConcurrentHashMap.
2. Evict related cache information for topics whose bundle trigged unload.
3. Turn on `DistributedClusterTest `.