### PR TITLE
upgrade pulsar dependency to 2.8.0-rc-202105291235

### DIFF
--- a/docs/kop.yaml
+++ b/docs/kop.yaml
@@ -1,1 +1,12 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 repository: https://github.com/streamnative/kop

--- a/docs/kop.yaml
+++ b/docs/kop.yaml
@@ -1,3 +1,4 @@
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -9,4 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+
 repository: https://github.com/streamnative/kop

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
     <pulsar.group.id>io.streamnative</pulsar.group.id>
-    <pulsar.version>2.8.0-rc-202105251229</pulsar.version>
+    <pulsar.version>2.8.0-rc-202105291235</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testcontainers.version>1.15.1</testcontainers.version>


### PR DESCRIPTION
### Modification
1. upgrade pulsar dependency to include the following bug fix
    - https://github.com/apache/pulsar/pull/10706 : fix load __consumer_offset topic timeout on bundle onLoad stage
    - https://github.com/apache/pulsar/pull/10341 :  fix create reader failed on bundle onLoad stage