### PR TITLE
[FEATURE] Add authorization to handle topic metadata request

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -434,7 +434,9 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                             topicMapFuture.completeExceptionally(e);
                             return;
                         }
-
+                        if (topicMapFuture.isCompletedExceptionally()) {
+                            return;
+                        }
                         for (String topic : topics) {
                             final TopicName topicName = TopicName.get(topic);
                             final String key = topicName.getPartitionedTopicName();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -42,7 +42,10 @@ import io.streamnative.pulsar.handlers.kop.format.EntryFormatterFactory;
 import io.streamnative.pulsar.handlers.kop.offset.OffsetAndMetadata;
 import io.streamnative.pulsar.handlers.kop.offset.OffsetMetadata;
 import io.streamnative.pulsar.handlers.kop.security.SaslAuthenticator;
+import io.streamnative.pulsar.handlers.kop.security.Session;
 import io.streamnative.pulsar.handlers.kop.security.auth.Authorizer;
+import io.streamnative.pulsar.handlers.kop.security.auth.Resource;
+import io.streamnative.pulsar.handlers.kop.security.auth.ResourceType;
 import io.streamnative.pulsar.handlers.kop.security.auth.SimpleAclAuthorizer;
 import io.streamnative.pulsar.handlers.kop.stats.StatsLogger;
 import io.streamnative.pulsar.handlers.kop.utils.CoreUtils;
@@ -89,6 +92,7 @@ import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.errors.CorruptRecordException;
 import org.apache.kafka.common.errors.LeaderNotAvailableException;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -417,7 +421,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     //     persistent://public/default/my-topic-partition-0
     //     persistent://public/default/my-topic-partition-1
     //     persistent://public/default/my-topic-partition-2
-    private void getAllTopicsAsync(CompletableFuture<Map<String, List<TopicName>>> topicMapFuture) {
+    private CompletableFuture<Map<String, List<TopicName>>> getAllTopicsAsync() {
+        CompletableFuture<Map<String, List<TopicName>>> topicMapFuture = new CompletableFuture<>();
         final Map<String, List<TopicName>> topicMap = new ConcurrentHashMap<>();
         final AtomicInteger pendingNamespacesCount = new AtomicInteger(allowedNamespaces.size());
 
@@ -427,9 +432,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                         if (e != null) {
                             log.error("Failed to getListOfPersistentTopic of {}", namespace, e);
                             topicMapFuture.completeExceptionally(e);
-                            return;
-                        }
-                        if (topicMapFuture.isDone()) {
                             return;
                         }
 
@@ -446,6 +448,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                         }
                     });
         }
