### PR TITLE
Fix publish throttling and LoadManager API for pulsar upgrade

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/InternalServerCnx.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/InternalServerCnx.java
@@ -13,9 +13,7 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.net.InetSocketAddress;
-import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.service.Producer;
@@ -31,10 +29,6 @@ import org.apache.pulsar.broker.service.ServerCnx;
 public class InternalServerCnx extends ServerCnx {
     @Getter
     KafkaRequestHandler kafkaRequestHandler;
-
-    private static final AtomicLongFieldUpdater<InternalServerCnx> KOP_MSG_PUBLISH_BUFFER_SIZE_UPDATER =
-            AtomicLongFieldUpdater.newUpdater(InternalServerCnx.class, "kopMessagePublishBufferSize");
-    private volatile long kopMessagePublishBufferSize = 0;
 
     public InternalServerCnx(KafkaRequestHandler kafkaRequestHandler) {
         super(kafkaRequestHandler.getPulsarService());
@@ -63,54 +57,21 @@ public class InternalServerCnx extends ServerCnx {
 
     // called after channel active
     public void updateCtx() {
-        this.remoteAddress = kafkaRequestHandler.getRemoteAddress();
+        this.remoteAddress = kafkaRequestHandler.remoteAddress;
     }
 
     @Override
     public void enableCnxAutoRead() {
-        if (!kafkaRequestHandler.ctx.channel().config().isAutoRead()) {
-            kafkaRequestHandler.ctx.channel().config().setAutoRead(true);
-            kafkaRequestHandler.ctx.read();
-            if (log.isDebugEnabled()) {
-                log.debug("Channel {}  auto read has set to true.", kafkaRequestHandler.ctx.channel());
-            }
-        }
+        // do nothing is this mock
     }
 
     @Override
     public void disableCnxAutoRead() {
-        if (kafkaRequestHandler.ctx.channel().config().isAutoRead()) {
-            kafkaRequestHandler.ctx.channel().config().setAutoRead(false);
-            if (log.isDebugEnabled()) {
-                log.debug("Channel {} auto read has set to false.", kafkaRequestHandler.ctx.channel());
-            }
-        }
-    }
-
-    public void increasePublishBuffer(long msgSize) {
-        KOP_MSG_PUBLISH_BUFFER_SIZE_UPDATER.getAndAdd(this, msgSize);
-        if (getBrokerService().isReachMessagePublishBufferThreshold()) {
-            disableCnxAutoRead();
-        }
-    }
-
-    public void decreasePublishBuffer(long msgSize) {
-        KOP_MSG_PUBLISH_BUFFER_SIZE_UPDATER.getAndAdd(this, -msgSize);
+        // do nothing is this mock
     }
 
     @Override
-    public long getMessagePublishBufferSize() {
-        return kopMessagePublishBufferSize;
-    }
-
-
     public void cancelPublishBufferLimiting() {
-        // do nothing.
+        // do nothing is this mock
     }
-
-    @VisibleForTesting
-    public void setMessagePublishBufferSize(long size) {
-        this.kopMessagePublishBufferSize = size;
-    }
-
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -161,7 +161,6 @@ import org.apache.pulsar.common.util.Murmur3_32Hash;
 import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
 import org.apache.pulsar.policies.data.loadbalancer.ServiceLookupData;
-import org.apache.pulsar.zookeeper.ZooKeeperCache;
 
 /**
  * This class contains all the request handling methods.
@@ -1759,8 +1758,9 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         }
         // advertised data is write in  /loadbalance/brokers/advertisedAddress:webServicePort
         // here we get the broker url, need to find related webServiceUrl.
-        ZooKeeperCache zkCache = pulsarService.getLocalZkCache();
-        zkCache.getChildrenAsync(LoadManager.LOADBALANCE_BROKERS_ROOT, zkCache)
+        pulsarService.getPulsarResources()
+            .getDynamicConfigResources()
+            .getChildrenAsync(LoadManager.LOADBALANCE_BROKERS_ROOT)
             .whenComplete((set, throwable) -> {
                 if (throwable != null) {
                     log.error("Error in getChildrenAsync(zk://loadbalance) for {}", pulsarAddress, throwable);

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,8 @@
     <log4j2.version>2.13.3</log4j2.version>
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
-    <pulsar.version>2.8.0-rc-202104202206</pulsar.version>
+    <pulsar.group.id>io.streamnative</pulsar.group.id>
+    <pulsar.version>2.8.0-rc-202105092228</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testcontainers.version>1.15.1</testcontainers.version>
@@ -105,35 +106,35 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.pulsar</groupId>
+      <groupId>${pulsar.group.id}</groupId>
       <artifactId>pulsar-broker</artifactId>
       <version>${pulsar.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.pulsar</groupId>
+      <groupId>${pulsar.group.id}</groupId>
       <artifactId>pulsar-broker-common</artifactId>
       <version>${pulsar.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.pulsar</groupId>
+      <groupId>${pulsar.group.id}</groupId>
       <artifactId>pulsar-client-original</artifactId>
       <version>${pulsar.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.pulsar</groupId>
+      <groupId>${pulsar.group.id}</groupId>
       <artifactId>pulsar-client-admin-original</artifactId>
       <version>${pulsar.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.apache.pulsar</groupId>
+      <groupId>${pulsar.group.id}</groupId>
       <artifactId>testmocks</artifactId>
       <version>${pulsar.version}</version>
       <scope>provided</scope>
@@ -214,7 +215,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.pulsar</groupId>
+      <groupId>${pulsar.group.id}</groupId>
       <artifactId>pulsar-broker</artifactId>
       <version>${pulsar.version}</version>
       <type>test-jar</type>
@@ -222,7 +223,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.pulsar</groupId>
+      <groupId>${pulsar.group.id}</groupId>
       <artifactId>managed-ledger</artifactId>
       <version>${pulsar.version}</version>
       <type>test-jar</type>
@@ -399,6 +400,11 @@
   </build>
 
   <repositories>
+    <repository>
+      <id>sonatype-streamnative-maven</id>
+      <name>sonatype</name>
+      <url>https://oss.sonatype.org/content/repositories/iostreamnative-1129</url>
+    </repository>
     <repository>
       <id>bintray-streamnative-maven</id>
       <name>bintray</name>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
 
     <!-- dependencies -->
-    <commons-lang3.version>3.4</commons-lang3.version>
+    <commons-lang3.version>3.11</commons-lang3.version>
     <guava.version>21.0</guava.version>
     <grpc.version>1.18.0</grpc.version>
     <jackson.version>2.12.1</jackson.version>
@@ -53,6 +53,8 @@
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testcontainers.version>1.15.1</testcontainers.version>
     <testng.version>6.14.3</testng.version>
+    <avro.version>1.10.2</avro.version>
+    <awaitility.version>4.0.3</awaitility.version>
     <!-- plugin dependencies -->
     <dockerfile-maven.version>1.4.9</dockerfile-maven.version>
     <license-maven-plugin.version>3.0.rc1</license-maven-plugin.version>
@@ -237,6 +239,12 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>${awaitility.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MessagePublishBufferThrottleTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MessagePublishBufferThrottleTestBase.java
@@ -15,11 +15,13 @@ package io.streamnative.pulsar.handlers.kop;
 
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.pulsar.broker.service.Topic;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -27,6 +29,7 @@ import org.testng.annotations.Test;
  * Test class for message publish buffer throttle from kop side.
  * */
 
+@Slf4j
 public abstract class MessagePublishBufferThrottleTestBase extends KopProtocolHandlerTestBase{
 
     public MessagePublishBufferThrottleTestBase(final String entryFormat) {
@@ -36,38 +39,35 @@ public abstract class MessagePublishBufferThrottleTestBase extends KopProtocolHa
     @Test
     public void testMessagePublishBufferThrottleDisabled() throws Exception {
         conf.setMaxMessagePublishBufferSizeInMB(-1);
-        conf.setMessagePublishBufferCheckIntervalInMillis(10);
         super.internalSetup();
 
         final String topic = "testMessagePublishBufferThrottleDisabled";
-        final String pulsarTopic = "persistent://public/default/" + topic + "-partition-0";
         Properties properties = new Properties();
-        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + kafkaBrokerPort);
-        properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
-                "org.apache.kafka.common.serialization.ByteArraySerializer");
-        properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
-                "org.apache.kafka.common.serialization.ByteArraySerializer");
-        properties.put("delivery.timeout.ms", 300000);
-        KafkaProducer<byte[], byte[]> producer = new org.apache.kafka.clients.producer.KafkaProducer(properties);
+        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + kafkaBrokerPort);
+        properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+        properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+        properties.put(ProducerConfig.BATCH_SIZE_CONFIG, 0);
+        final KafkaProducer<byte[], byte[]> producer = new KafkaProducer<>(properties);
 
-        // send one record to make sure InternalProducer build on broker side
-        producer.send(new ProducerRecord<>(topic, "test".getBytes())).get();
+        mockBookKeeper.addEntryDelay(1, TimeUnit.SECONDS);
 
-        Topic topicRef = pulsar.getBrokerService().getTopicReference(pulsarTopic).get();
-        Assert.assertNotNull(topicRef);
-        InternalServerCnx internalServerCnx = (InternalServerCnx)
-                ((InternalProducer) topicRef.getProducers().values().toArray()[0]).getCnx();
-        internalServerCnx.setMessagePublishBufferSize(Long.MAX_VALUE / 2);
-        // sleep to make sure the publish buffer check task has been executed
-        Thread.sleep(conf.getMessagePublishBufferCheckIntervalInMillis() * 2);
-        Assert.assertFalse(pulsar.getBrokerService().isReachMessagePublishBufferThreshold());
-        // Make sure the producer can publish succeed.
-        for (int i = 0; i < 10; i++) {
-            producer.send(new ProducerRecord<>(topic, new byte[1024])).get();
+        final byte[] payload = new byte[1024 * 256];
+        final int numMessages = 50;
+        final AtomicInteger numSend = new AtomicInteger(0);
+        for (int i = 0; i < numMessages; i++) {
+            final int index = i;
+            producer.send(new ProducerRecord<>(topic, payload), (metadata, exception) -> {
+                if (exception != null) {
+                    log.error("Failed to send {}: {}", index, exception.getMessage());
+                    return;
+                }
+                numSend.getAndIncrement();
+            });
         }
-        // sleep to make sure the publish buffer check task has been executed
-        Thread.sleep(conf.getMessagePublishBufferCheckIntervalInMillis() * 2);
-        Assert.assertFalse(pulsar.getBrokerService().isReachMessagePublishBufferThreshold());
+
+        Assert.assertEquals(pulsar.getBrokerService().getPausedConnections(), 0);
+        Awaitility.await().untilAsserted(() -> Assert.assertEquals(numSend.get(), numMessages));
+        producer.close();
         super.internalCleanup();
     }
 
@@ -75,46 +75,38 @@ public abstract class MessagePublishBufferThrottleTestBase extends KopProtocolHa
     public void testMessagePublishBufferThrottleEnable() throws Exception {
         // set size for max publish buffer before broker start
         conf.setMaxMessagePublishBufferSizeInMB(1);
-        conf.setMessagePublishBufferCheckIntervalInMillis(100);
         super.internalSetup();
-        Assert.assertFalse(pulsar.getBrokerService().isReachMessagePublishBufferThreshold());
 
         final String topic = "testMessagePublishBufferThrottleEnable";
-        final String pulsarTopic = "persistent://public/default/" + topic + "-partition-0";
         Properties properties = new Properties();
-        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + kafkaBrokerPort);
-        properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
-                "org.apache.kafka.common.serialization.ByteArraySerializer");
-        properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
-                "org.apache.kafka.common.serialization.ByteArraySerializer");
-        properties.put("delivery.timeout.ms", 300000);
-        KafkaProducer<byte[], byte[]> producer = new org.apache.kafka.clients.producer.KafkaProducer(properties);
+        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + kafkaBrokerPort);
+        properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+        properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+        properties.put(ProducerConfig.BATCH_SIZE_CONFIG, 0);
+        final KafkaProducer<byte[], byte[]> producer = new KafkaProducer<>(properties);
 
