### PR TITLE
Make build pass on JDK11

### DIFF
--- a/kafka-1-0/pom.xml
+++ b/kafka-1-0/pom.xml
@@ -57,11 +57,11 @@
               <relocations>
                 <relocation>
                   <pattern>org.apache.kafka.common</pattern>
-                  <shadedPattern>org.apache.kafka-1-0-0.common</shadedPattern>
+                  <shadedPattern>org.apache.kafka100.common</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.apache.kafka.clients</pattern>
-                  <shadedPattern>org.apache.kafka-1-0-0.clients</shadedPattern>
+                  <shadedPattern>org.apache.kafka100.clients</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/KafkaVersion.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/KafkaVersion.java
@@ -37,13 +37,13 @@ public enum KafkaVersion {
         if (this.equals(DEFAULT)) {
             return "org.apache.kafka.common.serialization.StringSerializer";
         }
-        return String.format("org.apache.kafka-%s.common.serialization.StringSerializer", name);
+        return String.format("org.apache.kafka%s.common.serialization.StringSerializer", name);
     }
 
     public String getStringDeserializer() {
         if (this.equals(DEFAULT)) {
             return "org.apache.kafka.common.serialization.StringDeserializer";
         }
-        return String.format("org.apache.kafka-%s.common.serialization.StringDeserializer", name);
+        return String.format("org.apache.kafka%s.common.serialization.StringDeserializer", name);
     }
 }

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/KafkaVersion.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/KafkaVersion.java
@@ -24,7 +24,7 @@ import lombok.Getter;
  */
 public enum KafkaVersion {
 
-    DEFAULT("default"), KAFKA_1_0_0("1-0-0");
+    DEFAULT("default"), KAFKA_1_0_0("100");
 
     @Getter
     private String name;


### PR DESCRIPTION
This patch allows you to build KOP on JDK11.

Without this patch the build fails with this error:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project kafka-client-factory: Compilation failure: Compilation failure: 
[ERROR] /Users/enrico.olivelli/dev/kop/kafka-client-factory/src/main/java/io/streamnative/kafka/client/api/KafkaClientFactoryImpl.java:[33,20] cannot access org.apache.kafka-1-0-0.clients.producer.KafkaProducer
[ERROR]   class file for org.apache.kafka-1-0-0.clients.producer.KafkaProducer not found
[ERROR] /Users/enrico.olivelli/dev/kop/kafka-client-factory/src/main/java/io/streamnative/kafka/client/api/KafkaClientFactoryImpl.java:[41,20] cannot access org.apache.kafka-1-0-0.clients.consumer.KafkaConsumer
[ERROR]   class file for org.apache.kafka-1-0-0.clients.consumer.KafkaConsumer not found
[ERROR] -> [Help 1]
[ERROR] 
```

**Modifications**
do not use '-' in the package name


As I do not have signed an ICLA with this repo, I would like to state explicitly that I am sending this patch according to the terms Apache License v2.