### PR TITLE
[WIP] Support kop for v0 version of SASL_HANDSHAKE

### DIFF
--- a/kafka-0-10/src/main/java/io/streamnative/kafka/client/zero/ten/Consumer010Impl.java
+++ b/kafka-0-10/src/main/java/io/streamnative/kafka/client/zero/ten/Consumer010Impl.java
@@ -16,9 +16,14 @@ package io.streamnative.kafka.client.zero.ten;
 import io.streamnative.kafka.client.api.Consumer;
 import io.streamnative.kafka.client.api.ConsumerConfiguration;
 import io.streamnative.kafka.client.api.ConsumerRecord;
+
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.PartitionInfo;
 
 /**
  * The implementation of Kafka consumer 0.10.0.0.
@@ -34,5 +39,10 @@ public class Consumer010Impl<K, V> extends KafkaConsumer<K, V> implements Consum
         final List<ConsumerRecord<K, V>> records = new ArrayList<>();
         poll(timeoutMs).forEach(record -> records.add(ConsumerRecord.createOldRecord(record)));
         return records;
+    }
+
+    @Override
+    public Map<String, List<PartitionInfo>> listTopics(long timeoutMS) {
+        return listTopics();
     }
 }

--- a/kafka-1-0/src/main/java/io/streamnative/kafka/client/one/zero/ConsumerImpl.java
+++ b/kafka-1-0/src/main/java/io/streamnative/kafka/client/one/zero/ConsumerImpl.java
@@ -16,9 +16,14 @@ package io.streamnative.kafka.client.one.zero;
 import io.streamnative.kafka.client.api.Consumer;
 import io.streamnative.kafka.client.api.ConsumerConfiguration;
 import io.streamnative.kafka.client.api.ConsumerRecord;
+
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.PartitionInfo;
 
 /**
  * The implementation of Kafka consumer 1.0.0.
@@ -34,5 +39,10 @@ public class ConsumerImpl<K, V> extends KafkaConsumer<K, V> implements Consumer<
         final List<ConsumerRecord<K, V>> records = new ArrayList<>();
         poll(timeoutMs).forEach(record -> records.add(ConsumerRecord.create(record)));
         return records;
+    }
+
+    @Override
+    public Map<String, List<PartitionInfo>> listTopics(long timeoutMS) {
+        return listTopics(timeoutMS);
     }
 }

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/Consumer.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/Consumer.java
@@ -14,12 +14,10 @@
 package io.streamnative.kafka.client.api;
 
 import java.io.Closeable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.NonNull;
+import org.apache.kafka.common.PartitionInfo;
 
 /**
  * A common interface of Kafka consumer.
@@ -57,4 +55,6 @@ public interface Consumer<K, V> extends Closeable {
         }
         return records;
     }
+
+    Map<String, List<PartitionInfo>> listTopics(long timeoutMS);
 }

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/ConsumerConfiguration.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/ConsumerConfiguration.java
@@ -28,6 +28,10 @@ public class ConsumerConfiguration {
     private Object valueDeserializer;
     @Builder.Default
     private boolean fromEarliest = true;
+    private String securityProtocol;
+    private String saslMechanism;
+    private String userName;
+    private String password;
 
     public Properties toProperties() {
         final Properties props = new Properties();
@@ -44,6 +48,17 @@ public class ConsumerConfiguration {
             props.put("value.deserializer", valueDeserializer);
         }
         props.put("auto.offset.reset", fromEarliest ? "earliest" : "latest");
+
+        if (securityProtocol != null) {
+            props.put("security.protocol", securityProtocol);
+        }
+        if (saslMechanism != null) {
+            props.put("sasl.mechanism", saslMechanism);
+        }
+        if (userName != null && password != null) {
+            final String kafkaAuth = String.format("username=\"%s\" password=\"%s\";", userName, password);
+            props.put("sasl.jaas.config", "org.apache.kafka.common.security.plain.PlainLoginModule required " + kafkaAuth);
+        }
         return props;
     }
 }

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/ProducerConfiguration.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/ProducerConfiguration.java
@@ -25,6 +25,11 @@ public class ProducerConfiguration {
     private String bootstrapServers;
     private Object keySerializer;
     private Object valueSerializer;
+    private String maxBlockMs;
+    private String securityProtocol;
+    private String saslMechanism;
+    private String userName;
+    private String password;
 
     public Properties toProperties() {
         final Properties props = new Properties();
@@ -36,6 +41,19 @@ public class ProducerConfiguration {
         }
         if (valueSerializer != null) {
             props.put("value.serializer", valueSerializer);
+        }
+        if (maxBlockMs != null) {
+            props.put("max.block.ms", maxBlockMs);
+        }
+        if (securityProtocol != null) {
+            props.put("security.protocol", securityProtocol);
+        }
+        if (saslMechanism != null) {
+            props.put("sasl.mechanism", saslMechanism);
+        }
+        if (userName != null && password != null) {
+            final String kafkaAuth = String.format("username=\"%s\" password=\"%s\";", userName, password);
+            props.put("sasl.jaas.config", "org.apache.kafka.common.security.plain.PlainLoginModule required " + kafkaAuth);
         }
         return props;
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -333,18 +333,26 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     }
 
     @Override
-    protected boolean hasAuthenticated(KafkaHeaderAndRequest request) {
+    protected boolean hasAuthenticated() {
         return authenticator == null || authenticator.complete();
     }
 
     @Override
-    protected void authenticate(KafkaHeaderAndRequest kafkaHeaderAndRequest,
-                                CompletableFuture<AbstractResponse> responseFuture) throws AuthenticationException {
+    protected void channelPrepare(ChannelHandlerContext ctx,
+                                  ByteBuf requestBuf) throws AuthenticationException {
         if (authenticator != null) {
-            authenticator.authenticate(
-                    kafkaHeaderAndRequest.getHeader(), kafkaHeaderAndRequest.getRequest(), responseFuture);
+            authenticator.authenticate(ctx, requestBuf);
         }
     }
+
+//    @Override
+//    protected void authenticate(KafkaHeaderAndRequest kafkaHeaderAndRequest,
+//                                CompletableFuture<AbstractResponse> responseFuture) throws AuthenticationException {
+//        if (authenticator != null) {
+//            authenticator.authenticate(
+//                    kafkaHeaderAndRequest.getHeader(), kafkaHeaderAndRequest.getRequest(), responseFuture);
+//        }
+//    }
 
     protected void handleApiVersionsRequest(KafkaHeaderAndRequest apiVersionRequest,
                                             CompletableFuture<AbstractResponse> resultFuture) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/PlainSaslServer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/PlainSaslServer.java
@@ -76,7 +76,7 @@ public class PlainSaslServer implements SaslServer {
 
             authorizationId = authState.getAuthRole();
             complete = true;
-            return null;
+            return new byte[0];
         } catch (AuthenticationException e) {
             throw new SaslException(e.getMessage());
         }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndTestBase.java
@@ -179,4 +179,30 @@ public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
                 .fromEarliest(true)
                 .build();
     }
+
+    protected ProducerConfiguration producerConfigurationWithSaslPlain(final KafkaVersion version, String username, String password) {
+        return ProducerConfiguration.builder()
+                .bootstrapServers("localhost:" + getKafkaBrokerPort())
+                .keySerializer(version.getStringSerializer())
+                .valueSerializer(version.getStringSerializer())
+                .securityProtocol("SASL_PLAINTEXT")
+                .saslMechanism("PLAIN")
+                .userName(username)
+                .password(password)
+                .build();
+    }
+
+    protected ConsumerConfiguration consumerConfigurationWithSaslPlain(final KafkaVersion version, String username, String password) {
+        return ConsumerConfiguration.builder()
+                .bootstrapServers("localhost:" + getKafkaBrokerPort())
+                .groupId("group-" + version.name())
+                .keyDeserializer(version.getStringDeserializer())
+                .valueDeserializer(version.getStringDeserializer())
+                .securityProtocol("SASL_PLAINTEXT")
+                .saslMechanism("PLAIN")
+                .userName(username)
+                .password(password)
+                .fromEarliest(true)
+                .build();
+    }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/DefaultKafkaClientFactory.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/DefaultKafkaClientFactory.java
@@ -24,10 +24,12 @@ import io.streamnative.kafka.client.api.RecordMetadata;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Future;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.header.internals.RecordHeader;
 
 /**
@@ -70,6 +72,11 @@ public class DefaultKafkaClientFactory implements KafkaClientFactory {
             final List<ConsumerRecord<K, V>> records = new ArrayList<>();
             poll(Duration.ofMillis(timeoutMs)).forEach(record -> records.add(ConsumerRecord.create(record)));
             return records;
+        }
+
+        @Override
+        public Map<String, List<PartitionInfo>> listTopics(long timeoutMS) {
+            return listTopics(Duration.ofMillis(timeoutMS));
         }
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/saslplain/SaslPlainEndToEndKafkaTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/saslplain/SaslPlainEndToEndKafkaTest.java
@@ -1,0 +1,8 @@
+package io.streamnative.pulsar.handlers.kop.compatibility.saslplain;
+
+public class SaslPlainEndToEndKafkaTest extends SaslPlainEndToEndTestBase {
+
+    public SaslPlainEndToEndKafkaTest() {
+        super("kafka");
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/saslplain/SaslPlainEndToEndPulsarTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/saslplain/SaslPlainEndToEndPulsarTest.java
@@ -1,0 +1,8 @@
+package io.streamnative.pulsar.handlers.kop.compatibility.saslplain;
+
+public class SaslPlainEndToEndPulsarTest extends SaslPlainEndToEndTestBase{
+
+    public SaslPlainEndToEndPulsarTest() {
+        super("pulsar");
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/saslplain/SaslPlainEndToEndTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/saslplain/SaslPlainEndToEndTestBase.java
@@ -1,0 +1,326 @@
+package io.streamnative.pulsar.handlers.kop.compatibility.saslplain;
+
+
+import static org.mockito.Mockito.spy;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+import com.google.common.collect.Sets;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.streamnative.kafka.client.api.Consumer;
+import io.streamnative.kafka.client.api.ConsumerRecord;
+import io.streamnative.kafka.client.api.Header;
+import io.streamnative.kafka.client.api.KafkaClientFactory;
+import io.streamnative.kafka.client.api.KafkaClientFactoryImpl;
+import io.streamnative.kafka.client.api.KafkaVersion;
+import io.streamnative.kafka.client.api.Producer;
+import io.streamnative.kafka.client.api.ProducerConfiguration;
+import io.streamnative.kafka.client.api.RecordMetadata;
+import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
+import io.streamnative.pulsar.handlers.kop.compatibility.DefaultKafkaClientFactory;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.security.JaasUtils;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.authentication.AuthenticationProviderToken;
+import org.apache.pulsar.broker.authentication.utils.AuthTokenUtils;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.impl.auth.AuthenticationToken;
+import org.apache.pulsar.common.policies.data.AuthAction;
+import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import javax.crypto.SecretKey;
+import javax.security.auth.login.Configuration;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class SaslPlainEndToEndTestBase extends KopProtocolHandlerTestBase{
+    private static final String SIMPLE_USER = "muggle_user";
+    private static final String TENANT = "SaslPlainTest";
+    private static final String ANOTHER_USER = "death_eater_user";
+    private static final String ADMIN_USER = "admin_user";
+    private static final String NAMESPACE = "ns1";
+    private static final String KAFKA_TOPIC = "topic1";
+    private static final String TOPIC = "persistent://" + TENANT + "/" + NAMESPACE + "/" + KAFKA_TOPIC;
+    private String adminToken;
+    private String userToken;
+    private String anotherToken;
+    private File jaasConfigFile;
+
+    protected Map<KafkaVersion, KafkaClientFactory> kafkaClientFactories = Arrays.stream(KafkaVersion.values())
+            .collect(Collectors.toMap(
+                    version -> version,
+                    version -> {
+                        if (version.equals(KafkaVersion.DEFAULT)) {
+                            return new DefaultKafkaClientFactory();
+                        } else {
+                            return new KafkaClientFactoryImpl(version);
+                        }
+                    },
+                    (k, v) -> {
+                        throw new IllegalStateException("Duplicated key: " + k);
+                    }, TreeMap::new));
+
+    public SaslPlainEndToEndTestBase(final String entryFormat) {
+        super(entryFormat);
+    }
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
+
+        AuthenticationProviderToken provider = new AuthenticationProviderToken();
+
+        Properties properties = new Properties();
+        properties.setProperty("tokenSecretKey", AuthTokenUtils.encodeKeyBase64(secretKey));
+        ServiceConfiguration authConf = new ServiceConfiguration();
+        authConf.setProperties(properties);
+        provider.initialize(authConf);
+
+        userToken = AuthTokenUtils.createToken(secretKey, SIMPLE_USER, Optional.empty());
+        adminToken = AuthTokenUtils.createToken(secretKey, ADMIN_USER, Optional.empty());
+        anotherToken = AuthTokenUtils.createToken(secretKey, ANOTHER_USER, Optional.empty());
+
+        super.resetConfig();
+        conf.setKopAllowedNamespaces(Collections.singleton(TENANT + "/" + NAMESPACE));
+        ((KafkaServiceConfiguration) conf).setSaslAllowedMechanisms(Sets.newHashSet("PLAIN"));
+        ((KafkaServiceConfiguration) conf).setKafkaMetadataTenant("internal");
+        ((KafkaServiceConfiguration) conf).setKafkaMetadataNamespace("__kafka");
+
+        conf.setClusterName(super.configClusterName);
+        conf.setAuthorizationEnabled(true);
+        conf.setAuthenticationEnabled(true);
+        conf.setAuthorizationAllowWildcardsMatching(true);
+        conf.setSuperUserRoles(Sets.newHashSet(ADMIN_USER));
+        conf.setAuthenticationProviders(
+                Sets.newHashSet("org.apache.pulsar.broker.authentication."
+                        + "AuthenticationProviderToken"));
+        conf.setBrokerClientAuthenticationPlugin(AuthenticationToken.class.getName());
+        conf.setBrokerClientAuthenticationParameters("token:" + adminToken);
+        conf.setProperties(properties);
+
+        super.internalSetup();
+
+        admin.tenants().createTenant(TENANT,
+                TenantInfo.builder()
+                        .adminRoles(Collections.singleton(ADMIN_USER))
+                        .allowedClusters(Collections.singleton(configClusterName))
+                        .build());
+        admin.namespaces().createNamespace(TENANT + "/" + NAMESPACE);
+        admin.topics().createPartitionedTopic(TOPIC, 1);
+        admin
+                .namespaces().grantPermissionOnNamespace(TENANT + "/" + NAMESPACE, SIMPLE_USER,
+                Sets.newHashSet(AuthAction.consume, AuthAction.produce));
+    }
+
+    @Override
+    protected void createAdmin() throws Exception {
+        super.admin = spy(PulsarAdmin.builder().serviceHttpUrl(brokerUrl.toString())
+                .authentication(this.conf.getBrokerClientAuthenticationPlugin(),
+                        this.conf.getBrokerClientAuthenticationParameters()).build());
+    }
+
+    @AfterClass
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+        jaasConfigFile.delete();
+    }
+
+    @AfterMethod
+    protected void cleanJaasConf() {
+        jaasConfigFile.delete();
+        Configuration.setConfiguration(null);
+    }
+
+    protected void writeJaasFile(String username, String password) throws IOException {
+        jaasConfigFile = File.createTempFile("jaas", ".conf");
+        jaasConfigFile.deleteOnExit();
+        System.setProperty(JaasUtils.JAVA_LOGIN_CONFIG_PARAM, jaasConfigFile.toString());
+        StringBuilder builder = new StringBuilder();
+        builder.append("org.apache.kafka.common.security.plain.PlainLoginModule");
+        builder.append(' ');
+        builder.append("required");
+        builder.append(' ');
+        builder.append("username");
+        builder.append('=');
+        builder.append(username);
+        builder.append(' ');
+        builder.append("password");
+        builder.append('=');
+        builder.append(password);
+        builder.append(';');
+        List<String> lines = Arrays.asList("KafkaClient { ", builder.toString(), "};");
+        Files.write(jaasConfigFile.toPath(), lines, StandardCharsets.UTF_8);
+    }
+
+    @Test(timeOut = 40000)
+    void simpleProduceAndConsume() throws Exception {
+
+        writeJaasFile(TENANT + "/" + NAMESPACE, "token:" + userToken);
+
+        final List<String> keys = new ArrayList<>();
+        final List<String> values = new ArrayList<>();
+        final List<Header> headers = new ArrayList<>();
+
+        long offset = 0;
+        for (KafkaVersion version : kafkaClientFactories.keySet()) {
+            final Producer<String, String> producer = kafkaClientFactories.get(version)
+                    .createProducer(producerConfigurationWithSaslPlain(version,
+                            TENANT + "/" + NAMESPACE,
+                            "token:" + userToken));
+            // send a message that only contains value
+            String value = "value-from-" + version.name() + offset;
+            values.add("value-from-" + version.name() + offset);
+
+            RecordMetadata metadata = producer.newContextBuilder(KAFKA_TOPIC, value).build().sendAsync().get();
+            log.info("Kafka client {} sent {} to {}", version, value, metadata);
+            Assert.assertEquals(metadata.getTopic(), KAFKA_TOPIC);
+            Assert.assertEquals(metadata.getPartition(), 0);
+            Assert.assertEquals(metadata.getOffset(), offset);
+            offset++;
+
+            // send a message that contains key and headers, which are optional
+            String key = "key-from-" + version.name() + offset;
+            value = "value-from-" + version.name() + offset;
+            keys.add(key);
+            values.add(value);
+            // Because there is no header in ProducerRecord before 0.11.x.
+            if (!version.equals(KafkaVersion.KAFKA_0_10_0_0)) {
+                headers.add(new Header("header-" + key, "header-" + value));
+            }
+
+            metadata = producer.newContextBuilder(KAFKA_TOPIC, value)
+                    .key(key)
+                    .headers(headers.subList(headers.size() - 1, headers.size()))
+                    .build()
+                    .sendAsync()
+                    .get();
+            log.info("Kafka client {} sent {} (key={}) to {}", version, value, key, metadata);
+            Assert.assertEquals(metadata.getTopic(), KAFKA_TOPIC);
+            Assert.assertEquals(metadata.getPartition(), 0);
+            Assert.assertEquals(metadata.getOffset(), offset);
+            offset++;
+
+            producer.close();
+        }
+
+        for (KafkaVersion version : kafkaClientFactories.keySet()) {
+            final Consumer<String, String> consumer = kafkaClientFactories.get(version)
+                    .createConsumer(consumerConfigurationWithSaslPlain(version,
+                            TENANT + "/" + NAMESPACE,
+                            "token:" + userToken));
+            consumer.subscribe(KAFKA_TOPIC);
+            final List<ConsumerRecord<String, String>> records = consumer.receiveUntil(values.size(), 6000);
+            Assert.assertEquals(records.stream().map(ConsumerRecord::getValue).collect(Collectors.toList()), values);
+            if (conf.getEntryFormat().equals("pulsar")) {
+                // NOTE: PulsarEntryFormatter will encode an empty String as key if key doesn't exist
+                Assert.assertEquals(records.stream()
+                        .map(ConsumerRecord::getKey)
+                        .filter(key -> key != null && !key.isEmpty())
+                        .collect(Collectors.toList()), keys);
+            } else {
+                Assert.assertEquals(records.stream()
+                        .map(ConsumerRecord::getKey)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList()), keys);
+            }
+            Assert.assertEquals(records.stream()
+                    .map(ConsumerRecord::getHeaders)
+                    .filter(Objects::nonNull)
+                    .map(headerList -> headerList.get(0))
+                    .collect(Collectors.toList()), headers);
+
+            // no more records
+            List<ConsumerRecord<String, String>> emptyRecords = consumer.receive(200);
+            assertTrue(emptyRecords.isEmpty());
+
+            // ensure that we can list the topic
+            Map<String, List<PartitionInfo>> result = consumer.listTopics(1000);
+            assertEquals(result.size(), 1);
+            assertTrue(result.containsKey(KAFKA_TOPIC),
+                    "list of topics " + result.keySet().toString() + "  does not contains " + KAFKA_TOPIC);
+            consumer.close();
+        }
+    }
+
+    @Test(timeOut = 20000)
+    void badCredentialFail() throws Exception {
+        writeJaasFile(TENANT + "/" + NAMESPACE, "token:dsa");
+        for (KafkaVersion version : kafkaClientFactories.keySet()) {
+            try {
+                @Cleanup final Producer<String, String> producer = kafkaClientFactories.get(version)
+                        .createProducer(producerConfigurationWithSaslPlain(version,
+                                TENANT + "/" + NAMESPACE,
+                                "token:" + userToken));
+                producer.newContextBuilder(KAFKA_TOPIC, "").build().sendAsync().get();
+                fail("should have failed");
+            } catch (Exception e) {
+                assertTrue(e.getMessage().contains("SaslAuthenticationException"));
+            }
+        }
+    }
+
+    @Test(timeOut = 20000)
+    void badUserFail() throws Exception {
+
+        writeJaasFile(TENANT + "/" + NAMESPACE, "token:" + anotherToken);
+
+        for (KafkaVersion version : kafkaClientFactories.keySet()) {
+            try {
+                @Cleanup final Producer<String, String> producer = kafkaClientFactories.get(version)
+                        .createProducer(producerConfigurationWithSaslPlain(version,
+                                TENANT + "/" + NAMESPACE,
+                                "token:" + userToken));
+                producer.newContextBuilder(KAFKA_TOPIC, "").build().sendAsync().get();
+                fail("should have failed");
+            } catch (Exception e) {
+                assertTrue(e.getMessage().contains("TopicAuthorizationException"));
+            }
+        }
+    }
+
+
+    @Test(timeOut = 60000)
+    void clientWithoutAuth() throws Exception {
+        final int metadataTimeoutMs = 3000;
+
+        for (KafkaVersion version : kafkaClientFactories.keySet()) {
+            try {
+                @Cleanup final Producer<String, String> producer = kafkaClientFactories.get(version)
+                        .createProducer(ProducerConfiguration.builder()
+                                .bootstrapServers("localhost:" + getKafkaBrokerPort())
+                                .keySerializer(version.getStringSerializer())
+                                .valueSerializer(version.getStringSerializer())
+                                .maxBlockMs(Integer.toString(metadataTimeoutMs))
+                                .build());
+
+                producer.newContextBuilder(KAFKA_TOPIC, "hello").build().sendAsync().get();
+                fail("should have failed");
+            } catch (Exception e) {
+                assertTrue(e.getCause() instanceof TimeoutException);
+                assertTrue(e.getMessage().contains("Failed to update metadata"));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #667 

### Motivation
If SaslHandshakeRequest version is v0, a series of SASL client and server tokens corresponding to the mechanism are sent as opaque packets without wrapping the messages with Kafka protocol headers. However, KoP always parses the header before a request is processed.

### Modifications
Support sasl/plain tokens are sent without Kafka SaslAuthenticate request/responses and compatible with existing authenticate.
