### PR TITLE
Refactor FETCH request handler to reduce GC

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -1305,8 +1305,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             });
         }
 
-        MessageFetchContext fetchContext = MessageFetchContext.get(this, requestStats);
-        fetchContext.handleFetch(resultFuture, fetch, transactionCoordinator, fetchPurgatory);
+        MessageFetchContext.get(this, fetch, resultFuture).handleFetch();
     }
 
     protected void handleJoinGroupRequest(KafkaHeaderAndRequest joinGroup,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopServerStats.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopServerStats.java
@@ -58,7 +58,6 @@ public interface KopServerStats {
      * </p>
      */
     String PREPARE_METADATA = "PREPARE_METADATA";
-    String TOTAL_MESSAGE_READ = "TOTAL_MESSAGE_READ";
     String MESSAGE_READ = "MESSAGE_READ";
     String FETCH_DECODE = "FETCH_DECODE";
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -69,6 +69,12 @@ import org.apache.pulsar.common.naming.TopicName;
 @Slf4j
 public final class MessageFetchContext {
 
+    private static final Recycler<MessageFetchContext> RECYCLER = new Recycler<MessageFetchContext>() {
+        protected MessageFetchContext newObject(Handle<MessageFetchContext> handle) {
+            return new MessageFetchContext(handle);
+        }
+    };
+
     private final Handle<MessageFetchContext> recyclerHandle;
     private Map<TopicPartition, PartitionData<MemoryRecords>> responseData;
     private List<DecodeResult> decodeResults;
@@ -105,11 +111,6 @@ public final class MessageFetchContext {
         this.recyclerHandle = recyclerHandle;
     }
 
-    private static final Recycler<MessageFetchContext> RECYCLER = new Recycler<MessageFetchContext>() {
-        protected MessageFetchContext newObject(Handle<MessageFetchContext> handle) {
-            return new MessageFetchContext(handle);
-        }
-    };
 
     private void recycle() {
         responseData = null;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -21,7 +21,6 @@ import static io.streamnative.pulsar.handlers.kop.KopServerStats.PARTITION_SCOPE
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.TOPIC_SCOPE;
 import static org.apache.kafka.common.protocol.CommonFields.THROTTLE_TIME_MS;
 
-import com.google.common.collect.Lists;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
 import io.streamnative.pulsar.handlers.kop.KafkaCommandDecoder.KafkaHeaderAndRequest;
@@ -31,9 +30,6 @@ import io.streamnative.pulsar.handlers.kop.format.EntryFormatter;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
 import io.streamnative.pulsar.handlers.kop.utils.MessageIdUtils;
 import io.streamnative.pulsar.handlers.kop.utils.ZooKeeperUtils;
-import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperation;
-import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperationKey;
-import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperationPurgatory;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -41,9 +37,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
+import java.util.concurrent.atomic.AtomicLong;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.util.MathUtils;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.MarkDeleteCallback;
@@ -56,6 +50,7 @@ import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.RecordBatch;
@@ -64,6 +59,7 @@ import org.apache.kafka.common.requests.FetchRequest;
 import org.apache.kafka.common.requests.FetchResponse;
 import org.apache.kafka.common.requests.FetchResponse.PartitionData;
 import org.apache.kafka.common.requests.IsolationLevel;
+import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.requests.ResponseCallbackWrapper;
 import org.apache.pulsar.common.naming.TopicName;
 
@@ -73,18 +69,37 @@ import org.apache.pulsar.common.naming.TopicName;
 @Slf4j
 public final class MessageFetchContext {
 
+    private final Handle<MessageFetchContext> recyclerHandle;
+    private Map<TopicPartition, PartitionData<MemoryRecords>> responseData;
+    private List<DecodeResult> decodeResults;
     private KafkaRequestHandler requestHandler;
+    private int maxReadEntriesNum;
+    private KafkaTopicManager topicManager;
     private RequestStats statsLogger;
+    private TransactionCoordinator tc;
+    private String clientHost;
+    private FetchRequest fetchRequest;
+    private RequestHeader header;
+    private volatile CompletableFuture<AbstractResponse> resultFuture;
 
     // recycler and get for this object
-    public static MessageFetchContext get(KafkaRequestHandler requestHandler, RequestStats statsLogger) {
+    public static MessageFetchContext get(KafkaRequestHandler requestHandler,
+                                          KafkaHeaderAndRequest kafkaHeaderAndRequest,
+                                          CompletableFuture<AbstractResponse> resultFuture) {
         MessageFetchContext context = RECYCLER.get();
+        context.responseData = new ConcurrentHashMap<>();
+        context.decodeResults = new ArrayList<>();
         context.requestHandler = requestHandler;
-        context.statsLogger = statsLogger;
+        context.maxReadEntriesNum = requestHandler.getMaxReadEntriesNum();
+        context.topicManager = requestHandler.getTopicManager();
+        context.statsLogger = requestHandler.requestStats;
+        context.tc = requestHandler.getTransactionCoordinator();
+        context.clientHost = kafkaHeaderAndRequest.getClientHost();
+        context.fetchRequest = (FetchRequest) kafkaHeaderAndRequest.getRequest();
+        context.header = kafkaHeaderAndRequest.getHeader();
+        context.resultFuture = resultFuture;
         return context;
     }
-
-    private final Handle<MessageFetchContext> recyclerHandle;
 
     private MessageFetchContext(Handle<MessageFetchContext> recyclerHandle) {
         this.recyclerHandle = recyclerHandle;
@@ -96,458 +111,276 @@ public final class MessageFetchContext {
         }
     };
 
-    public void recycle() {
+    private void recycle() {
+        responseData = null;
+        decodeResults = null;
         requestHandler = null;
+        maxReadEntriesNum = 0;
+        topicManager = null;
+        statsLogger = null;
+        tc = null;
+        clientHost = null;
+        fetchRequest = null;
+        header = null;
+        resultFuture = null;
         recyclerHandle.recycle(this);
     }
 
+    private void addErrorPartitionResponse(TopicPartition topicPartition, Errors errors) {
+        responseData.put(topicPartition, new PartitionData<>(
+                errors,
+                FetchResponse.INVALID_HIGHWATERMARK,
+                FetchResponse.INVALID_LAST_STABLE_OFFSET,
+                FetchResponse.INVALID_LOG_START_OFFSET,
+                null,
+                MemoryRecords.EMPTY));
+        tryComplete();
+    }
+
+    private void tryComplete() {
+        if (responseData.size() >= fetchRequest.fetchData().size()) {
+            complete();
+        }
+    }
+
+    public void complete() {
+        if (resultFuture == null) {
+            // the context has been recycled
+            return;
+        }
+        if (resultFuture.isCancelled()) {
+            // The request was cancelled by KafkaCommandDecoder when channel is closed or this request is expired,
+            // so the Netty buffers should be released.
+            decodeResults.forEach(DecodeResult::release);
+            return;
+        }
+        if (resultFuture.isDone()) {
+            // It may be triggered again in DelayedProduceAndFetch
+            return;
+        }
+
+        // Keep the order of TopicPartition
+        final LinkedHashMap<TopicPartition, PartitionData<MemoryRecords>> orderedResponseData = new LinkedHashMap<>();
+        // add the topicPartition with timeout error if it's not existed in responseData
+        fetchRequest.fetchData().keySet().forEach(topicPartition -> {
+            final PartitionData<MemoryRecords> partitionData = responseData.remove(topicPartition);
+            if (partitionData != null) {
+                orderedResponseData.put(topicPartition, partitionData);
+            } else {
+                orderedResponseData.put(topicPartition, new FetchResponse.PartitionData<>(
+                        Errors.REQUEST_TIMED_OUT,
+                        FetchResponse.INVALID_HIGHWATERMARK,
+                        FetchResponse.INVALID_LAST_STABLE_OFFSET,
+                        FetchResponse.INVALID_LOG_START_OFFSET,
+                        null,
+                        MemoryRecords.EMPTY));
+            }
+        });
+
+        // Create another reference to this.decodeResults so the lambda expression will capture this local reference
+        // because this.decodeResults will be reset to null after resultFuture is completed.
+        final List<DecodeResult> decodeResults = this.decodeResults;
+        resultFuture.complete(
+                new ResponseCallbackWrapper(
+                        new FetchResponse<>(
+                                Errors.NONE,
+                                orderedResponseData,
+                                ((Integer) THROTTLE_TIME_MS.defaultValue),
+                                fetchRequest.metadata().sessionId()),
+                        () -> {
+                            // release the batched ByteBuf if necessary
+                            decodeResults.forEach(DecodeResult::release);
+                        }));
+        recycle();
+    }
 
     // handle request
-    public CompletableFuture<AbstractResponse> handleFetch(
-            CompletableFuture<AbstractResponse> fetchResponse,
-            KafkaHeaderAndRequest fetchRequest,
-            TransactionCoordinator transactionCoordinator,
-            DelayedOperationPurgatory<DelayedOperation> fetchPurgatory) {
-        final long startPreparingMetadataNanos = MathUtils.nowInNano();
-        LinkedHashMap<TopicPartition, PartitionData<MemoryRecords>> responseData = new LinkedHashMap<>();
+    public void handleFetch() {
+        final boolean readCommitted =
+                (tc != null && fetchRequest.isolationLevel().equals(IsolationLevel.READ_COMMITTED));
 
-        // Map of partition and related tcm.
-        Map<TopicPartition, CompletableFuture<KafkaTopicConsumerManager>> topicsAndCursor =
-            ((FetchRequest) fetchRequest.getRequest())
-                .fetchData().entrySet().stream()
-                .map(entry -> {
-                    CompletableFuture<KafkaTopicConsumerManager> consumerManager =
-                        requestHandler.getTopicManager().getTopicConsumerManager(KopTopic.toString(entry.getKey()));
+        fetchRequest.fetchData().forEach((topicPartition, partitionData) -> {
+            final long startPrepareMetadataNanos = MathUtils.nowInNano();
+            final long offset = partitionData.fetchOffset;
 
-                    return Pair.of(
-                        entry.getKey(),
-                        consumerManager);
-                })
-                .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
-
-        Map<TopicPartition, Long> highWaterMarkMap = new ConcurrentHashMap<>();
-        // wait to get all the cursor, then readMessages
-        CompletableFuture
-            .allOf(topicsAndCursor.entrySet().stream().map(Map.Entry::getValue).toArray(CompletableFuture<?>[]::new))
-            .whenComplete((ignore, ex) -> {
-                Map<TopicPartition, Pair<ManagedCursor, Long>> partitionCursor =
-                    topicsAndCursor.entrySet().stream()
-                        .map(pair -> {
-                            final TopicPartition topicPartition = pair.getKey();
-                            // The future is completed now
-                            final KafkaTopicConsumerManager tcm = pair.getValue().getNow(null);
-                            if (tcm == null) {
-                                // Current broker is not the owner broker of the partition
-                                responseData.put(topicPartition, new FetchResponse.PartitionData<>(
-                                        Errors.NOT_LEADER_FOR_PARTITION,
-                                        FetchResponse.INVALID_HIGHWATERMARK,
-                                        FetchResponse.INVALID_LAST_STABLE_OFFSET,
-                                        FetchResponse.INVALID_LOG_START_OFFSET,
-                                        null,
-                                        MemoryRecords.EMPTY));
-                                // remove null future cache from consumerTopicManagers
-                                KafkaTopicManager.removeKafkaTopicConsumerManager(KopTopic.toString(topicPartition));
-                                // result got. this will be filtered in following filter method.
-                                return null;
-                            }
-
-                            long offset = ((FetchRequest) fetchRequest.getRequest()).fetchData()
-                                .get(topicPartition).fetchOffset;
-
-                            if (log.isDebugEnabled()) {
-                                log.debug("Fetch for {}: remove tcm to get cursor for fetch offset: {} .",
-                                    topicPartition, offset);
-                            }
-
-                            Pair<ManagedCursor, Long> cursorLongPair = tcm.remove(offset);
-                            if (cursorLongPair == null) {
-                                log.warn("KafkaTopicConsumerManager.remove({}) return null for topic {}. "
-                                        + "Fetch for topic return error.",
-                                    offset, topicPartition);
-
-                                responseData.put(topicPartition,
-                                    new FetchResponse.PartitionData<>(
-                                        Errors.NOT_LEADER_FOR_PARTITION,
-                                        FetchResponse.INVALID_HIGHWATERMARK,
-                                        FetchResponse.INVALID_LAST_STABLE_OFFSET,
-                                        FetchResponse.INVALID_LOG_START_OFFSET,
-                                        null,
-                                        MemoryRecords.EMPTY));
-                                // result got. this will be filtered in following filter method.
-                                return null;
-                            }
-
-                            highWaterMarkMap.put(topicPartition,
-                                    MessageIdUtils.getHighWatermark(cursorLongPair.getLeft().getManagedLedger()));
-
-                            return Pair.of(topicPartition, cursorLongPair);
-                        })
-                        .filter(x -> x != null)
-                        .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
-
-                requestHandler.requestStats.getPrepareMetadataStats().registerSuccessfulEvent(
-                        MathUtils.elapsedNanos(startPreparingMetadataNanos), TimeUnit.NANOSECONDS);
-
-                readMessages(fetchRequest, partitionCursor, fetchResponse, responseData,
-                        transactionCoordinator, highWaterMarkMap, fetchPurgatory);
-            });
-
-        return fetchResponse;
-    }
-
-
-    // read messages from given cursors.
-    // the pair Pair<ManagedCursor, Long> can be used to track the read offset?
-    private void readMessages(KafkaHeaderAndRequest fetch,
-                              Map<TopicPartition, Pair<ManagedCursor, Long>> cursors,
-                              CompletableFuture<AbstractResponse> resultFuture,
-                              LinkedHashMap<TopicPartition, PartitionData<MemoryRecords>> responseData,
-                              TransactionCoordinator tc,
-                              Map<TopicPartition, Long> highWaterMarkMap,
-                              DelayedOperationPurgatory<DelayedOperation> fetchPurgatory) {
-        AtomicInteger bytesRead = new AtomicInteger(0);
-        Map<TopicPartition, List<Entry>> entryValues = new ConcurrentHashMap<>();
-
-        final long startReadingTotalMessagesNanos = MathUtils.nowInNano();
-        readMessagesInternal(fetch, cursors, bytesRead, entryValues, resultFuture, responseData, tc, highWaterMarkMap,
-                startReadingTotalMessagesNanos, fetchPurgatory);
-    }
-
-    private void readMessagesInternal(KafkaHeaderAndRequest fetch,
-                                      Map<TopicPartition, Pair<ManagedCursor, Long>> cursors,
-                                      AtomicInteger bytesRead,
-                                      Map<TopicPartition, List<Entry>> responseValues,
-                                      CompletableFuture<AbstractResponse> resultFuture,
-                                      LinkedHashMap<TopicPartition, PartitionData<MemoryRecords>> responseData,
-                                      TransactionCoordinator tc,
-                                      Map<TopicPartition, Long> highWaterMarkMap,
-                                      long startReadingTotalMessagesNanos,
-                                      DelayedOperationPurgatory<DelayedOperation> fetchPurgatory) {
-        AtomicInteger entriesRead = new AtomicInteger(0);
-        // here do the real read, and in read callback put cursor back to KafkaTopicConsumerManager.
-        Map<TopicPartition, CompletableFuture<List<Entry>>> readFutures = readAllCursorOnce(cursors);
-        // delay fetch
-        FetchRequest fetchRequestRequest = (FetchRequest) fetch.getRequest();
-        List<DecodeResult> decodeResults = new ArrayList<>();
-        final AtomicInteger topicPartitionNum = new AtomicInteger(fetchRequestRequest.fetchData().entrySet().size());
-        int timeoutMs = fetchRequestRequest.maxWait();
-        Runnable complete = () -> {
-            topicPartitionNum.set(0);
-            if (resultFuture.isCancelled()) {
-                // The request was cancelled by KafkaCommandDecoder when channel is closed or this request is expired,
-                // so the Netty buffers should be released.
-                decodeResults.forEach(DecodeResult::release);
-                return;
-            }
-            if (resultFuture.isDone()) {
-                // It may be triggered again in DelayedProduceAndFetch
-                return;
-            }
-            // add the topicPartition with timeout error if it's not existed in responseData
-            fetchRequestRequest.fetchData().keySet().forEach(topicPartition -> {
-                if (!responseData.containsKey(topicPartition)) {
-                    responseData.put(topicPartition, new FetchResponse.PartitionData<>(
-                            Errors.REQUEST_TIMED_OUT,
-                            FetchResponse.INVALID_HIGHWATERMARK,
-                            FetchResponse.INVALID_LAST_STABLE_OFFSET,
-                            FetchResponse.INVALID_LOG_START_OFFSET,
-                            null,
-                            MemoryRecords.EMPTY));
+            final String fullTopicName = KopTopic.toString(topicPartition);
+            // the future that is returned by getTopicConsumerManager is always completed normally
+            topicManager.getTopicConsumerManager(fullTopicName).thenAccept(tcm -> {
+                if (tcm == null) {
+                    statsLogger.getPrepareMetadataStats().registerFailedEvent(
+                            MathUtils.elapsedNanos(startPrepareMetadataNanos), TimeUnit.NANOSECONDS);
+                    // remove null future cache
+                    KafkaTopicManager.removeKafkaTopicConsumerManager(KopTopic.toString(topicPartition));
+                    addErrorPartitionResponse(topicPartition, Errors.NOT_LEADER_FOR_PARTITION);
+                    return;
                 }
-            });
-            resultFuture.complete(
-                    new ResponseCallbackWrapper(
-                            new FetchResponse(
-                                    Errors.NONE,
-                                    responseData,
-                                    ((Integer) THROTTLE_TIME_MS.defaultValue),
-                                    ((FetchRequest) fetch.getRequest()).metadata().sessionId()),
-                            () -> {
-                                // release the batched ByteBuf if necessary
-                                decodeResults.forEach(DecodeResult::release);
-                            }));
-            this.recycle();
-        };
-        CompletableFuture.allOf(readFutures.values().stream().toArray(CompletableFuture<?>[]::new))
-            .whenComplete((ignore, ex) -> {
-
-                FetchRequest request = (FetchRequest) fetch.getRequest();
-                IsolationLevel isolationLevel = request.isolationLevel();
-
-                // keep entries since all read completed.
-                readFutures.entrySet().parallelStream().forEach(kafkaTopicReadEntry -> {
-                    TopicPartition kafkaTopic = kafkaTopicReadEntry.getKey();
-                    CompletableFuture<List<Entry>> readEntry = kafkaTopicReadEntry.getValue();
-                    List<Entry> entries = null;
-                    try {
-                        entries = readEntry.get();
-                    } catch (Exception e) {
-                        // readEntry.get failed because of readEntriesFailed. return error for this partition
-                        log.error("Request {}: Failed readEntry.get for topic: {}. ",
-                                fetch.getHeader(), kafkaTopic, e);
-
-                        // delete related cursor in TCM
-                        requestHandler.getTopicManager()
-                                .getTopicConsumerManager(KopTopic.toString(kafkaTopic))
-                                .thenAccept(cm -> {
-                                    // Notice, channel may be close, then TCM would be null.
-                                    if (cm != null) {
-                                        cm.deleteOneCursorAsync(
-                                                cursors.get(kafkaTopic).getLeft(),
-                                                "cursor.readEntry fail. deleteCursor");
-                                    } else {
-                                        // remove null future cache from consumerTopicManagers
-                                        KafkaTopicManager.removeKafkaTopicConsumerManager(
-                                                KopTopic.toString(kafkaTopic));
-                                        log.warn("Cursor deleted while TCM close.");
-                                    }
-                                });
-
-                        cursors.remove(kafkaTopic);
-
-                        responseData.put(kafkaTopic,
-                                new FetchResponse.PartitionData(
-                                        Errors.NONE,
-                                        FetchResponse.INVALID_HIGHWATERMARK,
-                                        FetchResponse.INVALID_LAST_STABLE_OFFSET,
-                                        FetchResponse.INVALID_LOG_START_OFFSET,
-                                        null,
-                                        MemoryRecords.EMPTY));
-                    }
-                    List<Entry> entryList = responseValues.computeIfAbsent(kafkaTopic, l -> Lists.newArrayList());
-
-                    if (entries != null && !entries.isEmpty()) {
-                        if (requestHandler.getKafkaConfig().isEnableTransactionCoordinator()
-                                && isolationLevel.equals(IsolationLevel.READ_COMMITTED)
-                                && tc != null) {
-                            TopicName topicName = TopicName.get(KopTopic.toString(kafkaTopic));
-                            long lso = tc.getLastStableOffset(topicName, highWaterMarkMap.get(kafkaTopic));
-                            for (Entry entry : entries) {
-                                if (lso >= MessageIdUtils.peekBaseOffsetFromEntry(entry)) {
-                                    entryList.add(entry);
-                                    entriesRead.incrementAndGet();
-                                    bytesRead.addAndGet(entry.getLength());
-                                } else {
-                                    break;
-                                }
-                            }
-                        } else {
-                            entryList.addAll(entries);
-                            entriesRead.addAndGet(entries.size());
-                            bytesRead.addAndGet(entryList.stream().parallel().map(e ->
-                                    e.getLength()).reduce(0, Integer::sum));
-                        }
-
-                        if (log.isDebugEnabled()) {
-                            log.debug("Request {}: For topic {}, entries in list: {}.",
-                                    fetch.getHeader(), kafkaTopic.toString(), entryList.size());
-                        }
-                    }
-
-                });
-
-                int maxBytes = request.maxBytes();
-                int minBytes = request.minBytes();
-
-                int allSize = bytesRead.get();
 
                 if (log.isDebugEnabled()) {
-                    log.debug("Request {}: One round read {} entries, "
-                            + "allSize/maxBytes/minBytes: {}/{}/{}",
-                        fetch.getHeader(), entriesRead.get(),
-                        allSize, maxBytes, minBytes);
+                    log.debug("Fetch for {}: remove tcm to get cursor for fetch offset: {} .",
+                            topicPartition, offset);
                 }
 
-                // all partitions read no entry, return earlier;
-                // reach maxTime, return;
-                // reach minBytes if no endTime, return;
-                if ((allSize == 0 && entriesRead.get() == 0)
-                    || allSize > minBytes
-                    || allSize > maxBytes){
-                    if (log.isDebugEnabled()) {
-                        log.debug(" Request {}: Complete read {} entries with size {}",
-                            fetch.getHeader(), entriesRead.get(), allSize);
+                final Pair<ManagedCursor, Long> cursorLongPair = tcm.remove(offset);
+                if (cursorLongPair == null) {
+                    log.warn("KafkaTopicConsumerManager.remove({}) return null for topic {}. "
+                                    + "Fetch for topic return error.",
+                            offset, topicPartition);
+                    addErrorPartitionResponse(topicPartition, Errors.NOT_LEADER_FOR_PARTITION);
+                    return;
+                }
+
+                final ManagedCursor cursor = cursorLongPair.getLeft();
+                final AtomicLong cursorOffset = new AtomicLong(cursorLongPair.getRight());
+                final long highWatermark = MessageIdUtils.getHighWatermark(
+                        cursorLongPair.getLeft().getManagedLedger());
+                statsLogger.getPrepareMetadataStats().registerSuccessfulEvent(
+                        MathUtils.elapsedNanos(startPrepareMetadataNanos), TimeUnit.NANOSECONDS);
+                readEntries(cursor, topicPartition, cursorOffset).whenComplete((entries, throwable) -> {
+                    if (throwable != null) {
+                        tcm.deleteOneCursorAsync(cursorLongPair.getLeft(), "cursor.readEntry fail. deleteCursor");
+                        addErrorPartitionResponse(topicPartition, Errors.forException(throwable));
+                        return;
                     }
-                    requestHandler.requestStats.getTotalMessageReadStats().registerSuccessfulEvent(
-                            MathUtils.elapsedNanos(startReadingTotalMessagesNanos), TimeUnit.NANOSECONDS);
+                    if (entries == null) {
+                        addErrorPartitionResponse(topicPartition,
+                                Errors.forException(new ApiException("Cursor is null")));
+                        return;
+                    }
 
-                    responseValues.entrySet().forEach(responseEntries -> {
-                        final PartitionData partitionData;
-                        TopicPartition kafkaPartition = responseEntries.getKey();
-                        List<Entry> entries = responseEntries.getValue();
-                        // Add cursor and offset back to TCM when all the read completed.
-                        Pair<ManagedCursor, Long> pair = cursors.get(kafkaPartition);
-                        requestHandler.getTopicManager()
-                            .getTopicConsumerManager(KopTopic.toString(kafkaPartition))
-                            .thenAccept(cm -> {
-                                // Notice, channel may be close, then TCM would be null.
-                                if (cm != null) {
-                                    cm.add(pair.getRight(), pair);
-                                } else {
-                                    // remove null future cache from consumerTopicManagers
-                                    KafkaTopicManager.removeKafkaTopicConsumerManager(
-                                            KopTopic.toString(kafkaPartition));
-                                    log.warn("Cursor deleted while TCM close, failed to add cursor back to TCM.");
-                                }
-                            });
+                    // Add new offset back to TCM after entries are read successfully
+                    tcm.add(cursorOffset.get(), Pair.of(cursor, cursorOffset.get()));
 
-                        if (entries.isEmpty()) {
-                            partitionData = new FetchResponse.PartitionData(
-                                Errors.NONE,
-                                FetchResponse.INVALID_HIGHWATERMARK,
-                                FetchResponse.INVALID_LAST_STABLE_OFFSET,
-                                FetchResponse.INVALID_LOG_START_OFFSET,
-                                null,
-                                MemoryRecords.EMPTY);
-                        } else {
-                            long highWatermark = highWaterMarkMap.get(kafkaPartition);
-
-                            // use compatible magic value by apiVersion
-                            short apiVersion = fetch.getHeader().apiVersion();
-                            byte magic = RecordBatch.CURRENT_MAGIC_VALUE;
-                            if (apiVersion <= 1) {
-                                magic = RecordBatch.MAGIC_VALUE_V0;
-                            } else if (apiVersion <= 3) {
-                                magic = RecordBatch.MAGIC_VALUE_V1;
+                    final long lso = (readCommitted
+                            ? tc.getLastStableOffset(TopicName.get(fullTopicName), highWatermark)
+                            : highWatermark);
+                    List<Entry> committedEntries = entries;
+                    if (readCommitted) {
+                        committedEntries = new ArrayList<>();
+                        for (Entry entry : entries) {
+                            if (lso >= MessageIdUtils.peekBaseOffsetFromEntry(entry)) {
+                                committedEntries.add(entry);
+                            } else {
+                                break;
                             }
-                            // get group and consumer
-                            String clientHost = fetch.getClientHost();
-                            String groupName = requestHandler
-                                    .getCurrentConnectedGroup().computeIfAbsent(clientHost, ignored -> {
+                        }
+                        if (log.isDebugEnabled()) {
+                            log.debug("Request {}: read {} entries but only {} entries are committed",
+                                    header, entries.size(), committedEntries.size());
+                        }
+                    } else {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Request {}: read {} entries", header, entries.size());
+                        }
+                    }
+                    if (committedEntries.isEmpty()) {
+                        addErrorPartitionResponse(topicPartition, Errors.NONE);
+                        return;
+                    }
+
+                    // use compatible magic value by apiVersion
+                    short apiVersion = header.apiVersion();
+                    byte magic = RecordBatch.CURRENT_MAGIC_VALUE;
+                    if (apiVersion <= 1) {
+                        magic = RecordBatch.MAGIC_VALUE_V0;
+                    } else if (apiVersion <= 3) {
+                        magic = RecordBatch.MAGIC_VALUE_V1;
+                    }
+
+                    // get group and consumer
+                    final String groupName = requestHandler
+                            .getCurrentConnectedGroup().computeIfAbsent(clientHost, ignored -> {
                                 String zkSubPath = ZooKeeperUtils.groupIdPathFormat(clientHost,
-                                        fetch.getHeader().clientId());
+                                        header.clientId());
                                 String groupId = ZooKeeperUtils.getData(requestHandler.getPulsarService().getZkClient(),
                                         requestHandler.getGroupIdStoredPath(), zkSubPath);
                                 log.info("get group name from zk for current connection:{} groupId:{}",
                                         clientHost, groupId);
                                 return groupId;
                             });
+                    final long startDecodingEntriesNanos = MathUtils.nowInNano();
+                    final DecodeResult decodeResult = requestHandler.getEntryFormatter().decode(entries, magic);
+                    requestHandler.requestStats.getFetchDecodeStats().registerSuccessfulEvent(
+                            MathUtils.elapsedNanos(startDecodingEntriesNanos), TimeUnit.NANOSECONDS);
+                    decodeResults.add(decodeResult);
 
-                            final long startDecodingEntriesNanos = MathUtils.nowInNano();
-                            final DecodeResult decodeResult = requestHandler.getEntryFormatter().decode(entries, magic);
-                            requestHandler.requestStats.getFetchDecodeStats().registerSuccessfulEvent(
-                                    MathUtils.elapsedNanos(startDecodingEntriesNanos), TimeUnit.NANOSECONDS);
-                            decodeResults.add(decodeResult);
+                    // collect consumer metrics
+                    updateConsumerStats(topicPartition, decodeResult.getRecords(), entries.size(), groupName);
 
-                            // collect consumer metrics
-                            updateConsumerStats(kafkaPartition, decodeResult.getRecords(), entries.size(), groupName);
-
-                            List<FetchResponse.AbortedTransaction> abortedTransactions;
-                            if (requestHandler.getKafkaConfig().isEnableTransactionCoordinator()
-                                    && isolationLevel.equals(IsolationLevel.READ_COMMITTED)
-                                    && tc != null) {
-                                abortedTransactions = tc.getAbortedIndexList(
-                                        request.fetchData().get(kafkaPartition).fetchOffset);
-                            } else {
-                                abortedTransactions = null;
-                            }
-                            partitionData = new FetchResponse.PartitionData(
-                                Errors.NONE,
-                                highWatermark,
-                                highWatermark,
-                                highWatermark,
-                                abortedTransactions,
-                                decodeResult.getRecords());
-                        }
-                        responseData.put(kafkaPartition, partitionData);
-                        // reset topicPartitionNum
-                        int restTopicPartitionNum = topicPartitionNum.decrementAndGet();
-                        if (restTopicPartitionNum < 0) {
-                            return;
-                        }
-                        if (restTopicPartitionNum == 0) {
-                            complete.run();
-                        }
-                    });
-                    // delay fetch
-                    if (timeoutMs <= 0) {
-                        complete.run();
-                    } else {
-                        List<Object> delayedCreateKeys =
-                                fetchRequestRequest.fetchData().keySet().stream()
-                                        .map(DelayedOperationKey.TopicPartitionOperationKey::new)
-                                        .collect(Collectors.toList());
-                        DelayedProduceAndFetch delayedFetch = new DelayedProduceAndFetch(timeoutMs,
-                                topicPartitionNum, complete);
-                        fetchPurgatory.tryCompleteElseWatch(delayedFetch, delayedCreateKeys);
-                    }
-                } else {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Request {}: Read time or size not reach, do another round of read before return.",
-                            fetch.getHeader());
-                    }
-                    // need do another round read
-                    readMessagesInternal(fetch, cursors, bytesRead, responseValues, resultFuture, responseData,
-                            tc, highWaterMarkMap, startReadingTotalMessagesNanos, fetchPurgatory);
-                }
+                    final List<FetchResponse.AbortedTransaction> abortedTransactions =
+                            (readCommitted ? tc.getAbortedIndexList(partitionData.fetchOffset) : null);
+                    responseData.put(topicPartition, new PartitionData<>(
+                            Errors.NONE,
+                            highWatermark,
+                            lso,
+                            highWatermark, // TODO: should it be changed to the logStartOffset?
+                            abortedTransactions,
+                            decodeResult.getRecords()));
+                    tryComplete();
+                });
             });
+        });
     }
 
-    private Map<TopicPartition, CompletableFuture<List<Entry>>> readAllCursorOnce(
-        Map<TopicPartition, Pair<ManagedCursor, Long>> cursors) {
-        Map<TopicPartition, CompletableFuture<List<Entry>>> readFutures = new ConcurrentHashMap<>();
+    private CompletableFuture<List<Entry>> readEntries(final ManagedCursor cursor,
+                                                       final TopicPartition topicPartition,
+                                                       final AtomicLong cursorOffset) {
+        final OpStatsLogger messageReadStats = statsLogger.getMessageReadStats();
+        // read readeEntryNum size entry.
+        final long startReadingMessagesNanos = MathUtils.nowInNano();
 
-        cursors.entrySet().parallelStream().forEach(cursorOffsetPair -> {
-            ManagedCursor cursor;
-            CompletableFuture<List<Entry>> readFuture = new CompletableFuture<>();
-            cursor = cursorOffsetPair.getValue().getLeft();
-            long currentOffset = cursorOffsetPair.getValue().getRight();
-            int readeEntryNum = requestHandler.getMaxReadEntriesNum();
+        final CompletableFuture<List<Entry>> readFuture = new CompletableFuture<>();
+        final long originalOffset = cursorOffset.get();
+        cursor.asyncReadEntries(maxReadEntriesNum, new ReadEntriesCallback() {
 
-            // read readeEntryNum size entry.
-            long startReadingMessagesNanos = MathUtils.nowInNano();
-            final OpStatsLogger messageReadStats = requestHandler.requestStats.getMessageReadStats();
-            cursor.asyncReadEntries(readeEntryNum,
-                    new ReadEntriesCallback() {
-                        @Override
-                        public void readEntriesComplete(List<Entry> list, Object o) {
-                            String fullPartitionName = KopTopic.toString(cursorOffsetPair.getKey());
+            @Override
+            public void readEntriesComplete(List<Entry> entries, Object ctx) {
+                if (!entries.isEmpty()) {
+                    final Entry lastEntry = entries.get(entries.size() - 1);
+                    final PositionImpl currentPosition = PositionImpl.get(
+                            lastEntry.getLedgerId(), lastEntry.getEntryId());
 
-                            if (!list.isEmpty()) {
-                                StreamSupport.stream(list.spliterator(), true).forEachOrdered(entry -> {
-                                    long offset = MessageIdUtils.peekOffsetFromEntry(entry);
-                                    PositionImpl currentPosition = PositionImpl
-                                            .get(entry.getLedgerId(), entry.getEntryId());
+                    try {
+                        final long lastOffset = MessageIdUtils.peekOffsetFromEntry(lastEntry);
 
-                                    // commit the offset, so backlog not affect by this cursor.
-                                    commitOffset((NonDurableCursorImpl) cursor, currentPosition);
+                        // commit the offset, so backlog not affect by this cursor.
+                        commitOffset((NonDurableCursorImpl) cursor, currentPosition);
 
-                                    long nextOffset = offset + 1;
+                        // and add back to TCM when all read complete.
+                        cursorOffset.set(lastOffset + 1);
 
-                                    // put next offset in to passed in cursors map.
-                                    // and add back to TCM when all read complete.
-                                    cursors.put(cursorOffsetPair.getKey(), Pair.of(cursor, nextOffset));
-
-                                    if (log.isDebugEnabled()) {
-                                        log.debug("Topic {} success read entry: ledgerId: {}, entryId: {}, size: {},"
-                                                        + " ConsumerManager original offset: {}, entryOffset: {} - {}, "
-                                                        + "nextOffset: {}",
-                                                fullPartitionName, entry.getLedgerId(), entry.getEntryId(),
-                                                entry.getLength(), currentOffset, offset, currentPosition,
-                                                nextOffset);
-                                    }
-                                });
-                            }
-
-                            readFuture.complete(list);
-                            messageReadStats.registerSuccessfulEvent(
-                                    MathUtils.elapsedNanos(startReadingMessagesNanos), TimeUnit.NANOSECONDS);
+                        if (log.isDebugEnabled()) {
+                            log.debug("Topic {} success read entry: ledgerId: {}, entryId: {}, size: {},"
+                                            + " ConsumerManager original offset: {}, lastEntryPosition: {}, "
+                                            + "nextOffset: {}",
+                                    topicPartition, lastEntry.getLedgerId(), lastEntry.getEntryId(),
+                                    lastEntry.getLength(), originalOffset, currentPosition,
+                                    cursorOffset.get());
                         }
-
-                    @Override
-                    public void readEntriesFailed(ManagedLedgerException e, Object o) {
-                        log.error("Error read entry for topic: {}", KopTopic.toString(cursorOffsetPair.getKey()));
-
-                        readFuture.completeExceptionally(e);
+                    } catch (Exception e) {
+                        log.error("[{}] Failed to peekOffsetFromEntry from position {}",
+                                topicPartition, currentPosition);
                         messageReadStats.registerFailedEvent(
                                 MathUtils.elapsedNanos(startReadingMessagesNanos), TimeUnit.NANOSECONDS);
+                        readFuture.completeExceptionally(e);
+                        return;
                     }
-                }, null, PositionImpl.latest);
+                }
 
-            readFutures.putIfAbsent(cursorOffsetPair.getKey(), readFuture);
-        });
+                messageReadStats.registerSuccessfulEvent(
+                        MathUtils.elapsedNanos(startReadingMessagesNanos), TimeUnit.NANOSECONDS);
+                readFuture.complete(entries);
+            }
 
-        return readFutures;
+            @Override
+            public void readEntriesFailed(ManagedLedgerException exception, Object ctx) {
+                log.error("Error read entry for topic: {}", KopTopic.toString(topicPartition));
+                messageReadStats.registerSuccessfulEvent(
+                        MathUtils.elapsedNanos(startReadingMessagesNanos), TimeUnit.NANOSECONDS);
+                readFuture.completeExceptionally(exception);
+            }
+        }, null, PositionImpl.latest);
+
+        return readFuture;
     }
 
     // commit the offset, so backlog not affect by this cursor.
@@ -564,7 +397,7 @@ public final class MessageFetchContext {
             @Override
             public void markDeleteFailed(ManagedLedgerException e, Object ctx) {
                 log.warn("Mark delete success for position: {} with error:",
-                    currentPosition, e);
+                        currentPosition, e);
             }
         }, null);
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/RequestStats.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/RequestStats.java
@@ -27,7 +27,6 @@ import static io.streamnative.pulsar.handlers.kop.KopServerStats.RESPONSE_BLOCKE
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.RESPONSE_BLOCKED_TIMES;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.RESPONSE_QUEUE_SIZE;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.SERVER_SCOPE;
-import static io.streamnative.pulsar.handlers.kop.KopServerStats.TOTAL_MESSAGE_READ;
 
 import io.streamnative.pulsar.handlers.kop.stats.StatsLogger;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -103,12 +102,6 @@ public class RequestStats {
     private final OpStatsLogger prepareMetadataStats;
 
     @StatsDoc(
-            name = TOTAL_MESSAGE_READ,
-            help = "stats of reading total entries in a single fetch request"
-    )
-    private final OpStatsLogger totalMessageReadStats;
-
-    @StatsDoc(
             name = MESSAGE_READ,
             help = "stats of performing a single cursor's async-read within fetch request"
     )
@@ -134,7 +127,6 @@ public class RequestStats {
         this.messageQueuedLatencyStats = statsLogger.getOpStatsLogger(MESSAGE_QUEUED_LATENCY);
 
         this.prepareMetadataStats = statsLogger.getOpStatsLogger(PREPARE_METADATA);
-        this.totalMessageReadStats = statsLogger.getOpStatsLogger(TOTAL_MESSAGE_READ);
         this.messageReadStats = statsLogger.getOpStatsLogger(MESSAGE_READ);
         this.fetchDecodeStats  = statsLogger.getOpStatsLogger(FETCH_DECODE);
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
@@ -93,6 +93,7 @@ public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
         assertEquals(receiveMessages(kafkaConsumer2, expectedMessages.size()), expectedMessages);
 
         kafkaProducer.close();
+        Thread.sleep(1000); // wait for Producer was removed from PersistentTopic
         try {
             // topics can be deleted even if the Kafka consumers are active because there are no broker side Consumers
             // that are attached to the PersistentTopic.

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
@@ -96,6 +97,7 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase{
         admin.topics().createPartitionedTopic(kafkaTopicName, partitionNumber);
 
         // 1. produce message with Kafka producer.
+        @Cleanup
         KProducer kProducer = new KProducer(kafkaTopicName, false, getKafkaBrokerPort());
 
         int totalMsgs = 10;
@@ -117,6 +119,7 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase{
         }
 
         // 2. consume messages with Kafka consumer
+        @Cleanup
         KConsumer kConsumer = new KConsumer(kafkaTopicName, getKafkaBrokerPort());
         List<TopicPartition> topicPartitions = IntStream.range(0, partitionNumber)
                 .mapToObj(i -> new TopicPartition(kafkaTopicName, i)).collect(Collectors.toList());
@@ -185,7 +188,6 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase{
 
         // fetch stats
         Assert.assertTrue(sb.toString().contains("kop_server_PREPARE_METADATA"));
-        Assert.assertTrue(sb.toString().contains("kop_server_TOTAL_MESSAGE_READ"));
         Assert.assertTrue(sb.toString().contains("kop_server_MESSAGE_READ"));
         Assert.assertTrue(sb.toString().contains("kop_server_FETCH_DECODE"));
 


### PR DESCRIPTION
### Motivation

When a consumer sends FETCH requests frequently, for example, polling in a tight loop,

```java
while (true) {
    ConsumerRecords<String, byte[]> records = consumer.poll(Duration.ofMillis(100));
    // process records quickly
}
```
the heap memory increasing quickly and GC will happen frequently about once per minute. The frequency is not related to the throughput but the count of FETCH requests.

It's because each time a FETCH request arrived, KoP will create a `MessageFetchContext`. Though it's allocated in a Netty recycler, there're a lot of small objects that are still allocated from heap memory. There're a lot of wait all operations, for example, after all `PersistentTopic`s of each partition were get, it collected all those `PersistentTopic`s to a list and retrieve partition's associated data from a `Map`.

We should process each partition in parallel and avoid collecting the middle result to a list and map.

### Modifications

Refactor the `MessageFetchContext`, only collect the results to a list after the final `PartitionData` of each partition was done.

Besides, this PR removes some implementation details.
1. Checks for `minBytes` and `maxBytes`. Because the existed check is wrong. The default `minBytes` is 1 so `allSize > minBytes || allSize > maxBytes` is always true.  The `maxBytes` check is meaningless.
2. This PR only tries to read `maxReadEntriesNum` entries for only once. It's the same reason as previous.
3. Remove the `TOTAL_MESSAGE_READ` metrics because we don't wait all partitions' messages read anymore.
4. Remove the handle of FETCH timeout process, because it was still wrong before that it didn't count for `asyncReadEntries`, which is more likely to be blocked.

For the read bytes limit like `max.partition.fetch.bytes` and `fetch.max.bytes`, we should open a new PR to implement it correctly.