### PR TITLE
Close offset consumers when channel is inactive

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -195,6 +195,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     private final Map<TopicPartition, PendingProduceQueue> pendingProduceQueueMap = new ConcurrentHashMap<>();
     private final StatsLogger statsLogger;
     private final RequestStats requestStats;
+    private final Set<String> groupIds = new HashSet<>();
 
     public KafkaRequestHandler(PulsarService pulsarService,
                                KafkaServiceConfiguration kafkaConfig,
@@ -261,6 +262,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 log.info("currentConnectedGroup remove {}", clientHost);
                 currentConnectedGroup.remove(clientHost);
             }
+            groupCoordinator.getOffsetAcker().close(groupIds);
         }
     }
 
@@ -1179,6 +1181,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         checkArgument(syncGroup.getRequest() instanceof SyncGroupRequest);
         SyncGroupRequest request = (SyncGroupRequest) syncGroup.getRequest();
 
+        groupIds.add(request.groupId());
         groupCoordinator.handleSyncGroup(
             request.groupId(),
             request.generationId(),

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -255,6 +255,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         if (isActive.getAndSet(false)) {
             log.info("close channel {}", ctx.channel());
             writeAndFlushWhenInactiveChannel(ctx.channel());
+            groupCoordinator.getOffsetAcker().close(groupIds);
             ctx.close();
             topicManager.close();
             String clientHost = ctx.channel().remoteAddress().toString();
@@ -262,7 +263,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 log.info("currentConnectedGroup remove {}", clientHost);
                 currentConnectedGroup.remove(clientHost);
             }
-            groupCoordinator.getOffsetAcker().close(groupIds);
         }
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/OffsetAcker.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/OffsetAcker.java
@@ -129,7 +129,7 @@ public class OffsetAcker implements Closeable {
             if (!consumers.containsKey(groupId)) {
                 return;
             }
-            consumers.get(groupId).values().forEach(consumerFuture -> {
+            consumers.remove(groupId).values().forEach(consumerFuture -> {
                 consumerFuture.whenComplete((consumer, throwable) -> {
                     if (throwable != null) {
                         log.warn("Error when get consumer for consumer group close:", throwable);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/OffsetAcker.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/OffsetAcker.java
@@ -124,26 +124,22 @@ public class OffsetAcker implements Closeable {
     }
 
     public void close(Set<String> groupIds) {
-        groupIds.forEach(groupId -> {
-            // consumers cache is empty if the broker restart.
-            if (!consumers.containsKey(groupId)) {
-                return;
-            }
-            consumers.remove(groupId).values().forEach(consumerFuture -> {
-                consumerFuture.whenComplete((consumer, throwable) -> {
-                    if (throwable != null) {
-                        log.warn("Error when get consumer for consumer group close:", throwable);
-                        return;
+        for (String groupId : groupIds) {
+            consumers.remove(groupId).forEach((topicPartition, consumerFuture) -> {
+                if (!consumerFuture.isDone()) {
+                    log.warn("Consumer of [group={}] [topic={}] is not done while being closed",
+                            groupId, topicPartition);
+                    consumerFuture.complete(null);
+                }
+                final Consumer<byte[]> consumer = consumerFuture.getNow(null);
+                if (consumer != null) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Try to close consumer of [group={}] [topic={}]", groupId, topicPartition.toString());
                     }
-                    try {
-                        consumer.close();
-                    } catch (Exception e) {
-                        log.warn("Error when close consumer topic: {}, sub: {}.",
-                                consumer.getTopic(), consumer.getSubscription(), e);
-                    }
-                });
+                    consumer.closeAsync();
+                }
             });
-        });
+        }
     }
 
     @Override

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndTestBase.java
@@ -49,6 +49,8 @@ import org.testng.annotations.BeforeClass;
 @Slf4j
 public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
 
+    protected static final String GROUP_ID = "my-group";
+
     public BasicEndToEndTestBase(final String entryFormat) {
         super(entryFormat);
     }
@@ -78,10 +80,14 @@ public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
     }
 
     protected KafkaConsumer<String, String> newKafkaConsumer(final String topic) {
+        return newKafkaConsumer(topic, null);
+    }
+
+    protected KafkaConsumer<String, String> newKafkaConsumer(final String topic, final String group) {
         final Properties props =  new Properties();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        props.put(ConsumerConfig.GROUP_ID_CONFIG, "my-group");
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, (group == null) ? GROUP_ID : group);
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaIntegrationTest.java
@@ -77,15 +77,7 @@ import org.testng.annotations.Test;
 public class KafkaIntegrationTest extends KopProtocolHandlerTestBase {
 
     public KafkaIntegrationTest(final String entryFormat) {
-        super(entryFormat);
-    }
-
-    @Factory
-    public static Object[] instances() {
-        return new Object[] {
-                new KafkaIntegrationTest("pulsar"),
-                new KafkaIntegrationTest("kafka")
-        };
+        super("kafka");
     }
 
     @DataProvider
@@ -166,8 +158,8 @@ public class KafkaIntegrationTest extends KopProtocolHandlerTestBase {
         ((KafkaServiceConfiguration) conf).setListeners(
                 PLAINTEXT_PREFIX + ip + ":" + kafkaBrokerPort + ","
                         + SSL_PREFIX + ip + ":" + kafkaBrokerPortTls);
-        conf.setKafkaAdvertisedListeners(PLAINTEXT_PREFIX + "127.0.0.1:" + kafkaBrokerPort
-                + "," + SSL_PREFIX + "127.0.0.1:" + kafkaBrokerPortTls);
+        conf.setKafkaAdvertisedListeners(PLAINTEXT_PREFIX + ip + ":" + kafkaBrokerPort
+                + "," + SSL_PREFIX + ip + ":" + kafkaBrokerPortTls);
         super.internalSetup();
 
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaIntegrationTest.java
@@ -157,8 +157,8 @@ public class KafkaIntegrationTest extends KopProtocolHandlerTestBase {
         ((KafkaServiceConfiguration) conf).setListeners(
                 PLAINTEXT_PREFIX + ip + ":" + kafkaBrokerPort + ","
                         + SSL_PREFIX + ip + ":" + kafkaBrokerPortTls);
-        conf.setKafkaAdvertisedListeners(PLAINTEXT_PREFIX + ip + ":" + kafkaBrokerPort
-                + "," + SSL_PREFIX + ip + ":" + kafkaBrokerPortTls);
+        conf.setKafkaAdvertisedListeners(PLAINTEXT_PREFIX + "127.0.0.1:" + kafkaBrokerPort
+                + "," + SSL_PREFIX + "127.0.0.1:" + kafkaBrokerPortTls);
         super.internalSetup();
 
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaIntegrationTest.java
@@ -49,7 +49,6 @@ import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
-import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 
 /**

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaMessageOrderKafkaTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaMessageOrderKafkaTest.java
@@ -1,0 +1,24 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+/**
+ * Unit test for Different kafka produce messages with `entryFormat=kafka`.
+ */
+public class KafkaMessageOrderKafkaTest extends KafkaMessageOrderTestBase {
+
+    public KafkaMessageOrderKafkaTest() {
+        super("kafka");
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaMessageOrderPulsarTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaMessageOrderPulsarTest.java
@@ -1,0 +1,24 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+/**
+ * Unit test for Different kafka produce messages with `entryFormat=pulsar`.
+ */
+public class KafkaMessageOrderPulsarTest extends KafkaMessageOrderTestBase {
+
+    public KafkaMessageOrderPulsarTest() {
+        super("pulsar");
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaMessageOrderTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaMessageOrderTestBase.java
@@ -46,25 +46,16 @@ import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
-import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
 
 /**
  * Unit test for Different kafka produce messages.
  */
 @Slf4j
-public class KafkaMessageOrderTest extends KopProtocolHandlerTestBase {
+public abstract class KafkaMessageOrderTestBase extends KopProtocolHandlerTestBase {
 
-    public KafkaMessageOrderTest(final String entryFormat) {
+    public KafkaMessageOrderTestBase(final String entryFormat) {
         super(entryFormat);
-    }
-
-    @Factory
-    public static Object[] instances() {
-        return new Object[] {
-                new KafkaMessageOrderTest("pulsar"),
-                new KafkaMessageOrderTest("kafka")
-        };
     }
 
     @DataProvider(name = "batchSizeList")


### PR DESCRIPTION
Fixes https://github.com/streamnative/kop/issues/229

### Motivation
The consumers of `OffsetAcker` are used to commit offsets only. However, they would never be closed. Therefore the topics that are consumed by Kafka clients cannot be deleted because topic has active producers/subscriptions.

### Modifications
- Record all group IDs before group coordinator handles `SYNC_GROUP` request, which will call `OffsetAcker#addOffsetsTracker` to add offset consumers if success.
- Close and remove the consumers associated with the recorded group IDs before during the close phase of channel. It's okay because `OffsetAcker#getConsumer` (called by `ackOffsets`) will recreate the consumer if it doesn't exist.
- Add tests to delete a topic after all Kafka clients are closed.