### PR TITLE
update kafka metadata namespace retention doc

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,7 +30,7 @@ The following table lists all KoP configurations.
 |groupInitialRebalanceDelayMs| The time the group coordinator waits for more consumers to join a new group before performing the first rebalance <br> A longer delay potentially reduces rebalances, but increases the time until processing begins.  |3000|
 |offsetsTopicCompressionCodec| Compression codec for the offsets topic <br>compression may be used to achieve "atomic" commits  |N/A|
 |offsetMetadataMaxSize| The maximum size in bytes for a metadata entry associated with an offset commit  |4096|
-|offsetsRetentionMinutes| Offsets older than this retention period are discarded |10080|
+|offsetsRetentionMinutes| Offsets older than this retention period are discarded |4320|
 |offsetsRetentionCheckIntervalMs| Frequency at which to check for stale offsets  |600000|
 |offsetsTopicNumPartitions| Number of partitions for the offsets topic  |8|
 |kopSslProtocol| Kafka SSL configuration map with: SSL_PROTOCOL_CONFIG = ssl.protocol |TLS|


### PR DESCRIPTION
### Changes
1. In order to sync with code default value, update kafka metadata namespace retention from 7 days to 3 days in configuration doc. 