### PR TITLE
Add test framework for Kafka clients of different versions

### DIFF
--- a/kafka-1-0/pom.xml
+++ b/kafka-1-0/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
+    <groupId>io.streamnative.pulsar.handlers</groupId>
+    <version>2.9.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>kafka-1-0</artifactId>
+  <name>StreamNative :: Pulsar Protocol Handler :: Kafka Client 1.0.0</name>
+  <description>The Kafka client wrapper for 1.0.0</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.streamnative.pulsar.handlers</groupId>
+      <artifactId>kafka-client-api</artifactId>
+      <version>2.9.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${mavem-shade-plugin.version}</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <relocations>
+                <relocation>
+                  <pattern>org.apache.kafka.common</pattern>
+                  <shadedPattern>org.apache.kafka-1-0-0.common</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.kafka.clients</pattern>
+                  <shadedPattern>org.apache.kafka-1-0-0.clients</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/kafka-1-0/src/main/java/io/streamnative/kafka/client/one/zero/ConsumerImpl.java
+++ b/kafka-1-0/src/main/java/io/streamnative/kafka/client/one/zero/ConsumerImpl.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kafka.client.one.zero;
+
+import io.streamnative.kafka.client.api.Consumer;
+import io.streamnative.kafka.client.api.ConsumerConfiguration;
+import io.streamnative.kafka.client.api.ConsumerRecord;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+
+/**
+ * The implementation of Kafka consumer 1.0.0.
+ */
+public class ConsumerImpl<K, V> extends KafkaConsumer<K, V> implements Consumer<K, V> {
+
+    public ConsumerImpl(final ConsumerConfiguration conf) {
+        super(conf.toProperties());
+    }
+
+    @Override
+    public List<ConsumerRecord<K, V>> receive(long timeoutMs) {
+        final List<ConsumerRecord<K, V>> records = new ArrayList<>();
+        poll(timeoutMs).forEach(record -> records.add(ConsumerRecord.create(record)));
+        return records;
+    }
+}

