### PR TITLE
[Transaction] Add producer state manager

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/BrokerProducerStateManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/BrokerProducerStateManager.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import com.google.common.collect.Maps;
+import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
+import java.util.Map;
+import org.apache.kafka.common.TopicPartition;
+
+
+/**
+ * Broker producer state manager.
+ */
+public class BrokerProducerStateManager {
+
+    private final Map<String, ProducerStateManager> producerStateManagerMap;
+    private int maxProducerIdExpirationMs;
+
+    public BrokerProducerStateManager(int maxProducerIdExpirationMs) {
+        producerStateManagerMap = Maps.newConcurrentMap();
+        this.maxProducerIdExpirationMs = maxProducerIdExpirationMs;
+    }
+
+    public ProducerStateManager getProducerStateManager(TopicPartition topicPartition) {
+        return getProducerStateManager(KopTopic.toString(topicPartition));
+    }
+
+    public ProducerStateManager getProducerStateManager(String topicPartition) {
+        return producerStateManagerMap.computeIfAbsent(topicPartition, key ->
+                new ProducerStateManager(topicPartition, maxProducerIdExpirationMs));
+    }
+
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
@@ -52,6 +52,8 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
     private final SslContextFactory sslContextFactory;
     @Getter
     private final StatsLogger statsLogger;
+    @Getter
+    private final BrokerProducerStateManager brokerProducerStateManager;
 
     public KafkaChannelInitializer(PulsarService pulsarService,
                                    KafkaServiceConfiguration kafkaConfig,
@@ -60,7 +62,8 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
                                    AdminManager adminManager,
                                    boolean enableTLS,
                                    EndPoint advertisedEndPoint,
-                                   StatsLogger statsLogger) {
+                                   StatsLogger statsLogger,
+                                   BrokerProducerStateManager brokerProducerStateManager) {
         super();
         this.pulsarService = pulsarService;
         this.kafkaConfig = kafkaConfig;
@@ -70,6 +73,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
         this.enableTls = enableTLS;
         this.advertisedEndPoint = advertisedEndPoint;
         this.statsLogger = statsLogger;
+        this.brokerProducerStateManager = brokerProducerStateManager;
 
         if (enableTls) {
             sslContextFactory = SSLUtils.createSslContextFactory(kafkaConfig);
@@ -88,8 +92,8 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
             new LengthFieldBasedFrameDecoder(MAX_FRAME_LENGTH, 0, 4, 0, 4));
         ch.pipeline().addLast("handler",
             new KafkaRequestHandler(pulsarService, kafkaConfig,
-                    groupCoordinator, transactionCoordinator, adminManager,
-                    enableTls, advertisedEndPoint, statsLogger));
+                    groupCoordinator, transactionCoordinator, adminManager, enableTls, advertisedEndPoint, statsLogger,
+                    brokerProducerStateManager));
     }
 
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -327,6 +327,12 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
     )
     private int kopPrometheusStatsLatencyRolloverSeconds = 60;
 
