### PR TITLE
Fix null KafkaTopicConsumerManager not removed

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -333,9 +333,9 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
             // case 4: responseFuture is completed normally
             responseFuture.thenApply(response -> {
                 if (log.isDebugEnabled()) {
-                    log.debug("Write kafka cmd responseAndRequest back to client. \n"
-                                    + "\trequest content: {} \n"
-                                    + "\tresponseAndRequest content: {}",
+                    log.debug("Write kafka cmd to client."
+                                    + " request content: {}"
+                                    + " responseAndRequest content: {}",
                             request, response.toString(request.getRequest().version()));
                 }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -345,7 +345,7 @@ public class KafkaProtocolHandler implements ProtocolHandler {
         }
         KafkaTopicManager.LOOKUP_CACHE.clear();
         KopBrokerLookupManager.clear();
-        KafkaTopicManager.getConsumerTopicManagers().clear();
+        KafkaTopicManager.closeKafkaTopicConsumerManagers();
         KafkaTopicManager.getReferences().clear();
         KafkaTopicManager.getTopics().clear();
         OffsetAcker.CONSUMERS.clear();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -135,6 +135,8 @@ public final class MessageFetchContext {
                                         FetchResponse.INVALID_LOG_START_OFFSET,
                                         null,
                                         MemoryRecords.EMPTY));
+                                // remove null future cache from consumerTopicManagers
+                                KafkaTopicManager.removeKafkaTopicConsumerManager(KopTopic.toString(topicPartition));
                                 // result got. this will be filtered in following filter method.
                                 return null;
                             }
@@ -242,8 +244,8 @@ public final class MessageFetchContext {
                                                 "cursor.readEntry fail. deleteCursor");
                                     } else {
                                         // remove null future cache from consumerTopicManagers
-                                        KafkaTopicManager.getConsumerTopicManagers()
-                                                .remove(KopTopic.toString(kafkaTopic));
+                                        KafkaTopicManager.removeKafkaTopicConsumerManager(
+                                                KopTopic.toString(kafkaTopic));
                                         log.warn("Cursor deleted while TCM close.");
                                     }
                                 });
@@ -335,8 +337,8 @@ public final class MessageFetchContext {
                                     cm.add(pair.getRight(), pair);
                                 } else {
                                     // remove null future cache from consumerTopicManagers
-                                    KafkaTopicManager.getConsumerTopicManagers()
-                                        .remove(KopTopic.toString(kafkaPartition));
+                                    KafkaTopicManager.removeKafkaTopicConsumerManager(
+                                            KopTopic.toString(kafkaPartition));
                                     log.warn("Cursor deleted while TCM close, failed to add cursor back to TCM.");
                                 }
                             });

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
@@ -107,7 +107,7 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
         KafkaTopicConsumerManager topicConsumerManager2 = tcm.get();
 
         assertTrue(topicConsumerManager == topicConsumerManager2);
-        assertEquals(kafkaTopicManager.getConsumerTopicManagers().size(), 1);
+        assertEquals(KafkaTopicManager.getNumberOfKafkaTopicConsumerManagers(), 1);
 
         // 2. verify another get with different topic will return different tcm
         String topicName2 = "persistent://public/default/testGetTopicConsumerManager2";
@@ -115,7 +115,7 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
         tcm = kafkaTopicManager.getTopicConsumerManager(topicName2);
         topicConsumerManager2 = tcm.get();
         assertTrue(topicConsumerManager != topicConsumerManager2);
-        assertEquals(kafkaTopicManager.getConsumerTopicManagers().size(), 2);
+        assertEquals(KafkaTopicManager.getNumberOfKafkaTopicConsumerManagers(), 2);
     }
 
 


### PR DESCRIPTION
Fixes https://github.com/streamnative/kop/issues/493

This bug was introduced by https://github.com/streamnative/kop/pull/473. In `MessageFetchContext#handleFetch`, when the `KafkaTopicConsumerManager`'s future is completed with null, we should remove the future from `KafkaTopicManager#consumerTopicManagers`.

In addition, this PR adds some refactors for `consumerTopicManagers`:
1. Don't use getter to expose this field, use methods to operate it instead.
2. Check null for completed future before close `KafkaTopicConsumerManager`.