--- a/kafka-1-0/src/main/java/io/streamnative/kafka/client/one/zero/ProducerImpl.java
+++ b/kafka-1-0/src/main/java/io/streamnative/kafka/client/one/zero/ProducerImpl.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kafka.client.one.zero;
+
+import io.streamnative.kafka.client.api.ProduceContext;
+import io.streamnative.kafka.client.api.Producer;
+import io.streamnative.kafka.client.api.ProducerConfiguration;
+import io.streamnative.kafka.client.api.RecordMetadata;
+import java.util.concurrent.Future;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
+
+/**
+ * The implementation of Kafka producer 1.0.0.
+ */
+public class ProducerImpl<K, V> extends KafkaProducer<K, V> implements Producer<K, V> {
+
+    public ProducerImpl(final ProducerConfiguration conf) {
+        super(conf.toProperties());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Future<RecordMetadata> sendAsync(ProduceContext<K, V> context) {
+        send(context.createProducerRecord(ProducerRecord.class, RecordHeader::new), context::complete);
+        return context.getFuture();
+    }
+}

--- a/kafka-1-0/src/main/java/io/streamnative/kafka/client/one/zero/ProducerImpl.java
+++ b/kafka-1-0/src/main/java/io/streamnative/kafka/client/one/zero/ProducerImpl.java
@@ -33,7 +33,7 @@ public class ProducerImpl<K, V> extends KafkaProducer<K, V> implements Producer<
 
     @SuppressWarnings("unchecked")
     @Override
-    public Future<RecordMetadata> sendAsync(ProduceContext<K, V> context) {
+    public Future<RecordMetadata> sendAsync(final ProduceContext<K, V> context) {
         send(context.createProducerRecord(ProducerRecord.class, RecordHeader::new), context::complete);
         return context.getFuture();
     }

--- a/kafka-1-0/src/main/java/io/streamnative/kafka/client/one/zero/package-info.java
+++ b/kafka-1-0/src/main/java/io/streamnative/kafka/client/one/zero/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kafka.client.one.zero;

--- a/kafka-client-api/pom.xml
+++ b/kafka-client-api/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
+    <groupId>io.streamnative.pulsar.handlers</groupId>
+    <version>2.9.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>kafka-client-api</artifactId>
+  <name>StreamNative :: Pulsar Protocol Handler :: Kafka Client API</name>
+  <description>The Kafka client API without any Kafka dependency</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>${lombok.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/kafka-client-api/pom.xml
+++ b/kafka-client-api/pom.xml
@@ -28,11 +28,4 @@
   <name>StreamNative :: Pulsar Protocol Handler :: Kafka Client API</name>
   <description>The Kafka client API without any Kafka dependency</description>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
-      <version>${lombok.version}</version>
-    </dependency>
-  </dependencies>
 </project>

--- a/kafka-client-api/pom.xml
+++ b/kafka-client-api/pom.xml
@@ -28,4 +28,11 @@
   <name>StreamNative :: Pulsar Protocol Handler :: Kafka Client API</name>
   <description>The Kafka client API without any Kafka dependency</description>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>${lombok.version}</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/Consumer.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/Consumer.java
@@ -46,12 +46,14 @@ public interface Consumer<K, V> extends Closeable {
         final int pollTimeoutMs = 100;
         final List<ConsumerRecord<K, V>> records = new ArrayList<>();
         final AtomicInteger numReceived = new AtomicInteger(0);
-        while (numReceived.get() < maxNumMessages) {
+
+        long elapsedTimeMs = 0;
+        while (numReceived.get() < maxNumMessages && elapsedTimeMs < timeoutMs) {
             receive(pollTimeoutMs).forEach(record -> {
                 records.add(record);
                 numReceived.incrementAndGet();
             });
-            timeoutMs -= pollTimeoutMs; // it may not be accurate, but it's not required to be accurate
+            elapsedTimeMs += pollTimeoutMs; // it may not be accurate, but it's not required to be accurate
         }
         return records;
     }

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/Consumer.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/Consumer.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kafka.client.api;
+
+import java.io.Closeable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A common interface of Kafka consumer.
+ */
+public interface Consumer<K, V> extends Closeable {
+
+    void subscribe(Collection<String> topics);
+
+    default void subscribe(String topic) {
+        subscribe(Collections.singleton(topic));
+    }
+
+    List<ConsumerRecord<K, V>> receive(long timeoutMs);
+}

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/ConsumerConfiguration.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/ConsumerConfiguration.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kafka.client.api;
+
+import java.util.Properties;
+import lombok.Builder;
+
+/**
+ * The configuration of Kafka consumer.
+ */
+@Builder
+public class ConsumerConfiguration {
+
+    private String bootstrapServers;
+    private String groupId;
+    private Object keyDeserializer;
+    private Object valueDeserializer;
+    @Builder.Default
+    private boolean fromEarliest = true;
+
+    public Properties toProperties() {
+        final Properties props = new Properties();
+        if (bootstrapServers != null) {
+            props.put("bootstrap.servers", bootstrapServers);
+        }
+        if (groupId != null) {
+            props.put("group.id", groupId);
+        }
+        if (keyDeserializer != null) {
+            props.put("key.deserializer", keyDeserializer);
+        }
+        if (valueDeserializer != null) {
+            props.put("value.deserializer", valueDeserializer);
+        }
+        props.put("auto.offset.reset", fromEarliest ? "earliest" : "latest");
+        return props;
+    }
+}

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/ConsumerRecord.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/ConsumerRecord.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kafka.client.api;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * A completable class of org.apache.kafka.clients.consumer.ConsumerRecord.
+ */
+@AllArgsConstructor
+@Getter
+public class ConsumerRecord<K, V> {
+
+    private final K key;
+    private final V value;
+    private final String topic;
+    private final int partition;
+    private final long offset;
+    private final List<Header> headers;
+
+    @SuppressWarnings("unchecked")
+    public static <K, V, T> ConsumerRecord<K, V> create(T originalRecord) {
+        final Class<?> clazz = originalRecord.getClass();
+        final Object originalHeaders = ReflectionUtils.invoke(clazz, "headers", originalRecord);
+        final List<Header> headers = Header.fromHeaders(
+                (Object[]) ReflectionUtils.invoke(originalHeaders.getClass(), "toArray", originalHeaders));
+
+        return new ConsumerRecord<>((K) ReflectionUtils.invoke(clazz, "key", originalRecord),
+                (V) ReflectionUtils.invoke(clazz, "value", originalRecord),
+                (String) ReflectionUtils.invoke(clazz, "topic", originalRecord),
+                (int) ReflectionUtils.invoke(clazz, "partition", originalRecord),
+                (long) ReflectionUtils.invoke(clazz, "offset", originalRecord),
+                headers);
+    }
+}

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/Header.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/Header.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kafka.client.api;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * A compatible class of Kafka header (org.apache.kafka.common.header.Header).
+ */
+@AllArgsConstructor
+@Getter
+public class Header {
+
+    private final String key;
+    private final String value;
+
+    private static Header fromHeader(final Object originalHeader) {
+        final Class<?> clazz = originalHeader.getClass();
+        return new Header(
+                (String) ReflectionUtils.invoke(clazz, "key", originalHeader),
+                new String((byte[]) ReflectionUtils.invoke(clazz, "value", originalHeader), StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Create a list of Header from a list of Kafka header.
+     *
+     * @param originalHeaders the list of Kafka headers whose type is org.apache.kafka.common.header.Header
+     * @return a list of converted Header
+     */
+    public static List<Header> fromHeaders(final Object[] originalHeaders) {
+        if (originalHeaders == null) {
+            return null;
+        }
+        final List<Header> headers = new ArrayList<>();
+        for (Object header : originalHeaders) {
+            headers.add(fromHeader(header));
+        }
+        return headers;
+    }
+
+    /**
+     * Convert a list of Header to a list of Kafka Header.
+     *
+     * @param headers a list of Header
+     * @param constructor the binary function of Kafka header's constructor
+     * @param <T> the type of Kafka header that is usually org.apache.kafka.common.header.RecordHeader
+     * @return the converted list of Kafka header
+     */
+    public static <T> List<T> toHeaders(final List<Header> headers, final BiFunction<String, byte[], T> constructor) {
+        if (headers == null) {
+            return null;
+        }
+        return headers.stream()
+                .map(header -> constructor.apply(header.getKey(), header.getValue().getBytes(StandardCharsets.UTF_8)))
+                .collect(Collectors.toList());
+    }
+}

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/Header.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/Header.java
@@ -16,6 +16,7 @@ package io.streamnative.kafka.client.api;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
@@ -45,7 +46,7 @@ public class Header {
      * @return a list of converted Header
      */
     public static List<Header> fromHeaders(final Object[] originalHeaders) {
-        if (originalHeaders == null) {
+        if (originalHeaders == null || originalHeaders.length == 0) {
             return null;
         }
         final List<Header> headers = new ArrayList<>();
@@ -64,11 +65,28 @@ public class Header {
      * @return the converted list of Kafka header
      */
     public static <T> List<T> toHeaders(final List<Header> headers, final BiFunction<String, byte[], T> constructor) {
-        if (headers == null) {
+        if (headers == null || headers.isEmpty()) {
             return null;
         }
         return headers.stream()
                 .map(header -> constructor.apply(header.getKey(), header.getValue().getBytes(StandardCharsets.UTF_8)))
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Header header = (Header) o;
+        return Objects.equals(key, header.key) && Objects.equals(value, header.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, value);
     }
 }

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/KafkaVersion.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/KafkaVersion.java
@@ -24,7 +24,7 @@ import lombok.Getter;
  */
 public enum KafkaVersion {
 
-    KAFKA_1_0_0("1-0-0");
+    DEFAULT("default"), KAFKA_1_0_0("1-0-0");
 
     @Getter
     private String name;
@@ -34,10 +34,16 @@ public enum KafkaVersion {
     }
 
     public String getStringSerializer() {
+        if (this.equals(DEFAULT)) {
+            return "org.apache.kafka.common.serialization.StringSerializer";
+        }
         return String.format("org.apache.kafka-%s.common.serialization.StringSerializer", name);
     }
 
     public String getStringDeserializer() {
+        if (this.equals(DEFAULT)) {
+            return "org.apache.kafka.common.serialization.StringDeserializer";
+        }
         return String.format("org.apache.kafka-%s.common.serialization.StringDeserializer", name);
     }
 }

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/KafkaVersion.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/KafkaVersion.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kafka.client.api;
+
+import lombok.Getter;
+
+/**
+ * The version that represents Kafka client's version.
+ *
+ * For each kafka-x.y.z module, the class path is relocated from `org.apache.kafka` to `org.apache.kafka-x-y-z` package.
+ * See each module's pom.xml for details. This class provides convenient methods to get the actual class path for
+ * different Kafka versions.
+ */
+public enum KafkaVersion {
+
+    KAFKA_1_0_0("1-0-0");
+
+    @Getter
+    private String name;
+
+    KafkaVersion(final String name) {
+        this.name = name;
+    }
+
+    public String getStringSerializer() {
+        return String.format("org.apache.kafka-%s.common.serialization.StringSerializer", name);
+    }
+
+    public String getStringDeserializer() {
+        return String.format("org.apache.kafka-%s.common.serialization.StringDeserializer", name);
+    }
+}

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/ProduceContext.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/ProduceContext.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kafka.client.api;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.function.BiFunction;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Context for producing messages.
+ */
+@Builder
+public class ProduceContext<K, V> {
+
+    private Producer<K, V> producer;
+    private String topic;
+    private Integer partition;
+    private Long timestamp;
+    private K key;
+    private V value;
+    private List<Header> headers;
+
+    @Getter
+    private final CompletableFuture<RecordMetadata> future = new CompletableFuture<>();
+
+    /**
+     * Create an instance of Kafka's ProducerRecord.
+     *
+     * @param clazz the class type of Kafka's ProducerRecord
+     * @param headerConstructor the constructor of Kafka's Header implementation
+     * @param <T> it should be org.apache.kafka.clients.producer.ProducerRecord
+     * @param <HeaderT> it should be an implementation of org.apache.kafka.common.header.Header, e.g. RecordHeader
+     * @return an instance of org.apache.kafka.clients.producer.ProducerRecord
+     */
+    public <T, HeaderT> T createProducerRecord(final Class<T> clazz,
+                                               final BiFunction<String, byte[], HeaderT> headerConstructor) {
+        try {
+            return clazz.getConstructor(
+                    String.class, Integer.class, Long.class, Object.class, Object.class, Iterable.class
+            ).newInstance(topic, partition, timestamp, key, value, Header.toHeaders(headers, headerConstructor));
+        } catch (InstantiationException
+                | IllegalAccessException
+                | InvocationTargetException
+                | NoSuchMethodException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    public Future<RecordMetadata> sendAsync() {
+        if (producer == null) {
+            throw new IllegalArgumentException("producer is null");
+        }
+        return producer.sendAsync(this);
+    }
+}

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/ProduceContext.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/ProduceContext.java
@@ -25,6 +25,7 @@ import lombok.Getter;
  * Context for producing messages.
  */
 @Builder
+@Getter
 public class ProduceContext<K, V> {
 
     private Producer<K, V> producer;
@@ -34,8 +35,6 @@ public class ProduceContext<K, V> {
     private K key;
     private V value;
     private List<Header> headers;
-
-    @Getter
     private final CompletableFuture<RecordMetadata> future = new CompletableFuture<>();
 
     /**

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/ProduceContext.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/ProduceContext.java
@@ -61,6 +61,26 @@ public class ProduceContext<K, V> {
         }
     }
 
+    /**
+     * Complete the internal `future` field.
+     *
+     * @param metadata the instance of Kafka's RecordMetadata
+     * @param e the exception to complete exceptionally if it's not null
+     * @param <T> it should be org.apache.kafka.clients.producer.RecordMetadata
+     */
+    public <T> void complete(final T metadata, final Exception e) {
+        if (e == null) {
+            future.complete(RecordMetadata.create(metadata));
+        } else {
+            future.completeExceptionally(e);
+        }
+    }
+
+    /**
+     * Send the message using ProduceContext instead of using Producer directly.
+     *
+     * @see Producer#sendAsync(ProduceContext)
+     */
     public Future<RecordMetadata> sendAsync() {
         if (producer == null) {
             throw new IllegalArgumentException("producer is null");

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/Producer.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/Producer.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kafka.client.api;
+
+import java.util.concurrent.Future;
+
+/**
+ * A common interface of Kafka producer.
+ */
+public interface Producer<K, V> extends AutoCloseable {
+
+    Future<RecordMetadata> sendAsync(ProduceContext<K, V> context);
+
+    default ProduceContext.ProduceContextBuilder<K, V> newContextBuilder(String topic, V value) {
+        return ProduceContext.<K, V>builder()
+                .producer(this)
+                .topic(topic)
+                .value(value);
+    }
+}

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/ProducerConfiguration.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/ProducerConfiguration.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kafka.client.api;
+
+import java.util.Properties;
+import lombok.Builder;
+
+/**
+ * The configuration of Kafka producer.
+ */
+@Builder
+public class ProducerConfiguration {
+
+    private String bootstrapServers;
+    private Object keySerializer;
+    private Object valueSerializer;
+
+    public Properties toProperties() {
+        final Properties props = new Properties();
+        if (bootstrapServers != null) {
+            props.put("bootstrap.servers", bootstrapServers);
+        }
+        if (keySerializer != null) {
+            props.put("key.serializer", keySerializer);
+        }
+        if (valueSerializer != null) {
+            props.put("value.serializer", valueSerializer);
+        }
+        return props;
+    }
+}

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/RecordMetadata.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/RecordMetadata.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kafka.client.api;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * A compatible class of Kafka's send result (org.apache.kafka.clients.producer.RecordMetadata).
+ */
+@Getter
+@RequiredArgsConstructor
+public class RecordMetadata {
+
+    private final String topic;
+    private final int partition;
+    private final long offset;
+
+    @Override
+    public String toString() {
+        return topic + "-" + partition + "@" + offset;
+    }
+
+    /**
+     * Create the RecordMetadata instance from Kafka's send result.
+     *
+     * @param originalMetadata the original Kafka's RecordMetadata
+     * @param <T> it should be org.apache.kafka.clients.producer.RecordMetadata
+     * @return the RecordMetadata instance
+     */
+    public static <T> RecordMetadata create(final T originalMetadata) {
+        final Class<?> clazz = originalMetadata.getClass();
+        return new RecordMetadata(
+                (String) ReflectionUtils.invoke(clazz, "topic", originalMetadata),
+                (int) ReflectionUtils.invoke(clazz, "partition", originalMetadata),
+                (long) ReflectionUtils.invoke(clazz, "offset", originalMetadata));
+    }
+}

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/ReflectionUtils.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/ReflectionUtils.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.streamnative.kafka.client.api;
 
 import java.lang.reflect.InvocationTargetException;

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/ReflectionUtils.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/ReflectionUtils.java
@@ -1,0 +1,26 @@
+package io.streamnative.kafka.client.api;
+
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * Utils methods for reflection.
+ */
+public class ReflectionUtils {
+
+    /**
+     * Invoke a method of an object but throw an unchecked exception.
+     *
+     * @param clazz the class type of `object`
+     * @param name the method name
+     * @param object the object to call the method
+     * @param <T> the type of `object`
+     * @return the returned value of the method
+     */
+    public static <T> Object invoke(Class<T> clazz, String name, Object object) {
+        try {
+            return clazz.getMethod(name).invoke(object);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/package-info.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kafka.client.api;

--- a/kafka-client-factory/pom.xml
+++ b/kafka-client-factory/pom.xml
@@ -24,15 +24,20 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>kafka-client-api</artifactId>
-  <name>StreamNative :: Pulsar Protocol Handler :: Kafka Client API</name>
-  <description>The Kafka client API without any Kafka dependency</description>
+  <artifactId>kafka-client-factory</artifactId>
+  <name>StreamNative :: Pulsar Protocol Handler :: Kafka Client Factory</name>
+  <description>The Kafka client factory to create different versions of Kafka clients</description>
 
   <dependencies>
     <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
-      <version>${lombok.version}</version>
+      <groupId>io.streamnative.pulsar.handlers</groupId>
+      <artifactId>kafka-client-api</artifactId>
+      <version>2.9.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>io.streamnative.pulsar.handlers</groupId>
+      <artifactId>kafka-1-0</artifactId>
+      <version>2.9.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
 </project>

--- a/kafka-client-factory/src/main/java/io/streamnative/kafka/client/api/KafkaClientFactory.java
+++ b/kafka-client-factory/src/main/java/io/streamnative/kafka/client/api/KafkaClientFactory.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kafka.client.api;
+
+import io.streamnative.kafka.client.one.zero.ConsumerImpl;
+import io.streamnative.kafka.client.one.zero.ProducerImpl;
+
+/**
+ * The factory class to create Kafka producers or consumers with a specific version.
+ */
+public class KafkaClientFactory {
+
+    private KafkaVersion kafkaVersion;
+
+    public KafkaClientFactory(final KafkaVersion kafkaVersion) {
+        this.kafkaVersion = kafkaVersion;
+    }
+
+    public <K, V> Producer<K, V> createProducer(final ProducerConfiguration conf) {
+        if (kafkaVersion.equals(KafkaVersion.KAFKA_1_0_0)) {
+            return new ProducerImpl<>(conf);
+        }
+        throw new IllegalArgumentException("No producer for version: " + kafkaVersion);
+    }
+
+    public <K, V> Consumer<K, V> createConsumer(final ConsumerConfiguration conf) {
+        if (kafkaVersion.equals(KafkaVersion.KAFKA_1_0_0)) {
+            return new ConsumerImpl<>(conf);
+        }
+        throw new IllegalArgumentException("No consumer for version: " + kafkaVersion);
+    }
+}

--- a/kafka-client-factory/src/main/java/io/streamnative/kafka/client/api/KafkaClientFactory.java
+++ b/kafka-client-factory/src/main/java/io/streamnative/kafka/client/api/KafkaClientFactory.java
@@ -13,31 +13,12 @@
  */
 package io.streamnative.kafka.client.api;
 
-import io.streamnative.kafka.client.one.zero.ConsumerImpl;
-import io.streamnative.kafka.client.one.zero.ProducerImpl;
-
 /**
- * The factory class to create Kafka producers or consumers with a specific version.
+ * The interface for Kafka client factory.
  */
-public class KafkaClientFactory {
+public interface KafkaClientFactory {
 
-    private KafkaVersion kafkaVersion;
+    <K, V> Producer<K, V> createProducer(ProducerConfiguration conf);
 
-    public KafkaClientFactory(final KafkaVersion kafkaVersion) {
-        this.kafkaVersion = kafkaVersion;
-    }
-
-    public <K, V> Producer<K, V> createProducer(final ProducerConfiguration conf) {
-        if (kafkaVersion.equals(KafkaVersion.KAFKA_1_0_0)) {
-            return new ProducerImpl<>(conf);
-        }
-        throw new IllegalArgumentException("No producer for version: " + kafkaVersion);
-    }
-
-    public <K, V> Consumer<K, V> createConsumer(final ConsumerConfiguration conf) {
-        if (kafkaVersion.equals(KafkaVersion.KAFKA_1_0_0)) {
-            return new ConsumerImpl<>(conf);
-        }
-        throw new IllegalArgumentException("No consumer for version: " + kafkaVersion);
-    }
+    <K, V> Consumer<K, V> createConsumer(ConsumerConfiguration conf);
 }

--- a/kafka-client-factory/src/main/java/io/streamnative/kafka/client/api/KafkaClientFactoryImpl.java
+++ b/kafka-client-factory/src/main/java/io/streamnative/kafka/client/api/KafkaClientFactoryImpl.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kafka.client.api;
+
+import io.streamnative.kafka.client.one.zero.ConsumerImpl;
+import io.streamnative.kafka.client.one.zero.ProducerImpl;
+
+/**
+ * The factory class to create Kafka producers or consumers with a specific version.
+ */
+public class KafkaClientFactoryImpl implements KafkaClientFactory {
+
+    private KafkaVersion kafkaVersion;
+
+    public KafkaClientFactoryImpl(final KafkaVersion kafkaVersion) {
+        this.kafkaVersion = kafkaVersion;
+    }
+
+    @Override
+    public <K, V> Producer<K, V> createProducer(final ProducerConfiguration conf) {
+        if (kafkaVersion.equals(KafkaVersion.KAFKA_1_0_0)) {
+            return new ProducerImpl<>(conf);
+        }
+        throw new IllegalArgumentException("No producer for version: " + kafkaVersion);
+    }
+
+    @Override
+    public <K, V> Consumer<K, V> createConsumer(final ConsumerConfiguration conf) {
+        if (kafkaVersion.equals(KafkaVersion.KAFKA_1_0_0)) {
+            return new ConsumerImpl<>(conf);
+        }
+        throw new IllegalArgumentException("No consumer for version: " + kafkaVersion);
+    }
+}

--- a/kafka-client-factory/src/main/java/io/streamnative/kafka/client/api/package-info.java
+++ b/kafka-client-factory/src/main/java/io/streamnative/kafka/client/api/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kafka.client.api;

--- a/kafka-impl/pom.xml
+++ b/kafka-impl/pom.xml
@@ -33,10 +33,6 @@
   <!-- include the dependencies -->
   <dependencies>
     <!-- runtime dependencies -->
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-clients</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/kafka-impl/pom.xml
+++ b/kafka-impl/pom.xml
@@ -33,6 +33,14 @@
   <!-- include the dependencies -->
   <dependencies>
     <!-- runtime dependencies -->
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kafka-impl/pom.xml
+++ b/kafka-impl/pom.xml
@@ -33,6 +33,10 @@
   <!-- include the dependencies -->
   <dependencies>
     <!-- runtime dependencies -->
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kafka-impl/pom.xml
+++ b/kafka-impl/pom.xml
@@ -33,14 +33,6 @@
   <!-- include the dependencies -->
   <dependencies>
     <!-- runtime dependencies -->
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-clients</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/oauth-client/pom.xml
+++ b/oauth-client/pom.xml
@@ -32,5 +32,9 @@
   <!-- include the dependencies -->
   <dependencies>
     <!-- runtime dependencies -->
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/oauth-client/pom.xml
+++ b/oauth-client/pom.xml
@@ -32,9 +32,5 @@
   <!-- include the dependencies -->
   <dependencies>
     <!-- runtime dependencies -->
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-clients</artifactId>
-    </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,8 @@
 
     <!-- dependencies -->
     <commons-lang3.version>3.11</commons-lang3.version>
+    <guava.version>21.0</guava.version>
+    <grpc.version>1.18.0</grpc.version>
     <jackson.version>2.12.1</jackson.version>
     <jcommander.version>1.48</jcommander.version>
     <kafka.version>2.0.0</kafka.version>
@@ -93,11 +95,6 @@
         <artifactId>spotbugs-annotations</artifactId>
         <version>${spotbugs-annotations.version}</version>
       </dependency>
-      <dependency>
-        <groupId>org.apache.kafka</groupId>
-        <artifactId>kafka-clients</artifactId>
-        <version>${kafka.version}</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -107,6 +104,12 @@
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-core</artifactId>
+      <version>${grpc.version}</version>
     </dependency>
 
     <dependency>
@@ -145,6 +148,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
@@ -154,21 +163,18 @@
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>${lombok.version}</version>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
       <version>${log4j2.version}</version>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <version>${log4j2.version}</version>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>
@@ -181,6 +187,12 @@
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
       <version>${jackson.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>${kafka.version}</version>
     </dependency>
 
     <dependency>
@@ -406,11 +418,25 @@
       <name>sonatype</name>
       <url>https://oss.sonatype.org/content/repositories/iostreamnative-1129</url>
     </repository>
+    <repository>
+      <id>bintray-streamnative-maven</id>
+      <name>bintray</name>
+      <url>https://dl.bintray.com/streamnative/maven</url>
+    </repository>
 
     <repository>
       <id>central</id>
       <layout>default</layout>
       <url>https://repo1.maven.org/maven2</url>
+    </repository>
+
+    <repository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>bintray-yahoo-maven</id>
+      <name>bintray</name>
+      <url>https://yahoo.bintray.com/maven</url>
     </repository>
   </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,12 +76,12 @@
   </licenses>
 
   <modules>
-    <module>kafka-impl</module>
-    <module>tests</module>
-    <module>oauth-client</module>
-    <module>kafka-client-api</module>
     <module>kafka-1-0</module>
+    <module>kafka-client-api</module>
     <module>kafka-client-factory</module>
+    <module>kafka-impl</module>
+    <module>oauth-client</module>
+    <module>tests</module>
   </modules>
 
   <!-- dependency definitions -->

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
     <license-maven-plugin.version>3.0.rc1</license-maven-plugin.version>
     <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+    <mavem-shade-plugin.version>3.2.4</mavem-shade-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
     <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
     <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>
@@ -81,6 +82,8 @@
     <module>tests</module>
     <module>oauth-client</module>
     <module>kafka-client-api</module>
+    <module>kafka-1-0</module>
+    <module>kafka-client-factory</module>
   </modules>
 
   <!-- dependency definitions -->

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,6 @@
 
     <!-- dependencies -->
     <commons-lang3.version>3.11</commons-lang3.version>
-    <guava.version>21.0</guava.version>
-    <grpc.version>1.18.0</grpc.version>
     <jackson.version>2.12.1</jackson.version>
     <jcommander.version>1.48</jcommander.version>
     <kafka.version>2.0.0</kafka.version>
@@ -107,12 +105,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-core</artifactId>
-      <version>${grpc.version}</version>
-    </dependency>
-
-    <dependency>
       <groupId>${pulsar.group.id}</groupId>
       <artifactId>pulsar-broker</artifactId>
       <version>${pulsar.version}</version>
@@ -148,12 +140,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
@@ -163,6 +149,7 @@
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>${lombok.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,8 @@
 
     <!-- dependencies -->
     <commons-lang3.version>3.11</commons-lang3.version>
+    <guava.version>21.0</guava.version>
+    <grpc.version>1.18.0</grpc.version>
     <jackson.version>2.12.1</jackson.version>
     <jcommander.version>1.48</jcommander.version>
     <kafka.version>2.0.0</kafka.version>
@@ -93,18 +95,6 @@
         <artifactId>spotbugs-annotations</artifactId>
         <version>${spotbugs-annotations.version}</version>
       </dependency>
-
-      <dependency>
-        <groupId>org.apache.kafka</groupId>
-        <artifactId>kafka-clients</artifactId>
-        <version>${kafka.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-        <version>${commons-lang3.version}</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -114,6 +104,12 @@
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-core</artifactId>
+      <version>${grpc.version}</version>
     </dependency>
 
     <dependency>
@@ -152,45 +148,63 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>${lombok.version}</version>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
       <version>${log4j2.version}</version>
-      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <version>${log4j2.version}</version>
-      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
       <version>${jackson.version}</version>
-      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>${kafka.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.beust</groupId>
+      <artifactId>jcommander</artifactId>
+      <version>${jcommander.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${commons-lang3.version}</version>
     </dependency>
 
     <dependency>
@@ -404,11 +418,25 @@
       <name>sonatype</name>
       <url>https://oss.sonatype.org/content/repositories/iostreamnative-1129</url>
     </repository>
+    <repository>
+      <id>bintray-streamnative-maven</id>
+      <name>bintray</name>
+      <url>https://dl.bintray.com/streamnative/maven</url>
+    </repository>
 
     <repository>
       <id>central</id>
       <layout>default</layout>
       <url>https://repo1.maven.org/maven2</url>
+    </repository>
+
+    <repository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>bintray-yahoo-maven</id>
+      <name>bintray</name>
+      <url>https://yahoo.bintray.com/maven</url>
     </repository>
   </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,6 @@
 
     <!-- dependencies -->
     <commons-lang3.version>3.11</commons-lang3.version>
-    <guava.version>21.0</guava.version>
-    <grpc.version>1.18.0</grpc.version>
     <jackson.version>2.12.1</jackson.version>
     <jcommander.version>1.48</jcommander.version>
     <kafka.version>2.0.0</kafka.version>
@@ -95,6 +93,11 @@
         <artifactId>spotbugs-annotations</artifactId>
         <version>${spotbugs-annotations.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.kafka</groupId>
+        <artifactId>kafka-clients</artifactId>
+        <version>${kafka.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -104,12 +107,6 @@
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
       <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-core</artifactId>
-      <version>${grpc.version}</version>
     </dependency>
 
     <dependency>
@@ -148,12 +145,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
@@ -163,18 +154,21 @@
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>${lombok.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
       <version>${log4j2.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <version>${log4j2.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
@@ -187,12 +181,6 @@
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
       <version>${jackson.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-clients</artifactId>
-      <version>${kafka.version}</version>
     </dependency>
 
     <dependency>
@@ -418,25 +406,11 @@
       <name>sonatype</name>
       <url>https://oss.sonatype.org/content/repositories/iostreamnative-1129</url>
     </repository>
-    <repository>
-      <id>bintray-streamnative-maven</id>
-      <name>bintray</name>
-      <url>https://dl.bintray.com/streamnative/maven</url>
-    </repository>
 
     <repository>
       <id>central</id>
       <layout>default</layout>
       <url>https://repo1.maven.org/maven2</url>
-    </repository>
-
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>bintray-yahoo-maven</id>
-      <name>bintray</name>
-      <url>https://yahoo.bintray.com/maven</url>
     </repository>
   </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
     <module>kafka-impl</module>
     <module>tests</module>
     <module>oauth-client</module>
+    <module>kafka-client-api</module>
   </modules>
 
   <!-- dependency definitions -->

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,6 @@
 
     <!-- dependencies -->
     <commons-lang3.version>3.11</commons-lang3.version>
-    <guava.version>21.0</guava.version>
-    <grpc.version>1.18.0</grpc.version>
     <jackson.version>2.12.1</jackson.version>
     <jcommander.version>1.48</jcommander.version>
     <kafka.version>2.0.0</kafka.version>
@@ -95,6 +93,18 @@
         <artifactId>spotbugs-annotations</artifactId>
         <version>${spotbugs-annotations.version}</version>
       </dependency>
+
+      <dependency>
+        <groupId>org.apache.kafka</groupId>
+        <artifactId>kafka-clients</artifactId>
+        <version>${kafka.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${commons-lang3.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -104,12 +114,6 @@
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
       <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-core</artifactId>
-      <version>${grpc.version}</version>
     </dependency>
 
     <dependency>
@@ -148,63 +152,45 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>${lombok.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
       <version>${log4j2.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <version>${log4j2.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
       <version>${jackson.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-clients</artifactId>
-      <version>${kafka.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.beust</groupId>
-      <artifactId>jcommander</artifactId>
-      <version>${jcommander.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>${commons-lang3.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
@@ -418,25 +404,11 @@
       <name>sonatype</name>
       <url>https://oss.sonatype.org/content/repositories/iostreamnative-1129</url>
     </repository>
-    <repository>
-      <id>bintray-streamnative-maven</id>
-      <name>bintray</name>
-      <url>https://dl.bintray.com/streamnative/maven</url>
-    </repository>
 
     <repository>
       <id>central</id>
       <layout>default</layout>
       <url>https://repo1.maven.org/maven2</url>
-    </repository>
-
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>bintray-yahoo-maven</id>
-      <name>bintray</name>
-      <url>https://yahoo.bintray.com/maven</url>
     </repository>
   </repositories>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -37,10 +37,6 @@
   <!-- include the dependencies -->
   <dependencies>
     <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-clients</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.streamnative.pulsar.handlers</groupId>
       <artifactId>kafka-client-api</artifactId>
       <version>2.9.0-SNAPSHOT</version>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -37,6 +37,16 @@
   <!-- include the dependencies -->
   <dependencies>
     <dependency>
+      <groupId>io.streamnative.pulsar.handlers</groupId>
+      <artifactId>kafka-client-api</artifactId>
+      <version>2.9.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>io.streamnative.pulsar.handlers</groupId>
+      <artifactId>kafka-client-factory</artifactId>
+      <version>2.9.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-streams</artifactId>
       <version>${kafka.version}</version>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -37,6 +37,10 @@
   <!-- include the dependencies -->
   <dependencies>
     <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.streamnative.pulsar.handlers</groupId>
       <artifactId>kafka-client-api</artifactId>
       <version>2.9.0-SNAPSHOT</version>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -37,6 +37,14 @@
   <!-- include the dependencies -->
   <dependencies>
     <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.streamnative.pulsar.handlers</groupId>
       <artifactId>kafka-client-api</artifactId>
       <version>2.9.0-SNAPSHOT</version>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -37,14 +37,6 @@
   <!-- include the dependencies -->
   <dependencies>
     <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-clients</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.streamnative.pulsar.handlers</groupId>
       <artifactId>kafka-client-api</artifactId>
       <version>2.9.0-SNAPSHOT</version>

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndKafkaTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndKafkaTest.java
@@ -13,24 +13,11 @@
  */
 package io.streamnative.pulsar.handlers.kop.compatibility;
 
-import io.streamnative.kafka.client.api.Consumer;
-import io.streamnative.kafka.client.api.ConsumerRecord;
-import io.streamnative.kafka.client.api.Header;
-import io.streamnative.kafka.client.api.KafkaVersion;
-import io.streamnative.kafka.client.api.Producer;
-import io.streamnative.kafka.client.api.RecordMetadata;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 /**
  * Basic end-to-end test for different versions of Kafka clients with `entryFormat=kafka`.
  */
-@Slf4j
 public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
 
     public BasicEndToEndKafkaTest() {
@@ -38,68 +25,7 @@ public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
     }
 
     @Test(timeOut = 30000)
-    public void testEndToEnd() throws Exception {
-        final String topic = "test-end-to-end";
-        admin.topics().createPartitionedTopic(topic, 1);
-
-        final List<String> keys = new ArrayList<>();
-        final List<String> values = new ArrayList<>();
-        final List<Header> headers = new ArrayList<>();
-
-        long offset = 0;
-        for (KafkaVersion version : kafkaClientFactories.keySet()) {
-            final Producer<String, String> producer = kafkaClientFactories.get(version)
-                    .createProducer(producerConfiguration(version));
-
-            // send a message that only contains value
-            String value = "value-from-" + version.name() + offset;
-            values.add("value-from-" + version.name() + offset);
-
-            RecordMetadata metadata = producer.newContextBuilder(topic, value).build().sendAsync().get();
-            log.info("Kafka client {} sent {} to {}", version, value, metadata);
-            Assert.assertEquals(metadata.getTopic(), topic);
-            Assert.assertEquals(metadata.getPartition(), 0);
-            Assert.assertEquals(metadata.getOffset(), offset);
-            offset++;
-
-            // send a message that contains key and headers, which are optional
-            String key = "key-from-" + version.name() + offset;
-            value = "value-from-" + version.name() + offset;
-            keys.add(key);
-            values.add(value);
-            headers.add(new Header("header-" + key, "header-" + value));
-
-            metadata = producer.newContextBuilder(topic, value)
-                    .key(key)
-                    .headers(headers.subList(headers.size() - 1, headers.size()))
-                    .build()
-                    .sendAsync()
-                    .get();
-            log.info("Kafka client {} sent {} (key={}) to {}", version, value, key, metadata);
-            Assert.assertEquals(metadata.getTopic(), topic);
-            Assert.assertEquals(metadata.getPartition(), 0);
-            Assert.assertEquals(metadata.getOffset(), offset);
-            offset++;
-
-            producer.close();
-        }
-
-        for (KafkaVersion version : kafkaClientFactories.keySet()) {
-            final Consumer<String, String> consumer = kafkaClientFactories.get(version)
-                    .createConsumer(consumerConfiguration(version));
-            consumer.subscribe(topic);
-            final List<ConsumerRecord<String, String>> records = consumer.receiveUntil(values.size(), 6000);
-            Assert.assertEquals(records.stream().map(ConsumerRecord::getValue).collect(Collectors.toList()), values);
-            Assert.assertEquals(records.stream()
-                    .map(ConsumerRecord::getKey)
-                    .filter(Objects::nonNull)
-                    .collect(Collectors.toList()), keys);
-            Assert.assertEquals(records.stream()
-                    .map(ConsumerRecord::getHeaders)
-                    .filter(Objects::nonNull)
-                    .map(headerList -> headerList.get(0))
-                    .collect(Collectors.toList()), headers);
-            consumer.close();
-        }
+    protected void testKafkaProduceKafkaConsume() throws Exception {
+        super.testKafkaProduceKafkaConsume();
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndKafkaTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndKafkaTest.java
@@ -13,11 +13,16 @@
  */
 package io.streamnative.pulsar.handlers.kop.compatibility;
 
+import io.streamnative.kafka.client.api.Consumer;
+import io.streamnative.kafka.client.api.ConsumerRecord;
+import io.streamnative.kafka.client.api.Header;
 import io.streamnative.kafka.client.api.KafkaVersion;
 import io.streamnative.kafka.client.api.Producer;
 import io.streamnative.kafka.client.api.RecordMetadata;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -37,23 +42,64 @@ public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
         final String topic = "test-end-to-end";
         admin.topics().createPartitionedTopic(topic, 1);
 
-        final List<String> messages = new ArrayList<>();
+        final List<String> keys = new ArrayList<>();
+        final List<String> values = new ArrayList<>();
+        final List<Header> headers = new ArrayList<>();
 
         long offset = 0;
         for (KafkaVersion version : kafkaClientFactories.keySet()) {
             final Producer<String, String> producer = kafkaClientFactories.get(version)
                     .createProducer(producerConfiguration(version));
-            final String value = "message-from-" + version.name();
-            messages.add(value);
-            final RecordMetadata metadata = producer.newContextBuilder(topic, value).build().sendAsync().get();
+
+            // send a message that only contains value
+            String value = "value-from-" + version.name() + offset;
+            values.add("value-from-" + version.name() + offset);
+
+            RecordMetadata metadata = producer.newContextBuilder(topic, value).build().sendAsync().get();
             log.info("Kafka client {} sent {} to {}", version, value, metadata);
             Assert.assertEquals(metadata.getTopic(), topic);
             Assert.assertEquals(metadata.getPartition(), 0);
             Assert.assertEquals(metadata.getOffset(), offset);
             offset++;
+
+            // send a message that contains key and headers, which are optional
+            String key = "key-from-" + version.name() + offset;
+            value = "value-from-" + version.name() + offset;
+            keys.add(key);
+            values.add(value);
+            headers.add(new Header("header-" + key, "header-" + value));
+
+            metadata = producer.newContextBuilder(topic, value)
+                    .key(key)
+                    .headers(headers.subList(headers.size() - 1, headers.size()))
+                    .build()
+                    .sendAsync()
+                    .get();
+            log.info("Kafka client {} sent {} (key={}) to {}", version, value, key, metadata);
+            Assert.assertEquals(metadata.getTopic(), topic);
+            Assert.assertEquals(metadata.getPartition(), 0);
+            Assert.assertEquals(metadata.getOffset(), offset);
+            offset++;
+
             producer.close();
         }
 
-        // TODO: add consumers
+        for (KafkaVersion version : kafkaClientFactories.keySet()) {
+            final Consumer<String, String> consumer = kafkaClientFactories.get(version)
+                    .createConsumer(consumerConfiguration(version));
+            consumer.subscribe(topic);
+            final List<ConsumerRecord<String, String>> records = consumer.receiveUntil(values.size(), 6000);
+            Assert.assertEquals(records.stream().map(ConsumerRecord::getValue).collect(Collectors.toList()), values);
+            Assert.assertEquals(records.stream()
+                    .map(ConsumerRecord::getKey)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList()), keys);
+            Assert.assertEquals(records.stream()
+                    .map(ConsumerRecord::getHeaders)
+                    .filter(Objects::nonNull)
+                    .map(headerList -> headerList.get(0))
+                    .collect(Collectors.toList()), headers);
+            consumer.close();
+        }
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndKafkaTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndKafkaTest.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.compatibility;
+
+import io.streamnative.kafka.client.api.KafkaVersion;
+import io.streamnative.kafka.client.api.Producer;
+import io.streamnative.kafka.client.api.RecordMetadata;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Basic end-to-end test for different versions of Kafka clients with `entryFormat=kafka`.
+ */
+@Slf4j
+public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
+
+    public BasicEndToEndKafkaTest() {
+        super("kafka");
+    }
+
+    @Test(timeOut = 30000)
+    public void testEndToEnd() throws Exception {
+        final String topic = "test-end-to-end";
+        admin.topics().createPartitionedTopic(topic, 1);
+
+        final List<String> messages = new ArrayList<>();
+
+        long offset = 0;
+        for (KafkaVersion version : kafkaClientFactories.keySet()) {
+            final Producer<String, String> producer = kafkaClientFactories.get(version)
+                    .createProducer(producerConfiguration(version));
+            final String value = "message-from-" + version.name();
+            messages.add(value);
+            final RecordMetadata metadata = producer.newContextBuilder(topic, value).build().sendAsync().get();
+            log.info("Kafka client {} sent {} to {}", version, value, metadata);
+            Assert.assertEquals(metadata.getTopic(), topic);
+            Assert.assertEquals(metadata.getPartition(), 0);
+            Assert.assertEquals(metadata.getOffset(), offset);
+            offset++;
+            producer.close();
+        }
+
+        // TODO: add consumers
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndPulsarTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndPulsarTest.java
@@ -1,0 +1,158 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.compatibility;
+
+import io.streamnative.kafka.client.api.Consumer;
+import io.streamnative.kafka.client.api.ConsumerRecord;
+import io.streamnative.kafka.client.api.Header;
+import io.streamnative.kafka.client.api.KafkaVersion;
+import io.streamnative.kafka.client.api.ProduceContext;
+import io.streamnative.kafka.client.api.Producer;
+import io.streamnative.kafka.client.api.RecordMetadata;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Basic end-to-end test for different versions of Kafka clients with `entryFormat=kafka`.
+ */
+@Slf4j
+public class BasicEndToEndPulsarTest extends BasicEndToEndTestBase {
+
+    public BasicEndToEndPulsarTest() {
+        super("pulsar");
+    }
+
+    @Test(timeOut = 30000)
+    protected void testKafkaProduceKafkaConsume() throws Exception {
+        super.testKafkaProduceKafkaConsume();
+    }
+
+    @Test(timeOut = 30000)
+    public void testKafkaProducePulsarConsume() throws Exception {
+        final String topic = "test-kafka-produce-pulsar-consume";
+        admin.topics().createPartitionedTopic(topic, 1);
+
+        final List<String> keys = new ArrayList<>();
+        final List<String> values = new ArrayList<>();
+        final List<Header> headers = new ArrayList<>();
+
+        long offset = 0;
+        for (KafkaVersion version : kafkaClientFactories.keySet()) {
+            final Producer<String, String> producer = kafkaClientFactories.get(version)
+                    .createProducer(producerConfiguration(version));
+            final ProduceContext<String, String> record = producer.newContextBuilder(topic, "value-" + version)
+                    .key("key-" + version)
+                    .headers(Collections.singletonList(new Header("header-key-" + version, "header-value-" + version)))
+                    .build();
+            keys.add(record.getKey());
+            values.add(record.getValue());
+            headers.add(record.getHeaders().get(0));
+
+            final RecordMetadata metadata = record.sendAsync().get();
+            log.info("Kafka client {} sent {} to {}", version, record.getValue(), metadata);
+            Assert.assertEquals(metadata.getTopic(), topic);
+            Assert.assertEquals(metadata.getPartition(), 0);
+            Assert.assertEquals(metadata.getOffset(), offset);
+            offset++;
+
+            producer.close();
+        }
+
+        final org.apache.pulsar.client.api.Consumer<byte[]> consumer = pulsarClient.newConsumer()
+                .topic(topic)
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
+                .subscriptionName("pulsar-sub")
+                .subscribe();
+        int numReceived = 0;
+        final List<Message<byte[]>> receivedMessages = new ArrayList<>();
+        while (numReceived < values.size()) {
+            final Message<byte[]> message = consumer.receive(1, TimeUnit.SECONDS);
+            if (message == null) {
+                continue;
+            }
+            log.info("Pulsar client received {}", message);
+            receivedMessages.add(message);
+            ++numReceived;
+        }
+        Assert.assertEquals(receivedMessages.stream()
+                .map(Message::getValue)
+                .map(value -> new String(value, StandardCharsets.UTF_8))
+                .collect(Collectors.toList()), values);
+        Assert.assertEquals(receivedMessages.stream()
+                .map(Message::getOrderingKey)
+                .map(key -> new String(key, StandardCharsets.UTF_8))
+                .collect(Collectors.toList()), keys);
+        Assert.assertEquals(receivedMessages.stream()
+                .map(Message::getProperties)
+                .map(BasicEndToEndPulsarTest::convertFirstPropertyToHeader)
+                .collect(Collectors.toList()), headers);
+        consumer.close();
+    }
+
+    @Test(timeOut = 30000)
+    public void testPulsarProduceKafkaConsume() throws Exception {
+        final String topic = "test-pulsar-produce-kafka-consume";
+        admin.topics().createPartitionedTopic(topic, 1);
+
+        final String key = "pulsar-key";
+        final String value = "pulsar-value";
+        final Header header = new Header("header-pulsar-key", "header-pulsar-value");
+
+        final org.apache.pulsar.client.api.Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .topic(topic)
+                .create();
+        producer.newMessage(Schema.STRING)
+                .orderingKey(key.getBytes(StandardCharsets.UTF_8))
+                .value(value)
+                .property(header.getKey(), header.getValue())
+                .send();
+        producer.close();
+
+        for (KafkaVersion version : kafkaClientFactories.keySet()) {
+            final Consumer<String, String> consumer = kafkaClientFactories.get(version)
+                    .createConsumer(consumerConfiguration(version));
+            consumer.subscribe(topic);
+            final List<ConsumerRecord<String, String>> records = consumer.receiveUntil(1, 6000);
+            Assert.assertEquals(records.size(), 1);
+            Assert.assertEquals(records.get(0).getValue(), value);
+            Assert.assertEquals(records.get(0).getKey(), key);
+            Assert.assertEquals(records.get(0).getHeaders().get(0), header);
+            consumer.close();
+        }
+    }
+
+    private static Header convertFirstPropertyToHeader(final Map<String, String> properties) {
+        if (properties == null || properties.isEmpty()) {
+            return null;
+        }
+        final Iterator<Map.Entry<String, String>> iterator = properties.entrySet().iterator();
+        if (iterator.hasNext()) {
+            final Map.Entry<String, String> entry = iterator.next();
+            return new Header(entry.getKey(), entry.getValue());
+        }
+        return null;
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndTestBase.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.compatibility;
+
+import io.streamnative.kafka.client.api.ConsumerConfiguration;
+import io.streamnative.kafka.client.api.KafkaClientFactory;
+import io.streamnative.kafka.client.api.KafkaClientFactoryImpl;
+import io.streamnative.kafka.client.api.KafkaVersion;
+import io.streamnative.kafka.client.api.ProducerConfiguration;
+import io.streamnative.pulsar.handlers.kop.KopProtocolHandlerTestBase;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+
+/**
+ * Basic end-to-end test for different versions of Kafka clients.
+ */
+public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
+
+    protected Map<KafkaVersion, KafkaClientFactory> kafkaClientFactories = Arrays.stream(KafkaVersion.values())
+            .collect(Collectors.toMap(
+                    version -> version,
+                    version -> {
+                        if (version.equals(KafkaVersion.DEFAULT)) {
+                            return new DefaultKafkaClientFactory();
+                        } else {
+                            return new KafkaClientFactoryImpl(version);
+                        }
+                    },
+                    (k, v) -> {
+                        throw new IllegalStateException("Duplicated key: " + k);
+                    }, TreeMap::new));
+
+    public BasicEndToEndTestBase(final String entryFormat) {
+        super(entryFormat);
+    }
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+    }
+
+    @AfterClass
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    protected ProducerConfiguration producerConfiguration(final KafkaVersion version) {
+        return ProducerConfiguration.builder()
+                .bootstrapServers("localhost:" + getKafkaBrokerPort())
+                .keySerializer(version.getStringSerializer())
+                .valueSerializer(version.getStringSerializer())
+                .build();
+    }
+
+    protected ConsumerConfiguration consumerConfiguration(final KafkaVersion version) {
+        return ConsumerConfiguration.builder()
+                .bootstrapServers("localhost:" + getKafkaBrokerPort())
+                .groupId("group-" + version.name())
+                .keyDeserializer(version.getStringDeserializer())
+                .valueDeserializer(version.getStringDeserializer())
+                .fromEarliest(true)
+                .build();
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndTestBase.java
@@ -13,22 +13,33 @@
  */
 package io.streamnative.pulsar.handlers.kop.compatibility;
 
+import io.streamnative.kafka.client.api.Consumer;
 import io.streamnative.kafka.client.api.ConsumerConfiguration;
+import io.streamnative.kafka.client.api.ConsumerRecord;
+import io.streamnative.kafka.client.api.Header;
 import io.streamnative.kafka.client.api.KafkaClientFactory;
 import io.streamnative.kafka.client.api.KafkaClientFactoryImpl;
 import io.streamnative.kafka.client.api.KafkaVersion;
+import io.streamnative.kafka.client.api.Producer;
 import io.streamnative.kafka.client.api.ProducerConfiguration;
+import io.streamnative.kafka.client.api.RecordMetadata;
 import io.streamnative.pulsar.handlers.kop.KopProtocolHandlerTestBase;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 
 /**
  * Basic end-to-end test for different versions of Kafka clients.
  */
+@Slf4j
 public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
 
     protected Map<KafkaVersion, KafkaClientFactory> kafkaClientFactories = Arrays.stream(KafkaVersion.values())
@@ -59,6 +70,79 @@ public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();
+    }
+
+    protected void testKafkaProduceKafkaConsume() throws Exception {
+        final String topic = "test-kafka-produce-kafka-consume";
+        admin.topics().createPartitionedTopic(topic, 1);
+
+        final List<String> keys = new ArrayList<>();
+        final List<String> values = new ArrayList<>();
+        final List<Header> headers = new ArrayList<>();
+
+        long offset = 0;
+        for (KafkaVersion version : kafkaClientFactories.keySet()) {
+            final Producer<String, String> producer = kafkaClientFactories.get(version)
+                    .createProducer(producerConfiguration(version));
+
+            // send a message that only contains value
+            String value = "value-from-" + version.name() + offset;
+            values.add("value-from-" + version.name() + offset);
+
+            RecordMetadata metadata = producer.newContextBuilder(topic, value).build().sendAsync().get();
+            log.info("Kafka client {} sent {} to {}", version, value, metadata);
+            Assert.assertEquals(metadata.getTopic(), topic);
+            Assert.assertEquals(metadata.getPartition(), 0);
+            Assert.assertEquals(metadata.getOffset(), offset);
+            offset++;
+
+            // send a message that contains key and headers, which are optional
+            String key = "key-from-" + version.name() + offset;
+            value = "value-from-" + version.name() + offset;
+            keys.add(key);
+            values.add(value);
+            headers.add(new Header("header-" + key, "header-" + value));
+
+            metadata = producer.newContextBuilder(topic, value)
+                    .key(key)
+                    .headers(headers.subList(headers.size() - 1, headers.size()))
+                    .build()
+                    .sendAsync()
+                    .get();
+            log.info("Kafka client {} sent {} (key={}) to {}", version, value, key, metadata);
+            Assert.assertEquals(metadata.getTopic(), topic);
+            Assert.assertEquals(metadata.getPartition(), 0);
+            Assert.assertEquals(metadata.getOffset(), offset);
+            offset++;
+
+            producer.close();
+        }
+
+        for (KafkaVersion version : kafkaClientFactories.keySet()) {
+            final Consumer<String, String> consumer = kafkaClientFactories.get(version)
+                    .createConsumer(consumerConfiguration(version));
+            consumer.subscribe(topic);
+            final List<ConsumerRecord<String, String>> records = consumer.receiveUntil(values.size(), 6000);
+            Assert.assertEquals(records.stream().map(ConsumerRecord::getValue).collect(Collectors.toList()), values);
+            if (conf.getEntryFormat().equals("pulsar")) {
+                // NOTE: PulsarEntryFormatter will encode an empty String as key if key doesn't exist
+                Assert.assertEquals(records.stream()
+                        .map(ConsumerRecord::getKey)
+                        .filter(key -> key != null && !key.isEmpty())
+                        .collect(Collectors.toList()), keys);
+            } else {
+                Assert.assertEquals(records.stream()
+                        .map(ConsumerRecord::getKey)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList()), keys);
+            }
+            Assert.assertEquals(records.stream()
+                    .map(ConsumerRecord::getHeaders)
+                    .filter(Objects::nonNull)
+                    .map(headerList -> headerList.get(0))
+                    .collect(Collectors.toList()), headers);
+            consumer.close();
+        }
     }
 
     protected ProducerConfiguration producerConfiguration(final KafkaVersion version) {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/DefaultKafkaClientFactory.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/DefaultKafkaClientFactory.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.compatibility;
+
+import io.streamnative.kafka.client.api.Consumer;
+import io.streamnative.kafka.client.api.ConsumerConfiguration;
+import io.streamnative.kafka.client.api.ConsumerRecord;
+import io.streamnative.kafka.client.api.KafkaClientFactory;
+import io.streamnative.kafka.client.api.ProduceContext;
+import io.streamnative.kafka.client.api.Producer;
+import io.streamnative.kafka.client.api.ProducerConfiguration;
+import io.streamnative.kafka.client.api.RecordMetadata;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Future;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
+
+/**
+ * Kafka client factory for the default version of Kafka client.
+ */
+public class DefaultKafkaClientFactory implements KafkaClientFactory {
+
+    @Override
+    public <K, V> Producer<K, V> createProducer(ProducerConfiguration conf) {
+        return new DefaultKafkaProducer<>(conf);
+    }
+
+    @Override
+    public <K, V> Consumer<K, V> createConsumer(ConsumerConfiguration conf) {
+        return new DefaultKafkaConsumer<>(conf);
+    }
+
+    private static class DefaultKafkaProducer<K, V> extends KafkaProducer<K, V> implements Producer<K, V> {
+
+        public DefaultKafkaProducer(final ProducerConfiguration conf) {
+            super(conf.toProperties());
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public Future<RecordMetadata> sendAsync(final ProduceContext<K, V> context) {
+            send(context.createProducerRecord(ProducerRecord.class, RecordHeader::new), context::complete);
+            return context.getFuture();
+        }
+    }
+
+    private static class DefaultKafkaConsumer<K, V> extends KafkaConsumer<K, V> implements Consumer<K, V> {
+
+        public DefaultKafkaConsumer(final ConsumerConfiguration conf) {
+            super(conf.toProperties());
+        }
+
+        @Override
+        public List<ConsumerRecord<K, V>> receive(long timeoutMs) {
+            final List<ConsumerRecord<K, V>> records = new ArrayList<>();
+            poll(Duration.ofMillis(timeoutMs)).forEach(record -> records.add(ConsumerRecord.create(record)));
+            return records;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

Currently KoP verifies other versions of Kafka client only by running a simple e2e test (`KafkaIntegrationTest`) that Kafka client is running inside the docker container.

This test is simple and has some flaws:
1. If we want to change the test code, we need to update the docker image.
2. We can't make use of IDE like Intellij Idea to debug the client side code.
3. It's too simple and doesn't cover the basic cases like whether the key, headers can be processed well and whether the Kafka producers/consumers of mixed versions.

And we can't test other versions just by changing the version of `kafka-clients` dependency. Because KoP server side depends on some common classes from `org.apache.kafka.common` package, which is also included in `kafka-clients` dependency. If we modified the `kafka-clients` dependency, the KoP server would be affected and might not be compiled successfully.

### Modifications
This PR uses maven-shade-plugin to import `kafka-clients` with multiple versions. Normally if we imported an artifact with multiple versions in a Maven project, it would only import one version of them eventually. However, maven-shade-plugin can include the dependencies to the JAR of a module and relocate the class path to avoid conflict.

Based on the maven-shade-plugin,  this PR adds following modifications:
1. Add a `kafka-client-api` module that includes interfaces for Kafka producer, consumer and the wrapper classes of other data structures without any `kafka-clients` dependency. Since Java doesn't support duck typing, it uses a lot of reflection operations to avoid much repeated code in the implementation of these interfaces.
2. Add a `kafka-1-0` module, which is the implementation for `kafka-client-api` with Kafka 1.0.0 dependency. It's a shaded JAR that is built by maven-shade-plugin. It relocated `org.apache.kafka.common` package to `org.apache.kafka.common-1-0-0` as well as `clients` package to avoid conflict.
3. Add a `kafka-client-factory` module as the factory class of `kafka-client-api`. It's a dependent module to avoid cyclic dependency.
4. Refactor the `pom.xml` of root directory because it imported many unused dependencies that might be not necessary for modules. Also after this change, the size of KoP NAR file reduced from 13 MB to 8 MB.
5. Add a `compatibility` package that contains tests for Kafka clients of different versions to cover following cases:
  - Different Kafka producers produce messages, different Kafka consumers consume all these messages.
  - (entryFormat=pulsar) Different Kafka producers produce messages, a Pulsar consumer consumes these messages.
  - (entryFormat=pulsar) A Pulsar producer produces a message, different Kafka consumers consume the message.

Since this PR only adds Kafka client 1.0.0, the tests only contain two Kafka versions (1.0.0 and default 2.0.0). We can add other versions in future because this PR already contains many changes.