-        // send one record to make sure InternalProducer build on broker side
-        producer.send(new ProducerRecord<>(topic, "test".getBytes())).get();
+        mockBookKeeper.addEntryDelay(1, TimeUnit.SECONDS);
 
-        Topic topicRef = pulsar.getBrokerService().getTopicReference(pulsarTopic).get();
-        Assert.assertNotNull(topicRef);
-        InternalServerCnx internalServerCnx = (InternalServerCnx)
-                ((InternalProducer) topicRef.getProducers().values().toArray()[0]).getCnx();
-        internalServerCnx.setMessagePublishBufferSize(Long.MAX_VALUE / 2);
-        Assert.assertFalse(pulsar.getBrokerService().isReachMessagePublishBufferThreshold());
-        // The first message can publish success, but the second message should be blocked
-        producer.send(new ProducerRecord<>(topic, new byte[1024])).get(1, TimeUnit.SECONDS);
-        // sleep to make sure the publish buffer check task has been executed
-        Thread.sleep(conf.getMessagePublishBufferCheckIntervalInMillis() * 2);
-        Assert.assertTrue(pulsar.getBrokerService().isReachMessagePublishBufferThreshold());
-
-        internalServerCnx.setMessagePublishBufferSize(0);
-        // sleep to make sure the publish buffer check task has been executed
-        Thread.sleep(conf.getMessagePublishBufferCheckIntervalInMillis() * 2);
-        Assert.assertFalse(pulsar.getBrokerService().isReachMessagePublishBufferThreshold());
-        // Make sure the producer can publish succeed.
-        for (int i = 0; i < 10; i++) {
-            producer.send(new ProducerRecord<>(topic, new byte[1024])).get();
+        final byte[] payload = new byte[1024 * 256];
+        final int numMessages = 50;
+        final AtomicInteger numSend = new AtomicInteger(0);
+        for (int i = 0; i < numMessages; i++) {
+            final int index = i;
+            producer.send(new ProducerRecord<>(topic, payload), (metadata, exception) -> {
+                if (exception != null) {
+                    log.error("Failed to send {}: {}", index, exception.getMessage());
+                    return;
+                }
+                numSend.getAndIncrement();
+            });
         }
-        Assert.assertFalse(pulsar.getBrokerService().isReachMessagePublishBufferThreshold());
-        Assert.assertEquals(internalServerCnx.getMessagePublishBufferSize(), 0);
+
+        Awaitility.await().untilAsserted(
+                () -> Assert.assertEquals(pulsar.getBrokerService().getPausedConnections(), 1L));
+        Awaitility.await().untilAsserted(() -> Assert.assertEquals(numSend.get(), numMessages));
+        Awaitility.await().untilAsserted(
+                () -> Assert.assertEquals(pulsar.getBrokerService().getPausedConnections(), 0L));
+        producer.close();
         super.internalCleanup();
     }
 


### PR DESCRIPTION
This PR upgrades pulsar dependency to 2.8.0-rc-202105092228, which has two major API changes.

https://github.com/apache/pulsar/pull/10391 changed `LoadManager` API so that `MetadataCache` is used instead of `ZookeeperCache` in this PR.

https://github.com/apache/pulsar/pull/7406 changed the throttling strategy. However, currently KoP is different from Pulsar that the produce and its callback may be in different threads. KoP calls `PersistentTopic#publishMessages` in a callback of `KafkaTopicManager#getTopic` if the returned future is not completed immediately. Otherwise, it's called just in the I/O thread. Therefore, here we still use a **channel based** publish bytes stats for throttling, while https://github.com/apache/pulsar/pull/7406 uses a **thread based** publish bytes stats.

The other refactors are:
1. Change the throttling related fields from `InternalServerCnx` to `KafkaRequestHandler`.
2. Use `BrokerService#getPausedConnections` to check if the channel's auto read is disabled and modify the tests as well.