### PR TITLE
Add inner topic protection

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -1708,7 +1708,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     }
 
     protected boolean isTransactionTopic(String topic) {
-        String transactionTopic = kafkaConfig.getKafkaMetadataNamespace() + "/"
+        String transactionTopic = kafkaConfig.getKafkaMetadataTenant() + "/"
             + kafkaConfig.getKafkaMetadataNamespace()
             + "/" + TRANSACTION_STATE_TOPIC_NAME;
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -78,6 +78,7 @@ import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.errors.CorruptRecordException;
+import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.errors.LeaderNotAvailableException;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
@@ -651,6 +652,13 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         for (Map.Entry<TopicPartition, ? extends Records> entry : produceRequest.partitionRecordsOrFail().entrySet()) {
             TopicPartition topicPartition = entry.getKey();
             try {
+                String fullPartitionName = KopTopic.toString(topicPartition);
+                if (isOffsetTopic(fullPartitionName) || isTransactionTopic(fullPartitionName)) {
+                    log.error("[{}] Request {}: not support produce message to inner topic. topic: {}",
+                        ctx.channel(), produceHar.getHeader(), topicPartition);
+                    throw new InvalidTopicException(Errors.INVALID_TOPIC_EXCEPTION.message());
+                }
+
                 MemoryRecords validRecords = validateRecords(produceHar.getHeader().apiVersion(),
                     topicPartition, (MemoryRecords) entry.getValue());
 
@@ -663,7 +671,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                         topicPartition.topic(), topicPartition.partition(), responsesSize);
                 }
 
-                String fullPartitionName = KopTopic.toString(topicPartition);
                 PendingProduce pendingProduce = new PendingProduce(partitionResponse, topicManager, fullPartitionName,
                     entryFormatter, validRecords, executor, transactionCoordinator, requestStats);
                 PendingProduceQueue queue =
@@ -1692,12 +1699,20 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         return returnFuture;
     }
 
