### PR TITLE
[WIP] use direct memory instead of heap for kafka entry formatter decode 

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaEntryFormatter.java
@@ -64,7 +64,7 @@ public class KafkaEntryFormatter implements EntryFormatter {
         // Concatenate multiple batch into one single MemoryRecords object
         // In this mode, batch and entry have a one-to-one correspondence
         int totalSize = orderedRecord.stream().mapToInt(MemoryRecords::sizeInBytes).sum();
-        ByteBuffer batchedBuffer = ByteBuffer.allocate(totalSize);
+        ByteBuffer batchedBuffer = ByteBuffer.allocateDirect(totalSize);
         for (MemoryRecords records : orderedRecord) {
             batchedBuffer.put(records.buffer());
         }


### PR DESCRIPTION
### Motivation
In KafkaEntryFormatter#decode, it will allocate a new ByteBuffer to store all entries' payload. However, the current implementation is use heap memory, which will lead to frequent GC.

### Changes
1. use direct memory instead of heap memory to store the entries' payload