### PR TITLE
[Transaction] Add initialize transaction metadata

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -17,6 +17,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.kafka.common.internals.Topic.GROUP_METADATA_TOPIC_NAME;
+import static org.apache.kafka.common.internals.Topic.TRANSACTION_STATE_TOPIC_NAME;
 import static org.apache.kafka.common.protocol.CommonFields.THROTTLE_TIME_MS;
 import static org.apache.kafka.common.requests.CreateTopicsRequest.TopicDetails;
 
@@ -353,7 +354,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         return admin.topics().getPartitionedTopicMetadataAsync(topicName);
     }
 
-    // Get all topics exclude `__consumer_offsets`, the result of `topicMapFuture` is a map:
+    // Get all topics exclude `__consumer_offsets` and `__transaction_state`, the result of `topicMapFuture` is a map:
     //   key: the full topic name without partition suffix, e.g. persistent://public/default/my-topic
     //   value: the partitions associated with the key, e.g. for a topic with 3 partitions,
     //     persistent://public/default/my-topic-partition-0
@@ -364,6 +365,11 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 kafkaConfig.getKafkaMetadataTenant(),
                 kafkaConfig.getKafkaMetadataNamespace(),
                 GROUP_METADATA_TOPIC_NAME)
+        ).getFullName();
+        final String txnTopicName = new KopTopic(String.join("/",
+                kafkaConfig.getKafkaMetadataTenant(),
+                kafkaConfig.getKafkaMetadataNamespace(),
+                TRANSACTION_STATE_TOPIC_NAME)
         ).getFullName();
         admin.tenants().getTenantsAsync().thenApply(tenants -> {
             if (tenants.isEmpty()) {
@@ -386,8 +392,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                     for (String topic : topics) {
                                         TopicName topicName = TopicName.get(topic);
                                         String key = topicName.getPartitionedTopicName();
-                                        // ignore the `__consumer_offsets` topic
-                                        if (key.equals(offsetsTopicName)) {
+                                        // ignore the `__consumer_offsets` and `__transaction_state` topic
+                                        if (key.equals(offsetsTopicName) || key.equals(txnTopicName)) {
                                             continue;
                                         }
                                         topicMap.computeIfAbsent(KopTopic.removeDefaultNamespacePrefix(key), ignored ->

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
@@ -56,7 +56,19 @@ public class MetadataUtils {
                 + "/" + Topic.TRANSACTION_STATE_TOPIC_NAME;
     }
 
-   /**
+    public static void createOffsetMetadataIfMissing(PulsarAdmin pulsarAdmin, KafkaServiceConfiguration conf)
+            throws PulsarServerException, PulsarAdminException {
+        KopTopic kopTopic = new KopTopic(constructOffsetsTopicBaseName(conf));
+        createKafkaMetadataIfMissing(pulsarAdmin, conf, kopTopic, conf.getOffsetsTopicNumPartitions());
+    }
+
+    public static void createTxnMetadataIfMissing(PulsarAdmin pulsarAdmin, KafkaServiceConfiguration conf)
+            throws PulsarServerException, PulsarAdminException {
+        KopTopic kopTopic = new KopTopic(constructTxnLogTopicBaseName(conf));
+        createKafkaMetadataIfMissing(pulsarAdmin, conf, kopTopic, conf.getTxnLogTopicNumPartitions());
+    }
+
+    /**
      * This method creates the Kafka metadata tenant and namespace if they are not currently present.
      * <ul>
      * <li>If the cluster does not exist this method will throw a PulsarServerException.NotFoundException</li>
@@ -70,13 +82,14 @@ public class MetadataUtils {
      * <li>If the offset topic exists but some partitions are missing, the missing partitions will be created</li>
      * </ul>
      */
-    public static void createKafkaMetadataIfMissing(PulsarAdmin pulsarAdmin, KafkaServiceConfiguration conf)
+    private static void createKafkaMetadataIfMissing(PulsarAdmin pulsarAdmin,
+                                                    KafkaServiceConfiguration conf,
+                                                    KopTopic kopTopic,
+                                                    int partitionNum)
         throws PulsarServerException, PulsarAdminException {
         String cluster = conf.getClusterName();
         String kafkaMetadataTenant = conf.getKafkaMetadataTenant();
         String kafkaMetadataNamespace = kafkaMetadataTenant + "/" + conf.getKafkaMetadataNamespace();
-
-        final KopTopic offsetsTopic = new KopTopic(constructOffsetsTopicBaseName(conf));
 
         boolean clusterExists, tenantExists, namespaceExists, offsetsTopicExists;
         clusterExists = tenantExists = namespaceExists = offsetsTopicExists = false;
@@ -114,7 +127,7 @@ public class MetadataUtils {
             if (!namespaces.getNamespaces(kafkaMetadataTenant).contains(kafkaMetadataNamespace)) {
                 log.info("Namespaces: {} does not exist in tenant: {}, creating it ...",
                     kafkaMetadataNamespace, kafkaMetadataTenant);
-                Set<String> replicationClusters = Sets.newHashSet(conf.getClusterName());
+                Set<String> replicationClusters = Sets.newHashSet(cluster);
                 namespaces.createNamespace(kafkaMetadataNamespace, replicationClusters);
                 namespaces.setNamespaceReplicationClusters(kafkaMetadataNamespace, replicationClusters);
                 namespaces.setRetention(kafkaMetadataNamespace,
@@ -134,35 +147,35 @@ public class MetadataUtils {
 
             // Check if the offsets topic exists and create it if not
             Topics topics = pulsarAdmin.topics();
-            PartitionedTopicMetadata offsetsTopicMetadata =
-                    topics.getPartitionedTopicMetadata(offsetsTopic.getFullName());
+            PartitionedTopicMetadata topicMetadata =
+                    topics.getPartitionedTopicMetadata(kopTopic.getFullName());
 
-            Set<String> offsetPartitionSet = new HashSet<String>(conf.getOffsetsTopicNumPartitions());
-            for (int i = 0; i < conf.getOffsetsTopicNumPartitions(); i++) {
-                offsetPartitionSet.add(offsetsTopic.getPartitionName(i));
+            Set<String> partitionSet = new HashSet<>(partitionNum);
+            for (int i = 0; i < partitionNum; i++) {
+                partitionSet.add(kopTopic.getPartitionName(i));
             }
 
-            if (offsetsTopicMetadata.partitions <= 0) {
-                log.info("Kafka group metadata topic {} doesn't exist. Creating it ...", offsetsTopic);
+            if (topicMetadata.partitions <= 0) {
+                log.info("Kafka group metadata topic {} doesn't exist. Creating it ...", kopTopic.getFullName());
 
                 topics.createPartitionedTopic(
-                        offsetsTopic.getFullName(),
-                        conf.getOffsetsTopicNumPartitions()
+                        kopTopic.getFullName(),
+                        partitionNum
                 );
 
-                log.info("Successfully created group metadata topic {} with {} partitions.",
-                        offsetsTopic, conf.getOffsetsTopicNumPartitions());
+                log.info("Successfully created kop metadata topic {} with {} partitions.",
+                        kopTopic.getFullName(), partitionNum);
             } else {
                 // Check to see if the partitions all exist
-                offsetPartitionSet.removeAll(
+                partitionSet.removeAll(
                         topics.getList(kafkaMetadataNamespace).stream()
-                                .filter((topic) -> topic.startsWith(offsetsTopic.getFullName()))
+                                .filter((topic) -> topic.startsWith(kopTopic.getFullName()))
                                 .collect(Collectors.toList())
                 );
 
-                if (!offsetPartitionSet.isEmpty()) {
-                    log.info("Identified missing offset topic partitions: {}", offsetPartitionSet);
-                    for (String offsetPartition : offsetPartitionSet) {
+                if (!partitionSet.isEmpty()) {
+                    log.info("Identified missing kop metadata topic {} partitions: {}", kopTopic, partitionSet);
+                    for (String offsetPartition : partitionSet) {
                         topics.createNonPartitionedTopic(offsetPartition);
                     }
                 }
@@ -181,7 +194,7 @@ public class MetadataUtils {
             log.info("Current state of kafka metadata, cluster: {} exists: {}, tenant: {} exists: {},"
                             + " namespace: {} exists: {}, topic: {} exists: {}",
                     cluster, clusterExists, kafkaMetadataTenant, tenantExists, kafkaMetadataNamespace, namespaceExists,
-                    offsetsTopic.getOriginalName(), offsetsTopicExists);
+                    kopTopic.getOriginalName(), offsetsTopicExists);
         }
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -170,6 +170,10 @@ public abstract class KopProtocolHandlerTestBase {
         // kafka related settings.
         kafkaConfig.setEnableGroupCoordinator(true);
         kafkaConfig.setOffsetsTopicNumPartitions(1);
+
+        kafkaConfig.setEnableTransactionCoordinator(true);
+        kafkaConfig.setTxnLogTopicNumPartitions(1);
+
         kafkaConfig.setKafkaListeners(
                 PLAINTEXT_PREFIX + "localhost:" + kafkaBrokerPort + ","
                         + SSL_PREFIX + "localhost:" + kafkaBrokerPortTls);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -235,7 +235,8 @@ public abstract class KopProtocolHandlerTestBase {
 
         createAdmin();
 
-        MetadataUtils.createKafkaMetadataIfMissing(admin, this.conf);
+        MetadataUtils.createOffsetMetadataIfMissing(admin, this.conf);
+        MetadataUtils.createTxnMetadataIfMissing(admin, this.conf);
 
         if (enableSchemaRegistry) {
             admin.topics().createPartitionedTopic(KAFKASTORE_TOPIC, 1);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/PulsarAuthEnabledTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/PulsarAuthEnabledTestBase.java
@@ -83,6 +83,7 @@ public abstract class PulsarAuthEnabledTestBase extends KopProtocolHandlerTestBa
         ((KafkaServiceConfiguration) conf).setKafkaMetadataTenant("internal");
         ((KafkaServiceConfiguration) conf).setKafkaMetadataNamespace("__kafka");
         ((KafkaServiceConfiguration) conf).setEnableGroupCoordinator(true);
+        ((KafkaServiceConfiguration) conf).setEnableTransactionCoordinator(true);
 
         conf.setClusterName(super.configClusterName);
         conf.setAuthorizationEnabled(true);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/ProducerIdManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/ProducerIdManagerTest.java
@@ -21,8 +21,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.zookeeper.data.Stat;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /**
@@ -43,7 +43,7 @@ public class ProducerIdManagerTest extends KopProtocolHandlerTestBase {
         super.internalCleanup();
     }
 
-    @AfterMethod
+    @BeforeMethod
     protected void cleanZNode() throws Exception {
         Stat stat = mockZooKeeper.exists(ProducerIdManager.KOP_PID_BLOCK_ZNODE, null);
         if (stat != null) {


### PR DESCRIPTION
# Motivation

Add initialize transaction metadata.

Transaction metadata initialization is the precondition of the transaction log. Transaction metadata base topic name `${KafkaMetadataTenant}/${KafkaMetadataNamespace}/__transaction_state`.

The metadata topic partition could be set by the configuration `txnLogTopicNumPartitions` of the KoP configuration.