### PR TITLE
Fix wrong semantics and usage of KafkaTopicManager#getTopic

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManager.java
@@ -117,7 +117,7 @@ public class KafkaTopicConsumerManager implements Closeable {
 
                 @Override
                 public void deleteCursorFailed(ManagedLedgerException exception, Object ctx) {
-                    log.warn("[{}] Error deleting cursor for topic {} for reason: {}.",
+                    log.warn("[{}] Error deleting cursor {} for topic {} for reason: {}.",
                         requestHandler.ctx.channel(), cursor.getName(), topic.getName(), reason, exception);
                 }
             }, null);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
@@ -258,13 +258,14 @@ public class KafkaTopicManager {
                 if (throwable instanceof BrokerServiceException.ServiceUnitNotReadyException) {
                     log.warn("[{}] Failed to getTopic {}: {}",
                             requestHandler.ctx.channel(), topicName, throwable.getMessage());
+                    topicCompletableFuture.complete(null);
                 } else {
                     log.error("[{}] Failed to getTopic {}. exception:",
                             requestHandler.ctx.channel(), topicName, throwable);
+                    topicCompletableFuture.completeExceptionally(throwable);
                 }
                 // failed to getTopic from current broker, remove cache, which added in getTopicBroker.
                 removeTopicManagerCache(topicName);
-                topicCompletableFuture.completeExceptionally(throwable);
                 return;
             }
             if (t2.isPresent()) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