-    private boolean isOffsetTopic(String topic) {
+    protected boolean isOffsetTopic(String topic) {
         String offsetsTopic = kafkaConfig.getKafkaMetadataTenant() + "/"
             + kafkaConfig.getKafkaMetadataNamespace()
             + "/" + GROUP_METADATA_TOPIC_NAME;
 
-        return topic.contains(offsetsTopic);
+        return topic != null && topic.contains(offsetsTopic);
+    }
+
+    protected boolean isTransactionTopic(String topic) {
+        String transactionTopic = kafkaConfig.getKafkaMetadataNamespace() + "/"
+            + kafkaConfig.getKafkaMetadataNamespace()
+            + "/" + TRANSACTION_STATE_TOPIC_NAME;
+
+        return topic != null && topic.contains(transactionTopic);
     }
 
     public CompletableFuture<PartitionMetadata> findBroker(TopicName topic) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/PendingProduce.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/PendingProduce.java
@@ -126,6 +126,12 @@ public class PendingProduce {
             throw new RuntimeException(e);
         }
 
+        if (persistentTopic.isSystemTopic()) {
+            log.error("Not support produce message to system topic: {}", persistentTopic);
+            responseFuture.complete(new PartitionResponse(Errors.INVALID_TOPIC_EXCEPTION));
+            return;
+        }
+
         if (log.isDebugEnabled()) {
             log.debug("publishMessages for topic partition: {}, records size is {}", partitionName, numMessages);
         }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/PendingProduce.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/PendingProduce.java
@@ -126,6 +126,12 @@ public class PendingProduce {
             throw new RuntimeException(e);
         }
 
+        if (persistentTopic.isSystemTopic()) {
+            log.error("Not support producing message to system topic: {}", persistentTopic);
+            responseFuture.complete(new PartitionResponse(Errors.INVALID_TOPIC_EXCEPTION));
+            return;
+        }
+
         if (log.isDebugEnabled()) {
             log.debug("publishMessages for topic partition: {}, records size is {}", partitionName, numMessages);
         }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/PendingProduce.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/PendingProduce.java
@@ -126,12 +126,6 @@ public class PendingProduce {
             throw new RuntimeException(e);
         }
 
-        if (persistentTopic.isSystemTopic()) {
-            log.error("Not support produce message to system topic: {}", persistentTopic);
-            responseFuture.complete(new PartitionResponse(Errors.INVALID_TOPIC_EXCEPTION));
-            return;
-        }
-
         if (log.isDebugEnabled()) {
             log.debug("publishMessages for topic partition: {}, records size is {}", partitionName, numMessages);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
     <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
     <puppycrawl.checkstyle.version>6.19</puppycrawl.checkstyle.version>
     <spotbugs-maven-plugin.version>3.1.8</spotbugs-maven-plugin.version>
+    <avro.version>1.10.2</avro.version>
   </properties>
 
   <licenses>
@@ -226,6 +227,13 @@
       <version>${pulsar.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>${avro.version}</version>
+      <scope>provided</scope>
     </dependency>
 
   </dependencies>

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/InnerTopicProtectionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/InnerTopicProtectionTest.java
@@ -65,8 +65,8 @@ public class InnerTopicProtectionTest extends KopProtocolHandlerTestBase {
         kConfig.setAllowAutoTopicCreation(true);
         kConfig.setAllowAutoTopicCreationType("partitioned");
         kConfig.setBrokerDeleteInactiveTopicsEnabled(false);
-        //kConfig.setSystemTopicEnabled(true);
-        //kConfig.setTopicLevelPoliciesEnabled(true);
+        kConfig.setSystemTopicEnabled(true);
+        kConfig.setTopicLevelPoliciesEnabled(true);
 
         // set protocol related config
         URL testHandlerUrl = this.getClass().getClassLoader().getResource("test-protocol-handler.nar");
@@ -156,6 +156,7 @@ public class InnerTopicProtectionTest extends KopProtocolHandlerTestBase {
         final String msg = "test-inner-topic-produce-and-consume";
         assertProduceMessage(kafkaProducer, offsetTopic, msg, true);
         assertProduceMessage(kafkaProducer, transactionTopic, msg, true);
+        assertProduceMessage(kafkaProducer, systemTopic, msg, true);
         assertProduceMessage(kafkaProducer, commonTopic, msg, false);
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/InnerTopicProtectionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/InnerTopicProtectionTest.java
@@ -162,15 +162,14 @@ public class InnerTopicProtectionTest extends KopProtocolHandlerTestBase {
     private void assertProduceMessage(KafkaProducer producer, final String topic, final String value,
                                       boolean assertException) {
         try {
-            producer.send(new ProducerRecord<>(topic, value), ((metadata, exception) -> {
-                if (assertException) {
-                    Assert.assertNotNull(exception);
-                } else {
-                    Assert.assertNull(exception);
-                }
-            })).get();
+            producer.send(new ProducerRecord<>(topic, value)).get();
         } catch (Exception e) {
-
+            if (assertException) {
+                Assert.assertEquals(e.getCause().getMessage(),
+                    "The request attempted to perform an operation on an invalid topic.");
+            } else {
+                Assert.fail();
+            }
         }
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/InnerTopicProtectionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/InnerTopicProtectionTest.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.streamnative.pulsar.handlers.kop;
 
 import com.google.common.collect.Sets;
@@ -13,6 +26,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.TenantInfo;
@@ -21,6 +35,9 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+/**
+ * Inner topic protection test.
+ */
 @Slf4j
 public class InnerTopicProtectionTest extends KopProtocolHandlerTestBase {
 
@@ -126,12 +143,13 @@ public class InnerTopicProtectionTest extends KopProtocolHandlerTestBase {
     }
 
     @Test(timeOut = 30000)
-    public void testInnerTopicProduce() throws Exception {
+    public void testInnerTopicProduce() throws PulsarAdminException {
         final String offsetTopic = "public/__kafka/__consumer_offsets";
         final String transactionTopic = "public/__kafka/__transaction_state";
         final String systemTopic = "__change_events";
         final String commonTopic = "normal-topic";
 
+        admin.topics().createPartitionedTopic(commonTopic, 3);
         // test inner topic produce
         @Cleanup
         final KafkaProducer<String, String> kafkaProducer = newKafkaProducer();


### PR DESCRIPTION
### Motivation
For inner topic, such as, __consumer_offsets, __transaction_stats, and system topic, such as, __change_event, they are expose to all users and can produce / consumer message to / from those topic, which will cause the cluster crash.

### Changes
1. add produce protection for inner topic on KOP side.

TODO
1. for consume protection, it's in testing.