### PR TITLE
expose consumer stats to prometheus instead of consumer internal stats

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -755,8 +755,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
 
     protected void handleProduceRequest(KafkaHeaderAndRequest produceHar,
                                         CompletableFuture<AbstractResponse> resultFuture) {
-        final long startProduceNanos = MathUtils.nowInNano();
-
         checkArgument(produceHar.getRequest() instanceof ProduceRequest);
         ProduceRequest produceRequest = (ProduceRequest) produceHar.getRequest();
 
@@ -781,8 +779,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Request {}: Complete handle produce.", ctx.channel(), produceHar.toString());
             }
-            requestStats.getHandleProduceRequestStats()
-                    .registerFailedEvent(MathUtils.elapsedNanos(startProduceNanos), TimeUnit.NANOSECONDS);
             resultFuture.complete(new ProduceResponse(responseMap));
         };
         BiConsumer<TopicPartition, PartitionResponse> addPartitionResponse = (topicPartition, response) -> {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -1285,17 +1285,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
 
     protected void handleFetchRequest(KafkaHeaderAndRequest fetch,
                                       CompletableFuture<AbstractResponse> resultFuture) {
-        long startFetchingRequestNanos = MathUtils.nowInNano();
-        resultFuture.whenComplete((r, e) -> {
-            if (e != null) {
-                requestStats.getHandleFetchRequestStats().registerFailedEvent(
-                        MathUtils.elapsedNanos(startFetchingRequestNanos), TimeUnit.NANOSECONDS);
-            } else {
-                requestStats.getHandleFetchRequestStats().registerSuccessfulEvent(
-                        MathUtils.elapsedNanos(startFetchingRequestNanos), TimeUnit.NANOSECONDS);
-            }
-        });
-
         checkArgument(fetch.getRequest() instanceof FetchRequest);
         FetchRequest request = (FetchRequest) fetch.getRequest();
 
@@ -1309,7 +1298,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             });
         }
 
