### PR TITLE
[Docs] Add more details for SSL keys

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -299,7 +299,7 @@ The following example shows how to connect KoP through SSL.
 
     - `server-keystore` for `server.keystore.jks` file
     - `server` for `ca-cert` and `ca-key` files
-    - `server-truststore` for `client.truststore.jks` file
+    - `server-truststore` for `server.truststore.jks` file
     - `client-truststore` for `client.truststore.jks` file
 
 2. Configure the KoP broker.


### PR DESCRIPTION
Currently the docs related to SSL keys is not friendly to users that are not familiar with `keytool` and `openssl` commands. For some commands we need to specify the password, while for some other commands we need to input the password we have specified before.

In addition, this PR removes the redundant blanks of the line tail.