### PR TITLE
skip to get kafka advertised addres from zk when lookup with listenerName

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -153,6 +153,7 @@ import org.apache.kafka.common.requests.TxnOffsetCommitRequest;
 import org.apache.kafka.common.requests.TxnOffsetCommitResponse;
 import org.apache.kafka.common.requests.WriteTxnMarkersRequest;
 import org.apache.kafka.common.requests.WriteTxnMarkersResponse;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
@@ -174,6 +175,7 @@ import org.apache.pulsar.common.util.Murmur3_32Hash;
 import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
 import org.apache.pulsar.policies.data.loadbalancer.ServiceLookupData;
+import org.eclipse.jetty.util.StringUtil;
 
 /**
  * This class contains all the request handling methods.
@@ -1944,6 +1946,22 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         if (future != null) {
             return future;
         }
+
+        // if kafkaListenerName is set, the lookup result is the advertised address
+        if (!StringUtil.isBlank(kafkaConfig.getKafkaListenerName())) {
+            // TODO:　should add SecurityProtocol according to which endpoint is handling the request.
+            //  firstly we only support PLAINTEXT when lookup with kafkaListenerName
+            String kafkaAdvertisedAddress = String.format("%s://%s:%s", SecurityProtocol.PLAINTEXT.name(),
+                    pulsarAddress.getHostName(), pulsarAddress.getPort());
+            KafkaTopicManager.KOP_ADDRESS_CACHE.put(topic.toString(), returnFuture);
+            returnFuture.complete(Optional.ofNullable(kafkaAdvertisedAddress));
+            if (log.isDebugEnabled()) {
+                log.debug("{} get kafka Advertised Address through kafkaListenerName: {}",
+                        topic, pulsarAddress);
+            }
+            return returnFuture;
+        }
+
         // advertised data is write in  /loadbalance/brokers/advertisedAddress:webServicePort
         // here we get the broker url, need to find related webServiceUrl.
         pulsarService.getPulsarResources()

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaListenerNameTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaListenerNameTest.java
@@ -39,10 +39,6 @@ public class KafkaListenerNameTest extends KopProtocolHandlerTestBase {
     public void testListenerName() throws Exception {
         super.resetConfig();
         conf.setAdvertisedAddress(null);
-        conf.setInternalListenerName("external");
-        // There's a limit that PulsarService doesn't use advertised listener's address as it's brokerServiceUrl's
-        // address. So here the "external" listener's port should be the same with brokerPort and address should be
-        // localhost.
         final String localAddress = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(null);
         final String advertisedListeners =
                 "internal:pulsar://192.168.0.2:6650,external:pulsar://" + localAddress + ":" + brokerPort;


### PR DESCRIPTION
This is the first step for #669, only support one listener which configed in `kafkaListenerName`, and only support PLAINTEXT