@@ -128,7 +128,7 @@ public class KafkaTopicManager {
             topicName,
             t -> {
                 final CompletableFuture<KafkaTopicConsumerManager> tcmFuture = new CompletableFuture<>();
-                getTopic(t).whenComplete((persistentTopic, throwable) -> {
+                getOrCreateTopic(t).whenComplete((persistentTopic, throwable) -> {
                     if (persistentTopic != null && throwable == null) {
                         if (log.isDebugEnabled()) {
                             log.debug("[{}] Call getTopicConsumerManager for {}, and create TCM for {}.",
@@ -233,8 +233,16 @@ public class KafkaTopicManager {
         }
     }
 
-    // A wrapper of `BrokerService#getTopic` that is to find the topic's associated `PersistentTopic` instance
+    public CompletableFuture<PersistentTopic> getOrCreateTopic(String topicName) {
+        return getTopic(topicName, true);
+    }
+
     public CompletableFuture<PersistentTopic> getTopic(String topicName) {
+        return getTopic(topicName, false);
+    }
+
+    // A wrapper of `BrokerService#getTopic` that is to find the topic's associated `PersistentTopic` instance
+    private CompletableFuture<PersistentTopic> getTopic(String topicName, boolean createIfMissing) {
         if (closed.get()) {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Return null for getTopic({}) since channel is closing",
@@ -243,7 +251,7 @@ public class KafkaTopicManager {
             return CompletableFuture.completedFuture(null);
         }
         CompletableFuture<PersistentTopic> topicCompletableFuture = new CompletableFuture<>();
-        brokerService.getTopic(topicName, false)
+        brokerService.getTopic(topicName, createIfMissing && brokerService.isAllowAutoTopicCreation(topicName))
                 .whenComplete((t2, throwable) -> {
             if (throwable != null) {
                 // The ServiceUnitNotReadyException is retriable so we should print a warning log instead of error log

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -123,21 +123,12 @@ public final class MessageFetchContext {
                 Map<TopicPartition, Pair<ManagedCursor, Long>> partitionCursor =
                     topicsAndCursor.entrySet().stream()
                         .map(pair -> {
-                            KafkaTopicConsumerManager tcm;
-                            try {
-                                // all future completed now.
-                                tcm = pair.getValue().get();
-                                if (tcm == null) {
-                                    // remove null future cache from consumerTopicManagers
-                                    KafkaTopicManager.getConsumerTopicManagers()
-                                            .remove(KopTopic.toString(pair.getKey()));
-                                    throw new NullPointerException("topic not owned, and return null TCM in fetch.");
-                                }
-                            } catch (Exception e) {
-                                log.warn("Error for get KafkaTopicConsumerManager.", e);
-
-                                responseData.put(pair.getKey(),
-                                    new FetchResponse.PartitionData(
+                            final TopicPartition topicPartition = pair.getKey();
+                            // The future is completed now
+                            final KafkaTopicConsumerManager tcm = pair.getValue().getNow(null);
+                            if (tcm == null) {
+                                // Current broker is not the owner broker of the partition
+                                responseData.put(topicPartition, new FetchResponse.PartitionData<>(
                                         Errors.NOT_LEADER_FOR_PARTITION,
                                         FetchResponse.INVALID_HIGHWATERMARK,
                                         FetchResponse.INVALID_LAST_STABLE_OFFSET,
@@ -149,21 +140,21 @@ public final class MessageFetchContext {
                             }
 
                             long offset = ((FetchRequest) fetchRequest.getRequest()).fetchData()
-                                .get(pair.getKey()).fetchOffset;
+                                .get(topicPartition).fetchOffset;
 
                             if (log.isDebugEnabled()) {
                                 log.debug("Fetch for {}: remove tcm to get cursor for fetch offset: {} .",
-                                    pair.getKey(), offset);
+                                    topicPartition, offset);
                             }
 
                             Pair<ManagedCursor, Long> cursorLongPair = tcm.remove(offset);
                             if (cursorLongPair == null) {
                                 log.warn("KafkaTopicConsumerManager.remove({}) return null for topic {}. "
                                         + "Fetch for topic return error.",
-                                    offset, pair.getKey());
+                                    offset, topicPartition);
 
-                                responseData.put(pair.getKey(),
-                                    new FetchResponse.PartitionData(
+                                responseData.put(topicPartition,
+                                    new FetchResponse.PartitionData<>(
                                         Errors.NOT_LEADER_FOR_PARTITION,
                                         FetchResponse.INVALID_HIGHWATERMARK,
                                         FetchResponse.INVALID_LAST_STABLE_OFFSET,
@@ -174,10 +165,10 @@ public final class MessageFetchContext {
                                 return null;
                             }
 
-                            highWaterMarkMap.put(pair.getKey(),
+                            highWaterMarkMap.put(topicPartition,
                                     MessageIdUtils.getHighWatermark(cursorLongPair.getLeft().getManagedLedger()));
 
-                            return Pair.of(pair.getKey(), cursorLongPair);
+                            return Pair.of(topicPartition, cursorLongPair);
                         })
                         .filter(x -> x != null)
                         .collect(Collectors.toMap(Pair::getKey, Pair::getValue));

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/OffsetAcker.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/OffsetAcker.java
@@ -13,6 +13,7 @@
  */
 package io.streamnative.pulsar.handlers.kop.coordinator.group;
 
+import io.streamnative.pulsar.handlers.kop.KafkaTopicManager;
 import io.streamnative.pulsar.handlers.kop.offset.OffsetAndMetadata;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
 import io.streamnative.pulsar.handlers.kop.utils.OffsetSearchPredicate;
@@ -106,6 +107,7 @@ public class OffsetAcker implements Closeable {
                 brokerService.getTopic(partitionTopicName, false).whenComplete((topic, error) -> {
                     if (error != null) {
                         log.error("[{}] get topic failed when ack for {}.", partitionTopicName, groupId, error);
+                        KafkaTopicManager.removeTopicManagerCache(partitionTopicName);
                         return;
                     }
                     if (topic.isPresent()) {
@@ -130,6 +132,7 @@ public class OffsetAcker implements Closeable {
                                 new MessageIdImpl(position.getLedgerId(), position.getEntryId(), -1));
                     } else {
                         log.error("[{}] Topic not exist when ack for {}.", partitionTopicName, groupId);
+                        KafkaTopicManager.removeTopicManagerCache(partitionTopicName);
                     }
                 });
             });

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
@@ -23,12 +23,12 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupCoordinator;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+
+import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.stats.NullStatsLogger;
@@ -53,7 +53,6 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
 
     private KafkaTopicManager kafkaTopicManager;
     private KafkaRequestHandler kafkaRequestHandler;
-    private SocketAddress serviceAddress;
     private AdminManager adminManager;
 
     @BeforeMethod
@@ -80,8 +79,6 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
         Channel mockChannel = mock(Channel.class);
         doReturn(mockChannel).when(mockCtx).channel();
         kafkaRequestHandler.ctx = mockCtx;
-
-        serviceAddress = new InetSocketAddress(pulsar.getBindAddress(), kafkaBrokerPort);
 
         kafkaTopicManager = new KafkaTopicManager(kafkaRequestHandler);
     }
@@ -127,9 +124,9 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
 
+        @Cleanup
         final KafkaProducer<Integer, String> producer = new KafkaProducer<>(props);
 
-        KProducer kProducer = new KProducer(topicName, true, getKafkaBrokerPort());
         int i = 0;
         String messagePrefix = "testTopicConsumerManagerRemoveAndAdd_message_";
         long offset = -1L;
@@ -198,6 +195,7 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
 
+        @Cleanup
         final KafkaProducer<Integer, String> producer = new KafkaProducer<>(props);
 
         int i = 0;


### PR DESCRIPTION
### Motivation

Many usages of `KafkaTopicManager#getTopic` are wrong because they didn't check null value so that NPE may happen. And the semantics of `KafkaTopicManager#getTopic` is wrong because the `createIfMissing` argument of `BrokerService#getTopic` is true, so if a not existed topic's name was accepted as the argument, the topic would be created automatically. This behavior is unexpected because we only want to create topics automatically in `METADATA` request handler.

### Modifications
1. In `KafkaTopicManager#getTopic`, when `BrokerService#getTopic` is completed exceptionally, returns an exceptionally completed future instead of a null completed future.
2. Use `whenComplete` for all `getTopic` references so that we can handle null completed futures and exceptionally completed futures.
3. The `LIST_OFFSET` request handler is modified according to the above changes
    - For exceptionally completed `getTopic` future, return the thrown exception.
    - For null completed `getTopic` future, return the `UNKNOWN_TOPIC_OR_PARTITION` error.
4. Add tests for listing offsets of a not existed topic. Since the default `ctx` of `KafkaRequestHandler` is null and may cause NPE during error logging, we also set a mocked `ChannelHandlerContext` in the test.
5. Remove redundant NPE warning logs in `MessageFetchContext#handleFetch` since we've already added logs to the case that the future of `KafkaTopicConsumerManager` is completed exceptionally.