### PR TITLE
Avoid creating a lot of MetadataCache instances

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -194,6 +194,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     private final SaslAuthenticator authenticator;
     private final Authorizer authorizer;
     private final AdminManager adminManager;
+    private final MetadataCache<LocalBrokerData> localBrokerDataCache;
 
     private final Boolean tlsEnabled;
     private final EndPoint advertisedEndPoint;
@@ -236,6 +237,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                GroupCoordinator groupCoordinator,
                                TransactionCoordinator transactionCoordinator,
                                AdminManager adminManager,
+                               MetadataCache<LocalBrokerData> localBrokerDataCache,
                                Boolean tlsEnabled,
                                EndPoint advertisedEndPoint,
                                StatsLogger statsLogger) throws Exception {
@@ -256,6 +258,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 ? new SimpleAclAuthorizer(pulsarService)
                 : null;
         this.adminManager = adminManager;
+        this.localBrokerDataCache = localBrokerDataCache;
         this.tlsEnabled = tlsEnabled;
         this.advertisedEndPoint = advertisedEndPoint;
         this.advertisedListeners = kafkaConfig.getKafkaAdvertisedListeners();
@@ -1970,10 +1973,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 }
 
                 // Get a list of ServiceLookupData for each matchBroker.
-                final MetadataCache<LocalBrokerData> metadataCache = pulsarService.getLocalMetadataStore()
-                        .getMetadataCache(LocalBrokerData.class);
                 List<CompletableFuture<Optional<LocalBrokerData>>> list = matchBrokers.stream()
-                    .map(matchBroker -> metadataCache.get(
+                    .map(matchBroker -> localBrokerDataCache.get(
                             String.format("%s/%s", LoadManager.LOADBALANCE_BROKERS_ROOT, matchBroker)))
                     .collect(Collectors.toList());
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/EntryPublishTimeTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/EntryPublishTimeTest.java
@@ -24,6 +24,7 @@ import io.streamnative.pulsar.handlers.kop.stats.NullStatsLogger;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import org.apache.pulsar.broker.protocol.ProtocolHandler;
+import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
@@ -59,6 +60,7 @@ public class EntryPublishTimeTest extends KopProtocolHandlerTestBase {
                 groupCoordinator,
                 transactionCoordinator,
                 adminManager,
+                pulsar.getLocalMetadataStore().getMetadataCache(LocalBrokerData.class),
                 false,
                 getPlainEndPoint(),
                 NullStatsLogger.INSTANCE);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
@@ -72,6 +72,7 @@ import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.pulsar.broker.protocol.ProtocolHandler;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
+import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Ignore;
@@ -126,6 +127,7 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
             groupCoordinator,
             transactionCoordinator,
             adminManager,
+            pulsar.getLocalMetadataStore().getMetadataCache(LocalBrokerData.class),
             false,
             getPlainEndPoint(),
             NullStatsLogger.INSTANCE);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -93,6 +93,7 @@ import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -147,6 +148,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
             groupCoordinator,
             transactionCoordinator,
             adminManager,
+            pulsar.getLocalMetadataStore().getMetadataCache(LocalBrokerData.class),
             false,
             getPlainEndPoint(),
             NullStatsLogger.INSTANCE);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
@@ -45,6 +45,7 @@ import org.apache.pulsar.broker.protocol.ProtocolHandler;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.policies.data.TopicStats;
+import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -75,6 +76,7 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
             groupCoordinator,
             transactionCoordinator,
             adminManager,
+            pulsar.getLocalMetadataStore().getMetadataCache(LocalBrokerData.class),
             false,
             getPlainEndPoint(),
             NullStatsLogger.INSTANCE);


### PR DESCRIPTION
### Motivation

When there're a lot of topics, there could be a lot of `MetadataCache` instances in memory.

![image](https://user-images.githubusercontent.com/18204803/129903767-4b2f3961-c0e1-4ad5-88b0-7451ed41393a.png)

This bug was introduced from https://github.com/streamnative/kop/pull/488 because the Pulsar side adopted a new class `MetadataCache` as ZK cache.  However, each time `MetadataStore#getMetadataCache` is called, a new `MetadataCache` instance will be created. In KoP, it means that each time a topic lookup is performed, a new `MetadataCache` instance will be created.

### Modifications

Only call `MetadataStore#getMetadataCache` once when KoP starts and reuse the same `MetadataCache` instance for each `KafkaRequestHandler` instance.