### PR TITLE
[ENHANCEMENT] Remove CompositeBytebuf to avoid on-heap memory copy

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -406,11 +406,7 @@ public final class MessageFetchContext {
                                             ((FetchRequest) fetch.getRequest()).metadata().sessionId()),
                                     () -> {
                                         // release the batched ByteBuf if necessary
-                                        decodeResults.forEach(decodeResult -> {
-                                            if (decodeResult.getReleasedByteBuf() != null) {
-                                                decodeResult.getReleasedByteBuf().release();
-                                            }
-                                        });
+                                        decodeResults.forEach(DecodeResult::release);
                                     }));
                     this.recycle();
                 } else {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/DecodeResult.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/DecodeResult.java
@@ -31,4 +31,10 @@ public class DecodeResult {
     public DecodeResult(MemoryRecords records) {
         this.records = records;
     }
+
+    public void release() {
+        if (releasedByteBuf != null) {
+            releasedByteBuf.release();
+        }
+    }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/DecodeResult.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/DecodeResult.java
@@ -14,25 +14,21 @@
 package io.streamnative.pulsar.handlers.kop.format;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-import java.util.List;
-import org.apache.bookkeeper.mledger.Entry;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 import org.apache.kafka.common.record.MemoryRecords;
 
 /**
- * The entry formatter that uses Kafka's format but has no header.
+ * Result of decode in entry formatter.
  */
-public class NoHeaderKafkaEntryFormatter implements EntryFormatter {
+@Data
+@AllArgsConstructor
+public class DecodeResult {
 
-    @Override
-    public ByteBuf encode(MemoryRecords records, int numMessages) {
-        // The difference from KafkaEntryFormatter is here we don't add the header
-        return Unpooled.wrappedBuffer(records.buffer());
-    }
+    private MemoryRecords records;
+    private ByteBuf releasedByteBuf;
 
-    @Override
-    public DecodeResult decode(List<Entry> entries, byte magic) {
-        // Do nothing
-        return null;
+    public DecodeResult(MemoryRecords records) {
+        this.records = records;
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatter.java
@@ -46,7 +46,7 @@ public interface EntryFormatter {
      * @param magic the Kafka record batch's magic value
      * @return the Kafka records
      */
-    MemoryRecords decode(final List<Entry> entries, final byte magic);
+    DecodeResult decode(final List<Entry> entries, final byte magic);
 
     /**
      * Get the number of messages from MemoryRecords.

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaEntryFormatter.java
@@ -17,7 +17,7 @@ import static org.apache.kafka.common.record.Records.MAGIC_OFFSET;
 import static org.apache.kafka.common.record.Records.OFFSET_OFFSET;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.CompositeByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.streamnative.pulsar.handlers.kop.utils.ByteBufUtils;
 import io.streamnative.pulsar.handlers.kop.utils.MessageIdUtils;
@@ -45,9 +45,8 @@ public class KafkaEntryFormatter implements EntryFormatter {
     }
 
     @Override
-    public MemoryRecords decode(List<Entry> entries, byte magic) {
-        // TODO The memory records should maintain multiple batches, one entry present one batch,
-        //  this is necessary, because one entry only belongs to one transaction.
+    public DecodeResult decode(List<Entry> entries, byte magic) {
+        //
         List<ByteBuf> orderedByteBuf = entries.stream().parallel().map(entry -> {
             long startOffset = MessageIdUtils.peekBaseOffsetFromEntry(entry);
             final ByteBuf byteBuf = entry.getDataBuffer();
@@ -57,11 +56,18 @@ public class KafkaEntryFormatter implements EntryFormatter {
             return byteBuf.slice(byteBuf.readerIndex(), byteBuf.readableBytes());
         }).collect(Collectors.toList());
 
-        CompositeByteBuf batchedByteBuf = Unpooled.compositeBuffer();
-        batchedByteBuf.addComponents(true, orderedByteBuf);
+        // batched ByteBuf should be released after sending to client
+        int totalSize = orderedByteBuf.stream().mapToInt(ByteBuf::readableBytes).sum();
+        ByteBuf batchedByteBuf = PooledByteBufAllocator.DEFAULT.directBuffer(totalSize);
 
-        MemoryRecords batchedMemoryRecords = MemoryRecords.readableRecords(ByteBufUtils.getNioBuffer(batchedByteBuf));
-        return batchedMemoryRecords;
+        for (ByteBuf byteBuf : orderedByteBuf) {
+            batchedByteBuf.writeBytes(byteBuf);
+        }
+
+        // release entries
+        entries.forEach(Entry::release);
+        return new DecodeResult(
+                MemoryRecords.readableRecords(ByteBufUtils.getNioBuffer(batchedByteBuf)), batchedByteBuf);
     }
 
     private static MessageMetadata getMessageMetadataWithNumberMessages(int numMessages) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaEntryFormatter.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.protocol.Commands;
 
@@ -58,7 +59,7 @@ public class KafkaEntryFormatter implements EntryFormatter {
 
         // batched ByteBuf should be released after sending to client
         int totalSize = orderedByteBuf.stream().mapToInt(ByteBuf::readableBytes).sum();
-        ByteBuf batchedByteBuf = PooledByteBufAllocator.DEFAULT.directBuffer(totalSize);
+        ByteBuf batchedByteBuf = PulsarByteBufAllocator.DEFAULT.directBuffer(totalSize);
 
         for (ByteBuf byteBuf : orderedByteBuf) {
             batchedByteBuf.writeBytes(byteBuf);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaEntryFormatter.java
@@ -17,7 +17,6 @@ import static org.apache.kafka.common.record.Records.MAGIC_OFFSET;
 import static org.apache.kafka.common.record.Records.OFFSET_OFFSET;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.streamnative.pulsar.handlers.kop.utils.ByteBufUtils;
 import io.streamnative.pulsar.handlers.kop.utils.MessageIdUtils;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaEntryFormatter.java
@@ -46,7 +46,7 @@ public class KafkaEntryFormatter implements EntryFormatter {
 
     @Override
     public DecodeResult decode(List<Entry> entries, byte magic) {
-        //
+        // reset header information
         List<ByteBuf> orderedByteBuf = entries.stream().parallel().map(entry -> {
             long startOffset = MessageIdUtils.peekBaseOffsetFromEntry(entry);
             final ByteBuf byteBuf = entry.getDataBuffer();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/PulsarEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/PulsarEntryFormatter.java
@@ -113,7 +113,7 @@ public class PulsarEntryFormatter implements EntryFormatter {
     }
 
     @Override
-    public MemoryRecords decode(final List<Entry> entries, final byte magic) {
+    public DecodeResult decode(final List<Entry> entries, final byte magic) {
         ByteBuffer byteBuffer = ByteBuffer.allocate(DEFAULT_FETCH_BUFFER_SIZE);
 
         entries.parallelStream().forEachOrdered(entry -> {
@@ -228,7 +228,7 @@ public class PulsarEntryFormatter implements EntryFormatter {
         });
 
         byteBuffer.flip();
-        return MemoryRecords.readableRecords(byteBuffer);
+        return new DecodeResult(MemoryRecords.readableRecords(byteBuffer));
     }
 
     // convert kafka Record to Pulsar Message.


### PR DESCRIPTION
Motivation: Remove CompositeBytebuf to avoid on-heap memory copy in `KafkaEntryFormatter#decode`

Related to: #447 