### PR TITLE
Fix AdminManager memory leak

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
@@ -55,7 +55,7 @@ class AdminManager {
         this.admin = admin;
     }
 
-    void shutdown() {
+    public void shutdown() {
         topicPurgatory.shutdown();
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
@@ -55,6 +55,10 @@ class AdminManager {
         this.admin = admin;
     }
 
+    void shutdown() {
+        topicPurgatory.shutdown();
+    }
+
     CompletableFuture<Map<String, ApiError>> createTopicsAsync(Map<String, TopicDetails> createInfo, int timeoutMs) {
         final Map<String, CompletableFuture<ApiError>> futureMap = new ConcurrentHashMap<>();
         final AtomicInteger numTopics = new AtomicInteger(createInfo.size());

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
@@ -43,6 +43,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
     private final GroupCoordinator groupCoordinator;
     @Getter
     private final TransactionCoordinator transactionCoordinator;
+    private final AdminManager adminManager;
     @Getter
     private final boolean enableTls;
     @Getter
@@ -56,6 +57,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
                                    KafkaServiceConfiguration kafkaConfig,
                                    GroupCoordinator groupCoordinator,
                                    TransactionCoordinator transactionCoordinator,
+                                   AdminManager adminManager,
                                    boolean enableTLS,
                                    EndPoint advertisedEndPoint,
                                    StatsLogger statsLogger) {
@@ -64,6 +66,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
         this.kafkaConfig = kafkaConfig;
         this.groupCoordinator = groupCoordinator;
         this.transactionCoordinator = transactionCoordinator;
+        this.adminManager = adminManager;
         this.enableTls = enableTLS;
         this.advertisedEndPoint = advertisedEndPoint;
         this.statsLogger = statsLogger;
@@ -85,7 +88,8 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
             new LengthFieldBasedFrameDecoder(MAX_FRAME_LENGTH, 0, 4, 0, 4));
         ch.pipeline().addLast("handler",
             new KafkaRequestHandler(pulsarService, kafkaConfig,
-                    groupCoordinator, transactionCoordinator, enableTls, advertisedEndPoint, statsLogger));
+                    groupCoordinator, transactionCoordinator, adminManager,
+                    enableTls, advertisedEndPoint, statsLogger));
     }
 
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -74,6 +74,7 @@ public class KafkaProtocolHandler implements ProtocolHandler {
     private StatsLogger rootStatsLogger;
     private PrometheusMetricsProvider statsProvider;
     private KopBrokerLookupManager kopBrokerLookupManager;
+    private AdminManager adminManager = null;
 
     /**
      * Listener for the changing of topic that stores offsets of consumer group.
@@ -258,6 +259,13 @@ public class KafkaProtocolHandler implements ProtocolHandler {
             KopVersion.getBuildHost(),
             KopVersion.getBuildTime());
 
+        try {
+            adminManager = new AdminManager(brokerService.getPulsar().getAdminClient());
+        } catch (PulsarServerException e) {
+            log.error("Failed to create PulsarAdmin: {}", e.getMessage());
+            throw new RuntimeException(e);
+        }
+
         // init and start group coordinator
         if (kafkaConfig.isEnableGroupCoordinator()) {
             try {
@@ -313,13 +321,13 @@ public class KafkaProtocolHandler implements ProtocolHandler {
                     case PLAINTEXT:
                     case SASL_PLAINTEXT:
                         builder.put(endPoint.getInetAddress(), new KafkaChannelInitializer(brokerService.getPulsar(),
-                                kafkaConfig, groupCoordinator, transactionCoordinator, false,
+                                kafkaConfig, groupCoordinator, transactionCoordinator, adminManager, false,
                             advertisedEndPoint, rootStatsLogger.scope(SERVER_SCOPE)));
                         break;
                     case SSL:
                     case SASL_SSL:
                         builder.put(endPoint.getInetAddress(), new KafkaChannelInitializer(brokerService.getPulsar(),
-                                kafkaConfig, groupCoordinator, transactionCoordinator, true,
+                                kafkaConfig, groupCoordinator, transactionCoordinator, adminManager, true,
                             advertisedEndPoint, rootStatsLogger.scope(SERVER_SCOPE)));
                         break;
                 }
@@ -334,6 +342,7 @@ public class KafkaProtocolHandler implements ProtocolHandler {
 
     @Override
     public void close() {
+        adminManager.shutdown();
         if (groupCoordinator != null) {
             groupCoordinator.shutdown();
         }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -263,7 +263,7 @@ public class KafkaProtocolHandler implements ProtocolHandler {
             adminManager = new AdminManager(brokerService.getPulsar().getAdminClient());
         } catch (PulsarServerException e) {
             log.error("Failed to create PulsarAdmin: {}", e.getMessage());
-            throw new RuntimeException(e);
+            throw new IllegalStateException(e);
         }
 
         // init and start group coordinator

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -202,6 +202,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                KafkaServiceConfiguration kafkaConfig,
                                GroupCoordinator groupCoordinator,
                                TransactionCoordinator transactionCoordinator,
+                               AdminManager adminManager,
                                Boolean tlsEnabled,
                                EndPoint advertisedEndPoint,
                                StatsLogger statsLogger) throws Exception {
@@ -218,7 +219,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         this.authenticator = authenticationEnabled
                 ? new SaslAuthenticator(pulsarService, kafkaConfig.getSaslAllowedMechanisms(), kafkaConfig)
                 : null;
-        this.adminManager = new AdminManager(admin);
+        this.adminManager = adminManager;
         this.tlsEnabled = tlsEnabled;
         this.advertisedEndPoint = advertisedEndPoint;
         this.advertisedListeners = kafkaConfig.getKafkaAdvertisedListeners();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/EntryPublishTimeTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/EntryPublishTimeTest.java
@@ -41,7 +41,7 @@ public class EntryPublishTimeTest extends KopProtocolHandlerTestBase {
 
     KafkaRequestHandler kafkaRequestHandler;
     SocketAddress serviceAddress;
-    AdminManager adminManager;
+    private AdminManager adminManager;
 
     public EntryPublishTimeTest(String format) {
         super(format);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/EntryPublishTimeTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/EntryPublishTimeTest.java
@@ -41,6 +41,7 @@ public class EntryPublishTimeTest extends KopProtocolHandlerTestBase {
 
     KafkaRequestHandler kafkaRequestHandler;
     SocketAddress serviceAddress;
+    AdminManager adminManager;
 
     public EntryPublishTimeTest(String format) {
         super(format);
@@ -85,11 +86,13 @@ public class EntryPublishTimeTest extends KopProtocolHandlerTestBase {
         GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler).getGroupCoordinator();
         TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler).getTransactionCoordinator();
 
+        adminManager = new AdminManager(pulsar.getAdminClient());
         kafkaRequestHandler = new KafkaRequestHandler(
                 pulsar,
                 (KafkaServiceConfiguration) conf,
                 groupCoordinator,
                 transactionCoordinator,
+                adminManager,
                 false,
                 getPlainEndPoint(),
                 NullStatsLogger.INSTANCE);
@@ -104,6 +107,7 @@ public class EntryPublishTimeTest extends KopProtocolHandlerTestBase {
     @AfterMethod
     @Override
     protected void cleanup() throws Exception {
+        adminManager.shutdown();
         super.internalCleanup();
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
@@ -87,6 +87,7 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
 
     KafkaRequestHandler kafkaRequestHandler;
     SocketAddress serviceAddress;
+    AdminManager adminManager;
 
     @Override
     protected void resetConfig() {
@@ -136,11 +137,13 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
         GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler).getGroupCoordinator();
         TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler).getTransactionCoordinator();
 
+        adminManager = new AdminManager(pulsar.getAdminClient());
         kafkaRequestHandler = new KafkaRequestHandler(
             pulsar,
             (KafkaServiceConfiguration) conf,
             groupCoordinator,
             transactionCoordinator,
+            adminManager,
             false,
             getPlainEndPoint(),
             NullStatsLogger.INSTANCE);
@@ -155,6 +158,7 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
     @AfterMethod
     @Override
     protected void cleanup() throws Exception {
+        adminManager.shutdown();
         super.internalCleanup();
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
@@ -87,7 +87,7 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
 
     KafkaRequestHandler kafkaRequestHandler;
     SocketAddress serviceAddress;
-    AdminManager adminManager;
+    private AdminManager adminManager;
 
     @Override
     protected void resetConfig() {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -95,6 +95,7 @@ import org.testng.annotations.Test;
 public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
 
     private KafkaRequestHandler handler;
+    private AdminManager adminManager;
 
     @BeforeMethod
     @Override
@@ -141,11 +142,13 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
         GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler1).getGroupCoordinator();
         TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler1).getTransactionCoordinator();
 
+        adminManager = new AdminManager(pulsar.getAdminClient());
         handler = new KafkaRequestHandler(
             pulsar,
             (KafkaServiceConfiguration) conf,
             groupCoordinator,
             transactionCoordinator,
+            adminManager,
             false,
             getPlainEndPoint(),
             NullStatsLogger.INSTANCE);
@@ -154,6 +157,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
     @AfterMethod
     @Override
     protected void cleanup() throws Exception {
+        adminManager.shutdown();
         super.internalCleanup();
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
@@ -54,6 +54,7 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
     private KafkaTopicManager kafkaTopicManager;
     private KafkaRequestHandler kafkaRequestHandler;
     private SocketAddress serviceAddress;
+    private AdminManager adminManager;
 
     @BeforeMethod
     @Override
@@ -64,11 +65,13 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
         GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler).getGroupCoordinator();
         TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler).getTransactionCoordinator();
 
+        adminManager = new AdminManager(pulsar.getAdminClient());
         kafkaRequestHandler = new KafkaRequestHandler(
             pulsar,
             (KafkaServiceConfiguration) conf,
             groupCoordinator,
             transactionCoordinator,
+            adminManager,
             false,
             getPlainEndPoint(),
             NullStatsLogger.INSTANCE);
@@ -86,6 +89,7 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
     @AfterMethod
     @Override
     protected void cleanup() throws Exception {
+        adminManager.shutdown();
         super.internalCleanup();
     }
 


### PR DESCRIPTION
Fixes #322 

The `DelayedOperationPurgatory` field of `AdminManager` will never be closed, so the `ShutdownableThread` would be started each time a request handler is created and won't be stopped.