### PR TITLE
Fix KoP will cause Kafka Errors.REQUEST_TIMED_OUT when consume multi TopicPartition in one consumer request

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -177,10 +177,9 @@ public final class MessageFetchContext {
     }
 
     private void tryComplete() {
-        if (resultFuture != null && responseData.size() >= fetchRequest.fetchData().size()) {
-            if (hasComplete.compareAndSet(false, true)) {
-                complete();
-            }
+        if (resultFuture != null && responseData.size() >= fetchRequest.fetchData().size()
+                && hasComplete.compareAndSet(false, true)) {
+            complete();
         }
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -141,7 +141,7 @@ public final class MessageFetchContext {
         tryComplete();
     }
 
-    private void tryComplete() {
+    private synchronized void tryComplete() {
         if (responseData.size() >= fetchRequest.fetchData().size()) {
             complete();
         }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -177,7 +177,7 @@ public final class MessageFetchContext {
     }
 
     private void tryComplete() {
-        if (responseData != null && responseData.size() >= fetchRequest.fetchData().size()) {
+        if (resultFuture != null && responseData.size() >= fetchRequest.fetchData().size()) {
             if (hasComplete.compareAndSet(false, true)) {
                 complete();
             }

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/MessageFetchContextTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/MessageFetchContextTest.java
@@ -2,9 +2,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/MessageFetchContextTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/MessageFetchContextTest.java
@@ -13,36 +13,24 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
-import static org.apache.kafka.common.protocol.CommonFields.THROTTLE_TIME_MS;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
 
-import io.streamnative.pulsar.handlers.kop.format.DecodeResult;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.requests.AbstractResponse;
 import org.apache.kafka.common.requests.FetchRequest;
-import org.apache.kafka.common.requests.FetchResponse;
 import org.apache.kafka.common.requests.ResponseCallbackWrapper;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.testng.collections.Maps;
 
 public class MessageFetchContextTest {
-
-    private static final Map<TopicPartition, FetchResponse.PartitionData<MemoryRecords>>
-            responseData = new ConcurrentHashMap();
 
     private static final Map<TopicPartition, FetchRequest.PartitionData> fetchData = Maps.newHashMap();
 
@@ -51,17 +39,9 @@ public class MessageFetchContextTest {
     FetchRequest fetchRequest = FetchRequest.Builder
             .forConsumer(0, 0, fetchData).build();
 
-    private static final ConcurrentLinkedQueue<DecodeResult> decodeResults = new ConcurrentLinkedQueue<>();
-
     private static final String topicName = "test-fetch";
     private static final TopicPartition tp1 = new TopicPartition(topicName, 1);
     private static final TopicPartition tp2 = new TopicPartition(topicName, 2);
-
-    // Competitive problems need a certain chance to appear.
-    // Try a few more times to have a higher chance of reproducing the problem.
-    private static final int totalAttempts = 200;
-
-    private static final AtomicInteger currentAttempts = new AtomicInteger(0);
 
     private static volatile MessageFetchContext messageFetchContext = null;
 
@@ -73,29 +53,17 @@ public class MessageFetchContextTest {
         messageFetchContext = MessageFetchContext.getForTest(fetchRequest, resultFuture);
     }
 
-    private void startThreads(Boolean isSafe) throws Exception {
+    private void startThreads() throws Exception {
         Thread run1 = new Thread(() -> {
-            if (isSafe) {
-                // For the synchronous method, we can check it only once,
-                // because if there is still has problem, it will eventually become a flaky test,
-                // If it does not become a flaky test, then we can keep this
-                messageFetchContext.addErrorPartitionResponseForTest(tp1, Errors.NONE);
-            } else {
-                for (int i = 0; i < 100; i++) {
-                    addErrorPartitionResponse(tp1, Errors.NONE);
-                }
-            }
+            // For the synchronous method, we can check it only once,
+            // because if there is still has problem, it will eventually become a flaky test,
+            // If it does not become a flaky test, then we can keep this
+            messageFetchContext.addErrorPartitionResponseForTest(tp1, Errors.NONE);
         });
 
         Thread run2 = new Thread(() -> {
-            if (isSafe) {
-                // As comment described in run1, we can check it only once.
-                messageFetchContext.addErrorPartitionResponseForTest(tp2, Errors.NONE);
-            } else {
-                for (int i = 0; i < 100; i++) {
-                    addErrorPartitionResponse(tp2, Errors.NONE);
-                }
-            }
+            // As comment described in run1, we can check it only once.
+            messageFetchContext.addErrorPartitionResponseForTest(tp2, Errors.NONE);
         });
 
         run1.start();
@@ -104,7 +72,7 @@ public class MessageFetchContextTest {
         run2.join();
     }
 
-    private void startAndGetResult(Boolean isSafe, AtomicReference<Set<Errors>> errorsSet, Boolean isBlock)
+    private void startAndGetResult(AtomicReference<Set<Errors>> errorsSet)
             throws Exception {
 
         BiConsumer<AbstractResponse, Throwable> action = (response, exception) -> {
@@ -114,24 +82,8 @@ public class MessageFetchContextTest {
             errorsSet.set(currentErrors);
         };
 
-        while (currentAttempts.getAndIncrement() <= totalAttempts || isBlock) {
-            startThreads(isSafe);
-            resultFuture.whenComplete(action);
-            resultFuture = new CompletableFuture<>();
-            responseData.clear();
-            if ((isBlock && errorsSet.get().contains(Errors.REQUEST_TIMED_OUT)) || isSafe) {
-                break;
-            }
-        }
-    }
-
-    // Since the code has been changed to a synchronized state,
-    // competitive problem is reproduced by simulating the code before the modification
-    @Test
-    public void testHandleFetchUnSafe() throws Exception {
-        AtomicReference<Set<Errors>> errorsSet = new AtomicReference<>(new HashSet<>());
-        startAndGetResult(false, errorsSet, true);
-        assertTrue(errorsSet.get().contains(Errors.REQUEST_TIMED_OUT));
+        startThreads();
+        resultFuture.whenComplete(action);
     }
 
     // Run the actually modified code logic in MessageFetchContext
@@ -141,76 +93,8 @@ public class MessageFetchContextTest {
     @Test
     public void testHandleFetchSafe() throws Exception {
         AtomicReference<Set<Errors>> errorsSet = new AtomicReference<>(new HashSet<>());
-        startAndGetResult(true, errorsSet, false);
+        startAndGetResult(errorsSet);
         assertFalse(errorsSet.get().contains(Errors.REQUEST_TIMED_OUT));
     }
 
-    private void addErrorPartitionResponse(TopicPartition topicPartition, Errors errors) {
-        responseData.put(topicPartition, new FetchResponse.PartitionData<>(
-                errors,
-                FetchResponse.INVALID_HIGHWATERMARK,
-                FetchResponse.INVALID_LAST_STABLE_OFFSET,
-                FetchResponse.INVALID_LOG_START_OFFSET,
-                null,
-                MemoryRecords.EMPTY));
-
-        tryComplete();
-    }
-
-    private void tryComplete() {
-        if (responseData.size() >= fetchRequest.fetchData().size()) {
-            complete();
-        }
-    }
-
-    private void complete() {
-        if (resultFuture == null) {
-            // the context has been recycled
-            return;
-        }
-        if (resultFuture.isCancelled()) {
-            // The request was cancelled by KafkaCommandDecoder when channel is closed or this request is expired,
-            // so the Netty buffers should be released.
-            decodeResults.forEach(DecodeResult::release);
-            return;
-        }
-        if (resultFuture.isDone()) {
-            // It may be triggered again in DelayedProduceAndFetch
-            return;
-        }
-
-        // Keep the order of TopicPartition
-        final LinkedHashMap<TopicPartition, FetchResponse.PartitionData<MemoryRecords>>
-                orderedResponseData = new LinkedHashMap<>();
-        // add the topicPartition with timeout error if it's not existed in responseData
-        fetchRequest.fetchData().keySet().forEach(topicPartition -> {
-            final FetchResponse.PartitionData<MemoryRecords> partitionData = responseData.remove(topicPartition);
-            if (partitionData != null) {
-                orderedResponseData.put(topicPartition, partitionData);
-            } else {
-                orderedResponseData.put(topicPartition, new FetchResponse.PartitionData<>(
-                        Errors.REQUEST_TIMED_OUT,
-                        FetchResponse.INVALID_HIGHWATERMARK,
-                        FetchResponse.INVALID_LAST_STABLE_OFFSET,
-                        FetchResponse.INVALID_LOG_START_OFFSET,
-                        null,
-                        MemoryRecords.EMPTY));
-            }
-        });
-
-        // Create another reference to this.decodeResults so the lambda expression will capture this local reference
-        // because this.decodeResults will be reset to null after resultFuture is completed.
-        final ConcurrentLinkedQueue<DecodeResult> decodeResults = MessageFetchContextTest.decodeResults;
-        resultFuture.complete(
-                new ResponseCallbackWrapper(
-                        new FetchResponse<>(
-                                Errors.NONE,
-                                orderedResponseData,
-                                ((Integer) THROTTLE_TIME_MS.defaultValue),
-                                fetchRequest.metadata().sessionId()),
-                        () -> {
-                            // release the batched ByteBuf if necessary
-                            decodeResults.forEach(DecodeResult::release);
-                        }));
-    }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MessageFetchContextTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MessageFetchContextTest.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.streamnative.pulsar.handlers.kop;
 
 import static org.apache.kafka.common.protocol.CommonFields.THROTTLE_TIME_MS;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MessageFetchContextTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MessageFetchContextTest.java
@@ -1,0 +1,198 @@
+package io.streamnative.pulsar.handlers.kop;
+
+import static org.apache.kafka.common.protocol.CommonFields.THROTTLE_TIME_MS;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import io.streamnative.pulsar.handlers.kop.format.DecodeResult;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.requests.FetchRequest;
+import org.apache.kafka.common.requests.FetchResponse;
+import org.apache.kafka.common.requests.ResponseCallbackWrapper;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.testng.collections.Maps;
+
+public class MessageFetchContextTest {
+
+    private static final Map<TopicPartition, FetchResponse.PartitionData<MemoryRecords>>
+            responseData = new ConcurrentHashMap();
+
+    private static final Map<TopicPartition, FetchRequest.PartitionData> fetchData = Maps.newHashMap();
+
+    private static CompletableFuture<AbstractResponse> resultFuture = null;
+
+    FetchRequest fetchRequest = FetchRequest.Builder
+            .forConsumer(0, 0, fetchData).build();
+
+    private static final ConcurrentLinkedQueue<DecodeResult> decodeResults = new ConcurrentLinkedQueue<>();
+
+    private static final TopicPartition tp1 = new TopicPartition("test-fetch", 1);
+    private static final TopicPartition tp2 = new TopicPartition("test-fetch", 2);
+
+    private static final ExecutorService threadPool = Executors.newFixedThreadPool(2);
+
+    // Competitive problems need a certain chance to appear.
+    // Try a few more times to have a higher chance of reproducing the problem.
+    private static final int totalAttempts = 200;
+
+    private static final AtomicInteger currentAttempts = new AtomicInteger(0);
+
+    @Before
+    public void init() {
+        fetchData.put(tp1, null);
+        fetchData.put(tp2, null);
+        resultFuture = new CompletableFuture<>();
+    }
+
+    private void startThreads(Boolean isSafe) throws ExecutionException, InterruptedException {
+        Runnable run1 = () -> {
+            for (int i = 0; i < 100; i++) {
+                addErrorPartitionResponse(tp1, Errors.NONE, isSafe);
+            }
+        };
+
+        Runnable run2 = () -> {
+            for (int i = 0; i < 100; i++) {
+                addErrorPartitionResponse(tp2, Errors.NONE, isSafe);
+            }
+        };
+        Future<?> future1 = threadPool.submit(run1);
+        Future<?> future2 = threadPool.submit(run2);
+        future1.get();
+        future2.get();
+    }
+
+    private void startAndGetResult(Boolean isSafe, AtomicReference<Set<Errors>> errorsSet)
+            throws ExecutionException, InterruptedException {
+
+        BiConsumer<AbstractResponse, Throwable> action = (response, exception) -> {
+            ResponseCallbackWrapper responseCallbackWrapper = (ResponseCallbackWrapper) response;
+            Set<Errors> currentErrors = errorsSet.get();
+            currentErrors.addAll(responseCallbackWrapper.errorCounts().keySet());
+            errorsSet.set(currentErrors);
+        };
+
+        while (currentAttempts.getAndIncrement() <= totalAttempts) {
+            startThreads(isSafe);
+            resultFuture.whenComplete(action);
+            resultFuture = new CompletableFuture<>();
+            responseData.clear();
+        }
+    }
+
+    @Test
+    public void testHandleFetchUnSafe() throws ExecutionException, InterruptedException {
+        AtomicReference<Set<Errors>> errorsSet = new AtomicReference<>(new HashSet<>());
+        startAndGetResult(false, errorsSet);
+        assertTrue(errorsSet.get().contains(Errors.REQUEST_TIMED_OUT));
+    }
+
+    @Test
+    public void testHandleFetchSafe() throws ExecutionException, InterruptedException {
+        AtomicReference<Set<Errors>> errorsSet = new AtomicReference<>(new HashSet<>());
+        startAndGetResult(true, errorsSet);
+        assertFalse(errorsSet.get().contains(Errors.REQUEST_TIMED_OUT));
+    }
+
+    private void addErrorPartitionResponse(TopicPartition topicPartition, Errors errors, Boolean isSafe) {
+        responseData.put(topicPartition, new FetchResponse.PartitionData<>(
+                errors,
+                FetchResponse.INVALID_HIGHWATERMARK,
+                FetchResponse.INVALID_LAST_STABLE_OFFSET,
+                FetchResponse.INVALID_LOG_START_OFFSET,
+                null,
+                MemoryRecords.EMPTY));
+        if (isSafe) {
+            tryCompleteThreadSafe();
+        } else {
+            tryComplete();
+        }
+    }
+
+    private void tryComplete() {
+        if (responseData.size() >= fetchRequest.fetchData().size()) {
+            complete();
+        }
+    }
+
+    private synchronized void tryCompleteThreadSafe() {
+        if (responseData.size() >= fetchRequest.fetchData().size()) {
+            complete();
+        }
+    }
+
+    private void complete() {
+        if (resultFuture == null) {
+            // the context has been recycled
+            return;
+        }
+        if (resultFuture.isCancelled()) {
+            // The request was cancelled by KafkaCommandDecoder when channel is closed or this request is expired,
+            // so the Netty buffers should be released.
+            decodeResults.forEach(DecodeResult::release);
+            return;
+        }
+        if (resultFuture.isDone()) {
+            // It may be triggered again in DelayedProduceAndFetch
+            return;
+        }
+
+        // Keep the order of TopicPartition
+        final LinkedHashMap<TopicPartition, FetchResponse.PartitionData<MemoryRecords>>
+                orderedResponseData = new LinkedHashMap<>();
+        // add the topicPartition with timeout error if it's not existed in responseData
+        fetchRequest.fetchData().keySet().forEach(topicPartition -> {
+            final FetchResponse.PartitionData<MemoryRecords> partitionData = responseData.remove(topicPartition);
+            if (partitionData != null) {
+                orderedResponseData.put(topicPartition, partitionData);
+            } else {
+                orderedResponseData.put(topicPartition, new FetchResponse.PartitionData<>(
+                        Errors.REQUEST_TIMED_OUT,
+                        FetchResponse.INVALID_HIGHWATERMARK,
+                        FetchResponse.INVALID_LAST_STABLE_OFFSET,
+                        FetchResponse.INVALID_LOG_START_OFFSET,
+                        null,
+                        MemoryRecords.EMPTY));
+            }
+        });
+
+        // Create another reference to this.decodeResults so the lambda expression will capture this local reference
+        // because this.decodeResults will be reset to null after resultFuture is completed.
+        final ConcurrentLinkedQueue<DecodeResult> decodeResults = MessageFetchContextTest.decodeResults;
+        resultFuture.complete(
+                new ResponseCallbackWrapper(
+                        new FetchResponse<>(
+                                Errors.NONE,
+                                orderedResponseData,
+                                ((Integer) THROTTLE_TIME_MS.defaultValue),
+                                fetchRequest.metadata().sessionId()),
+                        () -> {
+                            // release the batched ByteBuf if necessary
+                            decodeResults.forEach(DecodeResult::release);
+                        }));
+    }
+
+    @After
+    public void close() {
+        threadPool.shutdown();
+    }
+}


### PR DESCRIPTION
Fixes #604 

### Motivation
When consume multi TopicPartition in one request, in MessageFetchContext.handleFetch(), tryComplete() may enter race condition
When one topicPartition removed from responseData, maybe removed again, which will cause Errors.REQUEST_TIMED_OUT

ReadEntries and CompletableFuture.complete operations for each partition are all performed by BookKeeperClientWorker- Different threads in the OrderedExecutor thread pool are executed. When the partition can read data, because the read data and decode operations will take uncertain time, the competition in this case is relatively weak; and when the partition has no data to write, and the consumer After all the data has been consumed, I have been making empty fetch requests, which can be reproduced stably at this time.
Stable steps to reproduce:

A single broker has two partition leaders for one topic;
The topic is not writing data, and consumers have consumed the old data;
At this time, the consumer client continues to send Fetch requests to broker;
Basically, you will soon see that the server returns error_code=7, and the client will down。
1、One fetch request, two partitions, and two threads. The data obtained is an empty set without any protocol conversion operation.
2、When the BookKeeperClientWorker-OrderedExecutor-25-0 thread adds test_kop_222-1 to the responseData, BookKeeperClientWorker-OrderedExecutor-23- 0 thread adds test_kop_222-3 to responseData,
3、at this time responseData.size() >= fetchRequest.fetchData().size(), because tryComplete has no synchronization operation, two threads enter at the same time,
4、fetchRequest.fetchData().keySet() .forEach two threads traverse at the same time, resulting in the same partition multiple times responseData.remove(topicPartition), partitionData is null and cause the REQUEST_TIMED_OUT error.

![image](https://user-images.githubusercontent.com/35599757/129462871-37fbfc6f-1603-4da8-9815-95a278195936.png)

### Modifications
`MessageFetchContext.tryComplete` add synchronization lock