### PR TITLE
Allow setting listener name for topic lookup and optimize the lookup

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,6 +7,7 @@
 | kafkaListeners           | Comma-separated list of URIs that we will listen on and the listener names.<br>e.g. PLAINTEXT://localhost:9092,SSL://localhost:9093.<br>If the hostname is not set, the default interface is used. |
 | listeners                | Deprecated. `kafkaListeners` is used.                   |
 | kafkaAdvertisedListeners | Listeners published to the ZooKeeper for clients to use.<br>The format is the same as `kafkaListeners`. |
+| kafkaListenerName        | Specify the internal listener name for the broker.<br>The listener name must be contained in the advertisedListeners.<br>This config is used as the listener name in topic lookup. |
 
 > **NOTE**
 > 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -545,9 +545,10 @@ public class KafkaProtocolHandler implements ProtocolHandler {
             return getFailedAddressFuture(new IllegalStateException("NamespaceService is not available"));
         }
 
+        final PulsarClientImpl pulsarClient = getPulsarClientImpl(pulsarService);
         final LookupOptions options = LookupOptions.builder()
                 .authoritative(false)
-                .advertisedListenerName(null)
+                .advertisedListenerName(pulsarClient.getConfiguration().getListenerName())
                 .loadTopicsInBundle(true)
                 .build();
         final CompletableFuture<InetSocketAddress> future =
