### PR TITLE
Support Kafka consumer for Pulsar format messages when entryFormat is kafka

### DIFF
--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/Header.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/Header.java
@@ -33,6 +33,9 @@ public class Header {
     private final String value;
 
     private static Header fromHeader(final Object originalHeader) {
+        if (originalHeader == null) {
+            return null;
+        }
         final Class<?> clazz = originalHeader.getClass();
         return new Header(
                 (String) ReflectionUtils.invoke(clazz, "key", originalHeader),
@@ -69,7 +72,9 @@ public class Header {
             return null;
         }
         return headers.stream()
-                .map(header -> constructor.apply(header.getKey(), header.getValue().getBytes(StandardCharsets.UTF_8)))
+                .map(header -> (header != null)
+                        ? constructor.apply(header.getKey(), header.getValue().getBytes(StandardCharsets.UTF_8))
+                        : null)
                 .collect(Collectors.toList());
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -291,7 +291,7 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
 
     @FieldContext(
             category = CATEGORY_KOP,
-            doc = "Maximum number of entries that are read from cursor once per time, default is 1"
+            doc = "Maximum number of entries that are read from cursor once per time, default is 5"
     )
     private int maxReadEntriesNum = 5;
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaEntryFormatter.java
@@ -160,8 +160,7 @@ public class KafkaEntryFormatter implements EntryFormatter {
             return Unpooled.wrappedBuffer(records.buffer());
         }
 
-        // TODO: add cache for NIO buffer
-        final ByteBuffer byteBuffer = ByteBuffer.allocateDirect(DEFAULT_BUFFER_SIZE);
+        final ByteBuffer byteBuffer = ByteBuffer.allocate(DEFAULT_BUFFER_SIZE);
         final MemoryRecordsBuilder builder = new MemoryRecordsBuilder(
                 byteBuffer,
                 magic,
@@ -214,10 +213,11 @@ public class KafkaEntryFormatter implements EntryFormatter {
                     headers);
         }
 
-        builder.close();
+        final MemoryRecords records = builder.build();
         uncompressedPayload.release();
         byteBuffer.flip();
-        return Unpooled.wrappedBuffer(byteBuffer);
+
+        return Unpooled.wrappedBuffer(records.buffer());
     }
 
     @NonNull

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaEntryFormatter.java
@@ -18,18 +18,35 @@ import static org.apache.kafka.common.record.Records.OFFSET_OFFSET;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.util.ReferenceCounted;
 import io.streamnative.pulsar.handlers.kop.exceptions.KoPMessageMetadataNotFoundException;
 import io.streamnative.pulsar.handlers.kop.utils.ByteBufUtils;
 import io.streamnative.pulsar.handlers.kop.utils.MessageIdUtils;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.Optional;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Entry;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.record.ControlRecordType;
+import org.apache.kafka.common.record.EndTransactionMarker;
 import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.MemoryRecordsBuilder;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.record.TimestampType;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.api.proto.KeyValue;
+import org.apache.pulsar.common.api.proto.MarkerType;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
+import org.apache.pulsar.common.api.proto.SingleMessageMetadata;
+import org.apache.pulsar.common.compression.CompressionCodec;
+import org.apache.pulsar.common.compression.CompressionCodecProvider;
 import org.apache.pulsar.common.protocol.Commands;
 
 /**
@@ -41,6 +58,9 @@ public class KafkaEntryFormatter implements EntryFormatter {
     // These key-value identifies the entry's format as kafka
     private static final String IDENTITY_KEY = "entry.format";
     private static final String IDENTITY_VALUE = EntryFormatterFactory.EntryFormat.KAFKA.name().toLowerCase();
+
+    private static final int DEFAULT_BUFFER_SIZE = 1024 * 1024;
+    private static final int MAX_RECORDS_BUFFER_SIZE = 100 * 1024 * 1024;
 
     @Override
     public ByteBuf encode(MemoryRecords records, int numMessages) {
@@ -55,8 +75,11 @@ public class KafkaEntryFormatter implements EntryFormatter {
 
     @Override
     public DecodeResult decode(List<Entry> entries, byte magic) {
+        Optional<List<ByteBuf>> optionalByteBufs = Optional.empty();
+
         // reset header information
-        List<ByteBuf> orderedByteBuf = entries.stream().parallel().map(entry -> {
+        final List<ByteBuf> orderedByteBuf = new ArrayList<>();
+        for (Entry entry : entries) {
             try {
                 long startOffset = MessageIdUtils.peekBaseOffsetFromEntry(entry);
                 final ByteBuf byteBuf = entry.getDataBuffer();
@@ -64,17 +87,21 @@ public class KafkaEntryFormatter implements EntryFormatter {
                 if (isKafkaEntryFormat(metadata)) {
                     byteBuf.setLong(byteBuf.readerIndex() + OFFSET_OFFSET, startOffset);
                     byteBuf.setByte(byteBuf.readerIndex() + MAGIC_OFFSET, magic);
-                    return byteBuf.slice(byteBuf.readerIndex(), byteBuf.readableBytes());
+                    orderedByteBuf.add(byteBuf.slice(byteBuf.readerIndex(), byteBuf.readableBytes()));
                 } else {
-                    // TODO: treat it as Pulsar format and parse to Kafka format
-                    return null;
+                    final ByteBuf kafkaBuffer = createKafkaBuffer(startOffset, magic, metadata, byteBuf);
+                    orderedByteBuf.add(kafkaBuffer);
+                    if (!optionalByteBufs.isPresent()) {
+                        optionalByteBufs = Optional.of(new ArrayList<>());
+                    }
+                    optionalByteBufs.ifPresent(byteBufs -> byteBufs.add(kafkaBuffer));
                 }
-            } catch (KoPMessageMetadataNotFoundException e) { // skip failed decode entry
+            } catch (KoPMessageMetadataNotFoundException | IOException e) { // skip failed decode entry
                 log.error("[{}:{}] Failed to decode entry. ", entry.getLedgerId(), entry.getEntryId(), e);
                 entry.release();
                 return null;
             }
-        }).filter(Objects::nonNull).collect(Collectors.toList());
+        }
 
         // batched ByteBuf should be released after sending to client
         int totalSize = orderedByteBuf.stream().mapToInt(ByteBuf::readableBytes).sum();
@@ -83,6 +110,7 @@ public class KafkaEntryFormatter implements EntryFormatter {
         for (ByteBuf byteBuf : orderedByteBuf) {
             batchedByteBuf.writeBytes(byteBuf);
         }
+        optionalByteBufs.ifPresent(byteBufs -> byteBufs.forEach(ReferenceCounted::release));
 
         // release entries
         entries.forEach(Entry::release);
@@ -114,4 +142,94 @@ public class KafkaEntryFormatter implements EntryFormatter {
         return false;
     }
 
+    private ByteBuf createKafkaBuffer(final long offset,
+                                      final byte magic,
+                                      final MessageMetadata metadata,
+                                      final ByteBuf payload) throws IOException {
+        if (metadata.hasMarkerType()
+                && (metadata.getMarkerType() == MarkerType.TXN_COMMIT_VALUE
+                || metadata.getMarkerType() == MarkerType.TXN_ABORT_VALUE)) {
+            final MemoryRecords records = MemoryRecords.withEndTransactionMarker(
+                    offset,
+                    metadata.getPublishTime(),
+                    0,
+                    metadata.getTxnidMostBits(),
+                    (short) metadata.getTxnidLeastBits(),
+                    new EndTransactionMarker(metadata.getMarkerType() == MarkerType.TXN_COMMIT_VALUE
+                            ? ControlRecordType.COMMIT : ControlRecordType.ABORT, 0));
+            return Unpooled.wrappedBuffer(records.buffer());
+        }
+
+        // TODO: add cache for NIO buffer
+        final ByteBuffer byteBuffer = ByteBuffer.allocateDirect(DEFAULT_BUFFER_SIZE);
+        final MemoryRecordsBuilder builder = new MemoryRecordsBuilder(
+                byteBuffer,
+                magic,
+                CompressionType.NONE,
+                TimestampType.CREATE_TIME,
+                offset,
+                metadata.getPublishTime(),
+                RecordBatch.NO_PRODUCER_ID,
+                RecordBatch.NO_PRODUCER_EPOCH,
+                RecordBatch.NO_SEQUENCE,
+                metadata.hasTxnidMostBits() && metadata.hasTxnidLeastBits(),
+                false,
+                RecordBatch.NO_PARTITION_LEADER_EPOCH,
+                MAX_RECORDS_BUFFER_SIZE);
+
+        final int uncompressedSize = metadata.getUncompressedSize();
+        final CompressionCodec codec = CompressionCodecProvider.getCompressionCodec(metadata.getCompression());
+        final ByteBuf uncompressedPayload = codec.decode(payload, uncompressedSize);
+
+        if (metadata.hasNumMessagesInBatch()) {
+            final int numMessages = metadata.getNumMessagesInBatch();
+            for (int i = 0; i < numMessages; i++) {
+                final SingleMessageMetadata singleMessageMetadata = new SingleMessageMetadata();
+                final ByteBuf singleMessagePayload = Commands.deSerializeSingleMessageInBatch(
+                        uncompressedPayload, singleMessageMetadata, i, numMessages);
+
+                final long timestamp = (metadata.getEventTime() > 0)
+                        ? metadata.getEventTime()
+                        : metadata.getPublishTime();
+                final ByteBuffer value = (singleMessageMetadata.isNullValue())
+                        ? null
+                        : ByteBufUtils.getNioBuffer(singleMessagePayload);
+                final Header[] headers = getHeadersFromMetadata(metadata.getPropertiesList());
+                builder.appendWithOffset(offset + i,
+                        timestamp,
+                        ByteBufUtils.getKeyByteBuffer(singleMessageMetadata),
+                        value,
+                        headers);
+                singleMessagePayload.release();
+            }
+        } else {
+            final long timestamp = (metadata.getEventTime() > 0)
+                    ? metadata.getEventTime()
+                    : metadata.getPublishTime();
+            final Header[] headers = getHeadersFromMetadata(metadata.getPropertiesList());
+            builder.appendWithOffset(offset,
+                    timestamp,
+                    ByteBufUtils.getKeyByteBuffer(metadata),
+                    ByteBufUtils.getNioBuffer(uncompressedPayload),
+                    headers);
+        }
+
+        builder.close();
+        uncompressedPayload.release();
+        byteBuffer.flip();
+        return Unpooled.wrappedBuffer(byteBuffer);
+    }
+
+    @NonNull
+    private Header[] getHeadersFromMetadata(final List<KeyValue> properties) {
+        final Header[] headers = new Header[properties.size()];
+
+        int index = 0;
+        for (KeyValue keyValue : properties) {
+            headers[index] = new RecordHeader(keyValue.getKey(), keyValue.getValue().getBytes(StandardCharsets.UTF_8));
+            index++;
+        }
+
+        return headers;
+    }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ByteBufUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ByteBufUtils.java
@@ -21,9 +21,6 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
-import java.util.stream.IntStream;
-
-import io.netty.buffer.Unpooled;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.header.Header;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ByteBufUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ByteBufUtils.java
@@ -70,6 +70,9 @@ public class ByteBufUtils {
             return ByteBuffer.wrap(messageMetadata.getOrderingKey()).asReadOnlyBuffer();
         }
 
+        if (!messageMetadata.hasPartitionKey()) {
+            return null;
+        }
         String key = messageMetadata.getPartitionKey();
         if (messageMetadata.hasPartitionKeyB64Encoded()) {
             return ByteBuffer.wrap(Base64.getDecoder().decode(key));

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ByteBufUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ByteBufUtils.java
@@ -18,7 +18,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import io.netty.buffer.ByteBuf;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import lombok.NonNull;
@@ -177,7 +176,7 @@ public class ByteBufUtils {
         return properties.stream()
                 .map(property -> new RecordHeader(
                         property.getKey(),
-                        property.getValue().getBytes(StandardCharsets.UTF_8))
+                        property.getValue().getBytes(UTF_8))
                 ).toArray(Header[]::new);
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ByteBufUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ByteBufUtils.java
@@ -16,15 +16,35 @@ package io.streamnative.pulsar.handlers.kop.utils;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import io.netty.buffer.ByteBuf;
+import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.List;
+import java.util.stream.IntStream;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.record.ControlRecordType;
+import org.apache.kafka.common.record.EndTransactionMarker;
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.MemoryRecordsBuilder;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.pulsar.common.api.proto.KeyValue;
+import org.apache.pulsar.common.api.proto.MarkerType;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.api.proto.SingleMessageMetadata;
+import org.apache.pulsar.common.compression.CompressionCodec;
+import org.apache.pulsar.common.compression.CompressionCodecProvider;
+import org.apache.pulsar.common.protocol.Commands;
 
 
 /**
  * Utils for ByteBuf operations.
  */
+@Slf4j
 public class ByteBufUtils {
 
     public static ByteBuffer getKeyByteBuffer(SingleMessageMetadata messageMetadata) {
@@ -66,5 +86,109 @@ public class ByteBufUtils {
         final byte[] bytes = new byte[buffer.readableBytes()];
         buffer.getBytes(buffer.readerIndex(), bytes);
         return ByteBuffer.wrap(bytes);
+    }
+
+    public MemoryRecords decodePulsarEntryToKafkaRecords(final MessageMetadata msgMetadata,
+                                                         final ByteBuf payload,
+                                                         final long baseOffset,
+                                                         final byte magic,
+                                                         final long ledgerId,
+                                                         final long entryId) {
+
+        if (msgMetadata.hasMarkerType()
+                && (msgMetadata.getMarkerType() == MarkerType.TXN_COMMIT_VALUE
+                || msgMetadata.getMarkerType() == MarkerType.TXN_ABORT_VALUE)) {
+            return MemoryRecords.withEndTransactionMarker(
+                    baseOffset,
+                    msgMetadata.getPublishTime(),
+                    0,
+                    msgMetadata.getTxnidMostBits(),
+                    (short) msgMetadata.getTxnidLeastBits(),
+                    new EndTransactionMarker(
+                            msgMetadata.getMarkerType() == MarkerType.TXN_COMMIT_VALUE
+                                    ? ControlRecordType.COMMIT : ControlRecordType.ABORT, 0));
+        }
+
+        final CompressionCodec codec = CompressionCodecProvider.getCompressionCodec(msgMetadata.getCompression());
+        final int uncompressedSize = msgMetadata.getUncompressedSize();
+        ByteBuf uncompressedPayload;
+        try {
+            uncompressedPayload = codec.decode(payload, uncompressedSize);
+        } catch (IOException e) {
+            log.error("Failed to uncompress payload of offset: {} and skip it", baseOffset, e);
+            return null;
+        }
+
+        final ByteBuffer byteBuffer = ByteBuffer.allocate(1024 * 1024);
+        final MemoryRecordsBuilder builder = new MemoryRecordsBuilder(byteBuffer,
+                magic,
+                CompressionType.NONE,
+                TimestampType.CREATE_TIME,
+                baseOffset,
+                msgMetadata.getPublishTime(),
+                RecordBatch.NO_PRODUCER_ID,
+                RecordBatch.NO_PRODUCER_EPOCH,
+                RecordBatch.NO_SEQUENCE,
+                msgMetadata.hasTxnidMostBits() && msgMetadata.hasTxnidLeastBits(),
+                false,
+                RecordBatch.NO_PARTITION_LEADER_EPOCH,
+                100 * 1024 * 1024);
+        if (msgMetadata.hasTxnidMostBits()) {
+            builder.setProducerState(msgMetadata.getTxnidMostBits(), (short) msgMetadata.getTxnidLeastBits(), 0, true);
+        }
+
+        final int numMessages = msgMetadata.getNumMessagesInBatch();
+        final boolean isBatched = (msgMetadata.hasNumMessagesInBatch() || numMessages != 1);
+
+        if (log.isDebugEnabled()) {
+            log.debug("Entry to MemoryRecords, numMessages: {}, isBatched: {}, ledgerId: {}, entryId: {}",
+                    numMessages, isBatched, ledgerId, entryId);
+        }
+
+        if (isBatched) {
+            IntStream.range(0, numMessages).parallel().forEachOrdered(i -> {
+                if (log.isDebugEnabled()) {
+                    log.debug(" processing message num - {} in batch", i);
+                }
+                final SingleMessageMetadata singleMessageMetadata = new SingleMessageMetadata();
+                try {
+                    final ByteBuf singleMessagePayload = Commands.deSerializeSingleMessageInBatch(
+                            uncompressedPayload, singleMessageMetadata, i, numMessages);
+                    final ByteBuffer value = (singleMessageMetadata.isNullValue()
+                            ? null
+                            : getNioBuffer(singleMessagePayload));
+                    builder.appendWithOffset(
+                            baseOffset + i,
+                            msgMetadata.getEventTime() > 0 ? msgMetadata.getEventTime() : msgMetadata.getPublishTime(),
+                            ByteBufUtils.getKeyByteBuffer(singleMessageMetadata),
+                            value,
+                            getHeadersFromMetadata(singleMessageMetadata.getPropertiesList()));
+                    singleMessagePayload.release();
+                } catch (IOException e) {
+                    // TODO: how to handle the corrupted single message?
+                    log.error("Failed to deserialize single message in batch {}", i, e);
+                }
+            });
+        } else {
+            builder.appendWithOffset(
+                    baseOffset,
+                    msgMetadata.getEventTime() > 0 ? msgMetadata.getEventTime() : msgMetadata.getPublishTime(),
+                    getKeyByteBuffer(msgMetadata),
+                    getNioBuffer(uncompressedPayload),
+                    getHeadersFromMetadata(msgMetadata.getPropertiesList()));
+        }
+
+        uncompressedPayload.release();
+        builder.close();
+        byteBuffer.flip();
+        return MemoryRecords.readableRecords(byteBuffer);
+    }
+
+    private static Header[] getHeadersFromMetadata(final List<KeyValue> properties) {
+        return properties.stream()
+                .map(property -> new RecordHeader(
+                        property.getKey(),
+                        property.getValue().getBytes(StandardCharsets.UTF_8))
+                ).toArray(Header[]::new);
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ByteBufUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ByteBufUtils.java
@@ -60,7 +60,7 @@ public class ByteBufUtils {
 
         if (messageMetadata.hasPartitionKey()) {
             final String key = messageMetadata.getPartitionKey();
-            if (messageMetadata.hasPartitionKeyB64Encoded()) {
+            if (messageMetadata.isPartitionKeyB64Encoded()) {
                 return ByteBuffer.wrap(Base64.getDecoder().decode(key)).asReadOnlyBuffer();
             } else {
                 // for Base64 not encoded string, convert to UTF_8 chars
@@ -149,7 +149,7 @@ public class ByteBufUtils {
                 final ByteBuffer value = singleMessageMetadata.isNullValue()
                         ? null
                         : getNioBuffer(singleMessagePayload);
-                final Header[] headers = getHeadersFromMetadata(metadata.getPropertiesList());
+                final Header[] headers = getHeadersFromMetadata(singleMessageMetadata.getPropertiesList());
                 builder.appendWithOffset(baseOffset + i,
                         timestamp,
                         getKeyByteBuffer(singleMessageMetadata),

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ByteBufUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ByteBufUtils.java
@@ -54,16 +54,16 @@ public class ByteBufUtils {
             return ByteBuffer.wrap(messageMetadata.getOrderingKey()).asReadOnlyBuffer();
         }
 
-        if (messageMetadata.hasPartitionKey()) {
-            final String key = messageMetadata.getPartitionKey();
-            if (messageMetadata.isPartitionKeyB64Encoded()) {
-                return ByteBuffer.wrap(Base64.getDecoder().decode(key)).asReadOnlyBuffer();
-            } else {
-                // for Base64 not encoded string, convert to UTF_8 chars
-                return ByteBuffer.wrap(key.getBytes(UTF_8));
-            }
+        if (!messageMetadata.hasPartitionKey()) {
+            return null;
+        }
+
+        final String key = messageMetadata.getPartitionKey();
+        if (messageMetadata.isPartitionKeyB64Encoded()) {
+            return ByteBuffer.wrap(Base64.getDecoder().decode(key)).asReadOnlyBuffer();
         } else {
-            return ByteBuffer.allocate(0);
+            // for Base64 not encoded string, convert to UTF_8 chars
+            return ByteBuffer.wrap(key.getBytes(UTF_8));
         }
     }
 
@@ -76,7 +76,7 @@ public class ByteBufUtils {
             return null;
         }
         String key = messageMetadata.getPartitionKey();
-        if (messageMetadata.hasPartitionKeyB64Encoded()) {
+        if (messageMetadata.isPartitionKeyB64Encoded()) {
             return ByteBuffer.wrap(Base64.getDecoder().decode(key));
         } else {
             // for Base64 not encoded string, convert to UTF_8 chars

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
@@ -175,7 +175,7 @@ public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
     @Test(timeOut = 20000)
     public void testMixedProduceKafkaConsume() throws Exception {
         final String topic = "test-mixed-produce-kafka-consume";
-        final int numMessages = 60;
+        final int numMessages = 30;
         final List<String> values =
                 IntStream.range(0, numMessages).mapToObj(i -> "value-" + i).collect(Collectors.toList());
         // Some messages doesn't have keys
@@ -184,7 +184,7 @@ public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
                 .collect(Collectors.toList());
         // Some messages doesn't have properties or headers
         final List<Pair<String, String>> properties = IntStream.range(0, numMessages)
-                .mapToObj(i -> (i % 6 == 0) ? Pair.of("prop-key-" + i, "prop-value-" + i) : null)
+                .mapToObj(i -> (i % 5 == 0) ? Pair.of("prop-key-" + i, "prop-value-" + i) : null)
                 .collect(Collectors.toList());
 
         final KafkaProducer<String, String> kafkaProducer = newKafkaProducer();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
@@ -17,20 +17,30 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.TypedMessageBuilder;
 import org.testng.annotations.Test;
 
 /**
@@ -165,24 +175,77 @@ public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
     @Test(timeOut = 20000)
     public void testMixedProduceKafkaConsume() throws Exception {
         final String topic = "test-mixed-produce-kafka-consume";
-        final List<String> values = IntStream.range(0, 60).mapToObj(i -> "msg-" + i).collect(Collectors.toList());
+        final int numMessages = 60;
+        final List<String> values =
+                IntStream.range(0, numMessages).mapToObj(i -> "value-" + i).collect(Collectors.toList());
+        // Some messages doesn't have keys
+        final List<String> keys = IntStream.range(0, numMessages)
+                .mapToObj(i -> (i % 3 == 0) ? ("key-" + i) : null)
+                .collect(Collectors.toList());
+        // Some messages doesn't have properties or headers
+        final List<Pair<String, String>> properties = IntStream.range(0, numMessages)
+                .mapToObj(i -> (i % 6 == 0) ? Pair.of("prop-key-" + i, "prop-value-" + i) : null)
+                .collect(Collectors.toList());
 
         final KafkaProducer<String, String> kafkaProducer = newKafkaProducer();
         final Producer<byte[]> pulsarProducer = newPulsarProducer(topic);
 
-        for (int i = 0; i < values.size() / 3; i++) {
-            if (i % 2 == 0) {
-                sendSingleMessages(kafkaProducer, topic, Collections.singletonList(values.get(i)));
+        boolean useOrderingKey = false;
+        for (int i = 0; i < numMessages; i++) {
+            final String key = keys.get(i);
+            final String value = values.get(i);
+            final Pair<String, String> property = properties.get(i);
+
+            // Kafka's produce context
+            final Iterable<Header> headers = (property == null)
+                    ? null
+                    : Collections.singletonList(new RecordHeader(
+                    property.getKey(), property.getValue().getBytes(StandardCharsets.UTF_8)));
+            final ProducerRecord<String, String> producerRecord = new ProducerRecord<>(topic, 0, key, value, headers);
+
+            // Pulsar's produce context
+            final TypedMessageBuilder<byte[]> messageBuilder = pulsarProducer.newMessage()
+                    .value(value.getBytes(StandardCharsets.UTF_8));
+            if (key != null) {
+                // verify both orderingKey and key
+                if (useOrderingKey) {
+                    messageBuilder.orderingKey(key.getBytes());
+                    messageBuilder.key("XXX"); // verify ordering key's priority is higher
+                } else {
+                    messageBuilder.key(key);
+                }
+                useOrderingKey = !useOrderingKey;
+            }
+            if (property != null) {
+                messageBuilder.property(property.getKey(), property.getValue());
+            }
+
+            if (i >= numMessages * 2 / 3) {
+                // send in batch by Pulsar producer
+                final CompletableFuture<MessageId> future = messageBuilder.sendAsync();
+                if (i == numMessages - 1) {
+                    future.get();
+                }
+            } else if (i >= numMessages / 3) {
+                // send in batch by Kafka producer
+                final Future<RecordMetadata> future = kafkaProducer.send(producerRecord);
+                if (i == numMessages * 2 / 3 - 1) {
+                    future.get();
+                }
             } else {
-                sendSingleMessages(pulsarProducer, Collections.singletonList(values.get(i)));
+                // send single messages
+                if (i % 2 == 0) {
+                    kafkaProducer.send(producerRecord).get();
+                } else {
+                    messageBuilder.send();
+                }
             }
         }
-        sendBatchedMessages(kafkaProducer, topic, values.subList(values.size() / 3, values.size() / 3 * 2));
-        sendBatchedMessages(pulsarProducer, values.subList(values.size() / 3 * 2, values.size()));
 
         pulsarProducer.close();
         kafkaProducer.close();
 
+        @Cleanup
         final KafkaConsumer<String, String> kafkaConsumer = newKafkaConsumer(topic);
         final List<String> receivedValues = receiveMessages(kafkaConsumer, values.size());
         assertEquals(receivedValues, values);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
@@ -165,18 +165,20 @@ public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
     @Test(timeOut = 20000)
     public void testMixedProduceKafkaConsume() throws Exception {
         final String topic = "test-mixed-produce-kafka-consume";
-        final List<String> values = IntStream.range(0, 50).mapToObj(i -> "msg-" + i).collect(Collectors.toList());
+        final List<String> values = IntStream.range(0, 60).mapToObj(i -> "msg-" + i).collect(Collectors.toList());
 
         final KafkaProducer<String, String> kafkaProducer = newKafkaProducer();
         final Producer<byte[]> pulsarProducer = newPulsarProducer(topic);
 
-        for (int i = 0; i < values.size(); i++) {
+        for (int i = 0; i < values.size() / 3; i++) {
             if (i % 2 == 0) {
                 sendSingleMessages(kafkaProducer, topic, Collections.singletonList(values.get(i)));
             } else {
                 sendSingleMessages(pulsarProducer, Collections.singletonList(values.get(i)));
             }
         }
+        sendBatchedMessages(kafkaProducer, topic, values.subList(values.size() / 3, values.size() / 3 * 2));
+        sendBatchedMessages(pulsarProducer, values.subList(values.size() / 3 * 2, values.size()));
 
         pulsarProducer.close();
         kafkaProducer.close();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
@@ -18,6 +18,7 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -30,6 +31,7 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.Producer;
 import org.testng.annotations.Test;
 
 /**
@@ -159,5 +161,23 @@ public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
         kafkaConsumeCommitMessage(kConsumer4, totalMsg, msgStrPrefix, topicPartitions);
         kafkaConsumeCommitMessage(kConsumer5, totalMsg, msgStrPrefix, topicPartitions);
 
+    }
+
+    @Test(timeOut = 20000)
+    public void testPulsarProduceKafkaConsume() throws Exception {
+        final String topic = "test-pulsar-produce-kafka-consume";
+
+        final List<String> values = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            values.add("msg-" + i);
+        }
+
+        final Producer<byte[]> pulsarProducer = newPulsarProducer(topic);
+        sendSingleMessages(pulsarProducer, values);
+        pulsarProducer.close();
+
+        final KafkaConsumer<String, String> kafkaConsumer = newKafkaConsumer(topic);
+        final List<String> receivedValues = receiveMessages(kafkaConsumer, values.size());
+        assertEquals(receivedValues, values);
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndTestBase.java
@@ -102,7 +102,12 @@ public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
     }
 
     protected Producer<byte[]> newPulsarProducer(final String topic) throws PulsarClientException {
-        return pulsarClient.newProducer().topic(topic).create();
+        return newPulsarProducer(topic, true);
+    }
+
+    protected Producer<byte[]> newPulsarProducer(final String topic,
+                                                 final boolean enableBatching) throws PulsarClientException {
+        return pulsarClient.newProducer().topic(topic).enableBatching(enableBatching).create();
     }
 
     protected Consumer<byte[]> newPulsarConsumer(final String topic) throws PulsarClientException {


### PR DESCRIPTION
### Motivation

There's a limit when `entryFormat=kafka` is configured that Kafka client can only interact with Kafka client but not Pulsar client. This PR intends to support Kafka consumer interacts with Kafka producer.

BTW, to support Kafka producer interacts with Kafka consumer, we need a feature from Pulsar's side.

### Modifications

Add a method `decodePulsarEntryToKafkaRecords` to convert Pulsar's metadata and payload to Kafka's `MemoryRecords`. Since it's basically migrated from the current `PulsarEntryFormatter`'s implementation, both `KafkaEntryFormatter` and `PulsarEntryFormatter` will reuse this method.

In `KafkaEntryFormatter#decode`, for each entry, first parse the `entry.format` property that is set in `KafkaEntryFormatter#encode`, if it's not `kafka`, treat it as a message of Pulsar format and use `decodePulsarEntryToKafkaRecords` to decode it.

In addition, this PR also fixes some bugs of the original Pulsar format decode implementation:
1. Use `isPartitionKeyB64Encoded()` instead of `hasPartitionKeyB64Encoded()` to check if the key is Base64 encoded. Because currently Pulsar always set this field false so that `hasPartitionKeyB64Encoded()` returns true but the key is not Base64 encoded.
2. Don't return the `ByteBuffer` passed to `MemoryRecordsBuilder`'s constructor as the returned value. Because if `MemoryRecordsBuilder`'s internal `ByteBuffer` doesn't have enough space to contain more bytes, it will increased until the max bytes limit, then the outer `ByteBuffer` won't be the actual `ByteBuffer`. This bug was not exposed yet just because the initial buffer size is 1MB, which is great enough usually.

Finally, this PR adds two tests to verify it. One is to verify Pulsar producer and Kafka consumer for messages with or without keys or headers. The other is to verify mixed (Pulsar & Kafka) producers and Kafka consumer for messages with keys and headers.