### PR TITLE
Fix some corner cases not handled well for CreateTopics request

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
@@ -16,6 +16,7 @@ package io.streamnative.pulsar.handlers.kop;
 import static io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperationKey.TopicKey;
 import static org.apache.kafka.common.requests.CreateTopicsRequest.TopicDetails;
 
+import io.streamnative.pulsar.handlers.kop.exceptions.KoPTopicException;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
 import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperation;
 import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperationPurgatory;
@@ -88,7 +89,7 @@ class AdminManager {
             KopTopic kopTopic;
             try {
                 kopTopic = new KopTopic(topic);
-            } catch (RuntimeException e) {
+            } catch (KoPTopicException e) {
                 errorFuture.complete(ApiError.fromThrowable(e));
                 if (numTopics.decrementAndGet() == 0) {
                     complete.run();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -262,7 +262,7 @@ public class KafkaProtocolHandler implements ProtocolHandler {
             KopVersion.getBuildTime());
 
         try {
-            adminManager = new AdminManager(brokerService.getPulsar().getAdminClient());
+            adminManager = new AdminManager(brokerService.getPulsar().getAdminClient(), kafkaConfig);
         } catch (PulsarServerException e) {
             log.error("Failed to create PulsarAdmin: {}", e.getMessage());
             throw new IllegalStateException(e);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/EntryPublishTimeTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/EntryPublishTimeTest.java
@@ -52,7 +52,7 @@ public class EntryPublishTimeTest extends KopProtocolHandlerTestBase {
         GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler).getGroupCoordinator();
         TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler).getTransactionCoordinator();
 
-        adminManager = new AdminManager(pulsar.getAdminClient());
+        adminManager = new AdminManager(pulsar.getAdminClient(), conf);
         kafkaRequestHandler = new KafkaRequestHandler(
                 pulsar,
                 (KafkaServiceConfiguration) conf,

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
@@ -119,7 +119,7 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
         GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler).getGroupCoordinator();
         TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler).getTransactionCoordinator();
 
-        adminManager = new AdminManager(pulsar.getAdminClient());
+        adminManager = new AdminManager(pulsar.getAdminClient(), conf);
         kafkaRequestHandler = new KafkaRequestHandler(
             pulsar,
             (KafkaServiceConfiguration) conf,

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
@@ -68,7 +68,7 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
         GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler).getGroupCoordinator();
         TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler).getTransactionCoordinator();
 
-        adminManager = new AdminManager(pulsar.getAdminClient());
+        adminManager = new AdminManager(pulsar.getAdminClient(), conf);
         kafkaRequestHandler = new KafkaRequestHandler(
             pulsar,
             (KafkaServiceConfiguration) conf,


### PR DESCRIPTION
Fixes #591 

### Motivation

Kafka Connect use `Admin#createTopics` and check the `TopicExistsException` exception for existed topics. See https://github.com/apache/kafka/blob/ef3cd68c852daf21d8e207fa8e21c8770f4041d7/connect/runtime/src/main/java/org/apache/kafka/connect/util/TopicAdmin.java#L394 for details.

However, currently `Admin#createTopics` will return an `UnknownServerException` for any failure when create topics. In addition, the handler for CreateTopics request has other problems.

1. The default partition number (-1) is not handled, which may throw exception from `createPartitionedTopicAsync`.
2. If topic name is invalid, the future won't be completed until timeout. See https://github.com/streamnative/kop/pull/361, TimeoutException will be thrown in this case.

### Modifications

1. When the topic to create already exists, return a `TopicExistsException`.
2. Add a `tryComplete` method to complete a future of topic creation that may also complete the future of response.
3. Add related tests.