### PR TITLE
Apply getPartitionedTopicMetadata API with correct semantics

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -552,7 +552,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                     log.error("Topic {} is a non-partitioned topic", topic);
                                     allTopicMetadata.add(
                                             new TopicMetadata(
-                                                    Errors.UNKNOWN_TOPIC_OR_PARTITION,
+                                                    Errors.INVALID_TOPIC_EXCEPTION,
                                                     topic,
                                                     false,
                                                     Collections.emptyList()));

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtilsTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtilsTest.java
@@ -148,7 +148,7 @@ public class MetadataUtilsTest {
         verify(mockTenants, times(1)).updateTenant(eq(conf.getKafkaMetadataTenant()), any(TenantInfo.class));
         verify(mockNamespaces, times(2)).setNamespaceReplicationClusters(eq(conf.getKafkaMetadataTenant()
             + "/" + conf.getKafkaMetadataNamespace()), any(Set.class));
-        verify(mockTopics, times(2)).createNonPartitionedTopic(contains(offsetsTopic.getOriginalName()));
-        verify(mockTopics, times(2)).createNonPartitionedTopic(contains(txnTopic.getOriginalName()));
+        verify(mockTopics, times(1)).createMissedPartitions(contains(offsetsTopic.getOriginalName()));
+        verify(mockTopics, times(1)).createMissedPartitions(contains(txnTopic.getOriginalName()));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
     <pulsar.group.id>io.streamnative</pulsar.group.id>
-    <pulsar.version>2.8.0-rc-202105092228</pulsar.version>
+    <pulsar.version>2.8.0-rc-202105182205</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testcontainers.version>1.15.1</testcontainers.version>

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -349,8 +349,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
     }
 
 
-    //@Test(timeOut = 10000)
-    @Test
+    @Test(timeOut = 10000)
     public void testCreateAndDeleteTopics() throws Exception {
         Properties props = new Properties();
         props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getKafkaBrokerPort());

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -76,6 +76,8 @@ import org.apache.kafka.common.requests.ApiVersionsResponse;
 import org.apache.kafka.common.requests.IsolationLevel;
 import org.apache.kafka.common.requests.ListOffsetRequest;
 import org.apache.kafka.common.requests.ListOffsetResponse;
+import org.apache.kafka.common.requests.MetadataRequest;
+import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.requests.MetadataResponse.PartitionMetadata;
 import org.apache.kafka.common.requests.OffsetCommitRequest;
 import org.apache.kafka.common.requests.RequestHeader;
@@ -91,8 +93,9 @@ import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
@@ -104,7 +107,12 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
     private KafkaRequestHandler handler;
     private AdminManager adminManager;
 
-    @BeforeMethod
+    @DataProvider(name = "metadataVersions")
+    public static Object[][] metadataVersions() {
+        return new Object[][]{ { (short) 0 }, { (short) 1 } };
+    }
+
+    @BeforeClass
     @Override
     protected void setup() throws Exception {
         super.internalSetup();
@@ -165,7 +173,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
         handler.ctx = mockCtx;
     }
 
-    @AfterMethod
+    @AfterClass
     @Override
     protected void cleanup() throws Exception {
         adminManager.shutdown();
@@ -652,5 +660,22 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
         final ListOffsetResponse response = (ListOffsetResponse) responseFuture.get();
         assertTrue(response.responseData().containsKey(topicPartition));
         assertEquals(response.responseData().get(topicPartition).error, Errors.UNKNOWN_TOPIC_OR_PARTITION);
+    }
+
+    @Test(timeOut = 10000, dataProvider = "metadataVersions")
+    public void testMetadataForNonPartitionedTopic(short version) throws Exception {
+        final String topic = "testMetadataForNonPartitionedTopic-" + version;
+        admin.topics().createNonPartitionedTopic(topic);
+
+        final RequestHeader header = new RequestHeader(ApiKeys.METADATA, version, "client", 0);
+        final MetadataRequest request = new MetadataRequest(Collections.singletonList(topic), false, version);
+        final CompletableFuture<AbstractResponse> responseFuture = new CompletableFuture<>();
+        handler.handleTopicMetadataRequest(
+                new KafkaHeaderAndRequest(header, request, PulsarByteBufAllocator.DEFAULT.heapBuffer(), null),
+                responseFuture);
+        final MetadataResponse response = (MetadataResponse) responseFuture.get();
+        assertEquals(response.topicMetadata().size(), 1);
+        assertEquals(response.errors().size(), 1);
+        assertEquals(response.errors().get(topic), Errors.INVALID_TOPIC_EXCEPTION);
     }
 }


### PR DESCRIPTION
Upgrade pulsar dependency to a newer version (2.8.0-rc-202105182205) that contains https://github.com/apache/pulsar/pull/10601, which corrected the wrong semantics of `getPartitionedTopicMetadataAsync` that returns 0 for a non-existed topic.