### PR TITLE
Enable CI tests for branch name start with 'branch-'

### DIFF
--- a/.github/workflows/pr-impl-test.yml
+++ b/.github/workflows/pr-impl-test.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - master

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - master

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - branch-*
   push:
     branches:
       - master


### PR DESCRIPTION
Currently CI tests are disabled for branch-2.8, see https://github.com/streamnative/kop/pull/576. This PR enables CI tests for PRs that are merged to `branch-*`.