### PR TITLE
Don't save KafkaHeaderAndRequest in a real queue

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/FakeArrayBlockingQueue.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/FakeArrayBlockingQueue.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Simulate the ArrayBlockingQueue, but we don't store the actual element.
+ */
+public class FakeArrayBlockingQueue {
+
+    private final ReentrantLock lock = new ReentrantLock(false);
+    private final Condition notFull = lock.newCondition();
+    private int count = 0;
+    private final int capacity;
+
+    public FakeArrayBlockingQueue(int capacity) {
+        if (capacity <= 0) {
+            throw new IllegalArgumentException();
+        }
+        this.capacity = capacity;
+    }
+
+    public void put() throws InterruptedException {
+        lock.lockInterruptibly();
+        try {
+            while (count == capacity) {
+                notFull.await();
+            }
+            count++; // enqueue
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void poll() {
+        lock.lock();
+        try {
+            if (count == 0) {
+                throw new IllegalStateException("poll() is called when count is 0");
+            }
+            count--; // dequeue
+            notFull.signal();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void clear() {
+        lock.lock();
+        try {
+            count = 0;
+            notFull.signal();
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -253,7 +253,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             log.info("close channel {}", ctx.channel());
             writeAndFlushWhenInactiveChannelOrException(ctx.channel());
             groupCoordinator.getOffsetAcker().close(groupIds);
-            ctx.close();
+            super.close();
             topicManager.close();
             String clientHost = ctx.channel().remoteAddress().toString();
             if (currentConnectedGroup.containsKey(clientHost)){

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/FakeArrayBlockingQueueTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/FakeArrayBlockingQueueTest.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Test for FakeArrayBlockingQueueTest.
+ */
+public class FakeArrayBlockingQueueTest {
+
+    @Test(timeOut = 10000)
+    public void testBlockPut() throws InterruptedException {
+        final int capacity = 100;
+        final FakeArrayBlockingQueue queue = new FakeArrayBlockingQueue(capacity);
+        for (int i = 0; i < capacity; i++) {
+            queue.put();
+        }
+        // queue is full now
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        final AtomicBoolean completed = new AtomicBoolean(false);
+        final Runnable putAgain = () -> {
+            try {
+                queue.put(); // blocked until poll() is called
+            } catch (InterruptedException ignored) {
+            }
+            completed.set(true);
+        };
+        executor.execute(putAgain);
+        executor.awaitTermination(1, TimeUnit.SECONDS);
+        executor.shutdownNow(); // cancel the current putAgain task
+        Assert.assertFalse(completed.get());
+
+        executor = Executors.newSingleThreadExecutor();
+        executor.execute(putAgain);
+        queue.poll();
+        executor.awaitTermination(1, TimeUnit.SECONDS);
+        Assert.assertTrue(completed.get());
+
+        for (int i = 0; i < capacity / 2; i++) {
+            queue.poll();
+        }
+        for (int i = 0; i < capacity / 2; i++) {
+            queue.put(); // never blocked
+        }
+    }
+
+    @Test
+    public void testExceptionCases() {
+        try {
+            new FakeArrayBlockingQueue(0);
+            Assert.fail();
+        } catch (IllegalArgumentException ignored) {
+        }
+        try {
+            new FakeArrayBlockingQueue(-1);
+            Assert.fail();
+        } catch (IllegalArgumentException ignored) {
+        }
+
+        final FakeArrayBlockingQueue queue = new FakeArrayBlockingQueue(1);
+        try {
+            queue.poll();
+            Assert.fail();
+        } catch (IllegalStateException e) {
+            Assert.assertEquals(e.getMessage(), "poll() is called when count is 0");
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

https://github.com/streamnative/kop/pull/429 added the `maxQueuedRequests` to limit the number of pending requests for each channel. However, the elements of `requestQueue` are never used. In Kafka the request that is polled from `requestQueue` will be passed to `KafkaApis` to handle. However, KoP use Netty's `channelRead` to handle each request.

### Modifications

- Add a `FakeArrayBlockingQueue` class whose implementation is ported from `ArrayBlockingQueue`. The difference is that it never stores any element.
- Add unit tests for `FakeArrayBlockingQueue`.
- Change `requestQueue`'s type to `FakeArrayBlockingQueue`.
- Do some code refactors for `requestQueue` and `responseQueue` to avoid unnecessary null checks.