### PR TITLE
Handle group name was failed to be written to ZK gracefully

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -31,6 +31,7 @@ import io.streamnative.pulsar.handlers.kop.stats.StatsLogger;
 import io.streamnative.pulsar.handlers.kop.utils.ConfigurationUtils;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
 import io.streamnative.pulsar.handlers.kop.utils.MetadataUtils;
+import io.streamnative.pulsar.handlers.kop.utils.ZooKeeperUtils;
 import io.streamnative.pulsar.handlers.kop.utils.timer.SystemTimer;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -266,6 +267,9 @@ public class KafkaProtocolHandler implements ProtocolHandler {
             log.error("Failed to create PulsarAdmin: {}", e.getMessage());
             throw new IllegalStateException(e);
         }
+
+        ZooKeeperUtils.tryCreatePath(brokerService.pulsar().getZkClient(),
+                kafkaConfig.getGroupIdZooKeeperPath(), new byte[0]);
 
         // init and start group coordinator
         try {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -920,8 +920,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         String zkSubPath = ZooKeeperUtils.groupIdPathFormat(findCoordinator.getClientHost(),
                 findCoordinator.getHeader().clientId());
         byte[] groupIdBytes = groupId.getBytes(Charset.forName("UTF-8"));
-        ZooKeeperUtils.createPath(pulsarService.getZkClient(), groupIdStoredPath,
-                zkSubPath, groupIdBytes);
+        ZooKeeperUtils.tryCreatePath(pulsarService.getZkClient(), groupIdStoredPath + zkSubPath, groupIdBytes);
 
         findBroker(TopicName.get(pulsarTopicName))
                 .whenComplete((node, t) -> {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ZooKeeperUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ZooKeeperUtils.java
@@ -29,9 +29,12 @@ import org.apache.zookeeper.data.Stat;
 @Slf4j
 public class ZooKeeperUtils {
 
-    private static boolean tryCreatePath(ZooKeeper zooKeeper, String path, byte[] data) {
+    public static boolean tryCreatePath(ZooKeeper zooKeeper, String path, byte[] data) {
         try {
             zooKeeper.create(path, data, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            if (log.isDebugEnabled()) {
+                log.debug("Created ZK path: {} data: {}", path, new String(data, StandardCharsets.UTF_8));
+            }
         } catch (KeeperException e) {
             if (!e.code().equals(KeeperException.Code.NODEEXISTS)) {
                 log.error("Failed to create ZooKeeper node {}: {}", path, e.getMessage());
@@ -42,16 +45,6 @@ public class ZooKeeperUtils {
             return false;
         }
         return true;
-    }
-
-    public static void createPath(ZooKeeper zooKeeper, String zkPath, String subPath, byte[] data) {
-        tryCreatePath(zooKeeper, zkPath, new byte[0]);
-        final String addSubPath = zkPath + subPath;
-        final boolean result = tryCreatePath(zooKeeper, addSubPath, data);
-        if (result && log.isDebugEnabled()) {
-            log.debug("create zk path, addSubPath:{} data:{}.",
-                    addSubPath, new String(data, StandardCharsets.UTF_8));
-        }
     }
 
     public static @NonNull String getData(ZooKeeper zooKeeper, String zkPath, String subPath) {
@@ -69,6 +62,9 @@ public class ZooKeeperUtils {
 
     public static String groupIdPathFormat(String clientHost, String clientId) {
         String path = clientHost.split(":")[0] + "-" + clientId;
+        if (!path.startsWith("/")) {
+            path = "/" + path;
+        }
         return path;
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ZooKeeperUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ZooKeeperUtils.java
@@ -29,22 +29,15 @@ import org.apache.zookeeper.data.Stat;
 @Slf4j
 public class ZooKeeperUtils {
 
-    public static boolean tryCreatePath(ZooKeeper zooKeeper, String path, byte[] data) {
+    public static void tryCreatePath(ZooKeeper zooKeeper, String path, byte[] data) {
         try {
             zooKeeper.create(path, data, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
             if (log.isDebugEnabled()) {
                 log.debug("Created ZK path: {} data: {}", path, new String(data, StandardCharsets.UTF_8));
             }
-        } catch (KeeperException e) {
-            if (!e.code().equals(KeeperException.Code.NODEEXISTS)) {
-                log.error("Failed to create ZooKeeper node {}: {}", path, e.getMessage());
-                return false;
-            }
-        } catch (InterruptedException e) {
+        } catch (KeeperException | InterruptedException e) {
             log.error("Failed to create ZooKeeper node {}: {}", path, e.getMessage());
-            return false;
         }
-        return true;
     }
 
     public static @NonNull String getData(ZooKeeper zooKeeper, String zkPath, String subPath) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ZooKeeperUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ZooKeeperUtils.java
@@ -14,8 +14,10 @@
 package io.streamnative.pulsar.handlers.kop.utils;
 
 import java.nio.charset.StandardCharsets;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.Stat;
@@ -26,38 +28,43 @@ import org.apache.zookeeper.data.Stat;
  */
 @Slf4j
 public class ZooKeeperUtils {
-    public static void createPath(ZooKeeper zooKeeper, String zkPath, String subPath, byte[] data) {
+
+    private static boolean tryCreatePath(ZooKeeper zooKeeper, String path, byte[] data) {
         try {
-            if (zooKeeper.exists(zkPath, false) == null) {
-                zooKeeper.create(zkPath,
-                        new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            zooKeeper.create(path, data, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        } catch (KeeperException e) {
+            if (!e.code().equals(KeeperException.Code.NODEEXISTS)) {
+                log.error("Failed to create ZooKeeper node {}: {}", path, e.getMessage());
+                return false;
             }
-            String addSubPath = zkPath + subPath;
-            if (zooKeeper.exists(addSubPath, false) == null) {
-                zooKeeper.create(addSubPath,
-                        data, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
-            } else {
-                zooKeeper.setData(addSubPath, data, -1);
-            }
+        } catch (InterruptedException e) {
+            log.error("Failed to create ZooKeeper node {}: {}", path, e.getMessage());
+            return false;
+        }
+        return true;
+    }
+
+    public static void createPath(ZooKeeper zooKeeper, String zkPath, String subPath, byte[] data) {
+        tryCreatePath(zooKeeper, zkPath, new byte[0]);
+        final String addSubPath = zkPath + subPath;
+        final boolean result = tryCreatePath(zooKeeper, addSubPath, data);
+        if (result && log.isDebugEnabled()) {
             log.debug("create zk path, addSubPath:{} data:{}.",
                     addSubPath, new String(data, StandardCharsets.UTF_8));
-        } catch (Exception e) {
-            log.error("create zookeeper path error", e);
         }
     }
 
-    public static String getData(ZooKeeper zooKeeper, String zkPath, String subPath) {
-        String data = null;
+    public static @NonNull String getData(ZooKeeper zooKeeper, String zkPath, String subPath) {
         try {
             String addSubPath = zkPath + subPath;
             Stat zkStat = zooKeeper.exists(addSubPath, true);
             if (zkStat != null) {
-                data = new String(zooKeeper.getData(addSubPath, false, zkStat), StandardCharsets.UTF_8);
+                return new String(zooKeeper.getData(addSubPath, false, zkStat), StandardCharsets.UTF_8);
             }
         } catch (Exception e) {
             log.error("get zookeeper path data error", e);
         }
-        return data;
+        return "";
     }
 
     public static String groupIdPathFormat(String clientHost, String clientId) {


### PR DESCRIPTION
### Motivation

Currently KoP writes group name and the associated client's host and id to ZK so that consumer stats could be updated while FETCH request contains no group info. However, there is something wrong with ZooKeeperUtils.

First, when the `groupIdStoredPath` already existed, the write to ZK may fail with `NodeExists` because of race condition.

Second, if the data was failed to be written to ZK, every time a FETCH request comes, a ZK read operation will be performed. It's because `ZooKeeperUtils#getData` returns null if the node doesn't exist and a null value cannot be put into a `Map`. In this case, `ConcurrentHashMap#computeIfAbsent` will always execute the second argument to create a value.

### Modifications

- Create groupIdZooKeeperPath only when KoP starts, and only log the error message if ZK write failed.
- When `ZooKeeperUtils#getData` failed, returns an empty string instead of null so that if the group name was failed to be written to ZK, the empty returned value would be cached.