-        MessageFetchContext fetchContext = MessageFetchContext.get(this);
+        MessageFetchContext fetchContext = MessageFetchContext.get(this, requestStats);
         fetchContext.handleFetch(resultFuture, fetch, transactionCoordinator, fetchPurgatory);
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopServerStats.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopServerStats.java
@@ -22,6 +22,9 @@ public interface KopServerStats {
     String SERVER_SCOPE = "kop_server";
 
     String REQUEST_SCOPE = "request";
+    String TOPIC_SCOPE = "topic";
+    String PARTITION_SCOPE = "partition";
+    String GROUP_SCOPE = "group";
 
     /**
      * Request stats.
@@ -60,4 +63,11 @@ public interface KopServerStats {
     String TOTAL_MESSAGE_READ = "TOTAL_MESSAGE_READ";
     String MESSAGE_READ = "MESSAGE_READ";
     String FETCH_DECODE = "FETCH_DECODE";
+
+    /**
+     * Consumer stats.
+     */
+    String BYTES_OUT = "BYTES_OUT";
+    String MESSAGE_OUT = "MESSAGE_OUT";
+    String ENTRIES_OUT = "ENTRIES_OUT";
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopServerStats.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopServerStats.java
@@ -44,7 +44,6 @@ public interface KopServerStats {
     /**
      * PRODUCE STATS.
      */
-    String HANDLE_PRODUCE_REQUEST = "HANDLE_PRODUCE_REQUEST";
     String PRODUCE_ENCODE = "PRODUCE_ENCODE";
     String MESSAGE_PUBLISH = "MESSAGE_PUBLISH";
     String MESSAGE_QUEUED_LATENCY = "MESSAGE_QUEUED_LATENCY";
@@ -58,7 +57,6 @@ public interface KopServerStats {
      * 2) TOTAL_MESSAGE_READ = read-recursion-times * topic-partitions * MESSAGE_READ + Overhead
      * </p>
      */
-    String HANDLE_FETCH_REQUEST = "HANDLE_FETCH_REQUEST";
     String PREPARE_METADATA = "PREPARE_METADATA";
     String TOTAL_MESSAGE_READ = "TOTAL_MESSAGE_READ";
     String MESSAGE_READ = "MESSAGE_READ";

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -13,6 +13,12 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
+import static io.streamnative.pulsar.handlers.kop.KopServerStats.BYTES_OUT;
+import static io.streamnative.pulsar.handlers.kop.KopServerStats.ENTRIES_OUT;
+import static io.streamnative.pulsar.handlers.kop.KopServerStats.GROUP_SCOPE;
+import static io.streamnative.pulsar.handlers.kop.KopServerStats.MESSAGE_OUT;
+import static io.streamnative.pulsar.handlers.kop.KopServerStats.PARTITION_SCOPE;
+import static io.streamnative.pulsar.handlers.kop.KopServerStats.TOPIC_SCOPE;
 import static org.apache.kafka.common.protocol.CommonFields.THROTTLE_TIME_MS;
 
 import com.google.common.collect.Lists;
@@ -21,6 +27,7 @@ import io.netty.util.Recycler.Handle;
 import io.streamnative.pulsar.handlers.kop.KafkaCommandDecoder.KafkaHeaderAndRequest;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
 import io.streamnative.pulsar.handlers.kop.format.DecodeResult;
+import io.streamnative.pulsar.handlers.kop.format.EntryFormatter;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
 import io.streamnative.pulsar.handlers.kop.utils.MessageIdUtils;
 import io.streamnative.pulsar.handlers.kop.utils.ZooKeeperUtils;
@@ -67,11 +74,13 @@ import org.apache.pulsar.common.naming.TopicName;
 public final class MessageFetchContext {
 
     private KafkaRequestHandler requestHandler;
+    private RequestStats statsLogger;
 
     // recycler and get for this object
-    public static MessageFetchContext get(KafkaRequestHandler requestHandler) {
+    public static MessageFetchContext get(KafkaRequestHandler requestHandler, RequestStats statsLogger) {
         MessageFetchContext context = RECYCLER.get();
         context.requestHandler = requestHandler;
+        context.statsLogger = statsLogger;
         return context;
     }
 
@@ -214,7 +223,6 @@ public final class MessageFetchContext {
                                       Map<TopicPartition, Long> highWaterMarkMap,
                                       long startReadingTotalMessagesNanos,
                                       DelayedOperationPurgatory<DelayedOperation> fetchPurgatory) {
-
         AtomicInteger entriesRead = new AtomicInteger(0);
         // here do the real read, and in read callback put cursor back to KafkaTopicConsumerManager.
         Map<TopicPartition, CompletableFuture<List<Entry>>> readFutures = readAllCursorOnce(cursors);
@@ -420,8 +428,9 @@ public final class MessageFetchContext {
                             requestHandler.requestStats.getFetchDecodeStats().registerSuccessfulEvent(
                                     MathUtils.elapsedNanos(startDecodingEntriesNanos), TimeUnit.NANOSECONDS);
                             decodeResults.add(decodeResult);
-                            // TODO: replace the following line with the method to collect metrics
-                            log.info("TODO: collect metrics of group {}", groupName);
+
+                            // collect consumer metrics
+                            updateConsumerStats(kafkaPartition, decodeResult.getRecords(), entries.size(), groupName);
 
                             List<FetchResponse.AbortedTransaction> abortedTransactions;
                             if (requestHandler.getKafkaConfig().isEnableTransactionCoordinator()
@@ -558,6 +567,32 @@ public final class MessageFetchContext {
                     currentPosition, e);
             }
         }, null);
+    }
+
+    private void updateConsumerStats(final TopicPartition topicPartition, final MemoryRecords records,
+                                     int entrySize, final String groupId) {
+        int numMessages = EntryFormatter.parseNumMessages(records);
+
+        statsLogger.getStatsLogger()
+                .scopeLabel(TOPIC_SCOPE, topicPartition.topic())
+                .scopeLabel(PARTITION_SCOPE, String.valueOf(topicPartition.partition()))
+                .scopeLabel(GROUP_SCOPE, groupId)
+                .getCounter(BYTES_OUT)
+                .add(records.sizeInBytes());
+
+        statsLogger.getStatsLogger()
+                .scopeLabel(TOPIC_SCOPE, topicPartition.topic())
+                .scopeLabel(PARTITION_SCOPE, String.valueOf(topicPartition.partition()))
+                .scopeLabel(GROUP_SCOPE, groupId)
+                .getCounter(MESSAGE_OUT)
+                .add(numMessages);
+
+        statsLogger.getStatsLogger()
+                .scopeLabel(TOPIC_SCOPE, topicPartition.topic())
+                .scopeLabel(PARTITION_SCOPE, String.valueOf(topicPartition.partition()))
+                .scopeLabel(GROUP_SCOPE, groupId)
+                .getCounter(ENTRIES_OUT)
+                .add(entrySize);
     }
 
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/RequestStats.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/RequestStats.java
@@ -15,8 +15,6 @@ package io.streamnative.pulsar.handlers.kop;
 
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.CATEGORY_SERVER;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.FETCH_DECODE;
-import static io.streamnative.pulsar.handlers.kop.KopServerStats.HANDLE_FETCH_REQUEST;
-import static io.streamnative.pulsar.handlers.kop.KopServerStats.HANDLE_PRODUCE_REQUEST;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.MESSAGE_PUBLISH;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.MESSAGE_QUEUED_LATENCY;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.MESSAGE_READ;
@@ -81,12 +79,6 @@ public class RequestStats {
     private final OpStatsLogger responseBlockedLatency;
 
     @StatsDoc(
-        name = HANDLE_PRODUCE_REQUEST,
-        help = "handle produce request stats of Kop"
-    )
-    private final OpStatsLogger handleProduceRequestStats;
-
-    @StatsDoc(
         name = PRODUCE_ENCODE,
         help = "produce encode stats of Kop"
     )
@@ -103,12 +95,6 @@ public class RequestStats {
         help = "message queued stats from kop to pulsar broker"
     )
     private final OpStatsLogger messageQueuedLatencyStats;
-
-    @StatsDoc(
-            name = HANDLE_FETCH_REQUEST,
-            help = "stats of fetch request"
-    )
-    private final OpStatsLogger handleFetchRequestStats;
 
     @StatsDoc(
             name = PREPARE_METADATA,
@@ -143,12 +129,10 @@ public class RequestStats {
         this.responseBlockedLatency = statsLogger.getOpStatsLogger(RESPONSE_BLOCKED_LATENCY);
         this.responseBlockedTimes = statsLogger.getCounter(RESPONSE_BLOCKED_TIMES);
 
-        this.handleProduceRequestStats = statsLogger.getOpStatsLogger(HANDLE_PRODUCE_REQUEST);
         this.produceEncodeStats = statsLogger.getOpStatsLogger(PRODUCE_ENCODE);
         this.messagePublishStats = statsLogger.getOpStatsLogger(MESSAGE_PUBLISH);
         this.messageQueuedLatencyStats = statsLogger.getOpStatsLogger(MESSAGE_QUEUED_LATENCY);
 
-        this.handleFetchRequestStats = statsLogger.getOpStatsLogger(HANDLE_FETCH_REQUEST);
         this.prepareMetadataStats = statsLogger.getOpStatsLogger(PREPARE_METADATA);
         this.totalMessageReadStats = statsLogger.getOpStatsLogger(TOTAL_MESSAGE_READ);
         this.messageReadStats = statsLogger.getOpStatsLogger(MESSAGE_READ);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatter.java
@@ -19,7 +19,6 @@ import org.apache.bookkeeper.mledger.Entry;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.MutableRecordBatch;
 
-
 /**
  * The formatter for conversion between Kafka records and Bookie entries.
  */

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
@@ -164,8 +164,8 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase{
         Assert.assertTrue(sb.toString().contains("request=\"ApiVersions\""));
         Assert.assertTrue(sb.toString().contains("request=\"ListOffsets\""));
         Assert.assertTrue(sb.toString().contains("request=\"Fetch\""));
-        Assert.assertTrue(sb.toString().contains("kop_server_REQUEST_LATENCY{success=\"true\",quantile=\"0.999\", "
-                + "request=\"ListOffsets\"}"));
+        Assert.assertTrue(sb.toString().contains("kop_server_REQUEST_LATENCY{success=\"true\",quantile=\"0.99\", "
+                + "request=\"Fetch\"}"));
 
         // response stats
         Assert.assertTrue(sb.toString().contains("kop_server_RESPONSE_QUEUE_SIZE"));

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
@@ -150,6 +150,9 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase{
         StringBuffer sb = new StringBuffer();
         String str;
         while ((str = reader.readLine()) != null) {
+            if (str.contains("NaN") || str.contains("Infinity")) {
+                continue;
+            }
             sb.append(str);
         }
 
@@ -161,7 +164,7 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase{
         Assert.assertTrue(sb.toString().contains("request=\"ApiVersions\""));
         Assert.assertTrue(sb.toString().contains("request=\"ListOffsets\""));
         Assert.assertTrue(sb.toString().contains("request=\"Fetch\""));
-        Assert.assertTrue(sb.toString().contains("kop_server_REQUEST_LATENCY{success=\"false\",quantile=\"0.999\", "
+        Assert.assertTrue(sb.toString().contains("kop_server_REQUEST_LATENCY{success=\"true\",quantile=\"0.999\", "
                 + "request=\"ListOffsets\"}"));
 
         // response stats

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
@@ -141,6 +141,12 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase{
         // commit offsets
         kConsumer.getConsumer().commitSync(Duration.ofSeconds(5));
 
+        try {
+            Thread.sleep(1000);
+        } catch (Exception e) {
+
+        }
+
         HttpClient httpClient = HttpClientBuilder.create().build();
         final String metricsEndPoint = pulsar.getWebServiceAddress() + "/metrics";
         HttpResponse response = httpClient.execute(new HttpGet(metricsEndPoint));
@@ -165,7 +171,7 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase{
         Assert.assertTrue(sb.toString().contains("request=\"ListOffsets\""));
         Assert.assertTrue(sb.toString().contains("request=\"Fetch\""));
         Assert.assertTrue(sb.toString().contains("kop_server_REQUEST_LATENCY{success=\"true\",quantile=\"0.99\", "
-                + "request=\"Fetch\"}"));
+                + "request=\"Produce\"}"));
 
         // response stats
         Assert.assertTrue(sb.toString().contains("kop_server_RESPONSE_QUEUE_SIZE"));

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
@@ -89,7 +89,7 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase{
 
     @Test(timeOut = 30000)
     public void testMetricsProvider() throws Exception {
-        int partitionNumber = 3;
+        int partitionNumber = 1;
         String kafkaTopicName = "kopKafkaProducePulsarMetrics" + partitionNumber;
 
         // create partitioned topic.
@@ -181,5 +181,12 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase{
         Assert.assertTrue(sb.toString().contains("kop_server_TOTAL_MESSAGE_READ"));
         Assert.assertTrue(sb.toString().contains("kop_server_MESSAGE_READ"));
         Assert.assertTrue(sb.toString().contains("kop_server_FETCH_DECODE"));
+
+        // consumer stats
+        Assert.assertTrue(sb.toString().contains("kop_server_MESSAGE_OUT{group=\"DemoKafkaOnPulsarConsumer\","
+                + "partition=\"0\",topic=\"kopKafkaProducePulsarMetrics1\"} 10"));
+        Assert.assertTrue(sb.toString().contains("kop_server_BYTES_OUT{group=\"DemoKafkaOnPulsarConsumer\","
+                + "partition=\"0\",topic=\"kopKafkaProducePulsarMetrics1\"} 1130"));
+        Assert.assertTrue(sb.toString().contains("kop_server_BYTES_OUT"));
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
@@ -170,13 +170,11 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase{
         Assert.assertTrue(sb.toString().contains("kop_server_RESPONSE_BLOCKED_LATENCY"));
 
         // produce stats
-        Assert.assertTrue(sb.toString().contains("kop_server_HANDLE_PRODUCE_REQUEST"));
         Assert.assertTrue(sb.toString().contains("kop_server_PRODUCE_ENCODE"));
         Assert.assertTrue(sb.toString().contains("kop_server_MESSAGE_PUBLISH"));
         Assert.assertTrue(sb.toString().contains("kop_server_MESSAGE_QUEUED_LATENCY"));
 
         // fetch stats
-        Assert.assertTrue(sb.toString().contains("kop_server_HANDLE_FETCH_REQUEST"));
         Assert.assertTrue(sb.toString().contains("kop_server_PREPARE_METADATA"));
         Assert.assertTrue(sb.toString().contains("kop_server_TOTAL_MESSAGE_READ"));
         Assert.assertTrue(sb.toString().contains("kop_server_MESSAGE_READ"));


### PR DESCRIPTION
### Motivation
In order to expose consumer stats, KOP create a consumer and update the stats metric to consumer object.  
It's too expensive.

### Modifications
1. expose consumer stats to prometheus instead of consumer internal stats

### TODO
1. groupid still should store in zookeeper, it's hard to remove.