### PR TITLE
Fix flaky testMutiBrokerUnloadReload by running it at first

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
@@ -176,7 +176,7 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
     }
 
 
-    @AfterMethod(timeOut = 30000)
+    @AfterMethod(timeOut = 30000, alwaysRun = true)
     @Override
     public void cleanup() throws Exception {
         log.info("--- Shutting down ---");
@@ -379,10 +379,12 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
     }
 
     // Unit test for unload / reload user topic bundle, verify it works well.
+    // NOTE: Currently the testMultiBrokerUnloadReload is flaky. If it ran after other tests, it would be easy to fail.
+    //   So we just change the test name to make it run first to avoid CI failing at this test for this momemnt.
     @Test(timeOut = 30000)
-    public void testMutiBrokerUnloadReload() throws Exception {
+    public void testAMultiBrokerUnloadReload() throws Exception {
         int partitionNumber = 10;
-        String kafkaTopicName = "kopMutiBrokerUnloadReload" + partitionNumber;
+        String kafkaTopicName = "kopMultiBrokerUnloadReload" + partitionNumber;
         String pulsarTopicName = "persistent://public/default/" + kafkaTopicName;
         String kopNamespace = "public/default";
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
@@ -380,7 +380,7 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
 
     // Unit test for unload / reload user topic bundle, verify it works well.
     // NOTE: Currently the testMultiBrokerUnloadReload is flaky. If it ran after other tests, it would be easy to fail.
-    //   So we just change the test name to make it run first to avoid CI failing at this test for this momemnt.
+    //   So we just change the priority to make it run first to avoid CI failing at this test for this moment.
     @Test(timeOut = 30000, priority = -1)
     public void testMultiBrokerUnloadReload() throws Exception {
         int partitionNumber = 10;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
@@ -381,8 +381,8 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
     // Unit test for unload / reload user topic bundle, verify it works well.
     // NOTE: Currently the testMultiBrokerUnloadReload is flaky. If it ran after other tests, it would be easy to fail.
     //   So we just change the test name to make it run first to avoid CI failing at this test for this momemnt.
-    @Test(timeOut = 30000)
-    public void testAMultiBrokerUnloadReload() throws Exception {
+    @Test(timeOut = 30000, priority = -1)
+    public void testMultiBrokerUnloadReload() throws Exception {
         int partitionNumber = 10;
         String kafkaTopicName = "kopMultiBrokerUnloadReload" + partitionNumber;
         String pulsarTopicName = "persistent://public/default/" + kafkaTopicName;


### PR DESCRIPTION
Fixes https://github.com/streamnative/kop/issues/678

This PR doesn't fix the test completely. It just does the trick to change the test name so that the test can ran as the first test. See https://github.com/streamnative/kop/issues/682 for tracking this issue.