### PR TITLE
Add request related metrics

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -280,6 +280,8 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
             && requestsQueue.peek().getResponseFuture().isDone() && isActive.get()) {
             ResponseAndRequest response = requestsQueue.remove();
             requestStats.getRequestQueueSize().dec();
+            requestStats.getRequestQueuedLatencyStats().registerSuccessfulEvent(
+                    MathUtils.elapsedNanos(response.getCreatedTimestamp()), TimeUnit.NANOSECONDS);
             try {
                 if (log.isDebugEnabled()) {
                     log.debug("Write kafka cmd response back to client. \n"

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -194,8 +194,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     private final EntryFormatter entryFormatter;
 
     private final Map<TopicPartition, PendingProduceQueue> pendingProduceQueueMap = new ConcurrentHashMap<>();
-    private final StatsLogger statsLogger;
-    private final RequestStats requestStats;
     private final Set<String> groupIds = new HashSet<>();
 
     public KafkaRequestHandler(PulsarService pulsarService,
@@ -206,7 +204,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                Boolean tlsEnabled,
                                EndPoint advertisedEndPoint,
                                StatsLogger statsLogger) throws Exception {
-        super();
+        super(statsLogger);
         this.pulsarService = pulsarService;
         this.kafkaConfig = kafkaConfig;
         this.groupCoordinator = groupCoordinator;
@@ -229,8 +227,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         this.entryFormatter = EntryFormatterFactory.create(kafkaConfig.getEntryFormat());
         this.currentConnectedGroup = new ConcurrentHashMap<>();
         this.groupIdStoredPath = kafkaConfig.getGroupIdZooKeeperPath();
-        this.statsLogger = statsLogger;
-        this.requestStats = new RequestStats(statsLogger);
     }
 
     @Override

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopServerStats.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopServerStats.java
@@ -22,6 +22,13 @@ public interface KopServerStats {
     String SERVER_SCOPE = "kop_server";
 
     /**
+     * Request stats.
+     */
+    String REQUEST_QUEUE_SIZE = "REQUEST_QUEUE_SIZE";
+    String REQUEST_QUEUED_LATENCY = "REQUEST_QUEUED_LATENCY";
+    String REQUEST_PARSE = "REQUEST_PARSE";
+
+    /**
      * PRODUCE STATS.
      */
     String HANDLE_PRODUCE_REQUEST = "HANDLE_PRODUCE_REQUEST";

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/RequestStats.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/RequestStats.java
@@ -18,9 +18,13 @@ import static io.streamnative.pulsar.handlers.kop.KopServerStats.HANDLE_PRODUCE_
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.MESSAGE_PUBLISH;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.MESSAGE_QUEUED_LATENCY;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.PRODUCE_ENCODE;
+import static io.streamnative.pulsar.handlers.kop.KopServerStats.REQUEST_PARSE;
+import static io.streamnative.pulsar.handlers.kop.KopServerStats.REQUEST_QUEUED_LATENCY;
+import static io.streamnative.pulsar.handlers.kop.KopServerStats.REQUEST_QUEUE_SIZE;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.SERVER_SCOPE;
 
 import lombok.Getter;
+import org.apache.bookkeeper.stats.Counter;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.stats.annotations.StatsDoc;
@@ -36,6 +40,24 @@ import org.apache.bookkeeper.stats.annotations.StatsDoc;
 
 @Getter
 public class RequestStats {
+    @StatsDoc(
+            name = REQUEST_QUEUE_SIZE,
+            help = "request queue's size"
+    )
+    private final Counter requestQueueSize;
+
+    @StatsDoc(
+            name = REQUEST_QUEUED_LATENCY,
+            help = "latency from request enqueued to dequeued"
+    )
+    private final OpStatsLogger requestQueuedLatencyStats;
+
+    @StatsDoc(
+            name = REQUEST_PARSE,
+            help = "parse request to ByteBuf"
+    )
+    private final OpStatsLogger requestParseStats;
+
     @StatsDoc(
         name = HANDLE_PRODUCE_REQUEST,
         help = "handle produce request stats of Kop"
@@ -61,6 +83,9 @@ public class RequestStats {
     private final OpStatsLogger messageQueuedLatencyStats;
 
     public RequestStats(StatsLogger statsLogger) {
+        this.requestQueueSize = statsLogger.getCounter(REQUEST_QUEUE_SIZE);
+        this.requestQueuedLatencyStats = statsLogger.getOpStatsLogger(REQUEST_QUEUED_LATENCY);
+        this.requestParseStats = statsLogger.getOpStatsLogger(REQUEST_PARSE);
         this.handleProduceRequestStats = statsLogger.getOpStatsLogger(HANDLE_PRODUCE_REQUEST);
         this.produceEncodeStats = statsLogger.getOpStatsLogger(PRODUCE_ENCODE);
         this.messagePublishStats = statsLogger.getOpStatsLogger(MESSAGE_PUBLISH);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
@@ -121,6 +121,9 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase{
         while ((str = reader.readLine()) != null) {
             sb.append(str);
         }
+        Assert.assertTrue(sb.toString().contains("kop_server_REQUEST_QUEUE_SIZE"));
+        Assert.assertTrue(sb.toString().contains("kop_server_REQUEST_QUEUED_LATENCY"));
+        Assert.assertTrue(sb.toString().contains("kop_server_REQUEST_PARSE"));
         Assert.assertTrue(sb.toString().contains("kop_server_HANDLE_PRODUCE_REQUEST"));
         Assert.assertTrue(sb.toString().contains("kop_server_PRODUCE_ENCODE"));
         Assert.assertTrue(sb.toString().contains("kop_server_MESSAGE_PUBLISH"));


### PR DESCRIPTION
This PR introduces 3 metrics that are related to requests.
- REQUEST_QUEUE_SIZE: the size of `requestQueue` in `KafkaCommandDecoder`.
- REQUEST_QUEUED_LATENCY: the latency between a request enqueues to `requestQueue` and the request is dequeued.
- REQUEST_PARSE: the time to parse a raw request