### PR TITLE
Fix deadlock caused by synchronous asyncFindPosition

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManager.java
@@ -55,6 +55,7 @@ public class KafkaTopicConsumerManager implements Closeable {
 
     // used to track all created cursor, since above consumers may be remove and in fly,
     // use this map will not leak cursor when close.
+    @Getter
     private final ConcurrentMap<String, ManagedCursor> createdCursors;
 
     // track last access time(millis) for offsets <offset, time>

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MessageIdUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MessageIdUtils.java
@@ -15,7 +15,6 @@ package io.streamnative.pulsar.handlers.kop.utils;
 
 import io.netty.buffer.ByteBuf;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedLedger;
@@ -25,14 +24,11 @@ import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.intercept.ManagedLedgerInterceptorImpl;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.protocol.Commands;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Utils for Pulsar MessageId.
  */
 public class MessageIdUtils {
-    private static final Logger log = LoggerFactory.getLogger(MessageIdUtils.class);
 
     public static long getCurrentOffset(ManagedLedger managedLedger) {
         return ((ManagedLedgerInterceptorImpl) managedLedger.getManagedLedgerInterceptor()).getIndex();
@@ -91,15 +87,6 @@ public class MessageIdUtils {
             }
         }, null);
         return future;
-    }
-
-    public static PositionImpl getPositionForOffset(ManagedLedger managedLedger, Long offset) {
-        try {
-            return (PositionImpl) managedLedger.asyncFindPosition(new OffsetSearchPredicate(offset)).get();
-        } catch (InterruptedException | ExecutionException e) {
-            log.error("[{}] Failed to find position for offset {}", managedLedger.getName(), offset);
-            throw new RuntimeException(managedLedger.getName() + " failed to find position for offset " + offset);
-        }
     }
 
     public static long peekOffsetFromEntry(Entry entry) {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
@@ -144,8 +144,8 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
         KafkaTopicConsumerManager topicConsumerManager = tcm.get();
 
         // before a read, first get cursor of offset.
-        Pair<ManagedCursor, Long> cursorPair = topicConsumerManager.remove(offset);
-        assertEquals(topicConsumerManager.getConsumers().size(), 0);
+        Pair<ManagedCursor, Long> cursorPair = topicConsumerManager.removeCursorFuture(offset).get();
+        assertEquals(topicConsumerManager.getCursors().size(), 0);
         ManagedCursor cursor = cursorPair.getLeft();
         assertEquals(cursorPair.getRight(), Long.valueOf(offset));
 
@@ -156,11 +156,11 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
         // simulate a read complete;
         offset++;
         topicConsumerManager.add(offset, Pair.of(cursor, offset));
-        assertEquals(topicConsumerManager.getConsumers().size(), 1);
+        assertEquals(topicConsumerManager.getCursors().size(), 1);
 
         // another read, cache hit.
-        cursorPair  = topicConsumerManager.remove(offset);
-        assertEquals(topicConsumerManager.getConsumers().size(), 0);
+        cursorPair  = topicConsumerManager.removeCursorFuture(offset).get();
+        assertEquals(topicConsumerManager.getCursors().size(), 0);
         ManagedCursor cursor2 = cursorPair.getLeft();
 
         assertEquals(cursor2, cursor);
@@ -178,9 +178,9 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
         }
 
         // try read last messages, so read not continuous
-        cursorPair = topicConsumerManager.remove(offset);
+        cursorPair = topicConsumerManager.removeCursorFuture(offset).get();
         // since above remove will use a new cursor. there should be one in the map.
-        assertEquals(topicConsumerManager.getConsumers().size(), 1);
+        assertEquals(topicConsumerManager.getCursors().size(), 1);
         cursor2 = cursorPair.getLeft();
         assertNotEquals(cursor2.getName(), cursor.getName());
         assertEquals(cursorPair.getRight(), Long.valueOf(offset));
@@ -236,10 +236,10 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
         KafkaTopicConsumerManager topicConsumerManager = tcm.get();
 
         // before a read, first get cursor of offset.
-        Pair<ManagedCursor, Long> cursorPair1 = topicConsumerManager.remove(offset1);
-        Pair<ManagedCursor, Long> cursorPair2 = topicConsumerManager.remove(offset2);
-        Pair<ManagedCursor, Long> cursorPair3 = topicConsumerManager.remove(offset3);
-        assertEquals(topicConsumerManager.getConsumers().size(), 0);
+        Pair<ManagedCursor, Long> cursorPair1 = topicConsumerManager.removeCursorFuture(offset1).get();
+        Pair<ManagedCursor, Long> cursorPair2 = topicConsumerManager.removeCursorFuture(offset2).get();
+        Pair<ManagedCursor, Long> cursorPair3 = topicConsumerManager.removeCursorFuture(offset3).get();
+        assertEquals(topicConsumerManager.getCursors().size(), 0);
 
         ManagedCursor cursor1 = cursorPair1.getLeft();
         ManagedCursor cursor2 = cursorPair2.getLeft();
@@ -259,7 +259,7 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
         topicConsumerManager.add(offset1, Pair.of(cursor1, offset1));
         topicConsumerManager.add(offset2, Pair.of(cursor2, offset2));
         topicConsumerManager.add(offset3, Pair.of(cursor3, offset3));
-        assertEquals(topicConsumerManager.getConsumers().size(), 3);
+        assertEquals(topicConsumerManager.getCursors().size(), 3);
 
         // simulate cursor deleted, and backlog cleared.
         topicConsumerManager.deleteOneExpiredCursor(offset3);
@@ -269,7 +269,7 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
         topicConsumerManager.deleteOneExpiredCursor(offset1);
         verifyBacklogAndNumCursor(persistentTopic, 0, 0);
 
-        assertEquals(topicConsumerManager.getConsumers().size(), 0);
+        assertEquals(topicConsumerManager.getCursors().size(), 0);
     }
 
     // dump Topic Stats, mainly want to get and verify backlogSize.


### PR DESCRIPTION
Fixes https://github.com/streamnative/kop/issues/544

### Motivation

After the debugging, when a FETCH request contains many partitions, for each partition, `KafkaTopicConsumerManager#remove` will be executed in the same `pulsar-io-<suffix>` thread, which will eventually call `MessageIdUtils#getPositionForOffset` to get `PositionImpl` of the offset.

However, `getPositionForOffset` is a synchronous method that waits until a `CompletableFuture` is done. The future is returned by `ManagedLedgerImpl#asyncFindPosition` that calls `ManagedLedgerImpl#asyncReadEntry` internally. If the producer is publishing messages at the same time, the `asyncAddEntry` method could be called for the same `ManagedLedgerImpl` object. It will somehow cause the deadlock.
 
### Modifications
- Just use `ManagedLedgerImpl#asyncFindPosition` instead of the synchronous call in `MessageIdUtils#getPositionForOffset`.
- Caches the future of `Pair<ManagedCursor, Long>` in KafkaTopicConsumerManager instead of the `Pair<ManagedCursor, Long>`. Then in `MessageFetchContext`, use the `ManagedCursor` in future's callback .
- Add a unit test to ensure after this change, the non-durable cursor will be still created once for each consumer. This condition is easily to break in a refactor like this PR and it may cause performance problem because cursor might be created each time a FETCH request arrived. So here I added a test to avoid the case.