### PR TITLE
Fix group id z-node not updated for the same client id

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ZooKeeperUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ZooKeeperUtils.java
@@ -35,7 +35,21 @@ public class ZooKeeperUtils {
             if (log.isDebugEnabled()) {
                 log.debug("Created ZK path: {} data: {}", path, new String(data, StandardCharsets.UTF_8));
             }
-        } catch (KeeperException | InterruptedException e) {
+        } catch (KeeperException e) {
+            if (!e.code().equals(KeeperException.Code.NODEEXISTS)) {
+                log.error("Failed to create ZooKeeper node {}: {}", path, e.getMessage());
+            } else {
+                // update the group id
+                try {
+                    zooKeeper.setData(path, data, -1);
+                    if (log.isDebugEnabled()) {
+                        log.debug("Updated ZK path: {} data: {}", path, new String(data, StandardCharsets.UTF_8));
+                    }
+                } catch (KeeperException | InterruptedException setDataException) {
+                    log.error("Failed to set path '{}''s data to {}", path, data, setDataException);
+                }
+            }
+        } catch (InterruptedException e) {
             log.error("Failed to create ZooKeeper node {}: {}", path, e.getMessage());
         }
     }


### PR DESCRIPTION
Fixes #606 

### Motivation

If a consumer from the same machine subscribed the same topic with a different group id, the `FIND_COORDINATOR` request handler would fail to update the z-node for consumer metrics.

In another case, if a consumer from the same machine subscribed the same topic with the same group id again, the KoP side would print redundant error logs like #606.

### Modification

- If the z-node existed in `ZooKeeperUtils#tryCreatePath`, update the z-node's data instead of just printing an error log.
- Add a unit test to verify group id can be updated successfully.
