### PR TITLE
Fix leak of login callback handler

### DIFF
--- a/oauth-client/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/OauthLoginCallbackHandler.java
+++ b/oauth-client/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/OauthLoginCallbackHandler.java
@@ -86,16 +86,15 @@ public class OauthLoginCallbackHandler implements AuthenticateCallbackHandler {
         }
     }
 
-    private void handleCallback(OAuthBearerTokenCallback callback) {
+    private void handleCallback(OAuthBearerTokenCallback callback) throws IOException {
         if (callback.token() != null) {
             throw new IllegalArgumentException("Callback had a token already");
         }
-        final Authentication authentication = AuthenticationFactoryOAuth2.clientCredentials(
+        try (Authentication authentication = AuthenticationFactoryOAuth2.clientCredentials(
                 clientConfig.getIssuerUrl(),
                 clientConfig.getCredentialsUrl(),
                 clientConfig.getAudience()
-        );
-        try {
+        )) {
             authentication.start();
             final AuthenticationDataProvider provider = authentication.getAuthData();
             final AuthData authData = provider.authenticate(AuthData.INIT_AUTH_DATA);


### PR DESCRIPTION
When Kafka client uses KoP's `OauthLoginCallbackHandler` as its `sasl.login.callback.handler.class` config, the client cannot exit normally even after client is closed. It's caused by unclosed `Authentication` instance.