### PR TITLE
Optimize the protocol handler start

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -71,7 +71,6 @@ import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.policies.data.ClusterData;
-import org.apache.pulsar.compaction.Compactor;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.apache.pulsar.zookeeper.ZooKeeperClientFactory;
 import org.apache.pulsar.zookeeper.ZookeeperClientFactoryImpl;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -332,9 +332,6 @@ public abstract class KopProtocolHandlerTestBase {
         setupBrokerMocks(pulsar);
         pulsar.start();
 
-        Compactor spiedCompactor = spy(pulsar.getCompactor());
-        doReturn(spiedCompactor).when(pulsar).getCompactor();
-
         return pulsar;
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
@@ -152,6 +152,8 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase{
             sb.append(line);
         }
 
+        log.info("Metrics string:\n{}", sb.toString());
+
         // channel stats
         Assert.assertTrue(sb.toString().contains("kop_server_ALIVE_CHANNEL_COUNT"));
         Assert.assertTrue(sb.toString().contains("kop_server_ACTIVE_CHANNEL_COUNT"));


### PR DESCRIPTION
### Motivation

In K8s environment, the start of a KoP node might depend on a successful start of another KoP node. It's caused by the lookup request in `loadOffsetTopics`, here're the logs:

```
13:33:11.584 [pulsar-2-1] INFO  org.eclipse.jetty.server.RequestLog - 10.8.5.72 - - [08/Jul/2021:13:33:11 +0000] "GET /lookup/v2/topic/persistent/public/__kafka/__consumer_offsets-partition-0 HTTP/1.1" 307 0 "-" "Pulsar-Java-v2.8.0-rc-202106071430" 88
13:33:11.593 [pulsar-2-1] INFO  org.eclipse.jetty.server.RequestLog - 10.8.5.72 - - [08/Jul/2021:13:33:11 +0000] "GET /lookup/v2/topic/persistent/public/__kafka/__consumer_offsets-partition-0 HTTP/1.1" 307 0 "-" "Pulsar-Java-v2.8.0-rc-202106071430" 8
13:33:11.673 [pulsar-2-1] INFO  org.eclipse.jetty.server.RequestLog - 10.8.5.72 - - [08/Jul/2021:13:33:11 +0000] "GET /lookup/v2/topic/persistent/public/__kafka/__consumer_offsets-partition-0 HTTP/1.1" 307 0 "-" "Pulsar-Java-v2.8.0-rc-202106071430" 78
13:33:11.685 [pulsar-2-1] INFO  org.eclipse.jetty.server.RequestLog - 10.8.5.72 - - [08/Jul/2021:13:33:11 +0000] "GET /lookup/v2/topic/persistent/public/__kafka/__consumer_offsets-partition-0 HTTP/1.1" 307 0 "-" "Pulsar-Java-v2.8.0-rc-202106071430" 9
13:33:11.767 [pulsar-2-1] INFO  org.eclipse.jetty.server.RequestLog - 10.8.5.72 - - [08/Jul/2021:13:33:11 +0000] "GET /lookup/v2/topic/persistent/public/__kafka/__consumer_offsets-partition-0 HTTP/1.1" 307 0 "-" "Pulsar-Java-v2.8.0-rc-202106071430" 80
13:33:11.771 [main] ERROR io.streamnative.pulsar.handlers.kop.KafkaProtocolHandler - initGroupCoordinator failed with
org.apache.pulsar.client.admin.PulsarAdminException: java.util.concurrent.CompletionException: org.apache.pulsar.client.admin.internal.http.AsyncHttpConnector$RetryException: Could not complete the operation. Number of retries has been exhausted. Failed reason: test-broker-1.test-broker-headless.kop-test.svc.cluster.local
reason: test-broker-1.test-broker-headless.kop-test.svc.cluster.local
	at org.apache.pulsar.client.admin.internal.BaseResource.getApiException(BaseResource.java:247) ~[io.streamnative-pulsar-client-admin-original-2.8.0-rc-202106071430.jar:2.8.0-rc-202106071430]
	at org.apache.pulsar.client.admin.internal.LookupImpl$1.failed(LookupImpl.java:85) ~[io.streamnative-pulsar-client-admin-original-2.8.0-rc-202106071430.jar:2.8.0-rc-202106071430]
```

10.8.5.72 is the IP of another KoP node that had not started completely.

Actually `loadOffsetTopics` is not necessary, when a bundle load event happened, the offsets will be loaded in the bundle ownership listener. There's no reason to load the offsets in `start()` method, also when Kafka starts, it doesn't load offsets.

### Modifications

The most important change is to remove the `loadOffsetTopics` method.

In addition, this PR does some code factors to `KafkaProtocolHandler`:
- Remove unused fields
- Don't catch unchecked exceptions to make `start` fail fast
- Adjust the order of fields and methods to meet Codacy's requirement