### PR TITLE
Remove closed KafkaTopicConsumerManager from cache

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -250,7 +250,7 @@ public final class MessageFetchContext {
                     statsLogger.getPrepareMetadataStats().registerFailedEvent(
                             MathUtils.elapsedNanos(startPrepareMetadataNanos), TimeUnit.NANOSECONDS);
                     // remove null future cache
-                    KafkaTopicManager.removeKafkaTopicConsumerManager(KopTopic.toString(topicPartition));
+                    KafkaTopicManager.removeKafkaTopicConsumerManager(fullTopicName);
                     addErrorPartitionResponse(topicPartition, Errors.NOT_LEADER_FOR_PARTITION);
                     return;
                 }
@@ -279,7 +279,9 @@ public final class MessageFetchContext {
                 final CompletableFuture<Pair<ManagedCursor, Long>> cursorFuture = tcm.removeCursorFuture(offset);
                 if (cursorFuture == null) {
                     // tcm is closed, just return a NONE error because the channel may be still active
-                    log.warn("[{}] KafkaTopicConsumerManager is closed", requestHandler.ctx);
+                    log.warn("[{}] KafkaTopicConsumerManager is closed, remove TCM of {}",
+                            requestHandler.ctx, fullTopicName);
+                    KafkaTopicManager.removeKafkaTopicConsumerManager(fullTopicName);
                     addErrorPartitionResponse(topicPartition, Errors.NONE);
                     return;
                 }


### PR DESCRIPTION
### Motivation

When `KafkaTopicConsumerManager#removeCursorFuture()` returns null, it means the TCM (`KafkaTopicConsumerManager` instance) is closed accidentally. However, in this case, the TCM was not removed from `KafkaTopicConsumer.consumerTopicManagers` currently. Then next time `topicManager.getTopicConsumerManager` could still return the closed TCM.

### Modifications

When `KafkaTopicConsumerManager#removeCursorFuture()` returns null, remove the TCM from cache.