### PR TITLE
Remove dependency for freebuilder

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMetadata.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMetadata.java
@@ -16,6 +16,7 @@ package io.streamnative.pulsar.handlers.kop.coordinator.transaction;
 import com.google.common.collect.Sets;
 import io.streamnative.pulsar.handlers.kop.utils.CoreUtils;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -30,7 +31,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.RecordBatch;
-import org.inferred.freebuilder.shaded.com.google.common.collect.Maps;
 
 /**
  * Transaction metadata.
@@ -87,7 +87,7 @@ public class TransactionMetadata {
     private static Map<TransactionState, Set<TransactionState>> validPreviousStates;
 
     static {
-        validPreviousStates = Maps.newHashMap();
+        validPreviousStates = new HashMap<>();
         validPreviousStates.put(TransactionState.EMPTY, Sets.immutableEnumSet(
                 TransactionState.EMPTY,
                 TransactionState.COMPLETE_COMMIT,

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
     <pulsar.group.id>io.streamnative</pulsar.group.id>
-    <pulsar.version>2.8.0.1</pulsar.version>
+    <pulsar.version>2.8.0.3</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testcontainers.version>1.15.1</testcontainers.version>


### PR DESCRIPTION
Pulsar 2.8.0.3 removed the dependency for freebuilder. From `mvn dependency:tree` command, it was imported by `org.apache.bookkeeper:stream-storage-java-client:jar:4.14.1` before. This PR fixed the KoP build for Pulsar 2.8.0.3.