### PR TITLE
Bump pulsar to 2.8.0-rc-202104202206

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
@@ -160,7 +160,9 @@ public class MetadataUtils {
                 namespaces.setRetention(kafkaMetadataNamespace,
                         new RetentionPolicies((int) conf.getOffsetsRetentionMinutes(), -1));
             }
-            if (namespaces.getCompactionThreshold(kafkaMetadataNamespace) != MAX_COMPACTION_THRESHOLD) {
+
+            Long compactionThreshold = namespaces.getCompactionThreshold(kafkaMetadataNamespace);
+            if (compactionThreshold != null && compactionThreshold != MAX_COMPACTION_THRESHOLD) {
                 namespaces.setCompactionThreshold(kafkaMetadataNamespace, MAX_COMPACTION_THRESHOLD);
             }
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <log4j2.version>2.13.3</log4j2.version>
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
-    <pulsar.version>2.8.0-rc-202102252222</pulsar.version>
+    <pulsar.version>2.8.0-rc-202104202206</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testcontainers.version>1.15.1</testcontainers.version>


### PR DESCRIPTION
### Changes
Bump pulsar to 2.8.0-rc-202104202206 and fix the incompatible interface.