### PR TITLE
[ENHANCEMENT] memory tuning for decode phrase

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -41,6 +41,7 @@ import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.requests.AbstractResponse;
 import org.apache.kafka.common.requests.ApiVersionsRequest;
 import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.kafka.common.requests.ResponseCallbackWrapper;
 import org.apache.kafka.common.requests.ResponseHeader;
 import org.apache.kafka.common.requests.ResponseUtils;
 
@@ -298,6 +299,14 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
             } catch (Exception e) {
                 // should not comes here.
                 log.error("error to get Response ByteBuf:", e);
+            } finally {
+                try {
+                    if (response.getResponseFuture().get() instanceof ResponseCallbackWrapper) {
+                        ((ResponseCallbackWrapper) response.getResponseFuture().get()).responseComplete();
+                    }
+                } catch (Exception e) {
+                    log.error("Error in executing callback after sending response, ", e);
+                }
             }
         }
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -398,6 +398,14 @@ public final class MessageFetchContext {
                                     responseData,
                                     ((Integer) THROTTLE_TIME_MS.defaultValue),
                                     ((FetchRequest) fetch.getRequest()).metadata().sessionId()));
+                    resultFuture.whenComplete((r, e) -> {
+                        // ATTENTION: Please note that the release of entries should be placed after
+                        // future complete operation to ensure that the data has been successfully
+                        // written to the network channel
+                        responseValues.entrySet().forEach(topicPartitionListEntry -> {
+                            topicPartitionListEntry.getValue().forEach(Entry::release);
+                        });
+                    });
                     this.recycle();
                 } else {
                     if (log.isDebugEnabled()) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaEntryFormatter.java
@@ -17,10 +17,10 @@ import static org.apache.kafka.common.record.Records.MAGIC_OFFSET;
 import static org.apache.kafka.common.record.Records.OFFSET_OFFSET;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.Unpooled;
 import io.streamnative.pulsar.handlers.kop.utils.ByteBufUtils;
 import io.streamnative.pulsar.handlers.kop.utils.MessageIdUtils;
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.bookkeeper.mledger.Entry;
@@ -48,30 +48,19 @@ public class KafkaEntryFormatter implements EntryFormatter {
     public MemoryRecords decode(List<Entry> entries, byte magic) {
         // TODO The memory records should maintain multiple batches, one entry present one batch,
         //  this is necessary, because one entry only belongs to one transaction.
-        List<MemoryRecords> orderedRecord = entries.stream().parallel().map(entry -> {
+        List<ByteBuf> orderedByteBuf = entries.stream().parallel().map(entry -> {
             long startOffset = MessageIdUtils.peekBaseOffsetFromEntry(entry);
             final ByteBuf byteBuf = entry.getDataBuffer();
             Commands.skipMessageMetadata(byteBuf);
-            final MemoryRecords records = MemoryRecords.readableRecords(ByteBufUtils.getNioBuffer(byteBuf));
-
-            int p = records.buffer().position();
-            records.buffer().putLong(p + OFFSET_OFFSET, startOffset);
-            records.buffer().put(p + MAGIC_OFFSET, magic);
-
-            return records;
+            byteBuf.setLong(byteBuf.readerIndex() + OFFSET_OFFSET, startOffset);
+            byteBuf.setByte(byteBuf.readerIndex() + MAGIC_OFFSET, magic);
+            return byteBuf.slice(byteBuf.readerIndex(), byteBuf.readableBytes());
         }).collect(Collectors.toList());
 
-        // Concatenate multiple batch into one single MemoryRecords object
-        // In this mode, batch and entry have a one-to-one correspondence
-        int totalSize = orderedRecord.stream().mapToInt(MemoryRecords::sizeInBytes).sum();
-        ByteBuffer batchedBuffer = ByteBuffer.allocate(totalSize);
-        for (MemoryRecords records : orderedRecord) {
-            batchedBuffer.put(records.buffer());
-        }
-        batchedBuffer.flip();
+        CompositeByteBuf batchedByteBuf = Unpooled.compositeBuffer();
+        batchedByteBuf.addComponents(true, orderedByteBuf);
 
-        MemoryRecords batchedMemoryRecords = MemoryRecords.readableRecords(batchedBuffer);
-        entries.forEach(Entry::release);
+        MemoryRecords batchedMemoryRecords = MemoryRecords.readableRecords(ByteBufUtils.getNioBuffer(batchedByteBuf));
         return batchedMemoryRecords;
     }
 

--- a/kafka-impl/src/main/java/org/apache/kafka/common/requests/ResponseCallback.java
+++ b/kafka-impl/src/main/java/org/apache/kafka/common/requests/ResponseCallback.java
@@ -14,12 +14,12 @@
 package org.apache.kafka.common.requests;
 
 /**
- * Callback for cleaning-up after writing to channel
+ * Callback for cleaning-up after writing to channel.
  */
 public interface ResponseCallback {
 
     /**
-     * Callback for asynchronous call to cleanup
+     * Callback for asynchronous call to cleanup.
      */
     void responseComplete();
 }

--- a/kafka-impl/src/main/java/org/apache/kafka/common/requests/ResponseCallback.java
+++ b/kafka-impl/src/main/java/org/apache/kafka/common/requests/ResponseCallback.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+/**
+ * Callback for cleaning-up after writing to channel
+ */
+public interface ResponseCallback {
+
+    /**
+     * Callback for asynchronous call to cleanup
+     */
+    void responseComplete();
+}

--- a/kafka-impl/src/main/java/org/apache/kafka/common/requests/ResponseCallbackWrapper.java
+++ b/kafka-impl/src/main/java/org/apache/kafka/common/requests/ResponseCallbackWrapper.java
@@ -13,14 +13,14 @@
  */
 package org.apache.kafka.common.requests;
 
+import java.util.Map;
+
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.Struct;
 
-import java.util.Map;
-
 /**
  * A wrapper for {@link org.apache.kafka.common.requests.AbstractResponse} that
- * can perform some cleanup tasks after writing to the channel
+ * can perform some cleanup tasks after writing to the channel.
  */
 public class ResponseCallbackWrapper extends AbstractResponse {
 

--- a/kafka-impl/src/main/java/org/apache/kafka/common/requests/ResponseCallbackWrapper.java
+++ b/kafka-impl/src/main/java/org/apache/kafka/common/requests/ResponseCallbackWrapper.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.types.Struct;
+
+import java.util.Map;
+
+/**
+ * A wrapper for {@link org.apache.kafka.common.requests.AbstractResponse} that
+ * can perform some cleanup tasks after writing to the channel
+ */
+public class ResponseCallbackWrapper extends AbstractResponse {
+
+    private AbstractResponse abstractResponse;
+    private ResponseCallback responseCallback;
+
+    public ResponseCallbackWrapper(AbstractResponse abstractResponse, ResponseCallback responseCallback) {
+        this.abstractResponse = abstractResponse;
+        this.responseCallback = responseCallback;
+    }
+
+    @Override
+    public Map<Errors, Integer> errorCounts() {
+        return abstractResponse.errorCounts();
+    }
+
+    @Override
+    protected Struct toStruct(short i) {
+        return abstractResponse.toStruct(i);
+    }
+
+    public void responseComplete() {
+        responseCallback.responseComplete();
+    }
+}


### PR DESCRIPTION
## Motivation
Keep the data in the direct memory of nio as much as possible to reduce the damage to performance.

## Modifications
1. modify `ByteBuf` directly instead of `MemoryRecords`
2. delay the release timing of `Entry` until after writing to the network channel