### PR TITLE
fix bytebuf release bug

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -384,6 +384,7 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
                         }
                     });
                 });
+                continue;
             }
 
             // case 4: responseFuture is expired


### PR DESCRIPTION
### Motivation
When running kop and entered api operation completed and timeout, it will throw the following exception.
```
21:04:37.951 [pulsar-io-20-4:io.netty.util.concurrent.AbstractEventExecutor@166] WARN  io.netty.util.concurrent.AbstractEventExecutor - A task raised an exception. Task: io.streamnative.pulsar.handlers.kop.Kafka
CommandDecoder$$Lambda$893/1938241875@7b666c80
io.netty.util.IllegalReferenceCountException: refCnt: 0, decrement: 1
        at io.netty.util.internal.ReferenceCountUpdater.toLiveRealRefCnt(ReferenceCountUpdater.java:74) ~[netty-common-4.1.63.Final.jar:4.1.63.Final]
        at io.netty.util.internal.ReferenceCountUpdater.release(ReferenceCountUpdater.java:138) ~[netty-common-4.1.63.Final.jar:4.1.63.Final]
        at io.netty.buffer.AbstractReferenceCountedByteBuf.release(AbstractReferenceCountedByteBuf.java:100) ~[netty-buffer-4.1.63.Final.jar:4.1.63.Final]
        at io.netty.buffer.AbstractDerivedByteBuf.release0(AbstractDerivedByteBuf.java:98) ~[netty-buffer-4.1.63.Final.jar:4.1.63.Final]
        at io.netty.buffer.AbstractDerivedByteBuf.release(AbstractDerivedByteBuf.java:94) ~[netty-buffer-4.1.63.Final.jar:4.1.63.Final]
        at io.streamnative.pulsar.handlers.kop.KafkaCommandDecoder$KafkaHeaderAndRequest.close(KafkaCommandDecoder.java:543) ~[pulsar-protocol-handler-kafka-2.8.0-SNAPSHOT.jar:?]
        at io.streamnative.pulsar.handlers.kop.KafkaCommandDecoder.responseToByteBuf(KafkaCommandDecoder.java:150) ~[pulsar-protocol-handler-kafka-2.8.0-SNAPSHOT.jar:?]
        at io.streamnative.pulsar.handlers.kop.KafkaCommandDecoder$KafkaHeaderAndRequest.createErrorResponse(KafkaCommandDecoder.java:533) ~[pulsar-protocol-handler-kafka-2.8.0-SNAPSHOT.jar:?]
        at io.streamnative.pulsar.handlers.kop.KafkaCommandDecoder.writeAndFlushResponseToClient(KafkaCommandDecoder.java:396) ~[pulsar-protocol-handler-kafka-2.8.0-SNAPSHOT.jar:?]
        at io.streamnative.pulsar.handlers.kop.KafkaCommandDecoder.lambda$null$0(KafkaCommandDecoder.java:198) ~[pulsar-protocol-handler-kafka-2.8.0-SNAPSHOT.jar:?]
        at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164) [netty-common-4.1.63.Final.jar:4.1.63.Final]
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472) [netty-common-4.1.63.Final.jar:4.1.63.Final]
        at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:384) [netty-transport-native-epoll-4.1.63.Final-linux-x86_64.jar:4.1.63.Final]
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989) [netty-common-4.1.63.Final.jar:4.1.63.Final]
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [netty-common-4.1.63.Final.jar:4.1.63.Final]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-common-4.1.63.Final.jar:4.1.63.Final]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_172]
```

### Modification
1. add `continue` when dealed with `case 3` in `writeAndFlushResponseToClient`