### PR TITLE
Fix flaky testDeleteClosedTopics

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinator.java
@@ -810,12 +810,6 @@ public class GroupCoordinator {
                     });
             });
 
-        result.whenCompleteAsync((ignore, e) ->{
-            if (e == null){
-                offsetAcker.ackOffsets(groupId, offsetMetadata);
-            }
-        });
-
         return result;
     }
 
@@ -850,6 +844,7 @@ public class GroupCoordinator {
                 // The group is only using Kafka to store offsets.
                 // Also, for transactional offset commits we don't need to validate group membership
                 // and the generation.
+                offsetAcker.ackOffsets(group.groupId(), offsetMetadata);
                 return groupManager.storeOffsets(group, memberId, offsetMetadata, producerId, producerEpoch);
             } else if (group.is(CompletingRebalance)) {
                 return CompletableFuture.completedFuture(
@@ -866,6 +861,7 @@ public class GroupCoordinator {
             } else {
                 MemberMetadata member = group.get(memberId);
                 completeAndScheduleNextHeartbeatExpiration(group, member);
+                offsetAcker.ackOffsets(group.groupId(), offsetMetadata);
                 return groupManager.storeOffsets(
                     group, memberId, offsetMetadata
                 );

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
@@ -15,11 +15,13 @@ package io.streamnative.pulsar.handlers.kop;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -28,6 +30,7 @@ import org.testng.annotations.Test;
 /**
  * Basic end-to-end test with `entryFormat=kafka`.
  */
+@Slf4j
 public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
 
     public BasicEndToEndKafkaTest() {
@@ -61,7 +64,9 @@ public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
 
         try {
             admin.topics().deletePartitionedTopic(topic);
+            fail();
         } catch (PulsarAdminException e) {
+            log.info("Failed to delete partitioned topic \"{}\": {}", topic, e.getMessage());
             assertTrue(e.getMessage().contains("Topic has active producers/subscriptions"));
         }
 
@@ -69,7 +74,9 @@ public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
         assertEquals(receiveMessages(kafkaConsumer1, expectedMessages.size()), expectedMessages);
         try {
             admin.topics().deletePartitionedTopic(topic);
+            fail();
         } catch (PulsarAdminException e) {
+            log.info("Failed to delete partitioned topic \"{}\": {}", topic, e.getMessage());
             assertTrue(e.getMessage().contains("Topic has active producers/subscriptions"));
         }
 
@@ -80,7 +87,9 @@ public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
         kafkaConsumer1.close();
         try {
             admin.topics().deletePartitionedTopic(topic);
+            fail();
         } catch (PulsarAdminException e) {
+            log.info("Failed to delete partitioned topic \"{}\": {}", topic, e.getMessage());
             assertTrue(e.getMessage().contains("Topic has active producers/subscriptions"));
         }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
@@ -67,7 +67,8 @@ public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
             fail();
         } catch (PulsarAdminException e) {
             log.info("Failed to delete partitioned topic \"{}\": {}", topic, e.getMessage());
-            assertTrue(e.getMessage().contains("Topic has active producers/subscriptions"));
+            assertTrue(e.getMessage().contains("Topic has active producers/subscriptions")
+                    || e.getMessage().contains("Partitioned topic does not exist"));
         }
 
         final KafkaConsumer<String, String> kafkaConsumer1 = newKafkaConsumer(topic, "sub-1");
@@ -77,7 +78,8 @@ public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
             fail();
         } catch (PulsarAdminException e) {
             log.info("Failed to delete partitioned topic \"{}\": {}", topic, e.getMessage());
-            assertTrue(e.getMessage().contains("Topic has active producers/subscriptions"));
+            assertTrue(e.getMessage().contains("Topic has active producers/subscriptions")
+                    || e.getMessage().contains("Partitioned topic does not exist"));
         }
 
         final KafkaConsumer<String, String> kafkaConsumer2 = newKafkaConsumer(topic, "sub-2");
@@ -90,7 +92,8 @@ public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
             fail();
         } catch (PulsarAdminException e) {
             log.info("Failed to delete partitioned topic \"{}\": {}", topic, e.getMessage());
-            assertTrue(e.getMessage().contains("Topic has active producers/subscriptions"));
+            assertTrue(e.getMessage().contains("Topic has active producers/subscriptions")
+                    || e.getMessage().contains("Partitioned topic does not exist"));
         }
 
         kafkaConsumer2.close();


### PR DESCRIPTION
### Motivation
`testDeleteClosedTopics` is very easy to fail in CI environment because there's a race condition. https://github.com/streamnative/kop/pull/425 closes a group's offset consumers when the channel becomes inactive. However, before Kafka consumer closes, it sends a `COMMIT_OFFSET` request to commit offsets, which is the behavior of the default `enable.auto.commit=true` config. Currently, KoP acknowledges the offset's associated message id in the callback of `GroupMetadataManager#storeGroup`, see `GroupCoordinator#handleCommitOffsets`:

```java
        result.whenCompleteAsync((ignore, e) ->{
            if (e == null){
                offsetAcker.ackOffsets(groupId, offsetMetadata);
            }
        });
```

So it's asynchronous with `handleCommitOffsets` itself. There's a possibility that after the channel was closed and `OffsetAcker`'s consumer was removed and closed, `OffsetAcker#ackOffsets` would be invoked again, and `getConsumer` would be invoked so that a new offset consumer would be created to the topic.

Here're some related logs in CI tests as the evidence.

> 15:49:07.884 [pulsar-client-io-40-1:org.apache.pulsar.client.impl.ConsumerImpl@698] INFO  org.apache.pulsar.client.impl.ConsumerImpl - [persistent://public/default/test-delete-closed-topics-partition-0][sub-2] Subscribing to topic on cnx [id: 0xb7       fd0eb7, L:/127.0.0.1:50468 - R:localhost/127.0.0.1:15002], consumerId 2
> 15:49:07.980 [TestNG-method=testDeleteClosedTopics-1:org.apache.kafka.clients.consumer.KafkaConsumer@2152] DEBUG org.apache.kafka.clients.consumer.KafkaConsumer - [Consumer clientId=consumer-2, groupId=sub-2] Kafka consumer has been closed
> 15:49:07.986 [pulsar-client-io-40-1:org.apache.pulsar.client.impl.ConsumerImpl@698] INFO  org.apache.pulsar.client.impl.ConsumerImpl - [persistent://public/default/test-delete-closed-topics-partition-0][sub-2] Subscribing to topic on cnx [id: 0xb7fd0eb7, L:/127.0.0.1:50468 - R:localhost/127.0.0.1:15002], consumerId 3
>  ...
>  org.apache.pulsar.broker.service.BrokerServiceException$TopicBusyException: Topic has 1 connected producers/consumers

We can see after the Kafka consumer was closed, a new offset consumer was created again.

### Modifications
`ackOffsets` does the acknowledgement asynchronously but may triggers the creation of an offset consumer, so this PR makes `OffsetAcker#ackOffsets` be called before `GroupMetadataManager#storeGroup` and it prevents an offset consumer being created after channel is inactive.

Besides, it adds some condition checks to the test. In CI environment, sometimes topics cannot be deleted by 404 (`Partitioned topic does not exist`).