### PR TITLE
add message ttl for kafka metadata namespace

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,7 @@ The following table lists all KoP configurations.
 |offsetsTopicCompressionCodec| Compression codec for the offsets topic <br>compression may be used to achieve "atomic" commits  |N/A|
 |offsetMetadataMaxSize| The maximum size in bytes for a metadata entry associated with an offset commit  |4096|
 |offsetsRetentionMinutes| Offsets older than this retention period are discarded |10080|
+|offsetsMessageTTL| Offsets message ttl in seconds. | 259200 |
 |offsetsRetentionCheckIntervalMs| Frequency at which to check for stale offsets  |600000|
 |offsetsTopicNumPartitions| Number of partitions for the offsets topic  |8|
 |kopSslProtocol| Kafka SSL configuration map with: SSL_PROTOCOL_CONFIG = ssl.protocol |TLS|

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -45,6 +45,7 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
     // offset configuration
     private static final int OffsetsRetentionMinutes = 3 * 24 * 60;
     public static final int DefaultOffsetsTopicNumPartitions = 8;
+    private static final int OffsetsMessageTTL = 3 * 24 * 3600;
     // txn configuration
     public static final int DefaultTxnLogTopicNumPartitions = 8;
 
@@ -142,6 +143,12 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
         doc = "Offsets older than this retention period will be discarded"
     )
     private long offsetsRetentionMinutes = OffsetsRetentionMinutes;
+
+    @FieldContext(
+        category = CATEGORY_KOP,
+        doc = "Offsets message ttl in seconds. default is 259200."
+    )
+    private int offsetsMessageTTL = OffsetsMessageTTL;
 
     @FieldContext(
         category = CATEGORY_KOP,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
@@ -166,6 +166,12 @@ public class MetadataUtils {
                 namespaces.setCompactionThreshold(kafkaMetadataNamespace, MAX_COMPACTION_THRESHOLD);
             }
 
+            int targetMessageTTL = conf.getOffsetsMessageTTL();
+            Integer messageTTL = namespaces.getNamespaceMessageTTL(kafkaMetadataNamespace);
+            if (messageTTL == null || messageTTL != targetMessageTTL) {
+                namespaces.setNamespaceMessageTTL(kafkaMetadataNamespace, targetMessageTTL);
+            }
+
             namespaceExists = true;
 
             // Check if the offsets topic exists and create it if not

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtilsTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtilsTest.java
@@ -47,7 +47,7 @@ import org.testng.annotations.Test;
 */
 public class MetadataUtilsTest {
 
-    @Test()
+    @Test(timeOut = 30000)
     public void testCreateKafkaMetadataIfMissing() throws Exception {
         KopTopic.initialize("public/default");
         KafkaServiceConfiguration conf = new KafkaServiceConfiguration();
@@ -106,6 +106,8 @@ public class MetadataUtilsTest {
             + "/" + conf.getKafkaMetadataNamespace()), any(Set.class));
         verify(mockNamespaces, times(2)).setRetention(eq(conf.getKafkaMetadataTenant() + "/"
             + conf.getKafkaMetadataNamespace()), any(RetentionPolicies.class));
+        verify(mockNamespaces, times(2)).setNamespaceMessageTTL(eq(conf.getKafkaMetadataTenant() + "/"
+            + conf.getKafkaMetadataNamespace()), any(Integer.class));
         verify(mockTopics, times(1)).createPartitionedTopic(
                 eq(offsetsTopic.getFullName()), eq(conf.getOffsetsTopicNumPartitions()));
         verify(mockTopics, times(1)).createPartitionedTopic(


### PR DESCRIPTION
### Motivation
We need to add message ttl for kafka metadata namespace.

### Changes
1. add message ttl configuration for kafka metadata namespace.