### PR TITLE
create kafka namespace if missing

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
@@ -88,8 +88,10 @@ public class MetadataUtils {
         String kafkaMetadataTenant = conf.getKafkaMetadataTenant();
         String kafkaMetadataNamespace = kafkaMetadataTenant + "/" + conf.getKafkaMetadataNamespace();
 
-        boolean clusterExists, tenantExists, namespaceExists, offsetsTopicExists;
-        clusterExists = tenantExists = namespaceExists = offsetsTopicExists = false;
+        boolean clusterExists = false;
+        boolean tenantExists = false;
+        boolean namespaceExists = false;
+        boolean offsetsTopicExists = false;
 
         try {
             Clusters clusters = pulsarAdmin.clusters();
@@ -212,8 +214,9 @@ public class MetadataUtils {
         String kafkaTenant = conf.getKafkaTenant();
         String kafkaNamespace = kafkaTenant + "/" + conf.getKafkaNamespace();
 
-        boolean clusterExists, tenantExists, namespaceExists;
-        clusterExists = tenantExists = namespaceExists = false;
+        boolean clusterExists = false;
+        boolean tenantExists = false;
+        boolean namespaceExists = false;
 
         try {
             Clusters clusters = pulsarAdmin.clusters();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/PulsarAuthEnabledTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/PulsarAuthEnabledTestBase.java
@@ -38,7 +38,6 @@ import org.apache.pulsar.broker.authentication.utils.AuthTokenUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.impl.auth.AuthenticationToken;
 import org.apache.pulsar.common.policies.data.AuthAction;
-import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/PulsarAuthEnabledTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/PulsarAuthEnabledTestBase.java
@@ -104,7 +104,7 @@ public abstract class PulsarAuthEnabledTestBase extends KopProtocolHandlerTestBa
                             .allowedClusters(Collections.singleton(configClusterName))
                             .build());
         }
-        if (!admin.namespaces().getNamespaces(TENANT).contains(NAMESPACE)) {
+        if (!admin.namespaces().getNamespaces(TENANT).contains(TENANT + "/" + NAMESPACE)) {
             admin.namespaces().createNamespace(TENANT + "/" + NAMESPACE);
         }
         admin.namespaces()

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/PulsarAuthEnabledTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/PulsarAuthEnabledTestBase.java
@@ -97,13 +97,16 @@ public abstract class PulsarAuthEnabledTestBase extends KopProtocolHandlerTestBa
         conf.setProperties(properties);
 
         super.internalSetup();
-
-        admin.tenants().createTenant(TENANT,
-            TenantInfo.builder()
-                    .adminRoles(Collections.singleton(ADMIN_USER))
-                    .allowedClusters(Collections.singleton(configClusterName))
-                    .build());
-        admin.namespaces().createNamespace(TENANT + "/" + NAMESPACE);
+        if (admin.tenants().getTenantInfo(TENANT) == null) {
+            admin.tenants().createTenant(TENANT,
+                    TenantInfo.builder()
+                            .adminRoles(Collections.singleton(ADMIN_USER))
+                            .allowedClusters(Collections.singleton(configClusterName))
+                            .build());
+        }
+        if (!admin.namespaces().getNamespaces(TENANT).contains(NAMESPACE)) {
+            admin.namespaces().createNamespace(TENANT + "/" + NAMESPACE);
+        }
         admin.namespaces()
             .setNamespaceReplicationClusters(TENANT + "/" + NAMESPACE, Sets.newHashSet(super.configClusterName));
         admin.topics().createPartitionedTopic(TOPIC, 1);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/PulsarAuthEnabledTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/PulsarAuthEnabledTestBase.java
@@ -97,16 +97,6 @@ public abstract class PulsarAuthEnabledTestBase extends KopProtocolHandlerTestBa
         conf.setProperties(properties);
 
         super.internalSetup();
-        if (admin.tenants().getTenantInfo(TENANT) == null) {
-            admin.tenants().createTenant(TENANT,
-                    TenantInfo.builder()
-                            .adminRoles(Collections.singleton(ADMIN_USER))
-                            .allowedClusters(Collections.singleton(configClusterName))
-                            .build());
-        }
-        if (!admin.namespaces().getNamespaces(TENANT).contains(TENANT + "/" + NAMESPACE)) {
-            admin.namespaces().createNamespace(TENANT + "/" + NAMESPACE);
-        }
         admin.namespaces()
             .setNamespaceReplicationClusters(TENANT + "/" + NAMESPACE, Sets.newHashSet(super.configClusterName));
         admin.topics().createPartitionedTopic(TOPIC, 1);


### PR DESCRIPTION
Currently KoP  only creates the namespace for kafka metadata defined by `kafkaMetadataTenant` and `kafkaMetadataNamespace` when started, but not create the namespaces for kafka topics defined by `kafkaTenant` and `kafkaNamespace`.

This pull requeset add the initialization of namespaces for kafka topic.