+    @FieldContext(
+        category = CATEGORY_KOP,
+        doc = "Max producer id expiration millisecond."
+    )
+    private int maxProducerIdExpirationMs = 60 * 60 * 1000;
+
     public @NonNull String getKafkaAdvertisedListeners() {
         if (kafkaAdvertisedListeners != null) {
             return kafkaAdvertisedListeners;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -376,7 +376,11 @@ public final class MessageFetchContext {
                             if (requestHandler.getKafkaConfig().isEnableTransactionCoordinator()
                                     && isolationLevel.equals(IsolationLevel.READ_COMMITTED)
                                     && tc != null) {
-                                abortedTransactions = tc.getAbortedIndexList(
+
+                                ProducerStateManager producerStateManager =
+                                        requestHandler.getBrokerProducerStateManager()
+                                                .getProducerStateManager(kafkaPartition);
+                                abortedTransactions = producerStateManager.getAbortedIndexList(
                                         request.fetchData().get(kafkaPartition).fetchOffset);
                             } else {
                                 abortedTransactions = null;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/ProducerStateManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/ProducerStateManager.java
@@ -340,12 +340,10 @@ public class ProducerStateManager {
             log.info("append data batch checkSequence producerEpoch: {}, appendFirstSeq: {}",
                     producerEpoch, appendFirstSeq);
             if (!producerEpoch.equals(updatedEntry.producerEpoch)) {
-                if (appendFirstSeq != 0) {
-                    if (updatedEntry.producerEpoch != RecordBatch.NO_PRODUCER_EPOCH) {
-                        String msg = String.format("Invalid sequence number for new epoch in partition %s: %s "
-                                + "(request epoch), %s (seq. number)", topicPartition, producerEpoch, appendFirstSeq);
-                        throw new OutOfOrderSequenceException(msg);
-                    }
+                if (appendFirstSeq != 0 && updatedEntry.producerEpoch != RecordBatch.NO_PRODUCER_EPOCH) {
+                    String msg = String.format("Invalid sequence number for new epoch in partition %s: %s "
+                            + "(request epoch), %s (seq. number)", topicPartition, producerEpoch, appendFirstSeq);
+                    throw new OutOfOrderSequenceException(msg);
                 }
             } else {
                 int currentLastSeq;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/ProducerStateManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/ProducerStateManager.java
@@ -1,0 +1,675 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import com.google.common.collect.Maps;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.concurrent.LinkedBlockingDeque;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.compress.utils.Lists;
+import org.apache.kafka.common.errors.InvalidTxnStateException;
+import org.apache.kafka.common.errors.OutOfOrderSequenceException;
+import org.apache.kafka.common.record.ControlRecordType;
+import org.apache.kafka.common.record.EndTransactionMarker;
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.Record;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.requests.FetchResponse;
+
+/**
+ * Producer state manager.
+ */
+@Slf4j
+public class ProducerStateManager {
+
+    private final String topicPartition;
+    private final int maxProducerIdExpirationMs;
+
+    private final Map<Long, ProducerStateEntry> producers = Maps.newConcurrentMap();
+    private Long lastMapOffset = 0L;
+
+    // ongoing transactions sorted by the first offset of the transaction
+    private final TreeMap<Long, TxnMetadata> ongoingTxns = Maps.newTreeMap();
+    private final List<AbortedTxn> abortedIndexList = new ArrayList<>();
+
+    /**
+     * AppendOrigin is used mark the data origin.
+     */
+    public enum AppendOrigin {
+        Coordinator,
+        Client
+    }
+
+    /**
+     * TxnMetadata represents the ongoing transaction.
+     */
+    @EqualsAndHashCode
+    public static class TxnMetadata {
+        private final long producerId;
+        private final long firstOffset;
+        private long lastOffset;
+
+        public TxnMetadata(long producerId, long firstOffset) {
+            this.producerId = producerId;
+            this.firstOffset = firstOffset;
+        }
+
+        public TxnMetadata(long producerId, long firstOffset, long lastOffset) {
+            this.producerId = producerId;
+            this.firstOffset = firstOffset;
+            this.lastOffset = lastOffset;
+        }
+
+    }
+
+    /**
+     * BatchMetadata is used to check the message duplicate.
+     */
+    @AllArgsConstructor
+    public static class BatchMetadata {
+
+        private final Integer lastSeq;
+        private final Long lastOffset;
+        private final Integer offsetDelta;
+        private final Long timestamp;
+
+        public int firstSeq() {
+            return decrementSequence(lastSeq, offsetDelta);
+        }
+
+        public Long firstOffset() {
+            return lastOffset - offsetDelta;
+        }
+
+        private int decrementSequence(int sequence, int decrement) {
+            if (sequence < decrement) {
+                return Integer.MAX_VALUE - (decrement - sequence) + 1;
+            }
+            return sequence - decrement;
+        }
+
+        @Override
+        public String toString() {
+            return "BatchMetadata("
+                    + "firstSeq=" + firstSeq() + ", "
+                    + "lastSeq=" + lastSeq + ", "
+                    + "firstOffset=" + firstOffset() + ", "
+                    + "lastOffset=" + lastOffset + ", "
+                    + "timestamp=" + timestamp + ")";
+        }
+    }
+
+    /**
+     * the batchMetadata is ordered such that the batch with the lowest sequence is at the head of the queue while the
+     * batch with the highest sequence is at the tail of the queue. We will retain at most ProducerStateEntry.
+     * NumBatchesToRetain elements in the queue. When the queue is at capacity, we remove the first element to make
+     * space for the incoming batch.
+      */
+    @AllArgsConstructor
+    @Data
+    public static class ProducerStateEntry {
+
+        private static final Integer NumBatchesToRetain = 5;
+
+        private Long producerId;
+        private Deque<BatchMetadata> batchMetadata;
+        private Short producerEpoch;
+        private Integer coordinatorEpoch;
+        private Long lastTimestamp;
+        private Optional<Long> currentTxnFirstOffset;
+
+        private boolean isEmpty() {
+            return batchMetadata.isEmpty();
+        }
+
+        public Integer firstSeq() {
+            if (isEmpty()) {
+                return RecordBatch.NO_SEQUENCE;
+            } else {
+                return batchMetadata.getFirst().firstSeq();
+            }
+        }
+
+        public Long firstDataOffset() {
+            if (isEmpty()) {
+                return -1L;
+            } else {
+                return batchMetadata.getFirst().firstOffset();
+            }
+        }
+
+        public Integer lastSeq() {
+            if (isEmpty()) {
+                return RecordBatch.NO_SEQUENCE;
+            } else {
+                return batchMetadata.getLast().lastSeq;
+            }
+        }
+
+        public Long lastDataOffset() {
+            if (isEmpty()) {
+                return -1L;
+            } else {
+                return batchMetadata.getLast().lastOffset;
+            }
+        }
+
+        public Integer lastOffsetDelta() {
+            if (isEmpty()) {
+                return 0;
+            } else {
+                return batchMetadata.getLast().offsetDelta;
+            }
+        }
+
+        public void addBatch(Short producerEpoch, Integer lastSeq, Long lastOffset,
+                             Integer offsetDelta, Long timestamp) {
+            maybeUpdateProducerEpoch(producerEpoch);
+            addBatchMetadata(new BatchMetadata(lastSeq, lastOffset, offsetDelta, timestamp));
+            this.lastTimestamp = timestamp;
+        }
+
+        public boolean maybeUpdateProducerEpoch(Short producerEpoch) {
+            if (!this.producerEpoch.equals(producerEpoch)) {
+                batchMetadata.clear();
+                this.producerEpoch = producerEpoch;
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        public void addBatchMetadata(BatchMetadata batch) {
+            if (batchMetadata.size() == ProducerStateEntry.NumBatchesToRetain) {
+                batchMetadata.removeFirst();
+            }
+            batchMetadata.addLast(batch);
+        }
+
+        public void update(ProducerStateEntry nextEntry) {
+            maybeUpdateProducerEpoch(nextEntry.producerEpoch);
+            while (!nextEntry.batchMetadata.isEmpty()) {
+                addBatchMetadata(nextEntry.batchMetadata.pollFirst());
+            }
+            this.currentTxnFirstOffset = nextEntry.currentTxnFirstOffset;
+            this.lastTimestamp = nextEntry.lastTimestamp;
+        }
+
+        public Optional<BatchMetadata> findDuplicateBatch(RecordBatch batch) {
+            if (batch.producerEpoch() != producerEpoch) {
+                return Optional.empty();
+            } else {
+                return batchWithSequenceRange(batch.baseSequence(), batch.lastSequence());
+            }
+        }
+
+        // Return the batch metadata of the cached batch having the exact sequence range, if any.
+        private Optional<BatchMetadata> batchWithSequenceRange(Integer firstSeq, Integer lastSeq) {
+            return batchMetadata.stream().filter(batchMetadata ->
+                    firstSeq == batchMetadata.firstSeq() && lastSeq.equals(batchMetadata.lastSeq)).findFirst();
+        }
+
+        public static ProducerStateEntry empty(Long producerId){
+            return new ProducerStateEntry(producerId, new LinkedBlockingDeque<>(),
+                    RecordBatch.NO_PRODUCER_EPOCH, -1, RecordBatch.NO_TIMESTAMP, Optional.empty());
+        }
+
+        @Override
+        public String toString() {
+            return "ProducerStateEntry{"
+                    + "producerId=" + producerId
+                    + ", producerEpoch=" + producerEpoch
+                    + ", currentTxnFirstOffset=" + currentTxnFirstOffset
+                    + ", coordinatorEpoch=" + coordinatorEpoch
+                    + ", lastTimestamp=" + lastTimestamp
+                    + ", batchMetadata=" + batchMetadata
+                    + '}';
+        }
+    }
+
+    /**
+     * CompletedTxn.
+     */
+    @ToString
+    @AllArgsConstructor
+    @Data
+    public static class CompletedTxn {
+        private Long producerId;
+        private Long firstOffset;
+        private Long lastOffset;
+        private Boolean isAborted;
+    }
+
+    /**
+     * AbortedTxn is used cache the aborted index.
+     */
+    @AllArgsConstructor
+    private static class AbortedTxn {
+
+        private static final int VersionOffset = 0;
+        private static final int VersionSize = 2;
+        private static final int ProducerIdOffset = VersionOffset + VersionSize;
+        private static final int ProducerIdSize = 8;
+        private static final int FirstOffsetOffset = ProducerIdOffset + ProducerIdSize;
+        private static final int FirstOffsetSize = 8;
+        private static final int LastOffsetOffset = FirstOffsetOffset + FirstOffsetSize;
+        private static final int LastOffsetSize = 8;
+        private static final int LastStableOffsetOffset = LastOffsetOffset + LastOffsetSize;
+        private static final int LastStableOffsetSize = 8;
+        private static final int TotalSize = LastStableOffsetOffset + LastStableOffsetSize;
+
+        private static final Short CurrentVersion = 0;
+
+        private final Long producerId;
+        private final Long firstOffset;
+        private final Long lastOffset;
+        private final Long lastStableOffset;
+
+        public ByteBuffer toByteBuffer() {
+            ByteBuffer buffer = ByteBuffer.allocate(AbortedTxn.TotalSize);
+            buffer.putShort(CurrentVersion);
+            buffer.putLong(producerId);
+            buffer.putLong(firstOffset);
+            buffer.putLong(lastOffset);
+            buffer.putLong(lastStableOffset);
+            buffer.flip();
+            return buffer;
+        }
+    }
+
+    /**
+     * Producer append info.
+     */
+    public static class ProducerAppendInfo {
+
+        private final String topicPartition;
+        private final Long producerId;
+        private final ProducerStateEntry currentEntry;
+        private final AppendOrigin origin;
+        private final List<TxnMetadata> transactions = Lists.newArrayList();
+        private ProducerStateEntry updatedEntry;
+
+        public ProducerAppendInfo(String topicPartition, Long producerId,
+                                  ProducerStateEntry currentEntry, AppendOrigin origin) {
+            this.topicPartition = topicPartition;
+            this.producerId = producerId;
+            this.currentEntry = currentEntry;
+            this.origin = origin;
+
+            resetUpdatedEntry();
+        }
+
+        private void maybeValidateDataBatch(Short producerEpoch, Integer firstSeq) {
+            checkProducerEpoch(producerEpoch);
+            if (origin.equals(AppendOrigin.Client)) {
+                checkSequence(producerEpoch, firstSeq);
+            }
+        }
+
+        private void checkProducerEpoch(Short producerEpoch) {
+            if (producerEpoch < updatedEntry.producerEpoch) {
+                String message = String.format("Producer's epoch in %s is %s, which is smaller than the last seen "
+                        + "epoch %s", topicPartition, producerEpoch, currentEntry.producerEpoch);
+                throw new IllegalArgumentException(message);
+            }
+        }
+
+        private void checkSequence(Short producerEpoch, Integer appendFirstSeq) {
+            log.info("append data batch checkSequence producerEpoch: {}, appendFirstSeq: {}",
+                    producerEpoch, appendFirstSeq);
+            if (!producerEpoch.equals(updatedEntry.producerEpoch)) {
+                if (appendFirstSeq != 0) {
+                    if (updatedEntry.producerEpoch != RecordBatch.NO_PRODUCER_EPOCH) {
+                        String msg = String.format("Invalid sequence number for new epoch in partition %s: %s "
+                                + "(request epoch), %s (seq. number)", topicPartition, producerEpoch, appendFirstSeq);
+                        throw new OutOfOrderSequenceException(msg);
+                    }
+                }
+            } else {
+                int currentLastSeq;
+                if (!updatedEntry.isEmpty()) {
+                    currentLastSeq = updatedEntry.lastSeq();
+                } else if (producerEpoch.equals(currentEntry.producerEpoch)) {
+                    currentLastSeq = currentEntry.lastSeq();
+                } else {
+                    currentLastSeq = RecordBatch.NO_SEQUENCE;
+                }
+
+                // If there is no current producer epoch (possibly because all producer records have been deleted due to
+                // retention or the DeleteRecords API) accept writes with any sequence number
+                if (!(currentEntry.producerEpoch == RecordBatch.NO_PRODUCER_EPOCH
+                        || inSequence(currentLastSeq, appendFirstSeq))) {
+                    String msg = String.format("Out of order sequence number for producerId %s in partition %s: %s "
+                                    + "(incoming seq. number), %s (current end sequence number)",
+                            currentEntry.producerId, topicPartition, appendFirstSeq, currentLastSeq);
+                    throw new OutOfOrderSequenceException(msg);
+                }
+
+            }
+        }
+
+        private Boolean inSequence(Integer lastSeq, Integer nextSeq) {
+            log.info("append data batch lastSeq: {}, nextSeq: {}", lastSeq, nextSeq);
+            return nextSeq == lastSeq + 1L || (nextSeq == 0 && lastSeq == Integer.MAX_VALUE);
+        }
+
+        public Optional<CompletedTxn> append(RecordBatch batch, Optional<Long> firstOffset) {
+            if (batch.isControlBatch()) {
+                Iterator<Record> recordIterator = batch.iterator();
+                if (recordIterator.hasNext()) {
+                    Record record = recordIterator.next();
+                    EndTransactionMarker endTxnMarker = EndTransactionMarker.deserialize(record);
+                    return appendEndTxnMarker(
+                            endTxnMarker, batch.producerEpoch(), batch.baseOffset(), record.timestamp());
+                } else {
+                    // An empty control batch means the entire transaction has been cleaned from the log,
+                    // so no need to append
+                    return Optional.empty();
+                }
+            } else {
+                appendDataBatch(batch.producerEpoch(), batch.baseSequence(), batch.lastSequence(), batch.maxTimestamp(),
+                        firstOffset.orElse(batch.baseOffset()), batch.lastOffset(), batch.isTransactional());
+                return Optional.empty();
+            }
+        }
+
+        public void appendDataBatch(Short epoch, Integer firstSeq, Integer lastSeq, Long lastTimestamp,
+                            Long firstOffset, Long lastOffset, Boolean isTransactional) {
+            log.info("append data batch epoch: {}, firstSeq: {}, lastSeq: {}, firstOffset: {}, lastOffset: {}",
+                    epoch, firstSeq, lastSeq, firstOffset, lastOffset);
+            maybeValidateDataBatch(epoch, firstSeq);
+            updatedEntry.addBatch(epoch, lastSeq, lastOffset, (int) (lastOffset - firstOffset), lastTimestamp);
+
+            if (updatedEntry.currentTxnFirstOffset.isPresent()) {
+                if (!isTransactional) {
+                    // Received a non-transactional message while a transaction is active
+                    String msg = String.format("Expected transactional write from producer %s at offset %s in "
+                                    + "partition %s", producerId, firstOffset, topicPartition);
+                    throw new InvalidTxnStateException(msg);
+                }
+            } else {
+                if (isTransactional) {
+                    updatedEntry.currentTxnFirstOffset = Optional.of(firstOffset);
+                    transactions.add(new TxnMetadata(producerId, firstOffset));
+                }
+            }
+        }
+
+        public Optional<CompletedTxn> appendEndTxnMarker(
+                EndTransactionMarker endTxnMarker,
+                Short producerEpoch,
+                Long offset,
+                Long timestamp) {
+            checkProducerEpoch(producerEpoch);
+
+            // Only emit the `CompletedTxn` for non-empty transactions. A transaction marker
+            // without any associated data will not have any impact on the last stable offset
+            // and would not need to be reflected in the transaction index.
+            Optional<CompletedTxn> completedTxn = Optional.empty();
+            if (updatedEntry.currentTxnFirstOffset.isPresent()) {
+                completedTxn = Optional.of(
+                        new CompletedTxn(producerId, updatedEntry.currentTxnFirstOffset.get(), offset,
+                                endTxnMarker.controlType() == ControlRecordType.ABORT));
+            }
+
+            updatedEntry.maybeUpdateProducerEpoch(producerEpoch);
+            updatedEntry.currentTxnFirstOffset = Optional.empty();
+            updatedEntry.lastTimestamp = timestamp;
+            return completedTxn;
+        }
+
+        public ProducerStateEntry toEntry() {
+            return updatedEntry;
+        }
+
+        public List<TxnMetadata> startedTransactions() {
+            return transactions;
+        }
+
+        private void resetUpdatedEntry() {
+            updatedEntry = ProducerStateEntry.empty(producerId);
+            updatedEntry.producerEpoch = currentEntry.producerEpoch;
+            updatedEntry.coordinatorEpoch = currentEntry.coordinatorEpoch;
+            updatedEntry.lastTimestamp = currentEntry.lastTimestamp;
+            updatedEntry.currentTxnFirstOffset = currentEntry.currentTxnFirstOffset;
+        }
+
+        public void resetOffset(long baseOffset, boolean isTransactional) {
+            log.info("append data batch reset offset: {}", baseOffset);
+            short producerEpoch = updatedEntry.producerEpoch;
+            BatchMetadata batchMetadata = updatedEntry.batchMetadata.pollFirst();
+            if (batchMetadata == null) {
+                return;
+            }
+            resetUpdatedEntry();
+            transactions.clear();
+            int offsetDelta = batchMetadata.lastSeq - batchMetadata.firstSeq();
+            appendDataBatch(producerEpoch, batchMetadata.firstSeq(), batchMetadata.lastSeq, batchMetadata.timestamp,
+                    baseOffset, baseOffset + offsetDelta, isTransactional);
+        }
+
+        @Override
+        public String toString() {
+            return "ProducerAppendInfo("
+                    + "producerId=" + producerId + ", "
+                    + "producerEpoch=" + updatedEntry.producerEpoch + ", "
+                    + "firstSequence=" + updatedEntry.firstSeq() + ", "
+                    + "lastSequence=" + updatedEntry.lastSeq() + ", "
+                    + "currentTxnFirstOffset=" + updatedEntry.currentTxnFirstOffset + ", "
+                    + "coordinatorEpoch=" + updatedEntry.coordinatorEpoch + ", "
+                    + "lastTimestamp=" + updatedEntry.lastTimestamp + ", "
+                    + "startedTransactions=" + transactions + ")";
+        }
+
+    }
+
+    /**
+     * Analyze result.
+     */
+    @Data
+    @AllArgsConstructor
+    public static class AnalyzeResult {
+        private Map<Long, ProducerAppendInfo> appendInfoMap;
+        private List<CompletedTxn> completedTxnList;
+        private Optional<BatchMetadata> batchMetadata;
+    }
+
+    public ProducerStateManager(String topicPartition, int maxProducerIdExpirationMs) {
+        this.topicPartition = topicPartition;
+        this.maxProducerIdExpirationMs = maxProducerIdExpirationMs;
+    }
+
+    public ProducerAppendInfo prepareUpdate(Long producerId, AppendOrigin origin) {
+        ProducerStateEntry currentEntry = lastEntry(producerId).orElse(ProducerStateEntry.empty(producerId));
+        return new ProducerAppendInfo(topicPartition, producerId, currentEntry, origin);
+    }
+
+    public AnalyzeResult analyzeAndValidateProducerState(MemoryRecords records,
+                                                         Optional<Long> firstOffset,
+                                                         AppendOrigin origin) {
+        Map<Long, ProducerAppendInfo> updatedProducers = Maps.newHashMap();
+        List<CompletedTxn> completedTxns = Lists.newArrayList();
+
+        for (RecordBatch batch : records.batches()) {
+            if (batch.hasProducerId()) {
+                Optional<ProducerStateEntry> maybeLastEntry = lastEntry(batch.producerId());
+
+                // if this is a client produce request, there will be up to 5 batches which could have been duplicated.
+                // If we find a duplicate, we return the metadata of the appended batch to the client.
+                if (maybeLastEntry.isPresent()) {
+                    Optional<BatchMetadata> maybeDuplicate = maybeLastEntry.get().findDuplicateBatch(batch);
+                    if (maybeDuplicate.isPresent()) {
+                        return new AnalyzeResult(updatedProducers, completedTxns, maybeDuplicate);
+                    }
+                }
+                // We cache offset metadata for the start of each transaction. This allows us to
+                // compute the last stable offset without relying on additional index lookups.
+                Optional<CompletedTxn> maybeCompletedTxn =
+                        updateProducers(batch, updatedProducers, firstOffset, origin);
+                maybeCompletedTxn.ifPresent(completedTxns::add);
+            }
+        }
+        return new AnalyzeResult(updatedProducers, completedTxns, Optional.empty());
+    }
+
+    private Optional<CompletedTxn> updateProducers(RecordBatch batch,
+                                                   Map<Long, ProducerAppendInfo> producers,
+                                                   Optional<Long> firstOffset,
+                                                   AppendOrigin origin) {
+        Long producerId = batch.producerId();
+        ProducerAppendInfo appendInfo = producers.computeIfAbsent(producerId, pid -> prepareUpdate(producerId, origin));
+        return appendInfo.append(batch, firstOffset);
+    }
+
+
+    /**
+     * Compute the last stable offset of a completed transaction, but do not yet mark the transaction complete.
+     * That will be done in `completeTxn` below. This is used to compute the LSO that will be appended to the
+     * transaction index, but the completion must be done only after successfully appending to the index.
+     */
+    public long lastStableOffset(CompletedTxn completedTxn) {
+        for (TxnMetadata txnMetadata : ongoingTxns.values()) {
+            if (txnMetadata.producerId != completedTxn.producerId) {
+                return txnMetadata.firstOffset;
+            }
+        }
+        return completedTxn.lastOffset + 1;
+    }
+
+    public Optional<Long> firstUndecidedOffset() {
+        Map.Entry<Long, TxnMetadata> entry = ongoingTxns.firstEntry();
+        if (entry == null) {
+            return Optional.empty();
+        }
+        return Optional.of(entry.getValue().firstOffset);
+    }
+
+    private Boolean isProducerExpired(Long currentTimeMs, ProducerStateEntry producerState) {
+        return !producerState.currentTxnFirstOffset.isPresent()
+                && currentTimeMs - producerState.lastTimestamp >= maxProducerIdExpirationMs;
+    }
+
+    /**
+     * Expire any producer ids which have been idle longer than the configured maximum expiration timeout.
+     */
+    public void removeExpiredProducers(Long currentTimeMs) {
+        for (Map.Entry<Long, ProducerStateEntry> entry : producers.entrySet()) {
+            if (isProducerExpired(currentTimeMs, entry.getValue())) {
+                producers.remove(entry.getKey());
+            }
+        }
+    }
+
+    /**
+     * Get the last written entry for the given producer id.
+     */
+    public Optional<ProducerStateEntry> lastEntry(Long producerId) {
+        if (!producers.containsKey(producerId)) {
+            return Optional.empty();
+        }
+        return Optional.of(producers.get(producerId));
+    }
+
+    /**
+     * Update the mapping with the given append information.
+     */
+    public void update(ProducerAppendInfo appendInfo) {
+        if (appendInfo.producerId == RecordBatch.NO_PRODUCER_ID) {
+            throw new IllegalArgumentException("Invalid producer id ${appendInfo.producerId} passed to update for "
+                    + "partition " + topicPartition);
+        }
+
+        log.info("Updated producer {} state to {}", appendInfo.producerId, appendInfo);
+        ProducerStateEntry updatedEntry = appendInfo.toEntry();
+
+        producers.compute(appendInfo.producerId, (pid, stateEntry) -> {
+            if (stateEntry == null) {
+                stateEntry = updatedEntry;
+            } else {
+                stateEntry.update(updatedEntry);
+            }
+            return stateEntry;
+        });
+
+        for (TxnMetadata txn : appendInfo.startedTransactions()) {
+            ongoingTxns.put(txn.firstOffset, txn);
+        }
+    }
+
+    public void completeTxn(CompletedTxn completedTxn) {
+        TxnMetadata txnMetadata = ongoingTxns.remove(completedTxn.firstOffset);
+        if (txnMetadata == null) {
+            String msg = String.format("Attempted to complete transaction %s on partition "
+                    + "%s which was not started.", completedTxn, topicPartition);
+            throw new IllegalArgumentException(msg);
+        }
+
+        txnMetadata.lastOffset = completedTxn.lastOffset;
+
+        if (completedTxn.isAborted) {
+            abortedIndexList.add(new AbortedTxn(completedTxn.producerId, completedTxn.firstOffset,
+                    completedTxn.lastOffset, lastStableOffset(completedTxn)));
+        }
+    }
+
+    public void updateMapEndOffset(long offset) {
+        lastMapOffset = offset;
+    }
+
+    public List<FetchResponse.AbortedTransaction> getAbortedIndexList(long fetchOffset) {
+        List<FetchResponse.AbortedTransaction> abortedTransactions = new ArrayList<>();
+        for (AbortedTxn abortedTxn : abortedIndexList) {
+            if (abortedTxn.lastOffset >= fetchOffset) {
+                abortedTransactions.add(
+                        new FetchResponse.AbortedTransaction(abortedTxn.producerId, abortedTxn.firstOffset));
+            }
+        }
+        return abortedTransactions;
+    }
+
+    /**
+     * Returns the last offset of this map.
+     */
+    public Long mapEndOffset() {
+        return lastMapOffset;
+    }
+
+    /**
+     * Get a copy of the active producers.
+     */
+    public Map<Long, ProducerStateEntry> activeProducers() {
+        return producers;
+    }
+
+    /**
+     * Truncate the producer id mapping and remove all snapshots. This resets the state of the mapping.
+     */
+    public void truncate() {
+        producers.clear();
+        ongoingTxns.clear();
+        lastMapOffset = 0L;
+    }
+
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/EntryPublishTimeTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/EntryPublishTimeTest.java
@@ -85,6 +85,8 @@ public class EntryPublishTimeTest extends KopProtocolHandlerTestBase {
         ProtocolHandler handler = pulsar.getProtocolHandlers().protocol("kafka");
         GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler).getGroupCoordinator();
         TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler).getTransactionCoordinator();
+        BrokerProducerStateManager brokerProducerStateManager =
+                ((KafkaProtocolHandler) handler).getBrokerProducerStateManager();
 
         adminManager = new AdminManager(pulsar.getAdminClient());
         kafkaRequestHandler = new KafkaRequestHandler(
@@ -95,7 +97,8 @@ public class EntryPublishTimeTest extends KopProtocolHandlerTestBase {
                 adminManager,
                 false,
                 getPlainEndPoint(),
-                NullStatsLogger.INSTANCE);
+                NullStatsLogger.INSTANCE,
+                brokerProducerStateManager);
         ChannelHandlerContext mockCtx = mock(ChannelHandlerContext.class);
         Channel mockChannel = mock(Channel.class);
         doReturn(mockChannel).when(mockCtx).channel();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
@@ -136,6 +136,8 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
         ProtocolHandler handler = pulsar.getProtocolHandlers().protocol("kafka");
         GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler).getGroupCoordinator();
         TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler).getTransactionCoordinator();
+        BrokerProducerStateManager brokerProducerStateManager =
+                ((KafkaProtocolHandler) handler).getBrokerProducerStateManager();
 
         adminManager = new AdminManager(pulsar.getAdminClient());
         kafkaRequestHandler = new KafkaRequestHandler(
@@ -146,7 +148,8 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
             adminManager,
             false,
             getPlainEndPoint(),
-            NullStatsLogger.INSTANCE);
+            NullStatsLogger.INSTANCE,
+            brokerProducerStateManager);
         ChannelHandlerContext mockCtx = mock(ChannelHandlerContext.class);
         Channel mockChannel = mock(Channel.class);
         doReturn(mockChannel).when(mockCtx).channel();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -141,6 +141,8 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
         ProtocolHandler handler1 = pulsar.getProtocolHandlers().protocol("kafka");
         GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler1).getGroupCoordinator();
         TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler1).getTransactionCoordinator();
+        BrokerProducerStateManager brokerProducerStateManager =
+                ((KafkaProtocolHandler) handler1).getBrokerProducerStateManager();
 
         adminManager = new AdminManager(pulsar.getAdminClient());
         handler = new KafkaRequestHandler(
@@ -151,7 +153,8 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
             adminManager,
             false,
             getPlainEndPoint(),
-            NullStatsLogger.INSTANCE);
+            NullStatsLogger.INSTANCE,
+            brokerProducerStateManager);
     }
 
     @AfterMethod

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
@@ -64,6 +64,8 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
         ProtocolHandler handler = pulsar.getProtocolHandlers().protocol("kafka");
         GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler).getGroupCoordinator();
         TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler).getTransactionCoordinator();
+        BrokerProducerStateManager brokerProducerStateManager =
+                ((KafkaProtocolHandler) handler).getBrokerProducerStateManager();
 
         adminManager = new AdminManager(pulsar.getAdminClient());
         kafkaRequestHandler = new KafkaRequestHandler(
@@ -74,7 +76,8 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
             adminManager,
             false,
             getPlainEndPoint(),
-            NullStatsLogger.INSTANCE);
+            NullStatsLogger.INSTANCE,
+            brokerProducerStateManager);
 
         ChannelHandlerContext mockCtx = mock(ChannelHandlerContext.class);
         Channel mockChannel = mock(Channel.class);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/ProducerStateManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/ProducerStateManagerTest.java
