### PR TITLE
Create cluster if it doesn't exist during metadata initialisation

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -60,6 +60,7 @@ import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.util.FutureUtil;
 
 /**
@@ -370,7 +371,11 @@ public class KafkaProtocolHandler implements ProtocolHandler {
             .build();
 
         PulsarAdmin pulsarAdmin = service.pulsar().getAdminClient();
-        MetadataUtils.createOffsetMetadataIfMissing(pulsarAdmin, kafkaConfig);
+        ClusterData clusterData = new ClusterData(service.getPulsar().getWebServiceAddress(),
+                                                  service.getPulsar().getWebServiceAddressTls(),
+                                                  service.getPulsar().getBrokerServiceUrl(),
+                                                  service.getPulsar().getBrokerServiceUrlTls());
+        MetadataUtils.createOffsetMetadataIfMissing(pulsarAdmin, clusterData, kafkaConfig);
 
 
         this.groupCoordinator = GroupCoordinator.of(
@@ -403,7 +408,12 @@ public class KafkaProtocolHandler implements ProtocolHandler {
                 .build();
 
         PulsarAdmin pulsarAdmin = brokerService.getPulsar().getAdminClient();
-        MetadataUtils.createTxnMetadataIfMissing(pulsarAdmin, kafkaConfig);
+        ClusterData clusterData = new ClusterData(brokerService.getPulsar().getWebServiceAddress(),
+                                                  brokerService.getPulsar().getWebServiceAddressTls(),
+                                                  brokerService.getPulsar().getBrokerServiceUrl(),
+                                                  brokerService.getPulsar().getBrokerServiceUrlTls());
+
+        MetadataUtils.createTxnMetadataIfMissing(pulsarAdmin, clusterData, kafkaConfig);
 
         this.transactionCoordinator = TransactionCoordinator.of(
                 transactionConfig,

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtilsTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtilsTest.java
@@ -37,6 +37,7 @@ import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.Tenants;
 import org.apache.pulsar.client.admin.Topics;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
+import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.testng.annotations.Test;
@@ -50,6 +51,7 @@ public class MetadataUtilsTest {
     public void testCreateKafkaMetadataIfMissing() throws Exception {
         KopTopic.initialize("public/default");
         KafkaServiceConfiguration conf = new KafkaServiceConfiguration();
+        ClusterData clusterData = new ClusterData();
         conf.setClusterName("test");
         conf.setKafkaMetadataTenant("public");
         conf.setKafkaMetadataNamespace("default");
@@ -86,7 +88,7 @@ public class MetadataUtilsTest {
         TenantInfo partialTenant = new TenantInfo();
         doReturn(partialTenant).when(mockTenants).getTenantInfo(eq(conf.getKafkaMetadataTenant()));
 
-        MetadataUtils.createOffsetMetadataIfMissing(mockPulsarAdmin, conf);
+        MetadataUtils.createOffsetMetadataIfMissing(mockPulsarAdmin, clusterData, conf);
 
         // After call the createOffsetMetadataIfMissing, these methods should return expected data.
         doReturn(Lists.newArrayList(conf.getKafkaMetadataTenant())).when(mockTenants).getTenants();
@@ -95,7 +97,7 @@ public class MetadataUtilsTest {
         doReturn(Lists.newArrayList(conf.getClusterName())).when(mockNamespaces)
                 .getNamespaceReplicationClusters(eq(namespace));
 
-        MetadataUtils.createTxnMetadataIfMissing(mockPulsarAdmin, conf);
+        MetadataUtils.createTxnMetadataIfMissing(mockPulsarAdmin, clusterData, conf);
 
         verify(mockTenants, times(1)).createTenant(eq(conf.getKafkaMetadataTenant()), any(TenantInfo.class));
         verify(mockNamespaces, times(1)).createNamespace(eq(conf.getKafkaMetadataTenant() + "/"
@@ -141,8 +143,8 @@ public class MetadataUtilsTest {
         doReturn(incompletePartitionList).when(mockTopics).getList(eq(conf.getKafkaMetadataTenant()
             + "/" + conf.getKafkaMetadataNamespace()));
 
-        MetadataUtils.createOffsetMetadataIfMissing(mockPulsarAdmin, conf);
-        MetadataUtils.createTxnMetadataIfMissing(mockPulsarAdmin, conf);
+        MetadataUtils.createOffsetMetadataIfMissing(mockPulsarAdmin, clusterData, conf);
+        MetadataUtils.createTxnMetadataIfMissing(mockPulsarAdmin, clusterData, conf);
 
         verify(mockTenants, times(1)).updateTenant(eq(conf.getKafkaMetadataTenant()), any(TenantInfo.class));
         verify(mockNamespaces, times(2)).setNamespaceReplicationClusters(eq(conf.getKafkaMetadataTenant()

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -71,6 +71,7 @@ import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.compaction.Compactor;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.apache.pulsar.zookeeper.ZooKeeperClientFactory;
@@ -231,6 +232,8 @@ public abstract class KopProtocolHandlerTestBase {
         String brokerServiceUrl = "pulsar://" + this.conf.getAdvertisedAddress() + ":" + brokerPort;
         String brokerServiceUrlTls = null; // TLS not supported at this time
 
+        ClusterData clusterData = new ClusterData(serviceUrl, serviceUrlTls, brokerServiceUrl, null);
+
         mockZooKeeper = createMockZooKeeper(configClusterName, serviceUrl, serviceUrlTls, brokerServiceUrl,
             brokerServiceUrlTls);
         mockBookKeeper = createMockBookKeeper(mockZooKeeper, bkExecutor);
@@ -239,8 +242,8 @@ public abstract class KopProtocolHandlerTestBase {
 
         createAdmin();
 
-        MetadataUtils.createOffsetMetadataIfMissing(admin, this.conf);
-        MetadataUtils.createTxnMetadataIfMissing(admin, this.conf);
+        MetadataUtils.createOffsetMetadataIfMissing(admin, clusterData, this.conf);
+        MetadataUtils.createTxnMetadataIfMissing(admin, clusterData, this.conf);
 
         if (enableSchemaRegistry) {
             admin.topics().createPartitionedTopic(KAFKASTORE_TOPIC, 1);


### PR DESCRIPTION
This case is usually encountered when attempting to use KoP with
standalone mode. When new behavior was introduced in #168 standalone
mode was broken due to sample namespace setup etc not taking place until
after the broker is initalised (which in turn initialises protocol
handlers).

Fixes #185