+        return topicMapFuture;
     }
 
     protected void handleTopicMetadataRequest(KafkaHeaderAndRequest metadataHar,
@@ -470,14 +473,38 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         //      e.g. <topic1, {persistent://public/default/topic1-partition-0,...}>
         //   1. no topics provided, get all topics from namespace;
         //   2. topics provided, get provided topics.
-        CompletableFuture<Map<String, List<TopicName>>> pulsarTopicsFuture = new CompletableFuture<>();
+        CompletableFuture<Map<String, List<TopicName>>> pulsarTopicsFuture;
 
         if (topics == null || topics.isEmpty()) {
             // clean all cache when get all metadata for librdkafka(<1.0.0).
             KafkaTopicManager.clearTopicManagerCache();
-            // get all topics
-            getAllTopicsAsync(pulsarTopicsFuture);
+            // get all topics, filter by permissions.
+            pulsarTopicsFuture = getAllTopicsAsync().thenApply((allTopicMap)->{
+                final Map<String, List<TopicName>> topicMap = new ConcurrentHashMap<>();
+                allTopicMap.forEach((topic, list) -> {
+                   list.forEach((topicName -> {
+                       authorize(AclOperation.DESCRIBE, Resource.of(ResourceType.TOPIC, topicName.toString()))
+                               .whenComplete((authorized, ex) -> {
+                                   if (ex != null || !authorized) {
+                                       allTopicMetadata.add(new TopicMetadata(
+                                               Errors.TOPIC_AUTHORIZATION_FAILED,
+                                               topic,
+                                               isInternalTopic(topicName.toString()),
+                                               Collections.emptyList()));
+                                       return;
+                                   }
+                                   topicMap.computeIfAbsent(
+                                           topic,
+                                           ignored -> Collections.synchronizedList(new ArrayList<>())
+                                   ).add(topicName);
+                               });
+                   }));
+                });
+
+                return topicMap;
+            });
         } else {
+            pulsarTopicsFuture = new CompletableFuture<>();
             // get only the provided topics
             final Map<String, List<TopicName>> pulsarTopics = new ConcurrentHashMap<>();
 
@@ -504,76 +531,119 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 completeOneTopic.run();
             };
 
-            requestTopics.stream()
-                .forEach(topic -> {
-                    final String fullTopicName = new KopTopic(topic).getFullName();
+            final BiConsumer<String, String> completeOneAuthFailedTopic = (topic, fullTopicName) -> {
+                allTopicMetadata.add(new TopicMetadata(
+                        Errors.TOPIC_AUTHORIZATION_FAILED,
+                        topic,
+                        isInternalTopic(fullTopicName),
+                        Collections.emptyList()));
+                completeOneTopic.run();
+            };
 
-                    // get partition numbers for each topic.
-                    // If topic doesn't exist and allowAutoTopicCreation is enabled, the topic will be created first.
-                    getPartitionedTopicMetadataAsync(fullTopicName)
-                        .whenComplete((partitionedTopicMetadata, throwable) -> {
-                            if (throwable != null) {
-                                if (throwable instanceof PulsarAdminException.NotFoundException) {
-                                    if (kafkaConfig.isAllowAutoTopicCreation()
-                                            && metadataRequest.allowAutoTopicCreation()) {
-                                        log.info("[{}] Request {}: Topic {} doesn't exist, auto create it with {} "
-                                                        + "partitions", ctx.channel(), metadataHar.getHeader(),
-                                                topic, defaultNumPartitions);
-                                        admin.topics().createPartitionedTopicAsync(fullTopicName, defaultNumPartitions)
-                                                .whenComplete((ignored, e) -> {
-                                                    if (e == null) {
-                                                        addTopicPartition.accept(topic, defaultNumPartitions);
+            requestTopics.forEach(topic -> {
+                final String fullTopicName = new KopTopic(topic).getFullName();
+
+                authorize(AclOperation.DESCRIBE, Resource.of(ResourceType.TOPIC, fullTopicName))
+                    .whenComplete((authorized, ex) -> {
+                        if (ex != null) {
+                            // Authentication failed
+                            completeOneAuthFailedTopic.accept(topic, fullTopicName);
+                            return;
+                        }
+                        if (authorized) {
+                            // get partition numbers for each topic.
+                            // If topic doesn't exist and allowAutoTopicCreation is enabled,
+                            // the topic will be created first.
+                            getPartitionedTopicMetadataAsync(fullTopicName)
+                                .whenComplete((partitionedTopicMetadata, throwable) -> {
+                                    if (throwable != null) {
+                                        if (throwable instanceof PulsarAdminException.NotFoundException) {
+                                            if (kafkaConfig.isAllowAutoTopicCreation()
+                                                    && metadataRequest.allowAutoTopicCreation()) {
+                                                authorize(AclOperation.CREATE,
+                                                        Resource.of(ResourceType.NAMESPACE,
+                                                                TopicName.get(fullTopicName).getNamespace())
+                                                ).whenComplete((canCreateTopic, authEx) -> {
+                                                    if (authEx != null) {
+                                                        completeOneAuthFailedTopic.accept(topic, fullTopicName);
+                                                        return;
+                                                    }
+                                                    if (canCreateTopic){
+                                                        log.info("[{}] Request {}: Topic {} doesn't exist, "
+                                                                        + "auto create it with {} partitions",
+                                                                ctx.channel(), metadataHar.getHeader(),
+                                                                topic, defaultNumPartitions);
+                                                        admin.topics()
+                                                            .createPartitionedTopicAsync(
+                                                                    fullTopicName,
+                                                                    defaultNumPartitions)
+                                                            .whenComplete((ignored, e) -> {
+                                                                if (e == null) {
+                                                                    addTopicPartition.accept(topic,
+                                                                            defaultNumPartitions);
+                                                                } else {
+                                                                    log.error("[{}] Failed to create "
+                                                                                    + "partitioned topic {}",
+                                                                            ctx.channel(), topic, e);
+                                                                    completeOneTopic.run();
+                                                                }
+                                                            });
                                                     } else {
-                                                        log.error("[{}] Failed to create partitioned topic {}",
-                                                                ctx.channel(), topic, e);
-                                                        completeOneTopic.run();
+                                                        completeOneAuthFailedTopic.accept(topic, fullTopicName);
                                                     }
                                                 });
-                                    } else {
-                                        log.error("[{}] Request {}: Topic {} doesn't exist and it's not allowed to"
-                                                        + "auto create partitioned topic",
-                                                ctx.channel(), metadataHar.getHeader(), topic);
-                                        // not allow to auto create topic, return unknown topic
-                                        allTopicMetadata.add(
-                                                new TopicMetadata(
-                                                        Errors.UNKNOWN_TOPIC_OR_PARTITION,
-                                                        topic,
-                                                        isInternalTopic(fullTopicName),
-                                                        Collections.emptyList()));
-                                        completeOneTopic.run();
+                                            } else {
+                                                log.error("[{}] Request {}: Topic {} doesn't exist and it's "
+                                                                + "not allowed to auto create partitioned topic",
+                                                        ctx.channel(), metadataHar.getHeader(), topic);
+                                                // not allow to auto create topic, return unknown topic
+                                                allTopicMetadata.add(
+                                                        new TopicMetadata(
+                                                                Errors.UNKNOWN_TOPIC_OR_PARTITION,
+                                                                topic,
+                                                                isInternalTopic(fullTopicName),
+                                                                Collections.emptyList()));
+                                                completeOneTopic.run();
+                                            }
+                                        } else {
+                                            // Failed get partitions.
+                                            allTopicMetadata.add(
+                                                    new TopicMetadata(
+                                                            Errors.UNKNOWN_TOPIC_OR_PARTITION,
+                                                            topic,
+                                                            isInternalTopic(fullTopicName),
+                                                            Collections.emptyList()));
+                                            log.warn("[{}] Request {}: Failed to get partitioned pulsar topic {} "
+                                                            + "metadata: {}",
+                                                    ctx.channel(), metadataHar.getHeader(),
+                                                    fullTopicName, throwable.getMessage());
+                                            completeOneTopic.run();
+                                        }
+                                    } else { // the topic already existed
+                                        if (partitionedTopicMetadata.partitions > 0) {
+                                            if (log.isDebugEnabled()) {
+                                                log.debug("Topic {} has {} partitions",
+                                                        topic, partitionedTopicMetadata.partitions);
+                                            }
+                                            addTopicPartition.accept(topic, partitionedTopicMetadata.partitions);
+                                        } else {
+                                            log.error("Topic {} is a non-partitioned topic", topic);
+                                            allTopicMetadata.add(
+                                                    new TopicMetadata(
+                                                            Errors.INVALID_TOPIC_EXCEPTION,
+                                                            topic,
+                                                            isInternalTopic(fullTopicName),
+                                                            Collections.emptyList()));
+                                            completeOneTopic.run();
+                                        }
                                     }
-                                } else {
-                                    // Failed get partitions.
-                                    allTopicMetadata.add(
-                                            new TopicMetadata(
-                                                    Errors.UNKNOWN_TOPIC_OR_PARTITION,
-                                                    topic,
-                                                    isInternalTopic(fullTopicName),
-                                                    Collections.emptyList()));
-                                    log.warn("[{}] Request {}: Failed to get partitioned pulsar topic {} metadata: {}",
-                                            ctx.channel(), metadataHar.getHeader(),
-                                            fullTopicName, throwable.getMessage());
-                                    completeOneTopic.run();
-                                }
-                            } else { // the topic already existed
-                                if (partitionedTopicMetadata.partitions > 0) {
-                                    if (log.isDebugEnabled()) {
-                                        log.debug("Topic {} has {} partitions",
-                                            topic, partitionedTopicMetadata.partitions);
-                                    }
-                                    addTopicPartition.accept(topic, partitionedTopicMetadata.partitions);
-                                } else {
-                                    log.error("Topic {} is a non-partitioned topic", topic);
-                                    allTopicMetadata.add(
-                                            new TopicMetadata(
-                                                    Errors.INVALID_TOPIC_EXCEPTION,
-                                                    topic,
-                                                    isInternalTopic(fullTopicName),
-                                                    Collections.emptyList()));
-                                    completeOneTopic.run();
-                                }
-                            }
-                        });
+                                });
+                        } else {
+                            // Permission denied
+                            completeOneAuthFailedTopic.accept(topic, fullTopicName);
+                        }
+                    });
+
                 });
         }
 
@@ -2202,5 +2272,44 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 .add(numMessages);
 
         RequestStats.BATCH_COUNT_PER_MEMORY_RECORDS_INSTANCE.set(numMessages);
+    }
+
+    private CompletableFuture<Boolean> authorize(AclOperation operation, Resource resource) {
+        if (authorizer == null) {
+            return CompletableFuture.completedFuture(true);
+        }
+        if (authenticator.session() == null) {
+            return CompletableFuture.completedFuture(false);
+        }
+
+        CompletableFuture<Boolean> isAuthorizedFuture;
+        Session session = authenticator.session();
+        switch (operation) {
+            case READ:
+                isAuthorizedFuture = authorizer.canConsumeAsync(session.getPrincipal(), resource);
+                break;
+            case IDEMPOTENT_WRITE:
+            case WRITE:
+                isAuthorizedFuture = authorizer.canProduceAsync(session.getPrincipal(), resource);
+                break;
+            case DESCRIBE:
+                isAuthorizedFuture = authorizer.canLookupAsync(session.getPrincipal(), resource);
+                break;
+            case CREATE:
+            case DELETE:
+                isAuthorizedFuture = authorizer.canManageTopicAsync(session.getPrincipal(), resource);
+                break;
+            case CLUSTER_ACTION:
+            case DESCRIBE_CONFIGS:
+            case ALTER_CONFIGS:
+            case ALTER:
+            case UNKNOWN:
+            case ALL:
+            case ANY:
+            default:
+                return FutureUtil.failedFuture(
+                        new IllegalStateException("AclOperation [" + operation.name() + "] is not supported."));
+        }
+        return isAuthorizedFuture;
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -547,6 +547,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 authorize(AclOperation.DESCRIBE, Resource.of(ResourceType.TOPIC, fullTopicName))
                     .whenComplete((authorized, ex) -> {
                         if (ex != null) {
+                            log.error("Describe topic authorize failed, topic - {}. {}",
+                                    fullTopicName, ex.getMessage());
                             // Authentication failed
                             completeOneAuthFailedTopic.accept(topic, fullTopicName);
                             return;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/Authorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/Authorizer.java
@@ -54,4 +54,15 @@ public interface Authorizer {
      */
     CompletableFuture<Boolean> canConsumeAsync(KafkaPrincipal principal, Resource resource);
 
+    /**
+     * Check whether the specified role can manage topics.
+     *
+     * For that the caller needs to have created or delete topic permission.
+     *
+     * @param principal login info
+     * @param resource resources to be authorized
+     * @return a boolean to determine whether authorized or not
+     */
+    CompletableFuture<Boolean> canManageTopicAsync(KafkaPrincipal principal, Resource resource);
+
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/Authorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/Authorizer.java
@@ -55,14 +55,14 @@ public interface Authorizer {
     CompletableFuture<Boolean> canConsumeAsync(KafkaPrincipal principal, Resource resource);
 
     /**
-     * Check whether the specified role can manage topics.
+     * Check whether the specified role can create topics.
      *
-     * For that the caller needs to have created or delete topic permission.
+     * For that the caller needs to have created topic permission.
      *
      * @param principal login info
      * @param resource resources to be authorized
      * @return a boolean to determine whether authorized or not
      */
-    CompletableFuture<Boolean> canManageTopicAsync(KafkaPrincipal principal, Resource resource);
+    CompletableFuture<Boolean> canCreateTopicAsync(KafkaPrincipal principal, Resource resource);
 
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/Authorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/Authorizer.java
@@ -54,15 +54,4 @@ public interface Authorizer {
      */
     CompletableFuture<Boolean> canConsumeAsync(KafkaPrincipal principal, Resource resource);
 
-    /**
-     * Check whether the specified role can create topics.
-     *
-     * For that the caller needs to have created topic permission.
-     *
-     * @param principal login info
-     * @param resource resources to be authorized
-     * @return a boolean to determine whether authorized or not
-     */
-    CompletableFuture<Boolean> canCreateTopicAsync(KafkaPrincipal principal, Resource resource);
-
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/Resource.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/Resource.java
@@ -14,12 +14,14 @@
 package io.streamnative.pulsar.handlers.kop.security.auth;
 
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 /**
  * The Authorization resource.
  */
 @Getter
+@EqualsAndHashCode
 public class Resource {
 
     private final ResourceType resourceType;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/ResourceType.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/ResourceType.java
@@ -35,12 +35,6 @@ public enum ResourceType {
      */
     TOPIC((byte) 2),
 
-    /**
-     * A Pulsar namespace.
-     */
-    NAMESPACE((byte) 3),
-
-
     ;
 
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/ResourceType.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/ResourceType.java
@@ -34,6 +34,13 @@ public enum ResourceType {
      * A Pulsar topic.
      */
     TOPIC((byte) 2),
+
+    /**
+     * A Pulsar namespace.
+     */
+    NAMESPACE((byte) 3),
+
+
     ;
 
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
@@ -16,6 +16,7 @@ package io.streamnative.pulsar.handlers.kop.security.auth;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.base.Joiner;
 import io.streamnative.pulsar.handlers.kop.security.KafkaPrincipal;
 import java.util.Map;
 import java.util.Set;
@@ -26,6 +27,7 @@ import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.AuthAction;
+import org.apache.pulsar.common.policies.data.TenantInfo;
 
 /**
  * Simple acl authorizer.
@@ -33,7 +35,7 @@ import org.apache.pulsar.common.policies.data.AuthAction;
 @Slf4j
 public class SimpleAclAuthorizer implements Authorizer {
 
-    private static final String POLICY_ROOT = "/admin/policies";
+    private static final String POLICY_ROOT = "/admin/policies/";
 
     private final PulsarService pulsarService;
 
@@ -50,83 +52,88 @@ public class SimpleAclAuthorizer implements Authorizer {
 
     private CompletableFuture<Boolean> authorize(KafkaPrincipal principal, AuthAction action, Resource resource) {
         CompletableFuture<Boolean> permissionFuture = new CompletableFuture<>();
-        String namespaceName = "";
+        NamespaceName namespace = null;
         if (resource.getResourceType() == ResourceType.NAMESPACE) {
-            namespaceName = NamespaceName.get(resource.getName()).toString();
+            namespace = NamespaceName.get(resource.getName());
         } else if (resource.getResourceType() == ResourceType.TOPIC) {
-            namespaceName = TopicName.get(resource.getName()).getNamespace();
+            namespace = TopicName.get(resource.getName()).getNamespaceObject();
         }
-        String policiesPath = String.format("%s/%s", POLICY_ROOT, namespaceName);
-        isSuperUser(principal.getName()).whenComplete((isSuper, exception) -> {
+        if (namespace == null) {
+            permissionFuture.completeExceptionally(
+                    new IllegalArgumentException("Resource name must contains namespace."));
+            return permissionFuture;
+        }
+        String policiesPath = path(namespace.toString());
+        String tenantName = namespace.getTenant();
+        isSuperUserOrTenantAdmin(tenantName, principal.getName()).whenComplete((isSuperUserOrAdmin, exception) -> {
             if (exception != null) {
-                log.error("Check super user error: {}", exception.getMessage());
+                if (log.isDebugEnabled()) {
+                    log.debug("Verify if role {} is allowed to {} to resource {}: isSuperUserOrAdmin={}",
+                            principal.getName(), action, resource.getName(), isSuperUserOrAdmin);
+                }
+                isSuperUserOrAdmin = false;
+            }
+            if (isSuperUserOrAdmin) {
+                permissionFuture.complete(true);
                 return;
             }
-            if (isSuper) {
-                permissionFuture.complete(true);
-            } else {
-                getPulsarService()
-                        .getPulsarResources()
-                        .getNamespaceResources()
-                        .getAsync(policiesPath)
-                        .thenAccept(policies -> {
-                            if (!policies.isPresent()) {
-                                if (log.isDebugEnabled()) {
-                                    log.debug("Policies node couldn't be found for namespace : {}", principal);
-                                }
-                            } else {
-                                String role = principal.getName();
+            getPulsarService()
+                    .getPulsarResources()
+                    .getNamespaceResources()
+                    .getAsync(policiesPath)
+                    .thenAccept(policies -> {
+                        if (!policies.isPresent()) {
+                            if (log.isDebugEnabled()) {
+                                log.debug("Policies node couldn't be found for namespace : {}", principal);
+                            }
+                        } else {
+                            String role = principal.getName();
 
-                                // Check Topic level policies
-                                if (resource.getResourceType() == ResourceType.TOPIC) {
-                                    TopicName topicName = TopicName.get(resource.getName());
-                                    Map<String, Set<AuthAction>> topicRoles = policies.get()
-                                            .auth_policies
-                                            .getTopicAuthentication()
-                                            .get(topicName.toString());
-                                    if (topicRoles != null && role != null) {
-                                        // Topic has custom policy
-                                        Set<AuthAction> topicActions = topicRoles.get(role);
-                                        if (topicActions != null && topicActions.contains(action)) {
-                                            permissionFuture.complete(true);
-                                            return;
-                                        }
+                            // Check Topic level policies
+                            if (resource.getResourceType() == ResourceType.TOPIC) {
+                                TopicName topicName = TopicName.get(resource.getName());
+                                Map<String, Set<AuthAction>> topicRoles = policies.get()
+                                        .auth_policies
+                                        .getTopicAuthentication()
+                                        .get(topicName.toString());
+                                if (topicRoles != null && role != null) {
+                                    // Topic has custom policy
+                                    Set<AuthAction> topicActions = topicRoles.get(role);
+                                    if (topicActions != null && topicActions.contains(action)) {
+                                        permissionFuture.complete(true);
+                                        return;
                                     }
                                 }
-
-                                // Check Namespace level policies
-                                Map<String, Set<AuthAction>> namespaceRoles = policies.get().auth_policies
-                                        .getNamespaceAuthentication();
-                                Set<AuthAction> namespaceActions = namespaceRoles.get(role);
-                                if (namespaceActions != null && namespaceActions.contains(action)) {
-                                    permissionFuture.complete(true);
-                                    return;
-                                }
-
-                                // Check wildcard policies
-                                if (conf.isAuthorizationAllowWildcardsMatching()
-                                        && checkWildcardPermission(role, action, namespaceRoles)) {
-                                    // The role has namespace level permission by wildcard match
-                                    permissionFuture.complete(true);
-                                    return;
-                                }
                             }
-                            permissionFuture.complete(false);
-                        }).exceptionally(ex -> {
-                            log.warn("Client with Principal - {} failed to get permissions for resource - {}. {}",
-                                    principal, resource, ex.getMessage());
-                            permissionFuture.completeExceptionally(ex);
-                            return null;
-                        });
-            }
+
+                            // Check Namespace level policies
+                            Map<String, Set<AuthAction>> namespaceRoles = policies.get().auth_policies
+                                    .getNamespaceAuthentication();
+                            Set<AuthAction> namespaceActions = namespaceRoles.get(role);
+                            if (namespaceActions != null && namespaceActions.contains(action)) {
+                                permissionFuture.complete(true);
+                                return;
+                            }
+
+                            // Check wildcard policies
+                            if (conf.isAuthorizationAllowWildcardsMatching()
+                                    && checkWildcardPermission(role, action, namespaceRoles)) {
+                                // The role has namespace level permission by wildcard match
+                                permissionFuture.complete(true);
+                                return;
+                            }
+                        }
+                        permissionFuture.complete(false);
+                    }).exceptionally(ex -> {
+                        log.warn("Client with Principal - {} failed to get permissions for resource - {}. {}",
+                                principal, resource, ex.getMessage());
+                        permissionFuture.completeExceptionally(ex);
+                        return null;
+                    });
+
         });
 
         return permissionFuture;
-    }
-
-    private CompletableFuture<Boolean> isSuperUser(String role) {
-        Set<String> superUserRoles = conf.getSuperUserRoles();
-        return CompletableFuture.completedFuture(role != null && superUserRoles.contains(role));
     }
 
     private boolean checkWildcardPermission(String checkedRole, AuthAction checkedAction,
@@ -152,6 +159,51 @@ public class SimpleAclAuthorizer implements Authorizer {
         }
         return false;
     }
+
+    private CompletableFuture<Boolean> isSuperUser(String role) {
+        Set<String> superUserRoles = conf.getSuperUserRoles();
+        return CompletableFuture.completedFuture(role != null && superUserRoles.contains(role));
+    }
+
+    /**
+     * Check if specified role is an admin of the tenant or superuser.
+     *
+     * @param tenant the tenant to check
+     * @param role the role to check
+     * @return a CompletableFuture containing a boolean in which true means the role is an admin user
+     * and false if it is not
+     */
+    private CompletableFuture<Boolean> isSuperUserOrTenantAdmin(String tenant, String role) {
+        CompletableFuture<Boolean> future = new CompletableFuture<>();
+        isSuperUser(role).whenComplete((isSuperUser, ex) -> {
+            if (ex != null || !isSuperUser) {
+                pulsarService.getPulsarResources()
+                        .getTenantResources()
+                        .getAsync(path(tenant))
+                        .thenAccept(tenantInfo -> {
+                            if (!tenantInfo.isPresent()) {
+                                future.complete(false);
+                                return;
+                            }
+                            TenantInfo info = tenantInfo.get();
+                            future.complete(role != null
+                                    && info.getAdminRoles() != null
+                                    && info.getAdminRoles().contains(role));
+                        });
+                return;
+            }
+            future.complete(true);
+        });
+        return future;
+    }
+
+    private static String path(String... parts) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(POLICY_ROOT);
+        Joiner.on('/').appendTo(sb, parts);
+        return sb.toString();
+    }
+
 
     @Override
     public CompletableFuture<Boolean> canLookupAsync(KafkaPrincipal principal, Resource resource) {
@@ -202,9 +254,11 @@ public class SimpleAclAuthorizer implements Authorizer {
     }
 
     @Override
-    public CompletableFuture<Boolean> canManageTopicAsync(KafkaPrincipal principal, Resource resource) {
-        checkArgument(resource.getResourceType() == ResourceType.NAMESPACE,
-                String.format("Expected resource type is NAMESPACE, but have [%s]", resource.getResourceType()));
+    public CompletableFuture<Boolean> canCreateTopicAsync(KafkaPrincipal principal, Resource resource) {
+        checkArgument(resource.getResourceType() == ResourceType.TOPIC
+                || resource.getResourceType() == ResourceType.NAMESPACE,
+                String.format("Expected resource type is TOPIC or NAMESPACE, but have [%s]",
+                        resource.getResourceType()));
         return authorize(principal, AuthAction.packages, resource);
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
@@ -103,12 +103,11 @@ public class SimpleAclAuthorizer implements Authorizer {
                                 }
 
                                 // Check wildcard policies
-                                if (conf.isAuthorizationAllowWildcardsMatching()) {
-                                    if (checkWildcardPermission(role, action, namespaceRoles)) {
-                                        // The role has namespace level permission by wildcard match
-                                        permissionFuture.complete(true);
-                                        return;
-                                    }
+                                if (conf.isAuthorizationAllowWildcardsMatching()
+                                        && checkWildcardPermission(role, action, namespaceRoles)) {
+                                    // The role has namespace level permission by wildcard match
+                                    permissionFuture.complete(true);
+                                    return;
                                 }
                             }
                             permissionFuture.complete(false);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
@@ -23,6 +23,7 @@ import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.AuthAction;
 
@@ -51,7 +52,7 @@ public class SimpleAclAuthorizer implements Authorizer {
         CompletableFuture<Boolean> permissionFuture = new CompletableFuture<>();
         String namespaceName = "";
         if (resource.getResourceType() == ResourceType.NAMESPACE) {
-            namespaceName = resource.getName();
+            namespaceName = NamespaceName.get(resource.getName()).toString();
         } else if (resource.getResourceType() == ResourceType.TOPIC) {
             namespaceName = TopicName.get(resource.getName()).getNamespace();
         }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
@@ -125,8 +125,10 @@ public class SimpleAclAuthorizer implements Authorizer {
                         }
                         permissionFuture.complete(false);
                     }).exceptionally(ex -> {
-                        log.warn("Client with Principal - {} failed to get permissions for resource - {}. {}",
-                                principal, resource, ex.getMessage());
+                        if (log.isDebugEnabled()) {
+                            log.debug("Client with Principal - {} failed to get permissions for resource - {}. {}",
+                                    principal, resource, ex.getMessage());
+                        }
                         permissionFuture.completeExceptionally(ex);
                         return null;
                     });

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
@@ -14,12 +14,15 @@
 package io.streamnative.pulsar.handlers.kop.security.auth;
 
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import io.streamnative.pulsar.handlers.kop.security.KafkaPrincipal;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.AuthAction;
 
@@ -33,8 +36,11 @@ public class SimpleAclAuthorizer implements Authorizer {
 
     private final PulsarService pulsarService;
 
+    private final ServiceConfiguration conf;
+
     public SimpleAclAuthorizer(PulsarService pulsarService) {
         this.pulsarService = pulsarService;
+        this.conf = pulsarService.getConfiguration();
     }
 
     protected PulsarService getPulsarService() {
@@ -43,7 +49,13 @@ public class SimpleAclAuthorizer implements Authorizer {
 
     private CompletableFuture<Boolean> authorize(KafkaPrincipal principal, AuthAction action, Resource resource) {
         CompletableFuture<Boolean> permissionFuture = new CompletableFuture<>();
-        TopicName topicName = TopicName.get(resource.getName());
+        String namespaceName = "";
+        if (resource.getResourceType() == ResourceType.NAMESPACE) {
+            namespaceName = resource.getName();
+        } else if (resource.getResourceType() == ResourceType.TOPIC) {
+            namespaceName = TopicName.get(resource.getName()).getNamespace();
+        }
+        String policiesPath = String.format("%s/%s", POLICY_ROOT, namespaceName);
         isSuperUser(principal.getName()).whenComplete((isSuper, exception) -> {
             if (exception != null) {
                 log.error("Check super user error: {}", exception.getMessage());
@@ -55,7 +67,7 @@ public class SimpleAclAuthorizer implements Authorizer {
                 getPulsarService()
                         .getPulsarResources()
                         .getNamespaceResources()
-                        .getAsync(String.format("%s/%s", POLICY_ROOT, topicName.getNamespace()))
+                        .getAsync(policiesPath)
                         .thenAccept(policies -> {
                             if (!policies.isPresent()) {
                                 if (log.isDebugEnabled()) {
@@ -63,19 +75,25 @@ public class SimpleAclAuthorizer implements Authorizer {
                                 }
                             } else {
                                 String role = principal.getName();
-                                Map<String, Set<AuthAction>> topicRoles = policies.get()
-                                        .auth_policies
-                                        .getTopicAuthentication()
-                                        .get(topicName.toString());
-                                if (topicRoles != null && role != null) {
-                                    // Topic has custom policy
-                                    Set<AuthAction> topicActions = topicRoles.get(role);
-                                    if (topicActions != null && topicActions.contains(action)) {
-                                        permissionFuture.complete(true);
-                                        return;
+
+                                // Check Topic level policies
+                                if (resource.getResourceType() == ResourceType.TOPIC) {
+                                    TopicName topicName = TopicName.get(resource.getName());
+                                    Map<String, Set<AuthAction>> topicRoles = policies.get()
+                                            .auth_policies
+                                            .getTopicAuthentication()
+                                            .get(topicName.toString());
+                                    if (topicRoles != null && role != null) {
+                                        // Topic has custom policy
+                                        Set<AuthAction> topicActions = topicRoles.get(role);
+                                        if (topicActions != null && topicActions.contains(action)) {
+                                            permissionFuture.complete(true);
+                                            return;
+                                        }
                                     }
                                 }
 
+                                // Check Namespace level policies
                                 Map<String, Set<AuthAction>> namespaceRoles = policies.get().auth_policies
                                         .getNamespaceAuthentication();
                                 Set<AuthAction> namespaceActions = namespaceRoles.get(role);
@@ -83,11 +101,20 @@ public class SimpleAclAuthorizer implements Authorizer {
                                     permissionFuture.complete(true);
                                     return;
                                 }
+
+                                // Check wildcard policies
+                                if (conf.isAuthorizationAllowWildcardsMatching()) {
+                                    if (checkWildcardPermission(role, action, namespaceRoles)) {
+                                        // The role has namespace level permission by wildcard match
+                                        permissionFuture.complete(true);
+                                        return;
+                                    }
+                                }
                             }
                             permissionFuture.complete(false);
                         }).exceptionally(ex -> {
                             log.warn("Client with Principal - {} failed to get permissions for resource - {}. {}",
-                                    principal, topicName, ex.getMessage());
+                                    principal, resource, ex.getMessage());
                             permissionFuture.completeExceptionally(ex);
                             return null;
                         });
@@ -98,8 +125,32 @@ public class SimpleAclAuthorizer implements Authorizer {
     }
 
     private CompletableFuture<Boolean> isSuperUser(String role) {
-        Set<String> superUserRoles = getPulsarService().getConfiguration().getSuperUserRoles();
+        Set<String> superUserRoles = conf.getSuperUserRoles();
         return CompletableFuture.completedFuture(role != null && superUserRoles.contains(role));
+    }
+
+    private boolean checkWildcardPermission(String checkedRole, AuthAction checkedAction,
+                                            Map<String, Set<AuthAction>> permissionMap) {
+        for (Map.Entry<String, Set<AuthAction>> permissionData : permissionMap.entrySet()) {
+            String permittedRole = permissionData.getKey();
+            Set<AuthAction> permittedActions = permissionData.getValue();
+
+            // Prefix match
+            if (checkedRole != null) {
+                if (permittedRole.charAt(permittedRole.length() - 1) == '*'
+                        && checkedRole.startsWith(permittedRole.substring(0, permittedRole.length() - 1))
+                        && permittedActions.contains(checkedAction)) {
+                    return true;
+                }
+
+                // Suffix match
+                if (permittedRole.charAt(0) == '*' && checkedRole.endsWith(permittedRole.substring(1))
+                        && permittedActions.contains(checkedAction)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     @Override
@@ -138,12 +189,23 @@ public class SimpleAclAuthorizer implements Authorizer {
 
     @Override
     public CompletableFuture<Boolean> canProduceAsync(KafkaPrincipal principal, Resource resource) {
+        checkArgument(resource.getResourceType() == ResourceType.TOPIC,
+                String.format("Expected resource type is TOPIC, but have [%s]", resource.getName()));
         return authorize(principal, AuthAction.produce, resource);
     }
 
     @Override
     public CompletableFuture<Boolean> canConsumeAsync(KafkaPrincipal principal, Resource resource) {
+        checkArgument(resource.getResourceType() == ResourceType.TOPIC,
+                String.format("Expected resource type is TOPIC, but have [%s]", resource.getName()));
         return authorize(principal, AuthAction.consume, resource);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> canManageTopicAsync(KafkaPrincipal principal, Resource resource) {
+        checkArgument(resource.getResourceType() == ResourceType.NAMESPACE,
+                String.format("Expected resource type is NAMESPACE, but have [%s]", resource.getName()));
+        return authorize(principal, AuthAction.packages, resource);
     }
 
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
@@ -190,21 +190,21 @@ public class SimpleAclAuthorizer implements Authorizer {
     @Override
     public CompletableFuture<Boolean> canProduceAsync(KafkaPrincipal principal, Resource resource) {
         checkArgument(resource.getResourceType() == ResourceType.TOPIC,
-                String.format("Expected resource type is TOPIC, but have [%s]", resource.getName()));
+                String.format("Expected resource type is TOPIC, but have [%s]", resource.getResourceType()));
         return authorize(principal, AuthAction.produce, resource);
     }
 
     @Override
     public CompletableFuture<Boolean> canConsumeAsync(KafkaPrincipal principal, Resource resource) {
         checkArgument(resource.getResourceType() == ResourceType.TOPIC,
-                String.format("Expected resource type is TOPIC, but have [%s]", resource.getName()));
+                String.format("Expected resource type is TOPIC, but have [%s]", resource.getResourceType()));
         return authorize(principal, AuthAction.consume, resource);
     }
 
     @Override
     public CompletableFuture<Boolean> canManageTopicAsync(KafkaPrincipal principal, Resource resource) {
         checkArgument(resource.getResourceType() == ResourceType.NAMESPACE,
-                String.format("Expected resource type is NAMESPACE, but have [%s]", resource.getName()));
+                String.format("Expected resource type is NAMESPACE, but have [%s]", resource.getResourceType()));
         return authorize(principal, AuthAction.packages, resource);
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CustomOAuthBearerCallbackHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CustomOAuthBearerCallbackHandlerTest.java
@@ -83,7 +83,7 @@ public class CustomOAuthBearerCallbackHandlerTest extends KopProtocolHandlerTest
         admin.namespaces().grantPermissionOnNamespace(
                 tenant + "/" + namespace,
                 USER,
-                Sets.newHashSet(AuthAction.consume, AuthAction.produce, AuthAction.packages)
+                Sets.newHashSet(AuthAction.consume, AuthAction.produce)
         );
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CustomOAuthBearerCallbackHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CustomOAuthBearerCallbackHandlerTest.java
@@ -42,6 +42,7 @@ import org.apache.pulsar.broker.authentication.AuthenticationProviderToken;
 import org.apache.pulsar.broker.authentication.utils.AuthTokenUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.impl.auth.AuthenticationToken;
+import org.apache.pulsar.common.policies.data.AuthAction;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -52,6 +53,7 @@ import org.testng.annotations.Test;
 public class CustomOAuthBearerCallbackHandlerTest extends KopProtocolHandlerTestBase {
 
     private static final String ADMIN_USER = "admin_user";
+    private static final String USER = "user";
 
     public CustomOAuthBearerCallbackHandlerTest() {
         super("kafka");
@@ -78,6 +80,11 @@ public class CustomOAuthBearerCallbackHandlerTest extends KopProtocolHandlerTest
         conf.setKopOauth2AuthenticateCallbackHandler(MockedAuthenticateCallbackHandler.class.getName());
 
         super.internalSetup();
+        admin.namespaces().grantPermissionOnNamespace(
+                tenant + "/" + namespace,
+                USER,
+                Sets.newHashSet(AuthAction.consume, AuthAction.produce, AuthAction.packages)
+        );
     }
 
     @AfterClass
@@ -99,21 +106,20 @@ public class CustomOAuthBearerCallbackHandlerTest extends KopProtocolHandlerTest
     @Test(timeOut = 10000)
     public void testNumAuthenticateSuccess() throws Exception {
         final String topic = "testNumAuthenticateSuccess";
-        final String user = "user";
 
         final Properties props = newKafkaProducerProperties();
         final String jaasTemplate = "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule"
                 + " required unsecuredLoginStringClaim_sub=\"%s\";";
         props.setProperty("security.protocol", "SASL_PLAINTEXT");
         props.setProperty("sasl.mechanism", "OAUTHBEARER");
-        props.setProperty("sasl.jaas.config", String.format(jaasTemplate, user));
+        props.setProperty("sasl.jaas.config", String.format(jaasTemplate, USER));
 
         @Cleanup
         final KafkaProducer<String, String> producer = new KafkaProducer<>(props);
 
         assertTrue(MockedAuthenticateCallbackHandler.getAuthenticatedUsers().isEmpty());
         producer.send(new ProducerRecord<>(topic, "hello")).get();
-        assertEquals(MockedAuthenticateCallbackHandler.getAuthenticatedUsers(), Sets.newHashSet(user));
+        assertEquals(MockedAuthenticateCallbackHandler.getAuthenticatedUsers(), Sets.newHashSet(USER));
     }
 
     /**

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationKafkaTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationKafkaTest.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+/**
+ * Unit test for Authorization with `entryFormat=kafka`.
+ */
+public class KafkaAuthorizationKafkaTest extends KafkaAuthorizationTestBase{
+    public KafkaAuthorizationKafkaTest() {
+        super("kafka");
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationKafkaTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationKafkaTest.java
@@ -16,7 +16,7 @@ package io.streamnative.pulsar.handlers.kop;
 /**
  * Unit test for Authorization with `entryFormat=kafka`.
  */
-public class KafkaAuthorizationKafkaTest extends KafkaAuthorizationTestBase{
+public class KafkaAuthorizationKafkaTest extends KafkaAuthorizationTestBase {
     public KafkaAuthorizationKafkaTest() {
         super("kafka");
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationPulsarTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationPulsarTest.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+/**
+ * Unit test for Authorization with `entryFormat=pulsar`.
+ */
+public class KafkaAuthorizationPulsarTest extends KafkaAuthorizationTestBase{
+    public KafkaAuthorizationPulsarTest() {
+        super("pulsar");
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationPulsarTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationPulsarTest.java
@@ -16,7 +16,7 @@ package io.streamnative.pulsar.handlers.kop;
 /**
  * Unit test for Authorization with `entryFormat=pulsar`.
  */
-public class KafkaAuthorizationPulsarTest extends KafkaAuthorizationTestBase{
+public class KafkaAuthorizationPulsarTest extends KafkaAuthorizationTestBase {
     public KafkaAuthorizationPulsarTest() {
         super("pulsar");
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationTestBase.java
@@ -155,11 +155,11 @@ public abstract class KafkaAuthorizationTestBase extends KopProtocolHandlerTestB
     }
 
     @Test(timeOut = 20000)
-    void testSuccessAutoCreateTopicBySuperUser() throws PulsarAdminException {
-        String topic = "testSuccessAutoCreateTopic";
+    void testAuthorizationSuccess() throws PulsarAdminException {
+        String topic = "testAuthorizationSuccessTopic";
         String fullNewTopicName = "persistent://" + TENANT + "/" + NAMESPACE + "/" + topic;
         KProducer kProducer = new KProducer(topic, false, "localhost", getKafkaBrokerPort(),
-                TENANT + "/" + NAMESPACE, "token:" + adminToken);
+                TENANT + "/" + NAMESPACE, "token:" + userToken);
         int totalMsgs = 10;
         String messageStrPrefix = topic + "_message_";
 
@@ -168,7 +168,7 @@ public abstract class KafkaAuthorizationTestBase extends KopProtocolHandlerTestB
             kProducer.getProducer().send(new ProducerRecord<>(topic, i, messageStr));
         }
         KConsumer kConsumer = new KConsumer(topic, "localhost", getKafkaBrokerPort(), false,
-                TENANT + "/" + NAMESPACE, "token:" + adminToken, "DemoKafkaOnPulsarConsumer");
+                TENANT + "/" + NAMESPACE, "token:" + userToken, "DemoKafkaOnPulsarConsumer");
         kConsumer.getConsumer().subscribe(Collections.singleton(topic));
 
         int i = 0;
@@ -196,21 +196,6 @@ public abstract class KafkaAuthorizationTestBase extends KopProtocolHandlerTestB
         kProducer.close();
         kConsumer.close();
         admin.topics().deletePartitionedTopic(fullNewTopicName);
-    }
-
-    @Test(timeOut = 20000)
-    void testAutoCreateTopicFailedBySimpleUser() {
-        try {
-            String topic = "testAutoCreateTopic";
-            @Cleanup
-            KProducer kProducer = new KProducer(topic, false, "localhost", getKafkaBrokerPort(),
-                    TENANT + "/" + NAMESPACE, "token:" + userToken);
-            kProducer.getProducer().send(new ProducerRecord<>(topic, 0, "")).get();
-            fail("should have failed");
-        } catch (Exception e) {
-            e.printStackTrace();
-            assertTrue(e.getMessage().contains("TopicAuthorizationException"));
-        }
     }
 
     @Test(timeOut = 20000)

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationTestBase.java
@@ -1,0 +1,242 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import static org.mockito.Mockito.spy;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.AssertJUnit.fail;
+
+import com.google.common.collect.Sets;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import javax.crypto.SecretKey;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.ListTopicsResult;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.authentication.AuthenticationProviderToken;
+import org.apache.pulsar.broker.authentication.utils.AuthTokenUtils;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.impl.auth.AuthenticationToken;
+import org.apache.pulsar.common.policies.data.AuthAction;
+import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test
+@Slf4j
+public abstract class KafkaAuthorizationTestBase extends KopProtocolHandlerTestBase{
+
+    private static final String TENANT = "KafkaAuthorizationTest";
+    private static final String NAMESPACE = "ns1";
+    private static final String SHORT_TOPIC = "topic1";
+    private static final String TOPIC = "persistent://" + TENANT + "/" + NAMESPACE + "/" + SHORT_TOPIC;
+
+    private static final String SIMPLE_USER = "muggle_user";
+    private static final String ANOTHER_USER = "death_eater_user";
+    private static final String ADMIN_USER = "admin_user";
+
+    private String adminToken;
+    private String userToken;
+    private String anotherToken;
+
+    public KafkaAuthorizationTestBase(final String entryFormat) {
+        super(entryFormat);
+    }
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
+
+        AuthenticationProviderToken provider = new AuthenticationProviderToken();
+
+        Properties properties = new Properties();
+        properties.setProperty("tokenSecretKey", AuthTokenUtils.encodeKeyBase64(secretKey));
+        ServiceConfiguration authConf = new ServiceConfiguration();
+        authConf.setProperties(properties);
+        provider.initialize(authConf);
+
+        userToken = AuthTokenUtils.createToken(secretKey, SIMPLE_USER, Optional.empty());
+        adminToken = AuthTokenUtils.createToken(secretKey, ADMIN_USER, Optional.empty());
+        anotherToken = AuthTokenUtils.createToken(secretKey, ANOTHER_USER, Optional.empty());
+
+        super.resetConfig();
+        conf.setSaslAllowedMechanisms(Sets.newHashSet("PLAIN"));
+        conf.setKafkaMetadataTenant("internal");
+        conf.setKafkaMetadataNamespace("__kafka");
+        conf.setKafkaTenant(TENANT);
+        conf.setKafkaNamespace(NAMESPACE);
+
+        conf.setClusterName(super.configClusterName);
+        conf.setAuthorizationEnabled(true);
+        conf.setAuthenticationEnabled(true);
+        conf.setAuthorizationAllowWildcardsMatching(true);
+        conf.setSuperUserRoles(Sets.newHashSet(ADMIN_USER));
+        conf.setAuthenticationProviders(
+                Sets.newHashSet("org.apache.pulsar.broker.authentication."
+                        + "AuthenticationProviderToken"));
+        conf.setBrokerClientAuthenticationPlugin(AuthenticationToken.class.getName());
+        conf.setBrokerClientAuthenticationParameters("token:" + adminToken);
+        conf.setProperties(properties);
+
+        super.internalSetup();
+        admin.namespaces()
+                .setNamespaceReplicationClusters(TENANT + "/" + NAMESPACE, Sets.newHashSet(super.configClusterName));
+        admin.topics().createPartitionedTopic(TOPIC, 1);
+        admin.namespaces().grantPermissionOnNamespace(TENANT + "/" + NAMESPACE, SIMPLE_USER,
+                        Sets.newHashSet(AuthAction.consume, AuthAction.produce));
+    }
+
+    @Override
+    protected void createAdmin() throws Exception {
+        super.admin = spy(PulsarAdmin.builder().serviceHttpUrl(brokerUrl.toString())
+                .authentication(this.conf.getBrokerClientAuthenticationPlugin(),
+                        this.conf.getBrokerClientAuthenticationParameters()).build());
+    }
+
+    @AfterMethod
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test(timeOut = 20000)
+    void testAuthorizationFailed() {
+        try {
+            String newTenant = "newTenant";
+            String testTopic = "persistent://" + newTenant + "/" + NAMESPACE + "/topic1";
+            admin.tenants().createTenant(newTenant,
+                    TenantInfo.builder()
+                            .adminRoles(Collections.singleton(ADMIN_USER))
+                            .allowedClusters(Collections.singleton(configClusterName))
+                            .build());
+            admin.namespaces().createNamespace(newTenant + "/" + NAMESPACE);
+            admin.topics().createPartitionedTopic(testTopic, 1);
+            @Cleanup
+            KProducer kProducer = new KProducer(testTopic, false, "localhost", getKafkaBrokerPort(),
+                    TENANT + "/" + NAMESPACE, "token:" + userToken);
+            kProducer.getProducer().send(new ProducerRecord<>(testTopic, 0, "")).get();
+            fail("should have failed");
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("TopicAuthorizationException"));
+        }
+    }
+
+    @Test(timeOut = 20000)
+    void testSuccessAutoCreateTopicBySuperUser() {
+        String topic = "newTopic";
+        KProducer kProducer = new KProducer(topic, false, "localhost", getKafkaBrokerPort(),
+                TENANT + "/" + NAMESPACE, "token:" + adminToken);
+        int totalMsgs = 10;
+        String messageStrPrefix = topic + "_message_";
+
+        for (int i = 0; i < totalMsgs; i++) {
+            String messageStr = messageStrPrefix + i;
+            kProducer.getProducer().send(new ProducerRecord<>(topic, i, messageStr));
+        }
+
+        KConsumer kConsumer = new KConsumer(topic, "localhost", getKafkaBrokerPort(), false,
+                TENANT + "/" + NAMESPACE, "token:" + adminToken, "DemoKafkaOnPulsarConsumer");
+        kConsumer.getConsumer().subscribe(Collections.singleton(topic));
+
+        int i = 0;
+        while (i < totalMsgs) {
+            ConsumerRecords<Integer, String> records = kConsumer.getConsumer().poll(Duration.ofSeconds(1));
+            for (ConsumerRecord<Integer, String> record : records) {
+                Integer key = record.key();
+                assertEquals(messageStrPrefix + key.toString(), record.value());
+                i++;
+            }
+        }
+        assertEquals(i, totalMsgs);
+
+        // no more records
+        ConsumerRecords<Integer, String> records = kConsumer.getConsumer().poll(Duration.ofMillis(200));
+        assertTrue(records.isEmpty());
+
+        // ensure that we can list the topic
+        Map<String, List<PartitionInfo>> result = kConsumer
+                .getConsumer().listTopics(Duration.ofSeconds(1));
+        assertEquals(result.size(), 2);
+        assertTrue(result.containsKey(topic),
+                "list of topics " + result.keySet().toString() + "  does not contains " + topic);
+    }
+
+    @Test(timeOut = 20000)
+    void testAutoCreateTopicFailedBySimpleUser() {
+        try {
+            String topic = "newTopic";
+            @Cleanup
+            KProducer kProducer = new KProducer(topic, false, "localhost", getKafkaBrokerPort(),
+                    TENANT + "/" + NAMESPACE, "token:" + userToken);
+            kProducer.getProducer().send(new ProducerRecord<>(topic, 0, "")).get();
+            fail("should have failed");
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("TopicAuthorizationException"));
+        }
+    }
+
+    @Test(timeOut = 20000)
+    void testListTopic() throws Exception {
+        String newTopic = "newTopic";
+        String fullNewTopicName = "persistent://" + TENANT + "/" + NAMESPACE + "/" + newTopic;
+        @Cleanup
+        KConsumer kConsumer = new KConsumer(TOPIC, "localhost", getKafkaBrokerPort(), false,
+                TENANT + "/" + NAMESPACE, "token:" + userToken, "DemoKafkaOnPulsarConsumer");
+        Map<String, List<PartitionInfo>> result = kConsumer.getConsumer().listTopics(Duration.ofSeconds(1));
+        assertEquals(result.size(), 1);
+        admin.topics().createPartitionedTopic(fullNewTopicName, 1);
+
+        // Grant topic level permission to ANOTHER_USER
+        admin.topics().grantPermission(fullNewTopicName,
+                ANOTHER_USER,
+                Sets.newHashSet(AuthAction.consume, AuthAction.produce));
+
+        // Use consumer to list topic
+        result = kConsumer.getConsumer().listTopics(Duration.ofSeconds(1));
+        assertEquals(result.size(), 2);
+        assertTrue(result.containsKey(newTopic));
+
+        // Check AdminClient use specific user to list topic
+        Properties props = new Properties();
+        props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getKafkaBrokerPort());
+        String jaasTemplate = "org.apache.kafka.common.security.plain.PlainLoginModule "
+                + "required username=\"%s\" password=\"%s\";";
+        String jaasCfg = String.format(jaasTemplate, TENANT + "/" + NAMESPACE, "token:" + anotherToken);
+        props.put("sasl.jaas.config", jaasCfg);
+        props.put("security.protocol", "SASL_PLAINTEXT");
+        props.put("sasl.mechanism", "PLAIN");
+        AdminClient adminClient = AdminClient.create(props);
+        ListTopicsResult listTopicsResult = adminClient.listTopics();
+        Set<String> topics = listTopicsResult.names().get();
+        assertEquals(topics.size(), 1);
+        assertTrue(topics.contains(newTopic));
+    }
+
+
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationTestBase.java
@@ -50,6 +50,9 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+/**
+ * Unit test for KoP enable authorization.
+ */
 @Test
 @Slf4j
 public abstract class KafkaAuthorizationTestBase extends KopProtocolHandlerTestBase {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
@@ -69,8 +69,6 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
 
     private static final String ADMIN_USER = "admin_user";
 
-    private String adminToken;
-
     private KafkaRequestHandler handler;
     private AdminManager adminManager;
 
@@ -87,7 +85,7 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
         authConf.setProperties(properties);
         provider.initialize(authConf);
 
-        adminToken = AuthTokenUtils.createToken(secretKey, ADMIN_USER, Optional.empty());
+        String adminToken = AuthTokenUtils.createToken(secretKey, ADMIN_USER, Optional.empty());
 
         super.resetConfig();
         conf.setDefaultNumPartitions(DEFAULT_PARTITION_NUM);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
@@ -1,0 +1,262 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.testng.Assert.assertEquals;
+
+import com.google.common.collect.Sets;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupCoordinator;
+import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
+import io.streamnative.pulsar.handlers.kop.security.auth.Resource;
+import io.streamnative.pulsar.handlers.kop.security.auth.ResourceType;
+import io.streamnative.pulsar.handlers.kop.stats.NullStatsLogger;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import javax.crypto.SecretKey;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.requests.MetadataRequest;
+import org.apache.kafka.common.requests.MetadataResponse;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.authentication.AuthenticationProviderToken;
+import org.apache.pulsar.broker.authentication.utils.AuthTokenUtils;
+import org.apache.pulsar.broker.protocol.ProtocolHandler;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.impl.auth.AuthenticationToken;
+import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.RetentionPolicies;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Unit test for {@link KafkaRequestHandler} with authorization enabled.
+ */
+@Slf4j
+public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandlerTestBase {
+
+    private static final String TENANT = "KafkaAuthorizationTest";
+    private static final String NAMESPACE = "ns1";
+    private static final String SHORT_TOPIC = "topic1";
+    private static final String TOPIC = "persistent://" + TENANT + "/" + NAMESPACE + "/" + SHORT_TOPIC;
+    private static final int DEFAULT_PARTITION_NUM = 2;
+
+    private static final String ADMIN_USER = "admin_user";
+
+    private String adminToken;
+
+    private KafkaRequestHandler handler;
+    private AdminManager adminManager;
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
+
+        AuthenticationProviderToken provider = new AuthenticationProviderToken();
+
+        Properties properties = new Properties();
+        properties.setProperty("tokenSecretKey", AuthTokenUtils.encodeKeyBase64(secretKey));
+        ServiceConfiguration authConf = new ServiceConfiguration();
+        authConf.setProperties(properties);
+        provider.initialize(authConf);
+
+        adminToken = AuthTokenUtils.createToken(secretKey, ADMIN_USER, Optional.empty());
+
+        super.resetConfig();
+        conf.setDefaultNumPartitions(DEFAULT_PARTITION_NUM);
+        conf.setSaslAllowedMechanisms(Sets.newHashSet("PLAIN"));
+        conf.setKafkaMetadataTenant("internal");
+        conf.setKafkaMetadataNamespace("__kafka");
+        conf.setKafkaTenant(TENANT);
+        conf.setKafkaNamespace(NAMESPACE);
+
+        conf.setClusterName(super.configClusterName);
+        conf.setAuthorizationEnabled(true);
+        conf.setAuthenticationEnabled(true);
+        conf.setAuthorizationAllowWildcardsMatching(true);
+        conf.setSuperUserRoles(Sets.newHashSet(ADMIN_USER));
+        conf.setAuthenticationProviders(
+                Sets.newHashSet(AuthenticationProviderToken.class.getName()));
+        conf.setBrokerClientAuthenticationPlugin(AuthenticationToken.class.getName());
+        conf.setBrokerClientAuthenticationParameters("token:" + adminToken);
+        conf.setProperties(properties);
+
+        super.internalSetup();
+        log.info("success internal setup");
+
+        if (!admin.namespaces().getNamespaces(TENANT).contains(TENANT + "/__kafka")) {
+            admin.namespaces().createNamespace(TENANT + "/__kafka");
+            admin.namespaces().setNamespaceReplicationClusters(TENANT + "/__kafka", Sets.newHashSet("test"));
+            admin.namespaces().setRetention(TENANT + "/__kafka",
+                    new RetentionPolicies(-1, -1));
+        }
+
+        admin.topics().createPartitionedTopic(TOPIC, DEFAULT_PARTITION_NUM);
+
+        log.info("created namespaces, init handler");
+
+        ProtocolHandler handler1 = pulsar.getProtocolHandlers().protocol("kafka");
+        GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler1).getGroupCoordinator();
+        TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler1).getTransactionCoordinator();
+
+        adminManager = new AdminManager(pulsar.getAdminClient(), conf);
+        handler = new KafkaRequestHandler(
+                pulsar,
+                (KafkaServiceConfiguration) conf,
+                groupCoordinator,
+                transactionCoordinator,
+                adminManager,
+                false,
+                getPlainEndPoint(),
+                NullStatsLogger.INSTANCE);
+        ChannelHandlerContext mockCtx = mock(ChannelHandlerContext.class);
+        Channel mockChannel = mock(Channel.class);
+        doReturn(mockChannel).when(mockCtx).channel();
+        handler.ctx = mockCtx;
+    }
+
+    @Override
+    protected void createAdmin() throws Exception {
+        super.admin = spy(PulsarAdmin.builder().serviceHttpUrl(brokerUrl.toString())
+                .authentication(this.conf.getBrokerClientAuthenticationPlugin(),
+                        this.conf.getBrokerClientAuthenticationParameters()).build());
+    }
+
+    @AfterClass
+    @Override
+    protected void cleanup() throws Exception {
+        adminManager.shutdown();
+        super.internalCleanup();
+    }
+
+    @DataProvider(name = "metadataVersions")
+    public static Object[][] metadataVersions() {
+        return new Object[][]{ { (short) 0 }, { (short) 1 } };
+    }
+
+    @Test(timeOut = 10000, dataProvider = "metadataVersions")
+    public void testMetadataForPartitionedTopicFailed(short version) throws Exception {
+        final String topic = "testMetadataForPartitionedTopic-" + version;
+        admin.topics().createNonPartitionedTopic("persistent://" + TENANT + "/" + NAMESPACE + "/" + topic);
+
+        final RequestHeader header = new RequestHeader(ApiKeys.METADATA, version, "client", 0);
+        final MetadataRequest request =
+                new MetadataRequest(Collections.singletonList(topic), false, version);
+        final CompletableFuture<AbstractResponse> responseFuture = new CompletableFuture<>();
+        handler.handleTopicMetadataRequest(
+                new KafkaCommandDecoder.KafkaHeaderAndRequest(
+                        header, request, PulsarByteBufAllocator.DEFAULT.heapBuffer(), null),
+                responseFuture);
+        final MetadataResponse response = (MetadataResponse) responseFuture.get();
+        assertEquals(response.topicMetadata().size(), 1);
+        assertEquals(response.errors().size(), 1);
+        assertEquals(response.errors().get(topic), Errors.TOPIC_AUTHORIZATION_FAILED);
+    }
+
+    @Test(timeOut = 10000, dataProvider = "metadataVersions")
+    public void testMetadataForPartitionedTopicSuccess(short version) throws Exception {
+        final String topic = TOPIC + "-" + version;
+        KafkaRequestHandler spyHandler = spy(handler);
+        doReturn(CompletableFuture.completedFuture(true))
+                .when(spyHandler)
+                .authorize(eq(AclOperation.DESCRIBE), eq(Resource.of(ResourceType.TOPIC, topic)));
+        doReturn(CompletableFuture.completedFuture(true))
+                .when(spyHandler)
+                .authorize(eq(AclOperation.CREATE), eq(Resource.of(ResourceType.TOPIC, topic)));
+
+        final RequestHeader header = new RequestHeader(ApiKeys.METADATA, version, "client", 0);
+        final MetadataRequest request =
+                new MetadataRequest(Collections.singletonList(topic), true, version);
+        final CompletableFuture<AbstractResponse> responseFuture = new CompletableFuture<>();
+        spyHandler.handleTopicMetadataRequest(
+                new KafkaCommandDecoder.KafkaHeaderAndRequest(
+                        header, request, PulsarByteBufAllocator.DEFAULT.heapBuffer(), null),
+                responseFuture);
+         final MetadataResponse response = (MetadataResponse) responseFuture.get();
+        assertEquals(response.topicMetadata().size(), 1);
+        assertEquals(response.errors().size(), 0);
+    }
+
+    @Test(timeOut = 10000, dataProvider = "metadataVersions")
+    public void testMetadataForPartitionedTopicWithNoCreatePermission(short version) throws Exception {
+        final String topic = "persistent://" + TENANT + "/" + NAMESPACE + "/" + "noCreatePermissionTopic";
+        KafkaRequestHandler spyHandler = spy(handler);
+        doReturn(CompletableFuture.completedFuture(true))
+                .when(spyHandler)
+                .authorize(eq(AclOperation.DESCRIBE), eq(Resource.of(ResourceType.TOPIC, topic)));
+        doReturn(CompletableFuture.completedFuture(false))
+                .when(spyHandler)
+                .authorize(eq(AclOperation.CREATE), eq(Resource.of(ResourceType.TOPIC, topic)));
+        final RequestHeader header = new RequestHeader(ApiKeys.METADATA, version, "client", 0);
+        final MetadataRequest request =
+                new MetadataRequest(Collections.singletonList(topic), true, version);
+        final CompletableFuture<AbstractResponse> responseFuture = new CompletableFuture<>();
+        spyHandler.handleTopicMetadataRequest(
+                new KafkaCommandDecoder.KafkaHeaderAndRequest(
+                        header, request, PulsarByteBufAllocator.DEFAULT.heapBuffer(), null),
+                responseFuture);
+        final MetadataResponse response = (MetadataResponse) responseFuture.get();
+        assertEquals(response.topicMetadata().size(), 1);
+        assertEquals(response.errors().size(), 1);
+        assertEquals(response.errors().get(topic), Errors.TOPIC_AUTHORIZATION_FAILED);
+    }
+
+    @Test(timeOut = 10000)
+    public void testMetadataListTopic() throws Exception {
+        final String topic = TOPIC;
+        KafkaRequestHandler spyHandler = spy(handler);
+        for (int i = 0; i < DEFAULT_PARTITION_NUM; i++) {
+            doReturn(CompletableFuture.completedFuture(true))
+                    .when(spyHandler)
+                    .authorize(eq(AclOperation.DESCRIBE),
+                            eq(Resource.of(ResourceType.TOPIC, TopicName.get(topic).getPartition(i).toString()))
+                    );
+            doReturn(CompletableFuture.completedFuture(false))
+                    .when(spyHandler)
+                    .authorize(eq(AclOperation.CREATE),
+                            eq(Resource.of(ResourceType.TOPIC, TopicName.get(topic).getPartition(i).toString()))
+                    );
+        }
+
+        final RequestHeader header = new RequestHeader(ApiKeys.METADATA, (short) 1, "client", 0);
+        final MetadataRequest request =
+                new MetadataRequest(Collections.emptyList(), true, (short) 1);
+        final CompletableFuture<AbstractResponse> responseFuture = new CompletableFuture<>();
+        spyHandler.handleTopicMetadataRequest(
+                new KafkaCommandDecoder.KafkaHeaderAndRequest(
+                        header, request, PulsarByteBufAllocator.DEFAULT.heapBuffer(), null),
+                responseFuture);
+        final MetadataResponse response = (MetadataResponse) responseFuture.get();
+        assertEquals(response.topicMetadata().size(), 1);
+        assertEquals(response.errors().size(), 0);
+    }
+
+
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
@@ -50,6 +50,7 @@ import org.apache.pulsar.client.impl.auth.AuthenticationToken;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
+import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -131,6 +132,7 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
                 groupCoordinator,
                 transactionCoordinator,
                 adminManager,
+                pulsar.getLocalMetadataStore().getMetadataCache(LocalBrokerData.class),
                 false,
                 getPlainEndPoint(),
                 NullStatsLogger.INSTANCE);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
@@ -198,7 +198,7 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
                 new KafkaCommandDecoder.KafkaHeaderAndRequest(
                         header, request, PulsarByteBufAllocator.DEFAULT.heapBuffer(), null),
                 responseFuture);
-         final MetadataResponse response = (MetadataResponse) responseFuture.get();
+        final MetadataResponse response = (MetadataResponse) responseFuture.get();
         assertEquals(response.topicMetadata().size(), 1);
         assertEquals(response.errors().size(), 0);
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOauthDefaultHandlersTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOauthDefaultHandlersTest.java
@@ -25,6 +25,7 @@ import org.apache.pulsar.broker.authentication.AuthenticationProviderToken;
 import org.apache.pulsar.broker.authentication.utils.AuthTokenUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.impl.auth.AuthenticationToken;
+import org.apache.pulsar.common.policies.data.AuthAction;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -39,6 +40,7 @@ import org.testng.annotations.Test;
 public class SaslOauthDefaultHandlersTest extends SaslOauthBearerTestBase {
 
     private static final String ADMIN_USER = "admin_user";
+    private static final String USER = "user";
 
     @BeforeClass
     @Override
@@ -60,6 +62,12 @@ public class SaslOauthDefaultHandlersTest extends SaslOauthBearerTestBase {
         conf.setSaslAllowedMechanisms(Sets.newHashSet("OAUTHBEARER"));
         conf.setKopOauth2ConfigFile("src/test/resources/kop-default-oauth2.properties");
         super.internalSetup();
+
+        admin.namespaces().grantPermissionOnNamespace(
+                tenant + "/" + namespace,
+                USER,
+                Sets.newHashSet(AuthAction.consume, AuthAction.produce, AuthAction.packages)
+        );
     }
 
     @AfterClass
@@ -94,6 +102,6 @@ public class SaslOauthDefaultHandlersTest extends SaslOauthBearerTestBase {
                 + " required unsecuredLoginStringClaim_sub=\"%s\";";
         props.setProperty("security.protocol", "SASL_PLAINTEXT");
         props.setProperty("sasl.mechanism", "OAUTHBEARER");
-        props.setProperty("sasl.jaas.config", String.format(jaasTemplate, "user"));
+        props.setProperty("sasl.jaas.config", String.format(jaasTemplate, USER));
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOauthDefaultHandlersTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOauthDefaultHandlersTest.java
@@ -66,7 +66,7 @@ public class SaslOauthDefaultHandlersTest extends SaslOauthBearerTestBase {
         admin.namespaces().grantPermissionOnNamespace(
                 tenant + "/" + namespace,
                 USER,
-                Sets.newHashSet(AuthAction.consume, AuthAction.produce, AuthAction.packages)
+                Sets.newHashSet(AuthAction.consume, AuthAction.produce)
         );
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslPlainTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslPlainTestBase.java
@@ -190,21 +190,11 @@ public abstract class SaslPlainTestBase extends KopProtocolHandlerTestBase {
             kProducer.getProducer().send(new ProducerRecord<>(TOPIC, 0, "")).get();
             fail("should have failed");
         } catch (Exception e) {
-            assertTrue(e.getMessage().contains("SaslAuthenticationException"));
+            e.printStackTrace();
+            assertTrue(e.getMessage().contains("TopicAuthorizationException"));
         }
     }
 
-    @Test(timeOut = 20000)
-    void badNamespaceProvided() throws Exception {
-        try {
-            KProducer kProducer = new KProducer(TOPIC, false, "localhost", getKafkaBrokerPort(),
-                TENANT + "/ns2", "token:" + userToken);
-            kProducer.getProducer().send(new ProducerRecord<>(TOPIC, 0, "")).get();
-            fail("should have failed");
-        } catch (Exception e) {
-            assertTrue(e.getMessage().contains("SaslAuthenticationException"));
-        }
-    }
 
     @Test(timeOut = 20000)
     void clientWithoutAuth() throws Exception {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizerTest.java
@@ -33,6 +33,7 @@ import org.apache.pulsar.broker.authentication.AuthenticationProviderToken;
 import org.apache.pulsar.broker.authentication.utils.AuthTokenUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.impl.auth.AuthenticationToken;
+import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.testng.annotations.AfterMethod;
@@ -181,7 +182,31 @@ public class SimpleAclAuthorizerTest extends KopProtocolHandlerTestBase {
                 Resource.of(ResourceType.TOPIC, NOT_EXISTS_TENANT_TOPIC)).get();
 
         assertFalse(isAuthorized);
+    }
 
+    @Test
+    public void testAuthorizeManageTopic() throws ExecutionException, InterruptedException {
 
+        Boolean isAuthorized = simpleAclAuthorizer.canManageTopicAsync(
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER),
+                Resource.of(ResourceType.NAMESPACE, TopicName.get(TOPIC).getNamespace())).get();
+        assertFalse(isAuthorized);
+
+        isAuthorized = simpleAclAuthorizer.canManageTopicAsync(
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ADMIN_USER),
+                Resource.of(ResourceType.NAMESPACE, TopicName.get(TOPIC).getNamespace())).get();
+        assertTrue(isAuthorized);
+
+        isAuthorized = simpleAclAuthorizer.canManageTopicAsync(
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ANOTHER_USER),
+                Resource.of(ResourceType.NAMESPACE, TopicName.get(TOPIC).getNamespace())).get();
+
+        assertFalse(isAuthorized);
+
+        isAuthorized = simpleAclAuthorizer.canManageTopicAsync(
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ANOTHER_USER),
+                Resource.of(ResourceType.NAMESPACE, TopicName.get(NOT_EXISTS_TENANT_TOPIC).getNamespace())).get();
+
+        assertFalse(isAuthorized);
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizerTest.java
@@ -48,6 +48,8 @@ public class SimpleAclAuthorizerTest extends KopProtocolHandlerTestBase {
     private SimpleAclAuthorizer simpleAclAuthorizer;
 
     private static final String SIMPLE_USER = "muggle_user";
+    private static final String PRODUCE_USER = "produce_user";
+    private static final String CONSUMER_USER = "consumer_user";
     private static final String ANOTHER_USER = "death_eater_user";
     private static final String ADMIN_USER = "admin_user";
     private static final String TENANT_ADMIN_USER = "tenant_admin_user";
@@ -102,6 +104,11 @@ public class SimpleAclAuthorizerTest extends KopProtocolHandlerTestBase {
         admin.topics().createPartitionedTopic(TOPIC, 1);
         admin.namespaces().grantPermissionOnNamespace(TENANT + "/" + NAMESPACE, SIMPLE_USER,
                 Sets.newHashSet(AuthAction.consume, AuthAction.produce));
+        admin.namespaces().grantPermissionOnNamespace(TENANT + "/" + NAMESPACE, PRODUCE_USER,
+                Sets.newHashSet(AuthAction.produce));
+        admin.namespaces().grantPermissionOnNamespace(TENANT + "/" + NAMESPACE, CONSUMER_USER,
+                Sets.newHashSet(AuthAction.consume));
+
         simpleAclAuthorizer = new SimpleAclAuthorizer(pulsar);
     }
 
@@ -126,21 +133,28 @@ public class SimpleAclAuthorizerTest extends KopProtocolHandlerTestBase {
         assertTrue(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canProduceAsync(
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, PRODUCE_USER),
+                Resource.of(ResourceType.TOPIC, TOPIC)).get();
+        assertTrue(isAuthorized);
+
+        isAuthorized = simpleAclAuthorizer.canProduceAsync(
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, CONSUMER_USER),
+                Resource.of(ResourceType.TOPIC, TOPIC)).get();
+        assertFalse(isAuthorized);
+
+        isAuthorized = simpleAclAuthorizer.canProduceAsync(
                 new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ANOTHER_USER),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
-
         assertFalse(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canProduceAsync(
                 new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER),
                 Resource.of(ResourceType.TOPIC, NOT_EXISTS_TENANT_TOPIC)).get();
-
         assertFalse(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canProduceAsync(
                 new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ADMIN_USER),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
-
         assertTrue(isAuthorized);
     }
 
@@ -152,15 +166,23 @@ public class SimpleAclAuthorizerTest extends KopProtocolHandlerTestBase {
         assertTrue(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canConsumeAsync(
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, PRODUCE_USER),
+                Resource.of(ResourceType.TOPIC, TOPIC)).get();
+        assertFalse(isAuthorized);
+
+        isAuthorized = simpleAclAuthorizer.canConsumeAsync(
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, CONSUMER_USER),
+                Resource.of(ResourceType.TOPIC, TOPIC)).get();
+        assertTrue(isAuthorized);
+
+        isAuthorized = simpleAclAuthorizer.canConsumeAsync(
                 new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ANOTHER_USER),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
-
         assertFalse(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canConsumeAsync(
                 new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER),
                 Resource.of(ResourceType.TOPIC, NOT_EXISTS_TENANT_TOPIC)).get();
-
         assertFalse(isAuthorized);
     }
 
@@ -172,63 +194,46 @@ public class SimpleAclAuthorizerTest extends KopProtocolHandlerTestBase {
         assertTrue(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canLookupAsync(
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, PRODUCE_USER),
+                Resource.of(ResourceType.TOPIC, TOPIC)).get();
+        assertTrue(isAuthorized);
+
+        isAuthorized = simpleAclAuthorizer.canLookupAsync(
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, CONSUMER_USER),
+                Resource.of(ResourceType.TOPIC, TOPIC)).get();
+        assertTrue(isAuthorized);
+
+        isAuthorized = simpleAclAuthorizer.canLookupAsync(
                 new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ANOTHER_USER),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
-
         assertFalse(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canLookupAsync(
                 new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER),
                 Resource.of(ResourceType.TOPIC, NOT_EXISTS_TENANT_TOPIC)).get();
-
         assertFalse(isAuthorized);
     }
 
     @Test
-    public void testAuthorizeCreateTopic() throws ExecutionException, InterruptedException {
+    public void testAuthorizeTenantAdmin() throws ExecutionException, InterruptedException {
 
-        // SIMPLE_USER can't create topic because don't have package permission.
-        Boolean isAuthorized = simpleAclAuthorizer.canCreateTopicAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER),
-                Resource.of(ResourceType.TOPIC, TOPIC)).get();
-        assertFalse(isAuthorized);
-
-        // ADMIN_USER can create topic, because is superuser.
-        isAuthorized = simpleAclAuthorizer.canCreateTopicAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ADMIN_USER),
-                Resource.of(ResourceType.TOPIC, TOPIC)).get();
-        assertTrue(isAuthorized);
-
-        // ANOTHER_USER don't have any permission.
-        isAuthorized = simpleAclAuthorizer.canCreateTopicAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ANOTHER_USER),
-                Resource.of(ResourceType.TOPIC, TOPIC)).get();
-        assertFalse(isAuthorized);
-
-        // ANOTHER_USER can't create don't exist tenant's topic.
-        isAuthorized = simpleAclAuthorizer.canCreateTopicAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ANOTHER_USER),
-                Resource.of(ResourceType.TOPIC, NOT_EXISTS_TENANT_TOPIC)).get();
-        assertFalse(isAuthorized);
-
-        // TENANT_ADMIN_USER can't create don't exist tenant's topic,
+        // TENANT_ADMIN_USER can't produce don't exist tenant's topic,
         // because tenant admin depend on exist tenant.
-        isAuthorized = simpleAclAuthorizer.canCreateTopicAsync(
+        Boolean isAuthorized = simpleAclAuthorizer.canProduceAsync(
                 new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TENANT_ADMIN_USER),
                 Resource.of(ResourceType.TOPIC, NOT_EXISTS_TENANT_TOPIC)).get();
         assertFalse(isAuthorized);
 
-        // ADMIN_USER can create don't exist tenant's topic, because is superuser.
-        isAuthorized = simpleAclAuthorizer.canCreateTopicAsync(
+        // ADMIN_USER can produce don't exist tenant's topic, because is superuser.
+        isAuthorized = simpleAclAuthorizer.canProduceAsync(
                 new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ADMIN_USER),
                 Resource.of(ResourceType.TOPIC, NOT_EXISTS_TENANT_TOPIC)).get();
         assertTrue(isAuthorized);
 
-        // TENANT_ADMIN_USER can create topic.
-        isAuthorized = simpleAclAuthorizer.canCreateTopicAsync(
+        // TENANT_ADMIN_USER can produce.
+        isAuthorized = simpleAclAuthorizer.canProduceAsync(
                 new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TENANT_ADMIN_USER),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
-
         assertTrue(isAuthorized);
 
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizerTest.java
@@ -211,13 +211,14 @@ public class SimpleAclAuthorizerTest extends KopProtocolHandlerTestBase {
                 Resource.of(ResourceType.TOPIC, NOT_EXISTS_TENANT_TOPIC)).get();
         assertFalse(isAuthorized);
 
-        // TENANT_ADMIN_USER can't create don't exist tenant's topic, because tenant admin depend on exist topic.
+        // TENANT_ADMIN_USER can't create don't exist tenant's topic,
+        // because tenant admin depend on exist tenant.
         isAuthorized = simpleAclAuthorizer.canCreateTopicAsync(
                 new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TENANT_ADMIN_USER),
                 Resource.of(ResourceType.TOPIC, NOT_EXISTS_TENANT_TOPIC)).get();
         assertFalse(isAuthorized);
 
-        // ADMIN_USER can create don't exist tenant's topic, because is superuser
+        // ADMIN_USER can create don't exist tenant's topic, because is superuser.
         isAuthorized = simpleAclAuthorizer.canCreateTopicAsync(
                 new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ADMIN_USER),
                 Resource.of(ResourceType.TOPIC, NOT_EXISTS_TENANT_TOPIC)).get();


### PR DESCRIPTION
#236 Add authorization to handleTopicMetadataRequest.

Fix #415 and #571 

## Motivation
When client fetch metadata need check topic permission, so we need add authorization in handleTopicMetadataRequest, and do not perform role verification in authentication.

## Modifications
Add a common method in `KafkaRequestHandler#authorize` , this method use `authorizer` to authorization.
Modify the authentication behavior, and do not verify the role during authentication, verify the role in fetch metadata(#571  )