@@ -564,7 +565,7 @@ public class KafkaProtocolHandler implements ProtocolHandler {
             final LookupResult lookupResult = optLookupResult.get();
             if (lookupResult.isRedirect()) {
                 // Kafka client can't process redirect field, so here we fallback to PulsarClient's topic lookup
-                return getPulsarClientImpl(pulsarService).getLookup().getBroker(topicName).thenApply(Pair::getLeft);
+                return pulsarClient.getLookup().getBroker(topicName).thenApply(Pair::getLeft);
             } else {
                 return getAddressFutureFromBrokerUrl(lookupResult.getLookupData().getBrokerUrl());
             }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -102,6 +102,8 @@ public class KafkaProtocolHandler implements ProtocolHandler {
         final NamespaceName kafkaMetaNs;
         final NamespaceName kafkaTopicNs;
         final GroupCoordinator groupCoordinator;
+        final LookupClient lookupClient;
+
         public OffsetAndTopicListener(BrokerService service,
                                    KafkaServiceConfiguration kafkaConfig,
                                    GroupCoordinator groupCoordinator) {
@@ -111,6 +113,7 @@ public class KafkaProtocolHandler implements ProtocolHandler {
             this.groupCoordinator = groupCoordinator;
             this.kafkaTopicNs = NamespaceName
                     .get(kafkaConfig.getKafkaTenant(), kafkaConfig.getKafkaNamespace());
+            this.lookupClient = KafkaProtocolHandler.getLookupClient(service.pulsar());
         }
 
         @Override
@@ -138,8 +141,7 @@ public class KafkaProtocolHandler implements ProtocolHandler {
                             KopBrokerLookupManager.removeTopicManagerCache(name.toString());
                             // update lookup cache when onload
                             final CompletableFuture<InetSocketAddress> retFuture =
-                                    KafkaProtocolHandler.getLookupClient(service.pulsar())
-                                            .getBrokerAddress(TopicName.get(topic));
+                                    lookupClient.getBrokerAddress(TopicName.get(topic));
                             KafkaTopicManager.LOOKUP_CACHE.put(topic, retFuture);
                             KopBrokerLookupManager.updateTopicManagerCache(topic, retFuture);
                         }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -103,6 +103,7 @@ public class KafkaProtocolHandler implements ProtocolHandler {
         final NamespaceName kafkaTopicNs;
         final GroupCoordinator groupCoordinator;
         final LookupClient lookupClient;
+        final String brokerUrl;
 
         public OffsetAndTopicListener(BrokerService service,
                                    KafkaServiceConfiguration kafkaConfig,
@@ -114,10 +115,14 @@ public class KafkaProtocolHandler implements ProtocolHandler {
             this.kafkaTopicNs = NamespaceName
                     .get(kafkaConfig.getKafkaTenant(), kafkaConfig.getKafkaNamespace());
             this.lookupClient = KafkaProtocolHandler.getLookupClient(service.pulsar());
+            this.brokerUrl = service.pulsar().getBrokerServiceUrl();
         }
 
         @Override
         public void onLoad(NamespaceBundle bundle) {
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] onLoad bundle: {}", brokerUrl, bundle);
+            }
             // 1. get new partitions owned by this pulsar service.
             // 2. load partitions by GroupCoordinator.handleGroupImmigration.
             service.pulsar().getNamespaceService().getOwnedTopicListForNamespaceBundle(bundle)
@@ -155,6 +160,9 @@ public class KafkaProtocolHandler implements ProtocolHandler {
 
         @Override
         public void unLoad(NamespaceBundle bundle) {
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] unLoad bundle: {}", brokerUrl, bundle);
+            }
             // 1. get partitions owned by this pulsar service.
             // 2. remove partitions by groupCoordinator.handleGroupEmigration.
             service.pulsar().getNamespaceService().getOwnedTopicListForNamespaceBundle(bundle)

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -34,8 +34,6 @@ import io.streamnative.pulsar.handlers.kop.utils.MetadataUtils;
 import io.streamnative.pulsar.handlers.kop.utils.ZooKeeperUtils;
 import io.streamnative.pulsar.handlers.kop.utils.timer.SystemTimer;
 import java.net.InetSocketAddress;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -470,23 +468,6 @@ public class KafkaProtocolHandler implements ProtocolHandler {
         } else {
             log.info("Current broker: {} does not own any of the txn log topic partitions", currentBroker);
         }
-    }
-
-    private static CompletableFuture<InetSocketAddress> getFailedAddressFuture(final Throwable throwable) {
-        final CompletableFuture<InetSocketAddress> future = new CompletableFuture<>();
-        future.completeExceptionally(throwable);
-        return future;
-    }
-
-    private static CompletableFuture<InetSocketAddress> getAddressFutureFromBrokerUrl(final String brokerUrl) {
-        final CompletableFuture<InetSocketAddress> future = new CompletableFuture<>();
-        try {
-            final URI uri = new URI(brokerUrl);
-            future.complete(InetSocketAddress.createUnresolved(uri.getHost(), uri.getPort()));
-        } catch (URISyntaxException e) {
-            future.completeExceptionally(e);
-        }
-        return future;
     }
 
     public static @NonNull LookupClient getLookupClient(final PulsarService pulsarService) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -102,7 +102,6 @@ public class KafkaProtocolHandler implements ProtocolHandler {
         final NamespaceName kafkaMetaNs;
         final NamespaceName kafkaTopicNs;
         final GroupCoordinator groupCoordinator;
-        final LookupClient lookupClient;
         final String brokerUrl;
 
         public OffsetAndTopicListener(BrokerService service,
@@ -114,7 +113,6 @@ public class KafkaProtocolHandler implements ProtocolHandler {
             this.groupCoordinator = groupCoordinator;
             this.kafkaTopicNs = NamespaceName
                     .get(kafkaConfig.getKafkaTenant(), kafkaConfig.getKafkaNamespace());
-            this.lookupClient = KafkaProtocolHandler.getLookupClient(service.pulsar());
             this.brokerUrl = service.pulsar().getBrokerServiceUrl();
         }
 
@@ -144,11 +142,6 @@ public class KafkaProtocolHandler implements ProtocolHandler {
                             }
                             KafkaTopicManager.removeTopicManagerCache(name.toString());
                             KopBrokerLookupManager.removeTopicManagerCache(name.toString());
-                            // update lookup cache when onload
-                            final CompletableFuture<InetSocketAddress> retFuture =
-                                    lookupClient.getBrokerAddress(TopicName.get(topic));
-                            KafkaTopicManager.LOOKUP_CACHE.put(topic, retFuture);
-                            KopBrokerLookupManager.updateTopicManagerCache(topic, retFuture);
                         }
                     } else {
                         log.error("Failed to get owned topic list for "

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -1940,8 +1940,9 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         }
 
         // get kop address from cache to prevent query zk each time.
-        if (topicManager.KOP_ADDRESS_CACHE.containsKey(topic.toString())) {
-            return topicManager.KOP_ADDRESS_CACHE.get(topic.toString());
+        final CompletableFuture<Optional<String>> future = KafkaTopicManager.KOP_ADDRESS_CACHE.get(topic.toString());
+        if (future != null) {
+            return future;
         }
         // advertised data is write in  /loadbalance/brokers/advertisedAddress:webServicePort
         // here we get the broker url, need to find related webServiceUrl.
@@ -2049,6 +2050,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 if (!stringOptional.isPresent() || throwable != null) {
                     log.error("Not get advertise data for Kafka topic:{}. throwable",
                         topic, throwable);
+                    KafkaTopicManager.removeTopicManagerCache(topic.toString());
                     returnFuture.complete(null);
                     return;
                 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -2044,7 +2044,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         CompletableFuture<PartitionMetadata> returnFuture = new CompletableFuture<>();
 
         topicManager.getTopicBroker(topic.toString())
-            .thenCompose(pair -> getProtocolDataToAdvertise(pair, topic))
+            .thenCompose(address -> getProtocolDataToAdvertise(address, topic))
             .whenComplete((stringOptional, throwable) -> {
                 if (!stringOptional.isPresent() || throwable != null) {
                     log.error("Not get advertise data for Kafka topic:{}. throwable",

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -190,6 +190,14 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
 
     @FieldContext(
             category = CATEGORY_KOP,
+            doc = "Specify the internal listener name for the broker.\n"
+                    + "The listener name must be contained in the advertisedListeners.\n"
+                    + "This config is used as the listener name in topic lookup."
+    )
+    private String kafkaListenerName;
+
+    @FieldContext(
+            category = CATEGORY_KOP,
             doc = "limit the queue size for request, \n"
                 + "like queued.max.requests in kafka.\n"
     )

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
@@ -155,7 +155,7 @@ public class KafkaTopicManager {
 
     private Producer registerInPersistentTopic(PersistentTopic persistentTopic) {
         Producer producer = new InternalProducer(persistentTopic, internalServerCnx,
-            KafkaProtocolHandler.getPulsarClientImpl(pulsarService).newRequestId(),
+            KafkaProtocolHandler.getLookupClient(pulsarService).getPulsarClient().newRequestId(),
             brokerService.generateUniqueProducerName());
 
         if (log.isDebugEnabled()) {
@@ -183,7 +183,7 @@ public class KafkaTopicManager {
                 log.debug("[{}] topic {} not in Lookup_cache, call lookupBroker",
                     requestHandler.ctx.channel(), topicName);
             }
-            return KafkaProtocolHandler.getBroker(pulsarService, TopicName.get(topicName));
+            return KafkaProtocolHandler.getLookupClient(pulsarService).getBrokerAddress(TopicName.get(topicName));
         });
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
@@ -97,7 +97,8 @@ public class KopBrokerLookupManager {
     // retFuture will be completed with null when meet error.
     private CompletableFuture<InetSocketAddress> getTopicBroker(String topicPartition) {
         return LOOKUP_CACHE.computeIfAbsent(topicPartition,
-                ignored -> KafkaProtocolHandler.getBroker(pulsarService, TopicName.get(topicPartition)));
+                ignored -> KafkaProtocolHandler.getLookupClient(pulsarService)
+                        .getBrokerAddress(TopicName.get(topicPartition)));
     }
 
     private void checkTopicOwner(CompletableFuture<InetSocketAddress> future, String topic, EndPoint endPoint) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
@@ -43,6 +43,7 @@ public class KopBrokerLookupManager {
     private final PulsarService pulsarService;
     private final Boolean tlsEnabled;
     private final String advertisedListeners;
+    private final LookupClient lookupClient;
 
     public static final ConcurrentHashMap<String, CompletableFuture<InetSocketAddress>>
             LOOKUP_CACHE = new ConcurrentHashMap<>();
@@ -53,6 +54,7 @@ public class KopBrokerLookupManager {
         this.pulsarService = pulsarService;
         this.tlsEnabled = tlsEnabled;
         this.advertisedListeners = advertisedListeners;
+        this.lookupClient = KafkaProtocolHandler.getLookupClient(pulsarService);
     }
 
     public CompletableFuture<InetSocketAddress> findBroker(String topic) {
@@ -97,8 +99,7 @@ public class KopBrokerLookupManager {
     // retFuture will be completed with null when meet error.
     private CompletableFuture<InetSocketAddress> getTopicBroker(String topicPartition) {
         return LOOKUP_CACHE.computeIfAbsent(topicPartition,
-                ignored -> KafkaProtocolHandler.getLookupClient(pulsarService)
-                        .getBrokerAddress(TopicName.get(topicPartition)));
+                ignored -> lookupClient.getBrokerAddress(TopicName.get(topicPartition)));
     }
 
     private void checkTopicOwner(CompletableFuture<InetSocketAddress> future, String topic, EndPoint endPoint) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
@@ -254,10 +254,6 @@ public class KopBrokerLookupManager {
         KOP_ADDRESS_CACHE.remove(topicName);
     }
 
-    public static void updateTopicManagerCache(String topicName, CompletableFuture<InetSocketAddress> addressFuture) {
-        LOOKUP_CACHE.put(topicName, addressFuture);
-    }
-
     public static void clear() {
         LOOKUP_CACHE.clear();
         KOP_ADDRESS_CACHE.clear();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/LookupClient.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/LookupClient.java
@@ -1,0 +1,160 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import java.io.Closeable;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.concurrent.CompletableFuture;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pulsar.broker.PulsarServerException;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.lookup.LookupResult;
+import org.apache.pulsar.broker.namespace.LookupOptions;
+import org.apache.pulsar.broker.namespace.NamespaceService;
+import org.apache.pulsar.client.api.AuthenticationFactory;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.impl.ClientCnx;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.apache.pulsar.common.api.proto.ServerError;
+import org.apache.pulsar.common.naming.TopicName;
+
+/**
+ * The client that is responsible for topic lookup.
+ */
+@Slf4j
+public class LookupClient implements Closeable {
+
+    private final NamespaceService namespaceService;
+    @Getter
+    private final PulsarClientImpl pulsarClient;
+
+    public LookupClient(final PulsarService pulsarService, final KafkaServiceConfiguration kafkaConfig) {
+        namespaceService = pulsarService.getNamespaceService();
+        try {
+            pulsarClient = createPulsarClient(pulsarService, kafkaConfig);
+        } catch (PulsarClientException e) {
+            log.error("Failed to create PulsarClient", e);
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public LookupClient(final PulsarService pulsarService) {
+        log.warn("This constructor should not be called, it's only called "
+                + "when the PulsarService doesn't exist in KafkaProtocolHandlers.LOOKUP_CLIENT_UP");
+        namespaceService = pulsarService.getNamespaceService();
+        try {
+            pulsarClient = (PulsarClientImpl) pulsarService.getClient();
+        } catch (PulsarServerException e) {
+            log.error("Failed to create PulsarClient", e);
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public CompletableFuture<InetSocketAddress> getBrokerAddress(final TopicName topicName) {
+        // First try to use NamespaceService to find the broker directly.
+        final LookupOptions options = LookupOptions.builder()
+                .authoritative(false)
+                .advertisedListenerName(pulsarClient.getConfiguration().getListenerName())
+                .loadTopicsInBundle(true)
+                .build();
+        return namespaceService.getBrokerServiceUrlAsync(topicName, options).thenCompose(optLookupResult -> {
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] Lookup result {}", topicName.toString(), optLookupResult);
+            }
+            if (!optLookupResult.isPresent()) {
+                return getFailedAddressFuture(ClientCnx.getPulsarClientException(
+                        ServerError.ServiceNotReady,
+                        "No broker was available to own " + topicName));
+            }
+            final LookupResult lookupResult = optLookupResult.get();
+            if (lookupResult.isRedirect()) {
+                // Kafka client can't process redirect field, so here we fallback to PulsarClient
+                return pulsarClient.getLookup().getBroker(topicName).thenApply(Pair::getLeft);
+            } else {
+                return getAddressFutureFromBrokerUrl(lookupResult.getLookupData().getBrokerUrl());
+            }
+        });
+    }
+
+    @Override
+    public void close() {
+        try {
+            pulsarClient.close();
+        } catch (PulsarClientException e) {
+            log.warn("Failed to close PulsarClient of LookupClient", e);
+        }
+    }
+
+    private static PulsarClientImpl createPulsarClient(final PulsarService pulsarService,
+                                                       final KafkaServiceConfiguration kafkaConfig)
+            throws PulsarClientException {
+        // It's migrated from PulsarService#getClient() but it can configure listener name
+        final ClientConfigurationData conf = new ClientConfigurationData();
+        conf.setServiceUrl(kafkaConfig.isTlsEnabled()
+                ? pulsarService.getBrokerServiceUrlTls()
+                : pulsarService.getBrokerServiceUrl());
+        conf.setTlsAllowInsecureConnection(kafkaConfig.isTlsAllowInsecureConnection());
+        conf.setTlsTrustCertsFilePath(kafkaConfig.getTlsCertificateFilePath());
+
+        if (kafkaConfig.isBrokerClientTlsEnabled()) {
+            if (kafkaConfig.isBrokerClientTlsEnabledWithKeyStore()) {
+                conf.setUseKeyStoreTls(true);
+                conf.setTlsTrustStoreType(kafkaConfig.getBrokerClientTlsTrustStoreType());
+                conf.setTlsTrustStorePath(kafkaConfig.getBrokerClientTlsTrustStore());
+                conf.setTlsTrustStorePassword(kafkaConfig.getBrokerClientTlsTrustStorePassword());
+            } else {
+                conf.setTlsTrustCertsFilePath(
+                        isNotBlank(kafkaConfig.getBrokerClientTrustCertsFilePath())
+                                ? kafkaConfig.getBrokerClientTrustCertsFilePath()
+                                : kafkaConfig.getTlsCertificateFilePath());
+            }
+        }
+
+        if (isNotBlank(kafkaConfig.getBrokerClientAuthenticationPlugin())) {
+            conf.setAuthPluginClassName(kafkaConfig.getBrokerClientAuthenticationPlugin());
+            conf.setAuthParams(kafkaConfig.getBrokerClientAuthenticationParameters());
+            conf.setAuthParamMap(null);
+            conf.setAuthentication(AuthenticationFactory.create(
+                    kafkaConfig.getBrokerClientAuthenticationPlugin(),
+                    kafkaConfig.getBrokerClientAuthenticationParameters()));
+        }
+
+        conf.setListenerName(kafkaConfig.getKafkaListenerName());
+        return new PulsarClientImpl(conf, pulsarService.getIoEventLoopGroup());
+    }
+
+    private static CompletableFuture<InetSocketAddress> getFailedAddressFuture(final Throwable throwable) {
+        final CompletableFuture<InetSocketAddress> future = new CompletableFuture<>();
+        future.completeExceptionally(throwable);
+        return future;
+    }
+
+    private static CompletableFuture<InetSocketAddress> getAddressFutureFromBrokerUrl(final String brokerUrl) {
+        final CompletableFuture<InetSocketAddress> future = new CompletableFuture<>();
+        try {
+            final URI uri = new URI(brokerUrl);
+            future.complete(InetSocketAddress.createUnresolved(uri.getHost(), uri.getPort()));
+        } catch (URISyntaxException e) {
+            future.completeExceptionally(e);
+        }
+        return future;
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ConfigurationUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ConfigurationUtils.java
@@ -76,13 +76,11 @@ public final class ConfigurationUtils {
      * Creates PulsarConfiguration and loads it with populated attribute values from provided Properties object.
      *
      * @param properties The properties to populate the attributed from
-     * @throws IOException
-     * @throws IllegalArgumentException
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public static <T extends PulsarConfiguration> T create(
             Properties properties,
-            Class<? extends PulsarConfiguration> clazz) throws IOException, IllegalArgumentException {
+            Class<? extends PulsarConfiguration> clazz) {
         checkNotNull(properties);
         T configuration = null;
         try {

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
@@ -113,6 +113,7 @@ public class KafkaServiceConfigurationTest {
         printWriter.println("managedLedgerDefaultMarkDeleteRateLimit=5.0");
         printWriter.println("managedLedgerDigestType=CRC32C");
         printWriter.println("kopAllowedNamespaces=public/default,public/__kafka");
+        printWriter.println("kafkaListenerName=external");
 
         printWriter.close();
         testConfigFile.deleteOnExit();
@@ -134,6 +135,7 @@ public class KafkaServiceConfigurationTest {
         assertEquals(kafkaServiceConfig.getManagedLedgerDigestType(), DigestType.CRC32C);
         assertEquals(
                 kafkaServiceConfig.getKopAllowedNamespaces(), Sets.newHashSet("public/default", "public/__kafka"));
+        assertEquals(kafkaServiceConfig.getKafkaListenerName(), "external");
     }
 
     @Test

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaListenerNameTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaListenerNameTest.java
@@ -16,6 +16,7 @@ package io.streamnative.pulsar.handlers.kop;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.pulsar.broker.ServiceConfigurationUtils;
 import org.testng.annotations.Test;
 
 /**
@@ -42,8 +43,12 @@ public class KafkaListenerNameTest extends KopProtocolHandlerTestBase {
         // There's a limit that PulsarService doesn't use advertised listener's address as it's brokerServiceUrl's
         // address. So here the "external" listener's port should be the same with brokerPort and address should be
         // localhost.
-        conf.setAdvertisedListeners("internal:pulsar://192.168.0.2:6650,external:pulsar://localhost:" + brokerPort);
+        final String localAddress = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(null);
+        final String advertisedListeners =
+                "internal:pulsar://192.168.0.2:6650,external:pulsar://" + localAddress + ":" + brokerPort;
+        conf.setAdvertisedListeners(advertisedListeners);
         conf.setKafkaListenerName("external");
+        log.info("Set advertisedListeners to {}", advertisedListeners);
         super.internalSetup();
 
         final KafkaProducer<String, String> producer = new KafkaProducer<>(newKafkaProducerProperties());

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaListenerNameTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaListenerNameTest.java
@@ -26,10 +26,12 @@ public class KafkaListenerNameTest extends KopProtocolHandlerTestBase {
 
     @Override
     protected void setup() throws Exception {
+        // Set up in the test method
     }
 
     @Override
     protected void cleanup() throws Exception {
+        // Clean up in the test method
     }
 
     @Test(timeOut = 30000)

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaListenerNameTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaListenerNameTest.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.testng.annotations.Test;
+
+/**
+ * Test for kafkaListenerName config.
+ */
+@Slf4j
+public class KafkaListenerNameTest extends KopProtocolHandlerTestBase {
+
+    @Override
+    protected void setup() throws Exception {
+    }
+
+    @Override
+    protected void cleanup() throws Exception {
+    }
+
+    @Test(timeOut = 30000)
+    public void testListenerName() throws Exception {
+        super.resetConfig();
+        conf.setAdvertisedAddress(null);
+        conf.setInternalListenerName("external");
+        // There's a limit that PulsarService doesn't use advertised listener's address as it's brokerServiceUrl's
+        // address. So here the "external" listener's port should be the same with brokerPort and address should be
+        // localhost.
+        conf.setAdvertisedListeners("internal:pulsar://192.168.0.2:6650,external:pulsar://localhost:" + brokerPort);
+        conf.setKafkaListenerName("external");
+        super.internalSetup();
+
+        final KafkaProducer<String, String> producer = new KafkaProducer<>(newKafkaProducerProperties());
+        producer.send(new ProducerRecord<>("my-topic", "my-message"), (metadata, exception) -> {
+            if (exception == null) {
+                log.info("Send to {}", metadata);
+            } else {
+                log.error("Send failed: {}", exception.getMessage());
+            }
+        });
+        producer.close();
+
+        super.internalCleanup();
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -27,7 +27,6 @@ import io.streamnative.pulsar.handlers.kop.utils.MetadataUtils;
 import java.io.Closeable;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -39,7 +38,6 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import lombok.Getter;
@@ -69,7 +67,6 @@ import org.apache.pulsar.broker.auth.SameThreadOrderedSafeExecutor;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.PulsarClient;
-import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.apache.pulsar.zookeeper.ZooKeeperClientFactory;
@@ -91,7 +88,6 @@ public abstract class KopProtocolHandlerTestBase {
     protected PulsarAdmin admin;
     protected URL brokerUrl;
     protected URL brokerUrlTls;
-    protected URI lookupUrl;
     protected PulsarClient pulsarClient;
 
     protected int brokerWebservicePort = PortManager.nextFreePort();
@@ -107,7 +103,6 @@ public abstract class KopProtocolHandlerTestBase {
 
     protected MockZooKeeper mockZooKeeper;
     protected NonClosableMockBookKeeper mockBookKeeper;
-    protected boolean isTcpLookup = false;
     protected final String configClusterName = "test";
 
     protected final String tenant = "public";
@@ -202,15 +197,7 @@ public abstract class KopProtocolHandlerTestBase {
 
     protected final void internalSetup() throws Exception {
         init();
-        lookupUrl = new URI(brokerUrl.toString());
-        if (isTcpLookup) {
-            lookupUrl = new URI("broker://localhost:" + brokerPort);
-        }
-        pulsarClient = newPulsarClient(lookupUrl.toString(), 0);
-    }
-
-    protected PulsarClient newPulsarClient(String url, int intervalInSecs) throws PulsarClientException {
-        return PulsarClient.builder().serviceUrl(url).statsInterval(intervalInSecs, TimeUnit.SECONDS).build();
+        pulsarClient = KafkaProtocolHandler.getPulsarClientImpl(pulsar);
     }
 
     protected void createAdmin() throws Exception {


### PR DESCRIPTION
Fixes #644 

### Motivation

Using `PulsarClient` for topic lookup might encounter `TooManyRequestException` easily because all client connections share the same `PulsarClient` for topic lookup. It's also a waste of resource.

### Modifications

Add a common method `KafkaProtocolHandler#getTopic` for all places that need topic lookup in KoP. In this method, first use `NamespaceService.getBrokerServiceUrlAsync` to get broker's Internet address.

However, when the namespace bundle is not owned by any broker, which usually happens during a bundle unload, the `getBrokerServiceUrlAsync` might return a `LookupResult` instance whose `redirect` field is true. Pulsar client can handle this field and resend the lookup request to another broker, but Kafka client cannot do it. In this case, this PR use `PulsarClient` for topic lookup as a fallback.

In addition, this PR adds a `kafkaListenerName` config and `getPulsarClientImpl()` method to create a builtin `PulsarClient` with listener name configured.

Since the `DistributedClusterTest` might fail if its three tests were run in a whole, this PR removes the lookup logic in `OffsetAndTopicListener#onLoad`.