### PR TITLE
Fix deadlock caused by KafkaTopicConsumerManager

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManager.java
@@ -21,7 +21,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCursorCallback;
@@ -44,10 +44,7 @@ public class KafkaTopicConsumerManager implements Closeable {
     private final PersistentTopic topic;
     private final KafkaRequestHandler requestHandler;
 
-    // the lock for closed status change.
-    // once closed, should not add new cursor back, since consumers are cleared.
-    private final ReentrantReadWriteLock rwLock;
-    private boolean closed;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
 
     // key is the offset, value is the future of (cursor, offset), whose offset is the last offset in pair.
     @Getter
@@ -68,8 +65,6 @@ public class KafkaTopicConsumerManager implements Closeable {
         this.createdCursors = new ConcurrentHashMap<>();
         this.lastAccessTimes = new ConcurrentLongHashMap<>();
         this.requestHandler = requestHandler;
-        this.rwLock = new ReentrantReadWriteLock();
-        this.closed = false;
     }
 
     // delete expired cursors, so backlog can be cleared.
@@ -82,19 +77,12 @@ public class KafkaTopicConsumerManager implements Closeable {
     }
 
     void deleteOneExpiredCursor(long offset) {
-        CompletableFuture<Pair<ManagedCursor, Long>> cursorFuture;
-
-        // need not do anything, since this tcm already in closing state. and close() will delete every thing.
-        rwLock.readLock().lock();
-        try {
-            if (closed) {
-                return;
-            }
-            cursorFuture = cursors.remove(offset);
-            lastAccessTimes.remove(offset);
-        } finally {
-            rwLock.readLock().unlock();
+        if (closed.get()) {
+            return;
         }
+
+        final CompletableFuture<Pair<ManagedCursor, Long>> cursorFuture = cursors.remove(offset);
+        lastAccessTimes.remove(offset);
 
         if (cursorFuture != null) {
             if (log.isDebugEnabled()) {
@@ -115,6 +103,9 @@ public class KafkaTopicConsumerManager implements Closeable {
 
     // delete passed in cursor.
     void deleteOneCursorAsync(ManagedCursor cursor, String reason) {
+        if (closed.get()) {
+            return;
+        }
         if (cursor != null) {
             topic.getManagedLedger().asyncDeleteCursor(cursor.getName(), new DeleteCursorCallback() {
                 @Override
@@ -139,56 +130,42 @@ public class KafkaTopicConsumerManager implements Closeable {
     // remove from cache, so another same offset read could happen.
     // each success remove should have a following add.
     public CompletableFuture<Pair<ManagedCursor, Long>> removeCursorFuture(long offset) {
-        rwLock.readLock().lock();
-        try {
-            if (closed) {
-                return null;
-            }
-            lastAccessTimes.remove(offset);
-            final CompletableFuture<Pair<ManagedCursor, Long>> cursorFuture = cursors.remove(offset);
-            if (cursorFuture == null) {
-                return asyncCreateCursorIfNotExists(offset);
-            }
-
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Get cursor for offset: {} in cache. cache size: {}",
-                        requestHandler.ctx.channel(), offset, cursors.size());
-            }
-            return cursorFuture;
-        } finally {
-            rwLock.readLock().unlock();
+        if (closed.get()) {
+            return null;
         }
+
+        lastAccessTimes.remove(offset);
+        final CompletableFuture<Pair<ManagedCursor, Long>> cursorFuture = cursors.remove(offset);
+        if (cursorFuture == null) {
+            return asyncCreateCursorIfNotExists(offset);
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("[{}] Get cursor for offset: {} in cache. cache size: {}",
+                    requestHandler.ctx.channel(), offset, cursors.size());
+        }
+        return cursorFuture;
     }
 
     private CompletableFuture<Pair<ManagedCursor, Long>> asyncCreateCursorIfNotExists(long offset) {
-        rwLock.readLock().lock();
-        try {
-            if (closed) {
-                return null;
-            }
-            cursors.putIfAbsent(offset, asyncGetCursorByOffset(offset));
-
-            // notice:  above would add a <offset, null-Pair>
-            lastAccessTimes.remove(offset);
-            return cursors.remove(offset);
-        } finally {
-            rwLock.readLock().unlock();
+        if (closed.get()) {
+            return null;
         }
+        cursors.putIfAbsent(offset, asyncGetCursorByOffset(offset));
+
+        // notice:  above would add a <offset, null-Pair>
+        lastAccessTimes.remove(offset);
+        return cursors.remove(offset);
     }
 
     public void add(long offset, Pair<ManagedCursor, Long> pair) {
         checkArgument(offset == pair.getRight(),
                 "offset not equal. key: " + offset + " value: " + pair.getRight());
 
-        rwLock.readLock().lock();
-        try {
-            if (closed) {
-                ManagedCursor managedCursor = pair.getLeft();
-                deleteOneCursorAsync(managedCursor, "A race - add cursor back but tcm already closed");
-                return;
-            }
-        } finally {
-            rwLock.readLock().unlock();
+        if (closed.get()) {
+            ManagedCursor managedCursor = pair.getLeft();
+            deleteOneCursorAsync(managedCursor, "A race - add cursor back but tcm already closed");
+            return;
         }
 
         final CompletableFuture<Pair<ManagedCursor, Long>> cursorFuture = CompletableFuture.completedFuture(pair);
@@ -206,28 +183,21 @@ public class KafkaTopicConsumerManager implements Closeable {
     // called when channel closed.
     @Override
     public void close() {
+        if (!closed.compareAndSet(false, true)) {
+            return;
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("[{}] Close TCM for topic {}.",
+                requestHandler.ctx.channel(), topic.getName());
+        }
         final ConcurrentLongHashMap<CompletableFuture<Pair<ManagedCursor, Long>>> cursorFuturesToClose =
                 new ConcurrentLongHashMap<>();
-        ConcurrentMap<String, ManagedCursor> cursorsToClose;
-        rwLock.writeLock().lock();
-        try {
-            if (closed) {
-                return;
-            }
-            closed = true;
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Close TCM for topic {}.",
-                    requestHandler.ctx.channel(), topic.getName());
-            }
-            cursors.forEach(cursorFuturesToClose::put);
-            cursors.clear();
-            lastAccessTimes.clear();
-            cursorsToClose = new ConcurrentHashMap<>();
-            createdCursors.forEach(cursorsToClose::put);
-            createdCursors.clear();
-        } finally {
-            rwLock.writeLock().unlock();
-        }
+        cursors.forEach(cursorFuturesToClose::put);
+        cursors.clear();
+        lastAccessTimes.clear();
+        final ConcurrentMap<String, ManagedCursor> cursorsToClose = new ConcurrentHashMap<>();
+        createdCursors.forEach(cursorsToClose::put);
+        createdCursors.clear();
 
         cursorFuturesToClose.values().forEach(cursorFuture -> {
             cursorFuture.whenComplete((pair, e) -> {
@@ -249,6 +219,10 @@ public class KafkaTopicConsumerManager implements Closeable {
     }
 
     private CompletableFuture<Pair<ManagedCursor, Long>> asyncGetCursorByOffset(long offset) {
+        if (closed.get()) {
+            // return a null completed future instead of null because the returned value will be put into a Map
+            return CompletableFuture.completedFuture(null);
+        }
         final ManagedLedger ledger = topic.getManagedLedger();
         return ledger.asyncFindPosition(new OffsetSearchPredicate(offset)).thenApply(position -> {
             final String cursorName = "kop-consumer-cursor-" + topic.getName()


### PR DESCRIPTION
Fixes #618 

### Motivation

See https://github.com/streamnative/kop/issues/618#issuecomment-884764857 for the deadlock analysis.

### Modifications
- Use `ConcurrentHashMap` instead of `ConcurrentLongHashMap`. Though this bug may already be fixed in https://github.com/apache/pulsar/pull/9787, the `ConcurrentHashMap` from Java standard library is more reliable. The possible performance enhancement brought by `ConcurrentLongHashMap` still needs to be proved.
- Use `AtomicBoolean` as `KafkaTopicConsumerManager`'s state instead of read-write lock to avoid `close()` method that tries to acquire write lock blocking.
- Run a single cursor expire task instead one task per channel, since https://github.com/streamnative/kop/pull/404 changed `consumerTopicManagers` to a static field, there's no reason to run a task for each connection.