### PR TITLE
Remove unused maven repositories to speed up building

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -405,25 +405,11 @@
       <name>sonatype</name>
       <url>https://oss.sonatype.org/content/repositories/iostreamnative-1129</url>
     </repository>
-    <repository>
-      <id>bintray-streamnative-maven</id>
-      <name>bintray</name>
-      <url>https://dl.bintray.com/streamnative/maven</url>
-    </repository>
 
     <repository>
       <id>central</id>
       <layout>default</layout>
       <url>https://repo1.maven.org/maven2</url>
-    </repository>
-
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>bintray-yahoo-maven</id>
-      <name>bintray</name>
-      <url>https://yahoo.bintray.com/maven</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
### Motivation

When building KoP by `mvn clean install -DskipTests`, there're a lot of warning logs like

> [WARNING] Could not transfer metadata io.grpc:grpc-api/maven-metadata.xml from/to bintray-streamnative-maven (https://dl.bintray.com/streamnative/maven): authorization failed for https://dl.bintray.com/streamnative/maven/io/grpc/grpc-api/maven-metadata.xml, status: 403 Forbidden

It's because bintray became unavailable from 2021 May 1st and KoP still contains bintray's repositories. So when building KoP, it still tried to download dependencies from bintray and 403 happened.

### Modifications

Remove the bintray related repositories, which are replaced by sonatype now. After this change, the build time reduced from nearly 50s to 35s.

Before:

```
[INFO] Total time:  51.529 s
[INFO] Finished at: 2021-07-21T21:57:52+08:00
```

After:

```
[INFO] Total time:  35.586 s
[INFO] Finished at: 2021-07-21T21:56:05+08:00
```