@@ -553,8 +553,14 @@ public class ProducerStateManagerTest {
         assertEquals(Optional.empty(), stateManager.firstUndecidedOffset());
 
         append(stateManager, producerId, epoch, sequence, 99L, SystemTime.SYSTEM.milliseconds(), true);
-        appendEndTxnMarker(stateManager, producerId, (short) 3, ControlRecordType.COMMIT, 100L,
-                -1, SystemTime.SYSTEM.milliseconds());
+        try {
+            appendEndTxnMarker(stateManager, producerId, (short) 3, ControlRecordType.COMMIT, 100L,
+                    -1, SystemTime.SYSTEM.milliseconds());
+            fail("The control record with old epoch.");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("which is smaller than the last seen"));
+            log.info("Expected behavior.");
+        }
     }
 
     @Test

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/ProducerStateManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/ProducerStateManagerTest.java
@@ -32,7 +32,6 @@ import org.apache.kafka.common.record.EndTransactionMarker;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.utils.SystemTime;
 import org.mockito.Mockito;
-import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
@@ -311,7 +310,6 @@ public class ProducerStateManagerTest {
     @Test
     public void testLastStableOffsetCompletedTxn() {
         short producerEpoch = 0;
-        long segmentBaseOffset = 990000L;
 
         long producerId1 = producerId;
         long startOffset1 = 992342L;
@@ -461,7 +459,7 @@ public class ProducerStateManagerTest {
         // next append is invalid since we expect the sequence to be reset
         try {
             append(stateManager, producerId, bumpedEpoch, 2, 2L, SystemTime.SYSTEM.milliseconds(), true);
-            Assert.fail("Next append is invalid since we expect the sequence to be reset.");
+            fail("Next append is invalid since we expect the sequence to be reset.");
         } catch (OutOfOrderSequenceException e) {
             log.info("Expected behavior.");
         }
@@ -469,7 +467,7 @@ public class ProducerStateManagerTest {
         try {
             append(stateManager, producerId, (short) (bumpedEpoch + 1), 2, 2L,
                     SystemTime.SYSTEM.milliseconds(), true);
-            Assert.fail("[2] Next append is invalid since we expect the sequence to be reset.");
+            fail("[2] Next append is invalid since we expect the sequence to be reset.");
         } catch (OutOfOrderSequenceException e) {
             log.info("Expected behavior.");
         }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/ProducerStateManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/ProducerStateManagerTest.java
@@ -1,0 +1,640 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.coordinator.transaction;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import io.streamnative.pulsar.handlers.kop.ProducerStateManager;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.InvalidTxnStateException;
+import org.apache.kafka.common.errors.OutOfOrderSequenceException;
+import org.apache.kafka.common.internals.Topic;
+import org.apache.kafka.common.record.ControlRecordType;
+import org.apache.kafka.common.record.EndTransactionMarker;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.utils.SystemTime;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.testng.collections.Lists;
+
+/**
+ * Producer state manager test.
+ */
+@Slf4j
+public class ProducerStateManagerTest {
+
+    private ProducerStateManager stateManager;
+    private TopicPartition partition = new TopicPartition("test", 0);
+    private Long producerId = 1L;
+    private Long maxPidExpirationMs = 10 * 1000L;
+
+    @BeforeMethod
+    private void setup() {
+        stateManager = new ProducerStateManager(partition.toString(), maxPidExpirationMs.intValue());
+    }
+
+    @Test
+    public void testBasicIdMapping() {
+        short epoch = 0;
+
+        // First entry for id 0 added
+        append(stateManager, producerId, epoch, 0, 0L, 0L, false);
+
+        // Second entry for id 0 added
+        append(stateManager, producerId, epoch, 1, 0L, 1L, false);
+
+        // Duplicates are checked separately and should result in OutOfOrderSequence if appended
+        try {
+            append(stateManager, producerId, epoch, 1, 0L, 1L, false);
+            fail("Duplicates are checked separately and should result in OutOfOrderSequence if appended.");
+        } catch (OutOfOrderSequenceException e) {
+            log.info("Expected behavior.");
+        }
+
+        // Invalid sequence number (greater than next expected sequence number)
+        try {
+            append(stateManager, producerId, epoch, 5, 0L, 2L, false);
+            fail("Invalid sequence number (greater than next expected sequence number).");
+        } catch (OutOfOrderSequenceException e) {
+            log.info("Expected behavior.");
+        }
+
+        // Change epoch
+        append(stateManager, producerId, (short) (epoch + 1), 0, 0L, 3L, false);
+
+        // Incorrect epoch
+
+        try {
+            append(stateManager, producerId, epoch, 0, 0L, 4L, false);
+            fail("Incorrect epoch.");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("which is smaller than the last seen"));
+            log.info("Expected behavior.");
+        }
+    }
+
+    @Test
+    public void testAppendTxnMarkerWithNoProducerState() {
+        short producerEpoch = 2;
+        appendEndTxnMarker(stateManager, producerId, producerEpoch, ControlRecordType.COMMIT, 27L,
+                -1, SystemTime.SYSTEM.milliseconds());
+
+        ProducerStateManager.ProducerStateEntry firstEntry = stateManager.lastEntry(producerId).orElseGet(() -> {
+            fail("Expected last entry to be defined");
+            return null;
+        });
+
+        assertEquals(producerEpoch, firstEntry.getProducerEpoch().shortValue());
+        assertEquals(producerId, firstEntry.getProducerId());
+        assertEquals(RecordBatch.NO_SEQUENCE, firstEntry.lastSeq().intValue());
+
+        // Fencing should continue to work even if the marker is the only thing left
+        try {
+            append(stateManager, producerId, (short) 0, 0, 0L, 4L, false);
+            fail("Fencing should continue to work even if the marker is the only thing left.");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("which is smaller than the last seen"));
+            log.info("Expected behavior.");
+        }
+
+        // If the transaction marker is the only thing left in the log, then an attempt to write using a non-zero
+        // sequence number should cause an OutOfOrderSequenceException, so that the producer can reset its state
+        try {
+            append(stateManager, producerId, producerEpoch, 17, 0L, 4L, false);
+            fail("If the transaction marker is the only thing left in the log, then an attempt to write"
+                    + "using a non-zero sequence number should cause an OutOfOrderSequenceException, so that the "
+                    + "producer can reset its state.");
+        } catch (OutOfOrderSequenceException e) {
+            log.info("Expected behavior.");
+        }
+
+        // The broker should accept the request if the sequence number is reset to 0
+        append(stateManager, producerId, producerEpoch, 0, 39L, 4L, false);
+        ProducerStateManager.ProducerStateEntry secondEntry = stateManager.lastEntry(producerId).orElseGet(() -> {
+            fail("Expected last entry to be defined");
+            return null;
+        });
+        assertEquals(producerEpoch, secondEntry.getProducerEpoch().shortValue());
+        assertEquals(producerId, secondEntry.getProducerId());
+        assertEquals(0, secondEntry.lastSeq().intValue());
+    }
+
+    @Test
+    public void testProducerSequenceWrapAround() {
+        short epoch = 15;
+        Integer sequence = Integer.MAX_VALUE;
+        long offset = 735L;
+        append(stateManager, producerId, epoch, sequence, offset);
+
+        append(stateManager, producerId, epoch, 0, offset + 500);
+
+        Optional<ProducerStateManager.ProducerStateEntry> maybeLastEntry = stateManager.lastEntry(producerId);
+        assertTrue(maybeLastEntry.isPresent());
+
+        ProducerStateManager.ProducerStateEntry lastEntry = maybeLastEntry.get();
+        assertEquals(epoch, lastEntry.getProducerEpoch().shortValue());
+
+        assertEquals(Integer.MAX_VALUE, lastEntry.firstSeq().intValue());
+        assertEquals(0, lastEntry.lastSeq().intValue());
+    }
+
+    @Test
+    public void testProducerSequenceWithWrapAroundBatchRecord() {
+        short epoch = 15;
+
+        ProducerStateManager.ProducerAppendInfo appendInfo = stateManager.prepareUpdate(
+                producerId, ProducerStateManager.AppendOrigin.Coordinator);
+        // Sequence number wrap around
+        appendInfo.appendDataBatch(epoch, Integer.MAX_VALUE - 10, 9, SystemTime.SYSTEM.milliseconds(),
+                2000L, 2020L, false);
+        assertEquals(Optional.empty(), stateManager.lastEntry(producerId));
+        stateManager.update(appendInfo);
+        assertTrue(stateManager.lastEntry(producerId).isPresent());
+
+        ProducerStateManager.ProducerStateEntry lastEntry = stateManager.lastEntry(producerId).get();
+        assertEquals(Integer.MAX_VALUE - 10, lastEntry.firstSeq().intValue());
+        assertEquals(9, lastEntry.lastSeq().intValue());
+        assertEquals(2000L, lastEntry.firstDataOffset().longValue());
+        assertEquals(2020L, lastEntry.lastDataOffset().longValue());
+    }
+
+    @Test(expectedExceptions = OutOfOrderSequenceException.class)
+    public void testProducerSequenceInvalidWrapAround() {
+        short epoch = 15;
+        Integer sequence = Integer.MAX_VALUE;
+        long offset = 735L;
+        append(stateManager, producerId, epoch, sequence, offset);
+        append(stateManager, producerId, epoch, 1, offset + 500);
+    }
+
+    @Test
+    public void testNoValidationOnFirstEntryWhenLoadingLog() {
+        short epoch = 5;
+        Integer sequence = 16;
+        long offset = 735L;
+        append(stateManager, producerId, epoch, sequence, offset);
+
+        Optional<ProducerStateManager.ProducerStateEntry> maybeLastEntry = stateManager.lastEntry(producerId);
+        assertTrue(maybeLastEntry.isPresent());
+
+        ProducerStateManager.ProducerStateEntry lastEntry = maybeLastEntry.get();
+        assertEquals(epoch, lastEntry.getProducerEpoch().shortValue());
+        assertEquals(sequence, lastEntry.firstSeq());
+        assertEquals(sequence, lastEntry.lastSeq());
+        assertEquals(offset, lastEntry.lastDataOffset().longValue());
+        assertEquals(offset, lastEntry.firstDataOffset().longValue());
+    }
+
+    @Test
+    public void testControlRecordBumpsProducerEpoch() {
+        short producerEpoch = 0;
+        append(stateManager, producerId, producerEpoch, 0, 0L);
+
+        short bumpedProducerEpoch = 1;
+        appendEndTxnMarker(stateManager, producerId, bumpedProducerEpoch, ControlRecordType.ABORT, 1L,
+                -1, SystemTime.SYSTEM.milliseconds());
+
+        Optional<ProducerStateManager.ProducerStateEntry> maybeLastEntry = stateManager.lastEntry(producerId);
+        assertTrue(maybeLastEntry.isPresent());
+
+        ProducerStateManager.ProducerStateEntry lastEntry = maybeLastEntry.get();
+        assertEquals(bumpedProducerEpoch, lastEntry.getProducerEpoch().shortValue());
+        assertEquals(Optional.empty(), lastEntry.getCurrentTxnFirstOffset());
+        assertEquals(RecordBatch.NO_SEQUENCE, lastEntry.firstSeq().intValue());
+        assertEquals(RecordBatch.NO_SEQUENCE, lastEntry.lastSeq().intValue());
+
+        // should be able to append with the new epoch if we start at sequence 0
+        append(stateManager, producerId, bumpedProducerEpoch, 0, 2L);
+        assertEquals(0, stateManager.lastEntry(producerId).get().firstSeq().intValue());
+    }
+
+    @Test
+    public void testTxnFirstOffsetMetadataCached() {
+        short producerEpoch = 0;
+        long offset = 992342L;
+        int seq = 0;
+        ProducerStateManager.ProducerAppendInfo producerAppendInfo =
+                new ProducerStateManager.ProducerAppendInfo(
+                        partition.toString(), producerId, ProducerStateManager.ProducerStateEntry.empty(producerId),
+                        ProducerStateManager.AppendOrigin.Client);
+
+        producerAppendInfo.appendDataBatch(producerEpoch, seq, seq, SystemTime.SYSTEM.milliseconds(),
+                offset, offset, true);
+        stateManager.update(producerAppendInfo);
+
+        assertEquals(Optional.of(offset), stateManager.firstUndecidedOffset());
+    }
+
+    @Test
+    public void testSkipEmptyTransactions() {
+        short producerEpoch = 0;
+        short coordinatorEpoch = 27;
+        AtomicInteger seq = new AtomicInteger(0);
+
+        // Start one transaction in a separate append
+        ProducerStateManager.ProducerAppendInfo firstAppend = stateManager.prepareUpdate(
+                producerId, ProducerStateManager.AppendOrigin.Client);
+        appendData(16L, 20L, firstAppend, producerEpoch, seq);
+        assertEquals(new ProducerStateManager.TxnMetadata(producerId, 16L), firstAppend.startedTransactions().get(0));
+        stateManager.update(firstAppend);
+        assertEquals(16, stateManager.firstUndecidedOffset().get().longValue());
+
+        // Now do a single append which completes the old transaction, mixes in
+        // some empty transactions, one non-empty complete transaction, and one
+        // incomplete transaction
+        ProducerStateManager.ProducerAppendInfo secondAppend = stateManager.prepareUpdate(
+                producerId, ProducerStateManager.AppendOrigin.Client);
+        Optional<ProducerStateManager.CompletedTxn> firstCompletedTxn =
+                appendEndTxn(ControlRecordType.COMMIT, 21L, secondAppend, coordinatorEpoch, producerEpoch);
+        assertEquals(
+                Optional.of(new ProducerStateManager.CompletedTxn(producerId, 16L, 21L, false)),
+                firstCompletedTxn);
+        assertEquals(Optional.empty(),
+                appendEndTxn(ControlRecordType.COMMIT, 22L, secondAppend, coordinatorEpoch, producerEpoch));
+        assertEquals(Optional.empty(),
+                appendEndTxn(ControlRecordType.ABORT, 23L, secondAppend, coordinatorEpoch, producerEpoch));
+        appendData(24L, 27L, secondAppend, producerEpoch, seq);
+        Optional<ProducerStateManager.CompletedTxn> secondCompletedTxn = appendEndTxn(
+                ControlRecordType.ABORT, 28L, secondAppend, coordinatorEpoch, producerEpoch);
+        assertTrue(secondCompletedTxn.isPresent());
+        assertEquals(Optional.empty(),
+                appendEndTxn(ControlRecordType.ABORT, 29L, secondAppend, coordinatorEpoch, producerEpoch));
+        appendData(30L, 31L, secondAppend, producerEpoch, seq);
+
+        assertEquals(2, secondAppend.startedTransactions().size());
+        assertEquals(new ProducerStateManager.TxnMetadata(producerId, 24L),
+                secondAppend.startedTransactions().get(0));
+        assertEquals(new ProducerStateManager.TxnMetadata(producerId, 30L),
+                secondAppend.startedTransactions().get(secondAppend.startedTransactions().size() - 1));
+        stateManager.update(secondAppend);
+        stateManager.completeTxn(firstCompletedTxn.get());
+        stateManager.completeTxn(secondCompletedTxn.get());
+        assertEquals(30L, stateManager.firstUndecidedOffset().get().longValue());
+    }
+
+    private Optional<ProducerStateManager.CompletedTxn> appendEndTxn(
+            ControlRecordType recordType, Long offset, ProducerStateManager.ProducerAppendInfo appendInfo,
+            short coordinatorEpoch, short producerEpoch) {
+        return appendInfo.appendEndTxnMarker(new EndTransactionMarker(recordType, coordinatorEpoch),
+                producerEpoch, offset, SystemTime.SYSTEM.milliseconds());
+    }
+
+    public void appendData(Long startOffset, Long endOffset,
+                           ProducerStateManager.ProducerAppendInfo appendInfo,
+                           short producerEpoch, AtomicInteger seq) {
+        int count = (int) (endOffset - startOffset);
+        appendInfo.appendDataBatch(producerEpoch, seq.get(), seq.addAndGet(count), SystemTime.SYSTEM.milliseconds(),
+                startOffset, endOffset, true);
+        seq.incrementAndGet();
+    }
+
+    @Test
+    public void testLastStableOffsetCompletedTxn() {
+        short producerEpoch = 0;
+        long segmentBaseOffset = 990000L;
+
+        long producerId1 = producerId;
+        long startOffset1 = 992342L;
+        beginTxn(producerId1, producerEpoch, startOffset1);
+
+        long producerId2 = producerId + 1;
+        long startOffset2 = startOffset1 + 25;
+        beginTxn(producerId2, producerEpoch, startOffset2);
+
+        long producerId3 = producerId + 2;
+        long startOffset3 = startOffset1 + 57;
+        beginTxn(producerId3, producerEpoch, startOffset3);
+
+        long lastOffset1 = startOffset3 + 15;
+        ProducerStateManager.CompletedTxn completedTxn1 =
+                new ProducerStateManager.CompletedTxn(producerId1, startOffset1, lastOffset1, false);
+        assertEquals(startOffset2, stateManager.lastStableOffset(completedTxn1));
+        stateManager.completeTxn(completedTxn1);
+        assertEquals(startOffset2, stateManager.firstUndecidedOffset().get().longValue());
+
+        long lastOffset3 = lastOffset1 + 20;
+        ProducerStateManager.CompletedTxn completedTxn3 =
+                new ProducerStateManager.CompletedTxn(producerId3, startOffset3, lastOffset3, false);
+        assertEquals(startOffset2, stateManager.lastStableOffset(completedTxn3));
+        stateManager.completeTxn(completedTxn3);
+        assertEquals(startOffset2, stateManager.firstUndecidedOffset().get().longValue());
+
+        long lastOffset2 = lastOffset3 + 78;
+        ProducerStateManager.CompletedTxn completedTxn2 =
+                new ProducerStateManager.CompletedTxn(producerId2, startOffset2, lastOffset2, false);
+        assertEquals(lastOffset2 + 1, stateManager.lastStableOffset(completedTxn2));
+        stateManager.completeTxn(completedTxn2);
+        assertEquals(Optional.empty(), stateManager.firstUndecidedOffset());
+    }
+
+    private void beginTxn(Long producerId, short producerEpoch, Long startOffset) {
+        ProducerStateManager.ProducerAppendInfo producerAppendInfo = new ProducerStateManager.ProducerAppendInfo(
+                partition.toString(),
+                producerId,
+                ProducerStateManager.ProducerStateEntry.empty(producerId),
+                ProducerStateManager.AppendOrigin.Client
+        );
+        producerAppendInfo.appendDataBatch(producerEpoch, 0, 0, SystemTime.SYSTEM.milliseconds(),
+                startOffset, startOffset, true);
+        stateManager.update(producerAppendInfo);
+    }
+
+    @Test
+    public void testPrepareUpdateDoesNotMutate() {
+        short producerEpoch = 0;
+
+        ProducerStateManager.ProducerAppendInfo appendInfo = stateManager.prepareUpdate(
+                producerId, ProducerStateManager.AppendOrigin.Client);
+        appendInfo.appendDataBatch(producerEpoch, 0, 5, SystemTime.SYSTEM.milliseconds(),
+                15L, 20L, false);
+        assertEquals(Optional.empty(), stateManager.lastEntry(producerId));
+        stateManager.update(appendInfo);
+        assertTrue(stateManager.lastEntry(producerId).isPresent());
+
+        ProducerStateManager.ProducerAppendInfo nextAppendInfo = stateManager.prepareUpdate(
+                producerId, ProducerStateManager.AppendOrigin.Client);
+        nextAppendInfo.appendDataBatch(producerEpoch, 6, 10, SystemTime.SYSTEM.milliseconds(),
+                26L, 30L, false);
+        assertTrue(stateManager.lastEntry(producerId).isPresent());
+
+        ProducerStateManager.ProducerStateEntry lastEntry = stateManager.lastEntry(producerId).get();
+        assertEquals(0, lastEntry.firstSeq().intValue());
+        assertEquals(5, lastEntry.lastSeq().intValue());
+        assertEquals(20L, lastEntry.lastDataOffset().longValue());
+
+        stateManager.update(nextAppendInfo);
+        lastEntry = stateManager.lastEntry(producerId).get();
+        assertEquals(0, lastEntry.firstSeq().intValue());
+        assertEquals(10, lastEntry.lastSeq().intValue());
+        assertEquals(30L, lastEntry.lastDataOffset().longValue());
+    }
+
+    @Test
+    public void updateProducerTransactionState() {
+        short producerEpoch = 0;
+        short coordinatorEpoch = 15;
+        long offset = 9L;
+        append(stateManager, producerId, producerEpoch, 0, offset);
+
+        ProducerStateManager.ProducerAppendInfo appendInfo =
+                stateManager.prepareUpdate(producerId, ProducerStateManager.AppendOrigin.Client);
+        appendInfo.appendDataBatch(producerEpoch, 1, 5, SystemTime.SYSTEM.milliseconds(),
+                16L, 20L, true);
+        ProducerStateManager.ProducerStateEntry lastEntry = appendInfo.toEntry();
+        assertEquals(producerEpoch, lastEntry.getProducerEpoch().shortValue());
+        assertEquals(1, lastEntry.firstSeq().intValue());
+        assertEquals(5, lastEntry.lastSeq().intValue());
+        assertEquals(16L, lastEntry.firstDataOffset().longValue());
+        assertEquals(20L, lastEntry.lastDataOffset().longValue());
+        assertEquals(Optional.of(16L), lastEntry.getCurrentTxnFirstOffset());
+        assertEquals(
+                Lists.newArrayList(new ProducerStateManager.TxnMetadata(producerId, 16L)),
+                appendInfo.startedTransactions());
+
+        appendInfo.appendDataBatch(producerEpoch, 6, 10, SystemTime.SYSTEM.milliseconds(),
+                26L, 30L, true);
+        lastEntry = appendInfo.toEntry();
+        assertEquals(producerEpoch, lastEntry.getProducerEpoch().shortValue());
+        assertEquals(1, lastEntry.firstSeq().intValue());
+        assertEquals(10, lastEntry.lastSeq().intValue());
+        assertEquals(16L, lastEntry.firstDataOffset().longValue());
+        assertEquals(30L, lastEntry.lastDataOffset().longValue());
+        assertEquals(Optional.of(16L), lastEntry.getCurrentTxnFirstOffset());
+        assertEquals(
+                Lists.newArrayList(new ProducerStateManager.TxnMetadata(producerId, 16L)),
+                appendInfo.startedTransactions());
+
+        EndTransactionMarker endTxnMarker = new EndTransactionMarker(ControlRecordType.COMMIT, coordinatorEpoch);
+        Optional<ProducerStateManager.CompletedTxn> completedTxnOpt =
+                appendInfo.appendEndTxnMarker(endTxnMarker, producerEpoch, 40L, SystemTime.SYSTEM.milliseconds());
+        assertTrue(completedTxnOpt.isPresent());
+
+        ProducerStateManager.CompletedTxn completedTxn = completedTxnOpt.get();
+        assertEquals(producerId, completedTxn.getProducerId());
+        assertEquals(16L, completedTxn.getFirstOffset().longValue());
+        assertEquals(40L, completedTxn.getLastOffset().longValue());
+        assertFalse(completedTxn.getIsAborted());
+
+        lastEntry = appendInfo.toEntry();
+        assertEquals(producerEpoch, lastEntry.getProducerEpoch().shortValue());
+        // verify that appending the transaction marker doesn't affect the metadata of the cached record batches.
+        assertEquals(1, lastEntry.firstSeq().intValue());
+        assertEquals(10, lastEntry.lastSeq().intValue());
+        assertEquals(16L, lastEntry.firstDataOffset().longValue());
+        assertEquals(30L, lastEntry.lastDataOffset().longValue());
+        assertEquals(Optional.empty(), lastEntry.getCurrentTxnFirstOffset());
+        assertEquals(
+                Lists.newArrayList(new ProducerStateManager.TxnMetadata(producerId, 16L)),
+                appendInfo.startedTransactions());
+    }
+
+    @Test
+    public void testOutOfSequenceAfterControlRecordEpochBump() {
+        short epoch = 0;
+        append(stateManager, producerId, epoch, 0, 0L, SystemTime.SYSTEM.milliseconds(), true);
+        append(stateManager, producerId, epoch, 1, 1L, SystemTime.SYSTEM.milliseconds(), true);
+
+        short bumpedEpoch = 1;
+        appendEndTxnMarker(stateManager, producerId, bumpedEpoch, ControlRecordType.ABORT, 1L,
+                -1, SystemTime.SYSTEM.milliseconds());
+
+        // next append is invalid since we expect the sequence to be reset
+        try {
+            append(stateManager, producerId, bumpedEpoch, 2, 2L, SystemTime.SYSTEM.milliseconds(), true);
+            Assert.fail("Next append is invalid since we expect the sequence to be reset.");
+        } catch (OutOfOrderSequenceException e) {
+            log.info("Expected behavior.");
+        }
+
+        try {
+            append(stateManager, producerId, (short) (bumpedEpoch + 1), 2, 2L,
+                    SystemTime.SYSTEM.milliseconds(), true);
+            Assert.fail("[2] Next append is invalid since we expect the sequence to be reset.");
+        } catch (OutOfOrderSequenceException e) {
+            log.info("Expected behavior.");
+        }
+
+        // Append with the bumped epoch should be fine if starting from sequence 0
+        append(stateManager, producerId, bumpedEpoch, 0, 0L, SystemTime.SYSTEM.milliseconds(), true);
+        assertEquals(bumpedEpoch, stateManager.lastEntry(producerId).get().getProducerEpoch().shortValue());
+        assertEquals(0, stateManager.lastEntry(producerId).get().lastSeq().shortValue());
+    }
+
+    @Test(expectedExceptions = InvalidTxnStateException.class)
+    public void testNonTransactionalAppendWithOngoingTransaction() {
+        short epoch = 0;
+        append(stateManager, producerId, epoch, 0, 0L, SystemTime.SYSTEM.milliseconds(), true);
+        append(stateManager, producerId, epoch, 1, 1L, SystemTime.SYSTEM.milliseconds(), false);
+    }
+
+    @Test
+    public void testProducerStateAfterFencingAbortMarker() {
+        short epoch = 0;
+        append(stateManager, producerId, epoch, 0, 0L, SystemTime.SYSTEM.milliseconds(), true);
+        appendEndTxnMarker(stateManager, producerId, (short) (epoch + 1), ControlRecordType.ABORT,
+                1L, -1, SystemTime.SYSTEM.milliseconds());
+
+        ProducerStateManager.ProducerStateEntry lastEntry = stateManager.lastEntry(producerId).get();
+        assertEquals(Optional.empty(), lastEntry.getCurrentTxnFirstOffset());
+        assertEquals(-1, lastEntry.lastDataOffset().longValue());
+        assertEquals(-1, lastEntry.firstDataOffset().longValue());
+
+        // The producer should not be expired because we want to preserve fencing epochs
+        stateManager.removeExpiredProducers(SystemTime.SYSTEM.milliseconds());
+        assertTrue(stateManager.lastEntry(producerId).isPresent());
+    }
+
+    @Test
+    public void testPidExpirationTimeout() throws InterruptedException {
+        short epoch = 5;
+        int sequence = 37;
+        append(stateManager, producerId, epoch, sequence, 1L);
+        Thread.sleep(maxPidExpirationMs + 1);
+        stateManager.removeExpiredProducers(SystemTime.SYSTEM.milliseconds());
+        append(stateManager, producerId, epoch, sequence + 1, 2L);
+        assertEquals(1, stateManager.activeProducers().size());
+        assertEquals(sequence + 1, stateManager.activeProducers().get(producerId).lastSeq().shortValue());
+        assertEquals(3L, stateManager.mapEndOffset().longValue());
+    }
+
+    @Test
+    public void testProducersWithOngoingTransactionsDontExpire() throws InterruptedException {
+        short epoch = 5;
+        int sequence = 0;
+
+        append(stateManager, producerId, epoch, sequence, 99L, SystemTime.SYSTEM.milliseconds(), true);
+        assertEquals(Optional.of(99L), stateManager.firstUndecidedOffset());
+
+        Thread.sleep(maxPidExpirationMs + 1);
+        stateManager.removeExpiredProducers(SystemTime.SYSTEM.milliseconds());
+
+        assertTrue(stateManager.lastEntry(producerId).isPresent());
+        assertEquals(Optional.of(99L), stateManager.firstUndecidedOffset());
+
+        stateManager.removeExpiredProducers(SystemTime.SYSTEM.milliseconds());
+        assertTrue(stateManager.lastEntry(producerId).isPresent());
+    }
+
+    @Test
+    public void testSequenceNotValidatedForGroupMetadataTopic() {
+        TopicPartition partition = new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0);
+        ProducerStateManager stateManager = new ProducerStateManager(partition.topic(), maxPidExpirationMs.intValue());
+
+        short epoch = 0;
+        append(stateManager, producerId, epoch, RecordBatch.NO_SEQUENCE, 99L, SystemTime.SYSTEM.milliseconds(),
+                true, ProducerStateManager.AppendOrigin.Coordinator);
+        append(stateManager, producerId, epoch, RecordBatch.NO_SEQUENCE, 100L, SystemTime.SYSTEM.milliseconds(),
+                true, ProducerStateManager.AppendOrigin.Coordinator);
+    }
+
+    @Test
+    public void testOldEpochForControlRecord() {
+        short epoch = 5;
+        int sequence = 0;
+
+        assertEquals(Optional.empty(), stateManager.firstUndecidedOffset());
+
+        append(stateManager, producerId, epoch, sequence, 99L, SystemTime.SYSTEM.milliseconds(), true);
+        appendEndTxnMarker(stateManager, producerId, (short) 3, ControlRecordType.COMMIT, 100L,
+                -1, SystemTime.SYSTEM.milliseconds());
+    }
+
+    @Test
+    public void testAppendEmptyControlBatch() {
+        long producerId = 23423L;
+        long baseOffset = 15;
+
+        RecordBatch batch = Mockito.mock(RecordBatch.class);
+        Mockito.when(batch.isControlBatch()).thenReturn(true);
+        Mockito.when(batch.iterator()).thenReturn(Collections.emptyIterator());
+
+        // Appending the empty control batch should not throw and a new transaction shouldn't be started
+        append(stateManager, producerId, baseOffset, batch, ProducerStateManager.AppendOrigin.Client);
+        assertEquals(Optional.empty(), stateManager.lastEntry(producerId).get().getCurrentTxnFirstOffset());
+    }
+
+    private Optional<ProducerStateManager.CompletedTxn> appendEndTxnMarker(ProducerStateManager mapping,
+                                                                           Long producerId,
+                                                                           Short producerEpoch,
+                                                                           ControlRecordType controlType,
+                                                                           Long offset,
+                                                                           Integer coordinatorEpoch,
+                                                                           Long timestamp) {
+        ProducerStateManager.ProducerAppendInfo producerAppendInfo = stateManager.prepareUpdate(
+                producerId, ProducerStateManager.AppendOrigin.Coordinator);
+        EndTransactionMarker endTxnMarker = new EndTransactionMarker(controlType, coordinatorEpoch);
+        Optional<ProducerStateManager.CompletedTxn> completedTxnOpt =
+                producerAppendInfo.appendEndTxnMarker(endTxnMarker, producerEpoch, offset, timestamp);
+        mapping.update(producerAppendInfo);
+        completedTxnOpt.ifPresent(mapping::completeTxn);
+        mapping.updateMapEndOffset(offset + 1);
+        return completedTxnOpt;
+    }
+
+    private void append(ProducerStateManager stateManager,
+                        Long producerId,
+                        Short producerEpoch,
+                        Integer seq,
+                        Long offset) {
+        append(stateManager, producerId, producerEpoch, seq, offset, SystemTime.SYSTEM.milliseconds(),
+                false, ProducerStateManager.AppendOrigin.Client);
+    }
+
+    private void append(ProducerStateManager stateManager,
+                        Long producerId,
+                        Short producerEpoch,
+                        Integer seq,
+                        Long offset,
+                        Long timestamp,
+                        Boolean isTransactional) {
+        append(stateManager, producerId, producerEpoch, seq, offset, timestamp, isTransactional,
+                ProducerStateManager.AppendOrigin.Client);
+    }
+
+    private void append(ProducerStateManager stateManager,
+                        Long producerId,
+                        Short producerEpoch,
+                        Integer seq,
+                        Long offset,
+                        Long timestamp,
+                        Boolean isTransactional,
+                        ProducerStateManager.AppendOrigin origin) {
+        ProducerStateManager.ProducerAppendInfo producerAppendInfo = stateManager.prepareUpdate(producerId, origin);
+        producerAppendInfo.appendDataBatch(producerEpoch, seq, seq, timestamp, -1L, -1L, isTransactional);
+        producerAppendInfo.resetOffset(offset, isTransactional);
+        stateManager.update(producerAppendInfo);
+        stateManager.updateMapEndOffset(offset + 1);
+    }
+
+    private void append(ProducerStateManager stateManager,
+                        Long producerId,
+                        Long offset,
+                        RecordBatch batch,
+                        ProducerStateManager.AppendOrigin origin) {
+        ProducerStateManager.ProducerAppendInfo producerAppendInfo = stateManager.prepareUpdate(producerId, origin);
+        producerAppendInfo.append(batch, Optional.empty());
+        stateManager.update(producerAppendInfo);
+        stateManager.updateMapEndOffset(offset + 1);
+    }
+
+}


### PR DESCRIPTION
# Motivation

Add producer state manager to manage ongoing transactions, aborted transactions indexes, and make some checks (duplicate, producer epoch, sequence) for record batch.

The producer state snapshot and recovery are based on this PR.