### PR TITLE
[Transaction] Add transaction log key and transaction log value

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionLogKey.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionLogKey.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.coordinator.transaction;
+
+import io.netty.buffer.ByteBuf;
+import java.nio.ByteBuffer;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.apache.kafka.common.protocol.types.Field;
+import org.apache.kafka.common.protocol.types.Schema;
+import org.apache.kafka.common.protocol.types.Struct;
+import org.apache.kafka.common.protocol.types.Type;
+
+
+/**
+ * Transaction log key.
+ */
+@Data
+@AllArgsConstructor
+public class TransactionLogKey {
+
+    public static final short LOWEST_SUPPORTED_VERSION = 0;
+    public static final short HIGHEST_SUPPORTED_VERSION = 0;
+
+    private final String transactionId;
+
+    private static final String TXN_ID_FIELD = "transactional_id";
+
+    public static final Schema SCHEMA_0 =
+            new Schema(
+                    new Field(TXN_ID_FIELD, Type.STRING, "")
+            );
+
+    public static final Schema[] SCHEMAS = new Schema[] {
+            SCHEMA_0
+    };
+
+    public static Schema getSchema(short schemaVersion) {
+        return SCHEMAS[schemaVersion];
+    }
+
+    public byte[] toBytes() {
+        return toBytes(HIGHEST_SUPPORTED_VERSION);
+    }
+
+    public byte[] toBytes(short schemaVersion) {
+        Struct struct = new Struct(getSchema(schemaVersion));
+        struct.set(TXN_ID_FIELD, transactionId);
+
+        ByteBuffer byteBuffer = ByteBuffer.allocate(2 /* version */ + struct.sizeOf());
+        byteBuffer.putShort(schemaVersion);
+        struct.writeTo(byteBuffer);
+        return byteBuffer.array();
+    }
+
+    public static TransactionLogKey decode(ByteBuf byteBuf, short schemaVersion) {
+        Schema schema = getSchema(schemaVersion);
+        // skip version
+        byteBuf.readShort();
+        Struct struct = schema.read(byteBuf.nioBuffer());
+        return new TransactionLogKey(struct.getString(TXN_ID_FIELD));
+    }
+
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionLogKey.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionLogKey.java
@@ -42,7 +42,7 @@ public class TransactionLogKey {
                     new Field(TXN_ID_FIELD, Type.STRING, "")
             );
 
-    static final Schema[] SCHEMAS = new Schema[] {
+    private static final Schema[] SCHEMAS = new Schema[] {
             SCHEMA_0
     };
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionLogKey.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionLogKey.java
@@ -37,12 +37,12 @@ public class TransactionLogKey {
 
     private static final String TXN_ID_FIELD = "transactional_id";
 
-    public static final Schema SCHEMA_0 =
+    protected static final Schema SCHEMA_0 =
             new Schema(
                     new Field(TXN_ID_FIELD, Type.STRING, "")
             );
 
-    public static final Schema[] SCHEMAS = new Schema[] {
+    static final Schema[] SCHEMAS = new Schema[] {
             SCHEMA_0
     };
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionLogValue.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionLogValue.java
@@ -58,7 +58,7 @@ public class TransactionLogValue {
     private static final String TXN_LAST_UPDATE_TIMESTAMP_FIELD = "transaction_last_update_timestamp_ms";
     private static final String TXN_START_TIMESTAMP_FIELD = "transaction_start_timestamp_ms";
 
-    protected static final Schema SCHEMA_0 =
+    private static final Schema SCHEMA_0 =
             new Schema(
                     new Field(PRODUCER_ID_FIELD, Type.INT64, "Producer id in use by the transactional id"),
                     new Field(PRODUCER_EPOCH_FIELD, Type.INT16, "Epoch associated with the producer id"),
@@ -70,7 +70,7 @@ public class TransactionLogValue {
                     new Field(TXN_START_TIMESTAMP_FIELD, Type.INT64, "Time the transaction was started")
             );
 
-    static final Schema[] SCHEMAS = new Schema[] {
+    private static final Schema[] SCHEMAS = new Schema[] {
             SCHEMA_0
     };
 
@@ -181,28 +181,28 @@ public class TransactionLogValue {
     @AllArgsConstructor
     public static class PartitionsSchema {
 
+        public static final short LOWEST_SUPPORTED_VERSION = 0;
+        public static final short HIGHEST_SUPPORTED_VERSION = 0;
+
         private String topic;
         private List<Integer> partitionIds;
 
         private static final String TOPIC_FIELD = "topic";
         private static final String PARTITION_IDS_FIELD = "partition_ids";
 
-        protected static final Schema SCHEMA_0 =
+        private static final Schema SCHEMA_0 =
                 new Schema(
                         new Field(TOPIC_FIELD, Type.STRING, ""),
                         new Field(PARTITION_IDS_FIELD, new ArrayOf(Type.INT32), "")
                 );
 
-        static final Schema[] SCHEMAS = new Schema[] {
+        private static final Schema[] SCHEMAS = new Schema[] {
                 SCHEMA_0
         };
 
         public static Schema getSchema(short schemaVersion) {
             return SCHEMAS[schemaVersion];
         }
-
-        public static final short LOWEST_SUPPORTED_VERSION = 0;
-        public static final short HIGHEST_SUPPORTED_VERSION = 0;
 
         public Struct toStruct() {
             Struct struct = new Struct(getSchema(HIGHEST_SUPPORTED_VERSION));

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionLogValue.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionLogValue.java
@@ -1,0 +1,243 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.coordinator.transaction;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.protocol.types.ArrayOf;
+import org.apache.kafka.common.protocol.types.Field;
+import org.apache.kafka.common.protocol.types.Schema;
+import org.apache.kafka.common.protocol.types.Struct;
+import org.apache.kafka.common.protocol.types.Type;
+import org.apache.kafka.common.record.RecordBatch;
+
+
+/**
+ * Transaction log value.
+ */
+@Data
+@AllArgsConstructor
+public class TransactionLogValue {
+
+    public static final short LOWEST_SUPPORTED_VERSION = 0;
+    public static final short HIGHEST_SUPPORTED_VERSION = 0;
+
+    private final long producerId;
+    private final short producerEpoch;
+    private final int transactionTimeoutMs;
+    private final byte transactionStatus;
+    private final List<PartitionsSchema> transactionPartitions;
+    private final long transactionLastUpdateTimestampMs;
+    private final long transactionStartTimestampMs;
+
+    private static final String PRODUCER_ID_FIELD = "producer_id";
+    private static final String PRODUCER_EPOCH_FIELD = "producer_epoch";
+    private static final String TXN_TIMEOUT_MS_FIELD = "transaction_timeout_ms";
+    private static final String TXN_STATUS_FIELD = "transaction_status";
+    private static final String TXN_PARTITIONS_FIELD = "transaction_partitions";
+    private static final String TXN_LAST_UPDATE_TIMESTAMP_FIELD = "transaction_last_update_timestamp_ms";
+    private static final String TXN_START_TIMESTAMP_FIELD = "transaction_start_timestamp_ms";
+
+    public static final Schema SCHEMA_0 =
+            new Schema(
+                    new Field(PRODUCER_ID_FIELD, Type.INT64, "Producer id in use by the transactional id"),
+                    new Field(PRODUCER_EPOCH_FIELD, Type.INT16, "Epoch associated with the producer id"),
+                    new Field(TXN_TIMEOUT_MS_FIELD, Type.INT32, "Transaction timeout in milliseconds"),
+                    new Field(TXN_STATUS_FIELD, Type.INT8, "TransactionState the transaction is in"),
+                    new Field(TXN_PARTITIONS_FIELD, ArrayOf.nullable(PartitionsSchema.SCHEMA_0),
+                            "Set of partitions involved in the transaction"),
+                    new Field(TXN_LAST_UPDATE_TIMESTAMP_FIELD, Type.INT64, "Time the transaction was last updated"),
+                    new Field(TXN_START_TIMESTAMP_FIELD, Type.INT64, "Time the transaction was started")
+            );
+
+    public static final Schema[] SCHEMAS = new Schema[] {
+            SCHEMA_0
+    };
+
+    public TransactionLogValue(TransactionMetadata.TxnTransitMetadata txnTransitMetadata) {
+        if (txnTransitMetadata.getTxnState() == TransactionState.EMPTY
+                && !txnTransitMetadata.getTopicPartitions().isEmpty()) {
+            throw new IllegalStateException("Transaction is not expected to have any partitions since its state is "
+                    + txnTransitMetadata.getTxnState() + ":" + txnTransitMetadata.toString());
+        }
+
+        this.producerId = txnTransitMetadata.getProducerId();
+        this.producerEpoch = txnTransitMetadata.getProducerEpoch();
+        this.transactionTimeoutMs = txnTransitMetadata.getTxnTimeoutMs();
+        this.transactionStatus = txnTransitMetadata.getTxnState().getValue();
+        this.transactionPartitions = txnTransitMetadata.getTopicPartitions().stream()
+                .map(partition -> new PartitionsSchema(partition.topic(),
+                        Lists.newArrayList(partition.partition())))
+                .collect(Collectors.toList());
+        this.transactionLastUpdateTimestampMs = txnTransitMetadata.getTxnLastUpdateTimestamp();
+        this.transactionStartTimestampMs = txnTransitMetadata.getTxnStartTimestamp();
+    }
+
+    public static Schema getSchema(short schemaVersion) {
+        return SCHEMAS[schemaVersion];
+    }
+
+    public byte[] toBytes() {
+        return toBytes(HIGHEST_SUPPORTED_VERSION);
+    }
+
+    public byte[] toBytes(short schemaVersion) {
+        if (this.getTransactionStatus() == TransactionState.EMPTY.getValue() && !transactionPartitions.isEmpty()) {
+            throw new IllegalStateException("Transaction is not expected to have any partitions since its state is "
+                    + transactionStatus);
+        }
+
+        Struct struct = new Struct(getSchema(schemaVersion));
+        struct.set(PRODUCER_ID_FIELD, producerId);
+        struct.set(PRODUCER_EPOCH_FIELD, producerEpoch);
+        struct.set(TXN_TIMEOUT_MS_FIELD, transactionTimeoutMs);
+        struct.set(TXN_STATUS_FIELD, transactionStatus);
+        struct.set(TXN_PARTITIONS_FIELD,
+                transactionPartitions.stream().map(PartitionsSchema::toStruct).toArray());
+        struct.set(TXN_LAST_UPDATE_TIMESTAMP_FIELD, transactionLastUpdateTimestampMs);
+        struct.set(TXN_START_TIMESTAMP_FIELD, transactionStartTimestampMs);
+
+        ByteBuffer byteBuffer = ByteBuffer.allocate(2 /* version */ + struct.sizeOf());
+        byteBuffer.putShort(HIGHEST_SUPPORTED_VERSION);
+        struct.writeTo(byteBuffer);
+        return byteBuffer.array();
+    }
+
+    public static TransactionLogValue decode(ByteBuf byteBuf, short schemaVersion) {
+        Schema schema = getSchema(schemaVersion);
+        // skip version
+        byteBuf.readShort();
+        Struct struct = schema.read(byteBuf.nioBuffer());
+
+        List<PartitionsSchema> partitionsSchemas =
+                Arrays.stream(struct.getArray(TXN_PARTITIONS_FIELD))
+                        .map(obj -> PartitionsSchema.fromStruct((Struct) obj))
+                        .collect(Collectors.toList());
+
+        return new TransactionLogValue(
+                struct.getLong(PRODUCER_ID_FIELD),
+                struct.getShort(PRODUCER_EPOCH_FIELD),
+                struct.getInt(TXN_TIMEOUT_MS_FIELD),
+                struct.getByte(TXN_STATUS_FIELD),
+                partitionsSchemas,
+                struct.getLong(TXN_LAST_UPDATE_TIMESTAMP_FIELD),
+                struct.getLong(TXN_START_TIMESTAMP_FIELD)
+        );
+    }
+
+    public static TransactionMetadata readTxnRecordValue(String transactionalId, byte[] bytes) {
+        // tombstone
+        if (bytes == null) {
+            return null;
+        }
+        TransactionLogValue value = decode(Unpooled.wrappedBuffer(bytes), HIGHEST_SUPPORTED_VERSION);
+        TransactionMetadata metadata = TransactionMetadata.builder()
+                .transactionalId(transactionalId)
+                .producerId(value.getProducerId())
+                .lastProducerId(RecordBatch.NO_PRODUCER_ID)
+                .producerEpoch(value.getProducerEpoch())
+                .lastProducerEpoch(RecordBatch.NO_PRODUCER_EPOCH)
+                .txnTimeoutMs(value.getTransactionTimeoutMs())
+                .state(TransactionState.byteToState(value.getTransactionStatus()))
+                .topicPartitions(Sets.newHashSet())
+                .txnStartTimestamp(value.getTransactionStartTimestampMs())
+                .txnLastUpdateTimestamp(value.getTransactionLastUpdateTimestampMs())
+                .build();
+        if (!metadata.getState().equals(TransactionState.EMPTY)) {
+            value.getTransactionPartitions().forEach(partitionsSchema -> {
+                metadata.addPartitions(
+                        partitionsSchema.getPartitionIds().stream()
+                                .map(partition -> new TopicPartition(partitionsSchema.getTopic(), partition))
+                                .collect(Collectors.toSet()));
+            });
+        }
+        return metadata;
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class PartitionsSchema {
+
+        private String topic;
+        private List<Integer> partitionIds;
+
+        private static final String TOPIC_FIELD = "topic";
+        private static final String PARTITION_IDS_FIELD = "partition_ids";
+
+        public static final Schema SCHEMA_0 =
+                new Schema(
+                        new Field(TOPIC_FIELD, Type.STRING, ""),
+                        new Field(PARTITION_IDS_FIELD, new ArrayOf(Type.INT32), "")
+                );
+
+        public static final Schema[] SCHEMAS = new Schema[] {
+                SCHEMA_0
+        };
+
+        public static Schema getSchema(short schemaVersion) {
+            return SCHEMAS[schemaVersion];
+        }
+
+        public static final short LOWEST_SUPPORTED_VERSION = 0;
+        public static final short HIGHEST_SUPPORTED_VERSION = 0;
+
+        public Struct toStruct() {
+            Struct struct = new Struct(getSchema(HIGHEST_SUPPORTED_VERSION));
+            struct.set(TOPIC_FIELD, topic);
+            struct.set(PARTITION_IDS_FIELD, partitionIds.toArray());
+            return struct;
+        }
+
+        public static PartitionsSchema fromStruct(Struct struct) {
+            return new PartitionsSchema(
+                    struct.getString("topic"),
+                    Arrays.stream(struct.getArray("partition_ids"))
+                            .map(id -> (Integer) id)
+                            .collect(Collectors.toList())
+            );
+        }
+
+        public byte[] toBytes(short schemaVersion) {
+            Struct struct = new Struct(getSchema(schemaVersion));
+            struct.set(TOPIC_FIELD, topic);
+            struct.set(PARTITION_IDS_FIELD, partitionIds);
+
+            ByteBuffer byteBuffer = ByteBuffer.allocate(2 /* versoin */ + struct.sizeOf());
+            byteBuffer.putShort(schemaVersion);
+            struct.writeTo(byteBuffer);
+            return byteBuffer.array();
+        }
+
+        public static PartitionsSchema decode(ByteBuf byteBuf, short schemaVersion) {
+            Schema schema = getSchema(schemaVersion);
+            // skip version
+            byteBuf.readShort();
+            Struct struct = schema.read(byteBuf.nioBuffer());
+            Object[] partitionIdObjects = struct.getArray(PARTITION_IDS_FIELD);
+            return new PartitionsSchema(
+                    struct.getString(TOPIC_FIELD),
+                    Arrays.stream(partitionIdObjects).map(o -> (Integer) o).collect(Collectors.toList()));
+        }
+    }
+
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionLogValue.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionLogValue.java
@@ -58,7 +58,7 @@ public class TransactionLogValue {
     private static final String TXN_LAST_UPDATE_TIMESTAMP_FIELD = "transaction_last_update_timestamp_ms";
     private static final String TXN_START_TIMESTAMP_FIELD = "transaction_start_timestamp_ms";
 
-    public static final Schema SCHEMA_0 =
+    protected static final Schema SCHEMA_0 =
             new Schema(
                     new Field(PRODUCER_ID_FIELD, Type.INT64, "Producer id in use by the transactional id"),
                     new Field(PRODUCER_EPOCH_FIELD, Type.INT16, "Epoch associated with the producer id"),
@@ -70,7 +70,7 @@ public class TransactionLogValue {
                     new Field(TXN_START_TIMESTAMP_FIELD, Type.INT64, "Time the transaction was started")
             );
 
-    public static final Schema[] SCHEMAS = new Schema[] {
+    static final Schema[] SCHEMAS = new Schema[] {
             SCHEMA_0
     };
 
@@ -174,6 +174,9 @@ public class TransactionLogValue {
         return metadata;
     }
 
+    /**
+     * Partition schema.
+     */
     @Data
     @AllArgsConstructor
     public static class PartitionsSchema {
@@ -184,13 +187,13 @@ public class TransactionLogValue {
         private static final String TOPIC_FIELD = "topic";
         private static final String PARTITION_IDS_FIELD = "partition_ids";
 
-        public static final Schema SCHEMA_0 =
+        protected static final Schema SCHEMA_0 =
                 new Schema(
                         new Field(TOPIC_FIELD, Type.STRING, ""),
                         new Field(PARTITION_IDS_FIELD, new ArrayOf(Type.INT32), "")
                 );
 
-        public static final Schema[] SCHEMAS = new Schema[] {
+        static final Schema[] SCHEMAS = new Schema[] {
                 SCHEMA_0
         };
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMetadata.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMetadata.java
@@ -300,7 +300,8 @@ public class TransactionMetadata {
 
     // this is visible for test only
     public TxnTransitMetadata prepareNoTransit() {
-        // do not call transitTo as it will set the pending state, a follow-up call to abort the transaction will set its pending state
+        // do not call transitTo as it will set the pending state,
+        // a follow-up call to abort the transaction will set its pending state
         return new TxnTransitMetadata(producerId, lastProducerId, producerEpoch, lastProducerEpoch, txnTimeoutMs,
                 state, topicPartitions, txnStartTimestamp, txnLastUpdateTimestamp);
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMetadata.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMetadata.java
@@ -25,6 +25,7 @@ import java.util.function.Supplier;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.protocol.Errors;
@@ -173,6 +174,7 @@ public class TransactionMetadata {
     /**
      * Transaction transit metadata.
      */
+    @ToString
     @Builder
     @AllArgsConstructor
     @Data
@@ -294,6 +296,13 @@ public class TransactionMetadata {
         short transitEpoch = transitMetadata.producerEpoch;
         long transitProducerId = transitMetadata.producerId;
         return transitEpoch == producerEpoch + 1 || (transitEpoch == 0 && transitProducerId != producerId);
+    }
+
+    // this is visible for test only
+    public TxnTransitMetadata prepareNoTransit() {
+        // do not call transitTo as it will set the pending state, a follow-up call to abort the transaction will set its pending state
+        return new TxnTransitMetadata(producerId, lastProducerId, producerEpoch, lastProducerEpoch, txnTimeoutMs,
+                state, topicPartitions, txnStartTimestamp, txnLastUpdateTimestamp);
     }
 
     public TxnTransitMetadata prepareFenceProducerEpoch() {
@@ -468,5 +477,18 @@ public class TransactionMetadata {
         return producerEpoch >= Short.MAX_VALUE - 1;
     }
 
+    public void removePartition(TopicPartition topicPartition) {
+        if (state != TransactionState.PREPARE_COMMIT && state != TransactionState.PREPARE_ABORT) {
+            throw new IllegalStateException(
+                    String.format("Transaction metadata's current state is %s, and its pending state is %s while "
+                                + "trying to remove partitions whose txn marker has been sent, this is not expected",
+                                state, pendingState));
+        }
+        topicPartitions.remove(topicPartition);
+    }
+
+    public void addPartitions(Set<TopicPartition> partitions) {
+        topicPartitions.addAll(partitions);
+    }
 
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionState.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionState.java
@@ -23,7 +23,7 @@ public enum TransactionState {
      * transition: received AddPartitionsToTxnRequest => Ongoing
      *             received AddOffsetsToTxnRequest => Ongoing
      */
-    EMPTY,
+    EMPTY((byte) 0),
 
     /**
      * Transaction has started and ongoing.
@@ -32,40 +32,75 @@ public enum TransactionState {
      *             received AddPartitionsToTxnRequest => Ongoing
      *             received AddOffsetsToTxnRequest => Ongoing
      */
-    ONGOING,
+    ONGOING((byte) 1),
 
     /**
      * Group is preparing to commit.
      * transition: received acks from all partitions => CompleteCommit
      */
-    PREPARE_COMMIT,
+    PREPARE_COMMIT((byte) 2),
 
     /**
      * Group is preparing to abort.
      * transition: received acks from all partitions => CompleteAbort
      */
-    PREPARE_ABORT,
+    PREPARE_ABORT((byte) 3),
 
     /**
      * Group has completed commit.
      * Will soon be removed from the ongoing transaction cache
      */
-    COMPLETE_COMMIT,
+    COMPLETE_COMMIT((byte) 4),
 
     /**
      * Group has completed abort.
      * Will soon be removed from the ongoing transaction cache
      */
-    COMPLETE_ABORT,
+    COMPLETE_ABORT((byte) 5),
 
     /**
      * TransactionalId has expired and is about to be removed from the transaction cache.
      */
-    DEAD,
+    DEAD((byte) 6),
 
     /**
      * We are in the middle of bumping the epoch and fencing out older producers.
      */
-    PREPARE_EPOCH_FENCE;
+    PREPARE_EPOCH_FENCE((byte) 7);
+
+    private final byte value;
+
+    TransactionState(byte value) {
+        this.value = value;
+    }
+
+    public byte getValue() {
+        return value;
+    }
+
+    public static TransactionState byteToState(byte value) {
+        switch (value) {
+            case 0:
+                return EMPTY;
+            case 1:
+                return ONGOING;
+            case 2:
+                return PREPARE_COMMIT;
+            case 3:
+                return PREPARE_ABORT;
+            case 4:
+                return COMPLETE_COMMIT;
+            case 5:
+                return COMPLETE_ABORT;
+            case 6:
+                return DEAD;
+            case 7:
+                return PREPARE_EPOCH_FENCE;
+            default:
+                throw new IllegalStateException(
+                        "Unknown transaction state byte " + value + " from the transaction status message");
+        }
+    }
+
 
 }


### PR DESCRIPTION
# Motivation

Transaction log key and value are the preconditions of the transaction log.

The transaction log key will be encoded to bytes and set in message key bytes.
The transaction log value will be encoded to bytes and set in message value bytes.
