### PR TITLE
Fix request queue size metric and add response queue metrics

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/FakeArrayBlockingQueue.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/FakeArrayBlockingQueue.java
@@ -36,7 +36,7 @@ public class FakeArrayBlockingQueue {
     public void put() throws InterruptedException {
         lock.lockInterruptibly();
         try {
-            while (count == capacity) {
+            while (count >= capacity) {
                 notFull.await();
             }
             count++; // enqueue
@@ -48,7 +48,7 @@ public class FakeArrayBlockingQueue {
     public void poll() {
         lock.lock();
         try {
-            if (count == 0) {
+            if (count <= 0) {
                 throw new IllegalStateException("poll() is called when count is 0");
             }
             count--; // dequeue

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -26,8 +26,6 @@ import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.LinkedBlockingDeque;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.naming.AuthenticationException;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopServerStats.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopServerStats.java
@@ -29,6 +29,13 @@ public interface KopServerStats {
     String REQUEST_PARSE = "REQUEST_PARSE";
 
     /**
+     * Response stats.
+     */
+    String RESPONSE_QUEUE_SIZE = "RESPONSE_QUEUE_SIZE";
+    String RESPONSE_BLOCKED_TIMES = "RESPONSE_BLOCKED_TIMES";
+    String RESPONSE_BLOCKED_LATENCY = "RESPONSE_BLOCKED_LATENCY";
+
+    /**
      * PRODUCE STATS.
      */
     String HANDLE_PRODUCE_REQUEST = "HANDLE_PRODUCE_REQUEST";

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/RequestStats.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/RequestStats.java
@@ -31,14 +31,13 @@ import static io.streamnative.pulsar.handlers.kop.KopServerStats.RESPONSE_QUEUE_
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.SERVER_SCOPE;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.TOTAL_MESSAGE_READ;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Getter;
 import org.apache.bookkeeper.stats.Counter;
 import org.apache.bookkeeper.stats.Gauge;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.stats.annotations.StatsDoc;
-
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Kop request stats metric for prometheus metrics.

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/RequestStats.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/RequestStats.java
@@ -51,8 +51,8 @@ import org.apache.bookkeeper.stats.annotations.StatsDoc;
 @Getter
 public class RequestStats {
 
-    final AtomicInteger requestQueueSize = new AtomicInteger(0);
-    final AtomicInteger responseQueueSize = new AtomicInteger(0);
+    private final AtomicInteger requestQueueSize = new AtomicInteger(0);
+    private final AtomicInteger responseQueueSize = new AtomicInteger(0);
 
     @StatsDoc(
             name = REQUEST_QUEUED_LATENCY,

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
@@ -155,6 +155,11 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase{
         Assert.assertTrue(sb.toString().contains("kop_server_REQUEST_QUEUED_LATENCY"));
         Assert.assertTrue(sb.toString().contains("kop_server_REQUEST_PARSE"));
 
+        // response stats
+        Assert.assertTrue(sb.toString().contains("kop_server_RESPONSE_QUEUE_SIZE"));
+        Assert.assertTrue(sb.toString().contains("kop_server_RESPONSE_BLOCKED_TIMES"));
+        Assert.assertTrue(sb.toString().contains("kop_server_RESPONSE_BLOCKED_LATENCY"));
+
         // produce stats
         Assert.assertTrue(sb.toString().contains("kop_server_HANDLE_PRODUCE_REQUEST"));
         Assert.assertTrue(sb.toString().contains("kop_server_PRODUCE_ENCODE"));


### PR DESCRIPTION
### Motivation
Some request queue size metric doesn't use correct metric type.

### Modification
1. Fix request queue size metric type
2. Add response queue metric to leverage whether keep order operation cost too much time.