### PR TITLE
Update download link to synchronizing content to StreamNative hub

### DIFF
--- a/docs/kop.md
+++ b/docs/kop.md
@@ -1,5 +1,5 @@
 ---
-download: "https://github.com/streamnative/kop/releases/download/v2.8.0.1/pulsar-protocol-handler-kafka-2.8.0.1.nar"
+download: "https://github.com/streamnative/kop/releases/download/v{{protocol:version}}/pulsar-protocol-handler-kafka-{{protocol:version}}.nar"
 alias: KoP - Kafka on Pulsar
 ---
 


### PR DESCRIPTION
When KoP is auto released by streamnative-bot, the `{{protocol:version}}` will be replaced to the actual version so that https://hub.streamnative.io/protocol-handlers/kop/0.2.0 can grab the content.