### PR TITLE
Fix flaky tests of branch-2.7.1

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndPulsarTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndPulsarTest.java
@@ -36,6 +36,7 @@ public class BasicEndToEndPulsarTest extends BasicEndToEndTestBase {
     @Test(timeOut = 20000)
     public void testNullValueMessages() throws Exception {
         final String topic = "test-produce-null-value";
+        admin.topics().createPartitionedTopic(topic, 1);
 
         @Cleanup
         final KafkaProducer<String, String> kafkaProducer = newKafkaProducer();
@@ -53,7 +54,7 @@ public class BasicEndToEndPulsarTest extends BasicEndToEndTestBase {
         //  value. So here we just subscribe a single partition with ConsumerImpl.
         //  See https://github.com/apache/pulsar/pull/9113 for details.
         @Cleanup
-        final Consumer<byte[]> pulsarConsumer = newPulsarConsumer(topic + "-partition-0");
+        final Consumer<byte[]> pulsarConsumer = newPulsarConsumer(topic);
         List<String> pulsarReceives = receiveMessages(pulsarConsumer, expectValues.size());
         assertEquals(pulsarReceives, expectValues);
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndTestBase.java
@@ -181,12 +181,13 @@ public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
             throws PulsarClientException {
         List<String> values = new ArrayList<>();
         while (numMessages > 0) {
-            Message<byte[]> message = consumer.receive(100, TimeUnit.MILLISECONDS);
+            Message<byte[]> message = consumer.receive(3, TimeUnit.SECONDS);
             if (message != null) {
                 final byte[] value = message.getValue();
                 values.add((value == null) ? null : new String(value));
                 if (log.isDebugEnabled()) {
-                    log.debug("Pulsar Consumer receive: {}", values.get(values.size() - 1));
+                    log.debug("Pulsar Consumer receive: {} from {}",
+                            values.get(values.size() - 1), message.getMessageId());
                 }
             }
             numMessages--;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -440,6 +440,15 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
         final int numMessages = 10;
         final String messagePrefix = "msg-";
 
+        admin.topics().createPartitionedTopic(topic, 1);
+
+        @Cleanup
+        Consumer<byte[]> consumer = pulsarClient.newConsumer()
+                .topic(topic)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .subscriptionName("subscription-name")
+                .subscribe();
+
         final Properties props = new Properties();
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getKafkaBrokerPort());
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
@@ -468,14 +477,8 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
             //   https://github.com/streamnative/kop/issues/243
         }
 
-        @Cleanup
-        Consumer<byte[]> consumer = pulsarClient.newConsumer()
-                .topic(topic)
-                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
-                .subscriptionName("subscription-name")
-                .subscribe();
         for (int i = 0; i < numMessages; i++) {
-            Message<byte[]> message = consumer.receive(1, TimeUnit.SECONDS);
+            Message<byte[]> message = consumer.receive(5, TimeUnit.SECONDS);
             assertNotNull(message);
             consumer.acknowledge(message);
             assertTrue(indexToOffset.containsKey(i));


### PR DESCRIPTION
Fix flaky tests of branch-2.7.1, which includes:
- KafkaRequestHandlerTest#testProduceCallback
- BasicEndToEndPulsarTest#testNullValueMessages