### PR TITLE
[FEATURE] Add commit offset test for Kafka clients of different versions

### DIFF
--- a/kafka-0-10/src/main/java/io/streamnative/kafka/client/zero/ten/Consumer010Impl.java
+++ b/kafka-0-10/src/main/java/io/streamnative/kafka/client/zero/ten/Consumer010Impl.java
@@ -16,7 +16,6 @@ package io.streamnative.kafka.client.zero.ten;
 import io.streamnative.kafka.client.api.Consumer;
 import io.streamnative.kafka.client.api.ConsumerConfiguration;
 import io.streamnative.kafka.client.api.ConsumerRecord;
-
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;

--- a/kafka-0-10/src/main/java/io/streamnative/kafka/client/zero/ten/Consumer010Impl.java
+++ b/kafka-0-10/src/main/java/io/streamnative/kafka/client/zero/ten/Consumer010Impl.java
@@ -13,11 +13,14 @@
  */
 package io.streamnative.kafka.client.zero.ten;
 
+import com.google.common.collect.Maps;
 import io.streamnative.kafka.client.api.Consumer;
 import io.streamnative.kafka.client.api.ConsumerConfiguration;
 import io.streamnative.kafka.client.api.ConsumerRecord;
+import io.streamnative.kafka.client.api.TopicOffsetAndMetadata;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -47,7 +50,14 @@ public class Consumer010Impl<K, V> extends KafkaConsumer<K, V> implements Consum
     }
 
     @Override
-    public void commitOffsetSync(Map<TopicPartition, OffsetAndMetadata> offsets, Duration timeout) {
-        commitSync(offsets);
+    public void commitOffsetSync(List<TopicOffsetAndMetadata> offsets, Duration timeout) {
+        HashMap<TopicPartition, OffsetAndMetadata> offsetsMap = Maps.newHashMap();
+        offsets.forEach(
+                offsetAndMetadata -> offsetsMap.put(
+                        offsetAndMetadata.createTopicPartition(TopicPartition.class),
+                        offsetAndMetadata.createOffsetAndMetadata(OffsetAndMetadata.class)
+                )
+        );
+        commitSync(offsetsMap);
     }
 }

--- a/kafka-0-10/src/main/java/io/streamnative/kafka/client/zero/ten/Consumer010Impl.java
+++ b/kafka-0-10/src/main/java/io/streamnative/kafka/client/zero/ten/Consumer010Impl.java
@@ -16,11 +16,15 @@ package io.streamnative.kafka.client.zero.ten;
 import io.streamnative.kafka.client.api.Consumer;
 import io.streamnative.kafka.client.api.ConsumerConfiguration;
 import io.streamnative.kafka.client.api.ConsumerRecord;
+
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
 
 /**
  * The implementation of Kafka consumer 0.10.0.0.
@@ -41,5 +45,10 @@ public class Consumer010Impl<K, V> extends KafkaConsumer<K, V> implements Consum
     @Override
     public Map<String, List<PartitionInfo>> listTopics(long timeoutMS) {
         return listTopics();
+    }
+
+    @Override
+    public void commitOffsetSync(Map<TopicPartition, OffsetAndMetadata> offsets, Duration timeout) {
+        commitSync(offsets);
     }
 }

--- a/kafka-1-0/src/main/java/io/streamnative/kafka/client/one/zero/ConsumerImpl.java
+++ b/kafka-1-0/src/main/java/io/streamnative/kafka/client/one/zero/ConsumerImpl.java
@@ -13,11 +13,14 @@
  */
 package io.streamnative.kafka.client.one.zero;
 
+import com.google.common.collect.Maps;
 import io.streamnative.kafka.client.api.Consumer;
 import io.streamnative.kafka.client.api.ConsumerConfiguration;
 import io.streamnative.kafka.client.api.ConsumerRecord;
+import io.streamnative.kafka.client.api.TopicOffsetAndMetadata;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -47,7 +50,14 @@ public class ConsumerImpl<K, V> extends KafkaConsumer<K, V> implements Consumer<
     }
 
     @Override
-    public void commitOffsetSync(Map<TopicPartition, OffsetAndMetadata> offsets, Duration timeout) {
-        commitSync(offsets);
+    public void commitOffsetSync(List<TopicOffsetAndMetadata> offsets, Duration timeout) {
+        HashMap<TopicPartition, OffsetAndMetadata> offsetsMap = Maps.newHashMap();
+        offsets.forEach(
+                offsetAndMetadata -> offsetsMap.put(
+                        offsetAndMetadata.createTopicPartition(TopicPartition.class),
+                        offsetAndMetadata.createOffsetAndMetadata(OffsetAndMetadata.class)
+                )
+        );
+        commitSync(offsetsMap);
     }
 }

--- a/kafka-1-0/src/main/java/io/streamnative/kafka/client/one/zero/ConsumerImpl.java
+++ b/kafka-1-0/src/main/java/io/streamnative/kafka/client/one/zero/ConsumerImpl.java
@@ -16,11 +16,15 @@ package io.streamnative.kafka.client.one.zero;
 import io.streamnative.kafka.client.api.Consumer;
 import io.streamnative.kafka.client.api.ConsumerConfiguration;
 import io.streamnative.kafka.client.api.ConsumerRecord;
+
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
 
 /**
  * The implementation of Kafka consumer 1.0.0.
@@ -41,5 +45,10 @@ public class ConsumerImpl<K, V> extends KafkaConsumer<K, V> implements Consumer<
     @Override
     public Map<String, List<PartitionInfo>> listTopics(long timeoutMS) {
         return listTopics();
+    }
+
+    @Override
+    public void commitOffsetSync(Map<TopicPartition, OffsetAndMetadata> offsets, Duration timeout) {
+        commitSync(offsets);
     }
 }

--- a/kafka-1-0/src/main/java/io/streamnative/kafka/client/one/zero/ConsumerImpl.java
+++ b/kafka-1-0/src/main/java/io/streamnative/kafka/client/one/zero/ConsumerImpl.java
@@ -16,7 +16,6 @@ package io.streamnative.kafka.client.one.zero;
 import io.streamnative.kafka.client.api.Consumer;
 import io.streamnative.kafka.client.api.ConsumerConfiguration;
 import io.streamnative.kafka.client.api.ConsumerRecord;
-
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/Consumer.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/Consumer.java
@@ -22,9 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.NonNull;
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.PartitionInfo;
-import org.apache.kafka.common.TopicPartition;
 
 /**
  * A common interface of Kafka consumer.
@@ -65,5 +63,5 @@ public interface Consumer<K, V> extends Closeable {
 
     Map<String, List<PartitionInfo>> listTopics(long timeoutMS);
 
-    void commitOffsetSync(Map<TopicPartition, OffsetAndMetadata> offsets, Duration timeout);
+    void commitOffsetSync(List<TopicOffsetAndMetadata> offsets, Duration timeout);
 }

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/Consumer.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/Consumer.java
@@ -14,6 +14,7 @@
 package io.streamnative.kafka.client.api;
 
 import java.io.Closeable;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -21,7 +22,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.NonNull;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
 
 /**
  * A common interface of Kafka consumer.
@@ -61,4 +64,6 @@ public interface Consumer<K, V> extends Closeable {
     }
 
     Map<String, List<PartitionInfo>> listTopics(long timeoutMS);
+
+    void commitOffsetSync(Map<TopicPartition, OffsetAndMetadata> offsets, Duration timeout);
 }

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/ConsumerConfiguration.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/ConsumerConfiguration.java
@@ -33,6 +33,7 @@ public class ConsumerConfiguration {
     private String userName;
     private String password;
     private String requestTimeoutMs;
+    private Boolean enableAutoCommit;
 
     public Properties toProperties() {
         final Properties props = new Properties();
@@ -63,6 +64,9 @@ public class ConsumerConfiguration {
         }
         if (requestTimeoutMs != null) {
             props.put("request.timeout.ms", requestTimeoutMs);
+        }
+        if (enableAutoCommit != null) {
+            props.put("enable.auto.commit", enableAutoCommit);
         }
         return props;
     }

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/ConsumerConfiguration.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/ConsumerConfiguration.java
@@ -34,6 +34,7 @@ public class ConsumerConfiguration {
     private String password;
     private String requestTimeoutMs;
     private Boolean enableAutoCommit;
+    private String sessionTimeOutMs;
 
     public Properties toProperties() {
         final Properties props = new Properties();
@@ -67,6 +68,9 @@ public class ConsumerConfiguration {
         }
         if (enableAutoCommit != null) {
             props.put("enable.auto.commit", enableAutoCommit);
+        }
+        if (sessionTimeOutMs != null) {
+            props.put("session.timeout.ms", sessionTimeOutMs);
         }
         return props;
     }

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/KafkaVersion.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/KafkaVersion.java
@@ -24,7 +24,7 @@ import lombok.Getter;
  */
 public enum KafkaVersion {
 
-    DEFAULT("default"), KAFKA_1_0_0("100"), KAFKA_0_10_0_0("010");
+    KAFKA_0_10_0_0("010"), KAFKA_1_0_0("100"), DEFAULT("default");
 
     @Getter
     private String name;

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/KafkaVersion.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/KafkaVersion.java
@@ -24,7 +24,7 @@ import lombok.Getter;
  */
 public enum KafkaVersion {
 
-    KAFKA_0_10_0_0("010"), KAFKA_1_0_0("100"), DEFAULT("default");
+    DEFAULT("default"), KAFKA_1_0_0("100"), KAFKA_0_10_0_0("010");
 
     @Getter
     private String name;

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/Producer.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/Producer.java
@@ -23,9 +23,14 @@ public interface Producer<K, V> extends AutoCloseable {
     Future<RecordMetadata> sendAsync(ProduceContext<K, V> context);
 
     default ProduceContext.ProduceContextBuilder<K, V> newContextBuilder(String topic, V value) {
+        return newContextBuilder(topic, value, null);
+    }
+
+    default ProduceContext.ProduceContextBuilder<K, V> newContextBuilder(String topic, V value, Integer partition) {
         return ProduceContext.<K, V>builder()
                 .producer(this)
                 .topic(topic)
-                .value(value);
+                .value(value)
+                .partition(partition);
     }
 }

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/TopicOffsetAndMetadata.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/TopicOffsetAndMetadata.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.streamnative.kafka.client.api;
 
 import java.lang.reflect.InvocationTargetException;

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/TopicOffsetAndMetadata.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/TopicOffsetAndMetadata.java
@@ -1,0 +1,44 @@
+package io.streamnative.kafka.client.api;
+
+import java.lang.reflect.InvocationTargetException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * A completable class of org.apache.kafka.clients.consumer.OffsetAndMetadata.
+ */
+@AllArgsConstructor
+@Getter
+public class TopicOffsetAndMetadata {
+
+    private String topic;
+    private int partition;
+    private long offset;
+
+    public <T> T createTopicPartition(final Class<T> clazz) {
+        try {
+            return clazz.getConstructor(
+                    String.class, int.class
+            ).newInstance(topic, partition);
+        } catch (InvocationTargetException
+                | InstantiationException
+                | IllegalAccessException
+                | NoSuchMethodException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    public <T> T createOffsetAndMetadata(final Class<T> clazz) {
+        try {
+            return clazz.getConstructor(
+                    long.class
+            ).newInstance(offset);
+        } catch (InstantiationException
+                | IllegalAccessException
+                | InvocationTargetException
+                | NoSuchMethodException e) {
+            throw new IllegalArgumentException(e);
+        }
+
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -369,11 +369,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             for (ApiKeys apiKey : ApiKeys.values()) {
                 if (apiKey.minRequiredInterBrokerMagic <= RecordBatch.CURRENT_MAGIC_VALUE) {
                     switch (apiKey) {
-                        case FETCH:
-                            // V4 added MessageSets responses. We need to make sure RecordBatch format is not used
-                            versionList.add(new ApiVersionsResponse.ApiVersion((short) 1, (short) 4,
-                                    apiKey.latestVersion()));
-                            break;
                         case LIST_OFFSETS:
                             // V0 is needed for librdkafka
                             versionList.add(new ApiVersionsResponse.ApiVersion((short) 2, (short) 0,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KopRecordsUtil.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KopRecordsUtil.java
@@ -40,8 +40,8 @@ public class KopRecordsUtil {
         int totalSizeEstimate = 0;
 
         long batchStartOffset = firstOffset;
-        byte toBatchMagic = toMagic;
         for (RecordBatch batch : batches) {
+            byte toBatchMagic = toMagic;
             if (toMagic < RecordBatch.MAGIC_VALUE_V2) {
                 if (batch.isControlBatch()) {
                     continue;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KopRecordsUtil.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KopRecordsUtil.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.utils;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.record.AbstractRecords;
+import org.apache.kafka.common.record.ConvertedRecords;
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.MemoryRecordsBuilder;
+import org.apache.kafka.common.record.Record;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.record.TimestampType;
+
+/**
+ * Utils for DownConverted and ReAssignOffset operations.
+ */
+@Slf4j
+public class KopRecordsUtil {
+
+    public static ConvertedRecords<MemoryRecords> convertAndAssignOffsets(Iterable<? extends RecordBatch> batches,
+                                                              byte toMagic,
+                                                              long firstOffset) {
+        // maintain the batch along with the decompressed records to avoid the need to decompress again
+        List<RecordBatchAndRecords> recordBatchAndRecordsList = new ArrayList<>();
+        int totalSizeEstimate = 0;
+
+        long batchStartOffset = firstOffset;
+        for (RecordBatch batch : batches) {
+            if (toMagic < RecordBatch.MAGIC_VALUE_V2 && batch.isControlBatch()) {
+                continue;
+            }
+
+            List<Record> records = new ArrayList<>();
+            long batchIndex = 0;
+            for (Record record : batch) {
+                records.add(record);
+                batchIndex++;
+            }
+            log.error("batchStartOffset {}, batchIndex {}", batchStartOffset, batchIndex);
+
+            if (records.isEmpty()) {
+                continue;
+            }
+            totalSizeEstimate += AbstractRecords.estimateSizeInBytes(
+                    toMagic, batchStartOffset, batch.compressionType(), records);
+            recordBatchAndRecordsList.add(new RecordBatchAndRecords(batch, records, batchStartOffset));
+            batchStartOffset += batchIndex;
+        }
+
+        ByteBuffer buffer = ByteBuffer.allocate(totalSizeEstimate);
+        for (RecordBatchAndRecords recordBatchAndRecords : recordBatchAndRecordsList) {
+            MemoryRecordsBuilder builder = convertRecordBatch(toMagic, buffer, recordBatchAndRecords);
+            buffer = builder.buffer();
+        }
+
+        buffer.flip();
+        recordBatchAndRecordsList.clear();
+        return new ConvertedRecords<>(MemoryRecords.readableRecords(buffer), null);
+    }
+
+    private static MemoryRecordsBuilder convertRecordBatch(byte magic,
+                                                           ByteBuffer buffer,
+                                                           RecordBatchAndRecords recordBatchAndRecords) {
+        RecordBatch batch = recordBatchAndRecords.batch;
+        final TimestampType timestampType = batch.timestampType();
+        long logAppendTime = timestampType
+                == TimestampType.LOG_APPEND_TIME ? batch.maxTimestamp() : RecordBatch.NO_TIMESTAMP;
+
+        MemoryRecordsBuilder builder = MemoryRecords.builder(buffer, magic, batch.compressionType(),
+                timestampType, recordBatchAndRecords.baseOffset, logAppendTime);
+
+        long startOffset = recordBatchAndRecords.baseOffset;
+        for (Record record : recordBatchAndRecords.records) {
+            if (magic > RecordBatch.MAGIC_VALUE_V1) {
+                builder.appendWithOffset(startOffset++,
+                        record.timestamp(),
+                        record.key(),
+                        record.value(),
+                        record.headers());
+            } else {
+                builder.appendWithOffset(startOffset++,
+                        record.timestamp(),
+                        record.key(),
+                        record.value());
+            }
+        }
+
+        builder.close();
+        return builder;
+    }
+
+    private static class RecordBatchAndRecords {
+        private final RecordBatch batch;
+        private final List<Record> records;
+        private final Long baseOffset;
+
+        private RecordBatchAndRecords(RecordBatch batch, List<Record> records, Long baseOffset) {
+            this.batch = batch;
+            this.records = records;
+            this.baseOffset = baseOffset;
+        }
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KopRecordsUtil.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KopRecordsUtil.java
@@ -50,7 +50,6 @@ public class KopRecordsUtil {
                 records.add(record);
                 batchIndex++;
             }
-            log.error("batchStartOffset {}, batchIndex {}", batchStartOffset, batchIndex);
 
             if (records.isEmpty()) {
                 continue;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndKafkaTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndKafkaTest.java
@@ -28,4 +28,9 @@ public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
     protected void testKafkaProduceKafkaConsume() throws Exception {
         super.testKafkaProduceKafkaConsume();
     }
+
+    @Test(timeOut = 30000)
+    protected void testKafkaProduceKafkaCommitOffset() throws Exception {
+        super.testKafkaProduceKafkaCommitOffset();
+    }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndKafkaTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndKafkaTest.java
@@ -29,7 +29,7 @@ public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
         super.testKafkaProduceKafkaConsume();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 60000)
     protected void testKafkaProduceKafkaCommitOffset() throws Exception {
         super.testKafkaProduceKafkaCommitOffset();
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndPulsarTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndPulsarTest.java
@@ -171,7 +171,11 @@ public class BasicEndToEndPulsarTest extends BasicEndToEndTestBase {
         int sends = 75;
 
         // 1.Produce messages with pulsar producer
-        org.apache.pulsar.client.api.Producer<String> producer = null;
+        org.apache.pulsar.client.api.Producer<String> producer =
+                pulsarClient.newProducer(Schema.STRING)
+                        .topic(topic)
+                        .create();
+
         Hash hash = JavaStringHash.getInstance();
         for (int i = 0; i < sends; i++) {
             final String key = "pulsar-key-" + i;
@@ -183,10 +187,6 @@ public class BasicEndToEndPulsarTest extends BasicEndToEndTestBase {
             // Record the message corresponding to each partition,
             // and later we will use it to compare the consumption results.
             valuesMap.put(partition, values);
-
-            producer = pulsarClient.newProducer(Schema.STRING)
-                    .topic(topic)
-                    .create();
 
             producer.newMessage(Schema.STRING)
                     .key(key)

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndPulsarTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndPulsarTest.java
@@ -51,6 +51,11 @@ public class BasicEndToEndPulsarTest extends BasicEndToEndTestBase {
     }
 
     @Test(timeOut = 30000)
+    protected void testKafkaProduceKafkaCommitOffset() throws Exception {
+        super.testKafkaProduceKafkaCommitOffset();
+    }
+
+    @Test(timeOut = 30000)
     public void testKafkaProducePulsarConsume() throws Exception {
         final String topic = "test-kafka-produce-pulsar-consume";
         admin.topics().createPartitionedTopic(topic, 1);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndPulsarTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndPulsarTest.java
@@ -50,7 +50,7 @@ public class BasicEndToEndPulsarTest extends BasicEndToEndTestBase {
         super.testKafkaProduceKafkaConsume();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 60000)
     protected void testKafkaProduceKafkaCommitOffset() throws Exception {
         super.testKafkaProduceKafkaCommitOffset();
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndPulsarTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndPulsarTest.java
@@ -29,11 +29,15 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.util.MathUtils;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.impl.Hash;
+import org.apache.pulsar.client.impl.JavaStringHash;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import org.testng.collections.Maps;
 
 /**
  * Basic end-to-end test for different versions of Kafka clients with `entryFormat=kafka`.
@@ -154,6 +158,47 @@ public class BasicEndToEndPulsarTest extends BasicEndToEndTestBase {
             }
             consumer.close();
         }
+    }
+
+    @Test(timeOut = 60000)
+    public void testPulsarProduceKafkaCommit() throws Exception {
+        final String topic = "test-pulsar-produce-kafka-commit-offset";
+        int numPartitions = 5;
+        admin.topics().createPartitionedTopic(topic, numPartitions);
+
+        Map<Integer, List<String>> valuesMap = Maps.newHashMap();
+
+        int sends = 75;
+
+        // 1.Produce messages with pulsar producer
+        org.apache.pulsar.client.api.Producer<String> producer = null;
+        Hash hash = JavaStringHash.getInstance();
+        for (int i = 0; i < sends; i++) {
+            final String key = "pulsar-key-" + i;
+            final String value = "pulsar-value-" + i;
+
+            int partition = MathUtils.signSafeMod(hash.makeHash(key), numPartitions);
+            List<String> values = valuesMap.computeIfAbsent(partition, k -> new ArrayList<>());
+            values.add(value);
+            // Record the message corresponding to each partition,
+            // and later we will use it to compare the consumption results.
+            valuesMap.put(partition, values);
+
+            producer = pulsarClient.newProducer(Schema.STRING)
+                    .topic(topic)
+                    .create();
+
+            producer.newMessage(Schema.STRING)
+                    .key(key)
+                    .value(value)
+                    .send();
+        }
+
+        producer.close();
+
+        // 2.Consume messages with different kafka client versions
+        super.verifyManualCommitOffset(topic, sends, numPartitions, valuesMap);
+
     }
 
     private static Header convertFirstPropertyToHeader(final Map<String, String> properties) {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndTestBase.java
@@ -327,7 +327,7 @@ public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
                 .valueDeserializer(version.getStringDeserializer())
                 .fromEarliest(true)
                 .enableAutoCommit(enableAutoCommit)
-                .sessionTimeOutMs("1000")
+                .sessionTimeOutMs("10000")
                 .build();
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndTestBase.java
@@ -24,7 +24,6 @@ import io.streamnative.kafka.client.api.Producer;
 import io.streamnative.kafka.client.api.ProducerConfiguration;
 import io.streamnative.kafka.client.api.RecordMetadata;
 import io.streamnative.pulsar.handlers.kop.KopProtocolHandlerTestBase;
-
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -197,7 +196,8 @@ public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
                 // and later we will use it to compare the consumption results.
                 valuesMap.put(partition, values);
 
-                RecordMetadata recordMetadata = producer.newContextBuilder(topic, value, partition).build().sendAsync().get();
+                RecordMetadata recordMetadata = producer.newContextBuilder(topic, value, partition).
+                        build().sendAsync().get();
                 log.info("Kafka client {} sent {} to {}", version, value, recordMetadata);
                 Assert.assertEquals(recordMetadata.getTopic(), topic);
                 Assert.assertEquals(recordMetadata.getPartition(), partition);
@@ -224,7 +224,9 @@ public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
             // and the records of each partition are compared with the partition data recorded above.
             totalRecordsGroupByPartition.keySet().forEach(
                     partition -> Assert.assertEquals(
-                            totalRecordsGroupByPartition.get(partition).stream().map(ConsumerRecord::getValue).collect(Collectors.toList()),
+                            totalRecordsGroupByPartition.get(partition).stream()
+                                    .map(ConsumerRecord::getValue)
+                                    .collect(Collectors.toList()),
                             valuesMap.get(partition))
             );
 
@@ -236,7 +238,8 @@ public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
                 long offset = record.getOffset();
                 String value = record.getValue();
 
-                Map<Long, String> offsetAndValue = partitionAndOffsetValue.computeIfAbsent(partition, k -> new HashMap<>());
+                Map<Long, String> offsetAndValue = partitionAndOffsetValue
+                        .computeIfAbsent(partition, k -> new HashMap<>());
 
                 offsetAndValue.put(offset, value);
                 partitionAndOffsetValue.put(partition, offsetAndValue);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndTestBase.java
@@ -182,6 +182,7 @@ public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
 
             // 4.Consume all messages
             List<ConsumerRecord<String, String>> records = consumer.receiveUntil(count, 6000);
+            Assert.assertEquals(count, records.size());
             Map<Integer, List<ConsumerRecord<String, String>>> totalRecordsGroupByPartition = records.stream()
                     .collect(Collectors.groupingBy(ConsumerRecord::getPartition));
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndTestBase.java
@@ -24,17 +24,24 @@ import io.streamnative.kafka.client.api.Producer;
 import io.streamnative.kafka.client.api.ProducerConfiguration;
 import io.streamnative.kafka.client.api.RecordMetadata;
 import io.streamnative.pulsar.handlers.kop.KopProtocolHandlerTestBase;
+
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.collections.Maps;
 
 /**
  * Basic end-to-end test for different versions of Kafka clients.
@@ -131,11 +138,6 @@ public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
         }
 
         for (KafkaVersion version : kafkaClientFactories.keySet()) {
-            // Due to some known issues, kop return the minimum Fetch apiVersion is 4,
-            // kafka client versions before 0.11.x not support apiVersion=4
-            if (version.equals(KafkaVersion.KAFKA_0_10_0_0)) {
-                continue;
-            }
             final Consumer<String, String> consumer = kafkaClientFactories.get(version)
                     .createConsumer(consumerConfiguration(version));
             consumer.subscribe(topic);
@@ -153,12 +155,137 @@ public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
                         .filter(Objects::nonNull)
                         .collect(Collectors.toList()), keys);
             }
-            Assert.assertEquals(records.stream()
-                    .map(ConsumerRecord::getHeaders)
-                    .filter(Objects::nonNull)
-                    .map(headerList -> headerList.get(0))
-                    .collect(Collectors.toList()), headers);
+
+            // Because there is no header in ProducerRecord before 0.11.x.
+            if (!version.equals(KafkaVersion.KAFKA_0_10_0_0)) {
+                Assert.assertEquals(records.stream()
+                        .map(ConsumerRecord::getHeaders)
+                        .filter(Objects::nonNull)
+                        .map(headerList -> headerList.get(0))
+                        .collect(Collectors.toList()), headers);
+            }
             consumer.close();
+        }
+    }
+
+    protected void testKafkaProduceKafkaCommitOffset() throws Exception {
+        final String topic = "test-kafka-produce-kafka-commit-offset";
+        int numPartitions = 5;
+        admin.topics().createPartitionedTopic(topic, numPartitions);
+
+        Map<Integer, List<String>> valuesMap = Maps.newHashMap();
+
+        // The number of messages sent by the producer of each version
+        long sends = 25;
+
+        // Record the total number of messages
+        int count = 0;
+        // 1.Produce messages with different versions
+        for (KafkaVersion version : kafkaClientFactories.keySet()) {
+
+            Producer<String, String> producer = kafkaClientFactories.get(version)
+                    .createProducer(producerConfiguration(version));
+
+            for (int i = 0; i < sends; i++) {
+                String value = "value-commit-from" + version.name() + i;
+
+                // (Round Robin) Select the partition to send record
+                int partition = i % numPartitions;
+                List<String> values = valuesMap.computeIfAbsent(partition, k -> new ArrayList<>());
+                values.add(value);
+                // Record the message corresponding to each partition,
+                // and later we will use it to compare the consumption results.
+                valuesMap.put(partition, values);
+
+                RecordMetadata recordMetadata = producer.newContextBuilder(topic, value, partition).build().sendAsync().get();
+                log.info("Kafka client {} sent {} to {}", version, value, recordMetadata);
+                Assert.assertEquals(recordMetadata.getTopic(), topic);
+                Assert.assertEquals(recordMetadata.getPartition(), partition);
+                count++;
+            }
+        }
+
+        // 2.Consume messagesUse with different versions
+        for (KafkaVersion version : kafkaClientFactories.keySet()) {
+
+            // 3.Forbidden to commit the offset automatically.
+            // We will manually submit the offset later.
+            Consumer<String, String> consumer = kafkaClientFactories.get(version)
+                    .createConsumer(consumerConfiguration(version, false));
+
+            consumer.subscribe(topic);
+
+            // 4.Consume all messages
+            List<ConsumerRecord<String, String>> records = consumer.receiveUntil(count, 6000);
+            Map<Integer, List<ConsumerRecord<String, String>>> totalRecordsGroupByPartition = records.stream()
+                    .collect(Collectors.groupingBy(ConsumerRecord::getPartition));
+
+            // 5.The results of consumption are grouped according to partitions,
+            // and the records of each partition are compared with the partition data recorded above.
+            totalRecordsGroupByPartition.keySet().forEach(
+                    partition -> Assert.assertEquals(
+                            totalRecordsGroupByPartition.get(partition).stream().map(ConsumerRecord::getValue).collect(Collectors.toList()),
+                            valuesMap.get(partition))
+            );
+
+            // 6.Group by partition, record the offset and value of all data in the partition,
+            // and later we will use it to compare with the consumption result after manually committing offsets.
+            Map<Integer, Map<Long, String>> partitionAndOffsetValue = Maps.newConcurrentMap();
+            records.forEach(record -> {
+                int partition = record.getPartition();
+                long offset = record.getOffset();
+                String value = record.getValue();
+
+                Map<Long, String> offsetAndValue = partitionAndOffsetValue.computeIfAbsent(partition, k -> new HashMap<>());
+
+                offsetAndValue.put(offset, value);
+                partitionAndOffsetValue.put(partition, offsetAndValue);
+            });
+
+            // 7.Manually commit offset of each partition as the int value of the partition number,
+            // this is for the convenience of calculation
+            Map<TopicPartition, OffsetAndMetadata> commitOffsets = Maps.newHashMap();
+            int messagesSize = count;
+            for (int i = 0; i < numPartitions; i++) {
+                commitOffsets.put(new TopicPartition(topic, i), new OffsetAndMetadata(i));
+                messagesSize -= i;
+            }
+
+            // 8.Commit offset synchronously
+            consumer.commitOffsetSync(commitOffsets, Duration.ofMillis(10000));
+
+            // 9.Close current consumer
+            consumer.close();
+
+            // 10.Use the same consumer group to start a new consumer group,
+            // and consumers will start to consume from the offset manually committed above
+            consumer = kafkaClientFactories.get(version)
+                    .createConsumer(consumerConfiguration(version));
+            consumer.subscribe(topic);
+
+            // 11.Consume messages and verify that the number of messages is the same
+            // as the number of messages calculated according to the commit offset
+            List<ConsumerRecord<String, String>> commitRecordList = consumer.receiveUntil(messagesSize, 6000);
+            Assert.assertEquals(messagesSize, commitRecordList.size());
+
+            // 12.The results of consumption are grouped according to partitions to facilitate
+            // the comparison between the results of consumption and the messages produced later
+            Map<Integer, List<ConsumerRecord<String, String>>> recordsGroupByPartition = commitRecordList.stream()
+                    .collect(Collectors.groupingBy(ConsumerRecord::getPartition));
+
+            // 13.Compare the number of messages consumed by each partition
+            // is the same as the number calculated by manual commit offset
+            int finalCount = count;
+            recordsGroupByPartition.keySet().forEach(
+                    partition -> Assert.assertEquals(finalCount / numPartitions - partition,
+                            recordsGroupByPartition.getOrDefault(partition, Collections.emptyList()).size())
+            );
+
+            // 14.Verify the accuracy of the offset and the corresponding message value consumed by each partition
+            commitRecordList.forEach(record -> {
+                Assert.assertEquals(partitionAndOffsetValue.get(record.getPartition()).get(record.getOffset()),
+                        record.getValue());
+            });
         }
     }
 
@@ -171,12 +298,17 @@ public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
     }
 
     protected ConsumerConfiguration consumerConfiguration(final KafkaVersion version) {
+        return consumerConfiguration(version, true);
+    }
+
+    protected ConsumerConfiguration consumerConfiguration(final KafkaVersion version, Boolean enableAutoCommit) {
         return ConsumerConfiguration.builder()
                 .bootstrapServers("localhost:" + getKafkaBrokerPort())
                 .groupId("group-" + version.name())
                 .keyDeserializer(version.getStringDeserializer())
                 .valueDeserializer(version.getStringDeserializer())
                 .fromEarliest(true)
+                .enableAutoCommit(enableAutoCommit)
                 .build();
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndTestBase.java
@@ -228,12 +228,12 @@ public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
             // 10.Use the same consumer group to start a new consumer group,
             // and consumers will start to consume from the offset manually committed above
             consumer = kafkaClientFactories.get(version)
-                    .createConsumer(consumerConfiguration(version));
+                    .createConsumer(consumerConfiguration(version, false));
             consumer.subscribe(topic);
 
             // 11.Consume messages and verify that the number of messages is the same
             // as the number of messages calculated according to the commit offset
-            List<ConsumerRecord<String, String>> commitRecordList = consumer.receiveUntil(messagesSize, 6000);
+            List<ConsumerRecord<String, String>> commitRecordList = consumer.receiveUntil(messagesSize, 12000);
             Assert.assertEquals(messagesSize, commitRecordList.size());
 
             // 12.The results of consumption are grouped according to partitions to facilitate

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndTestBase.java
@@ -171,7 +171,7 @@ public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
                                             final int count,
                                             final int numPartitions,
                                             final Map<Integer, List<String>> valuesMap)
-            throws IOException, InterruptedException {
+            throws IOException {
         for (KafkaVersion version : kafkaClientFactories.keySet()) {
             // 3.Forbidden to commit the offset automatically.
             // We will manually submit the offset later.
@@ -226,14 +226,6 @@ public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
 
             // 9.Close current consumer
             consumer.close();
-
-            // for version 0.10.0.0, default SESSION_TIMEOUT_MS_CONFIG=30000ms
-            // in consumerConfiguration method, we set sessionTimeOutMs=10000
-            // In order for the previous consumer instance to leave the group completely,
-            // we let the thread wait for 10 seconds
-//            Thread.sleep(10000);
-
-            log.error("commitOffsetTest version {}", version);
 
             // 10.Use the same consumer group to start a new consumer group,
             // and consumers will start to consume from the offset manually committed above

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndTestBase.java
@@ -170,7 +170,8 @@ public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
     protected void verifyManualCommitOffset(final String topic,
                                             final int count,
                                             final int numPartitions,
-                                            final Map<Integer, List<String>> valuesMap) throws IOException {
+                                            final Map<Integer, List<String>> valuesMap)
+            throws IOException, InterruptedException {
         for (KafkaVersion version : kafkaClientFactories.keySet()) {
             // 3.Forbidden to commit the offset automatically.
             // We will manually submit the offset later.
@@ -224,6 +225,12 @@ public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
 
             // 9.Close current consumer
             consumer.close();
+
+            // for version 0.10.0.0, default SESSION_TIMEOUT_MS_CONFIG=30000ms
+            // in consumerConfiguration method, we set sessionTimeOutMs=10000
+            // In order for the previous consumer instance to leave the group completely,
+            // we let the thread wait for 10 seconds
+            Thread.sleep(10000);
 
             // 10.Use the same consumer group to start a new consumer group,
             // and consumers will start to consume from the offset manually committed above
@@ -320,6 +327,8 @@ public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
                 .valueDeserializer(version.getStringDeserializer())
                 .fromEarliest(true)
                 .enableAutoCommit(enableAutoCommit)
+                .sessionTimeOutMs("1000")
                 .build();
     }
+
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/BasicEndToEndTestBase.java
@@ -230,7 +230,9 @@ public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
             // in consumerConfiguration method, we set sessionTimeOutMs=10000
             // In order for the previous consumer instance to leave the group completely,
             // we let the thread wait for 10 seconds
-            Thread.sleep(10000);
+//            Thread.sleep(10000);
+
+            log.error("commitOffsetTest version {}", version);
 
             // 10.Use the same consumer group to start a new consumer group,
             // and consumers will start to consume from the offset manually committed above

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/DefaultKafkaClientFactory.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/DefaultKafkaClientFactory.java
@@ -13,6 +13,7 @@
  */
 package io.streamnative.pulsar.handlers.kop.compatibility;
 
+import com.google.common.collect.Maps;
 import io.streamnative.kafka.client.api.Consumer;
 import io.streamnative.kafka.client.api.ConsumerConfiguration;
 import io.streamnative.kafka.client.api.ConsumerRecord;
@@ -21,8 +22,10 @@ import io.streamnative.kafka.client.api.ProduceContext;
 import io.streamnative.kafka.client.api.Producer;
 import io.streamnative.kafka.client.api.ProducerConfiguration;
 import io.streamnative.kafka.client.api.RecordMetadata;
+import io.streamnative.kafka.client.api.TopicOffsetAndMetadata;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
@@ -82,8 +85,15 @@ public class DefaultKafkaClientFactory implements KafkaClientFactory {
         }
 
         @Override
-        public void commitOffsetSync(Map<TopicPartition, OffsetAndMetadata> offsets, Duration timeout) {
-            commitSync(offsets, timeout);
+        public void commitOffsetSync(List<TopicOffsetAndMetadata> offsets, Duration timeout) {
+            HashMap<TopicPartition, OffsetAndMetadata> offsetsMap = Maps.newHashMap();
+            offsets.forEach(
+                    offsetAndMetadata -> offsetsMap.put(
+                            offsetAndMetadata.createTopicPartition(TopicPartition.class),
+                            offsetAndMetadata.createOffsetAndMetadata(OffsetAndMetadata.class)
+                    )
+            );
+            commitSync(offsetsMap, timeout);
         }
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/DefaultKafkaClientFactory.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/DefaultKafkaClientFactory.java
@@ -27,9 +27,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Future;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.internals.RecordHeader;
 
 /**
@@ -77,6 +79,11 @@ public class DefaultKafkaClientFactory implements KafkaClientFactory {
         @Override
         public Map<String, List<PartitionInfo>> listTopics(long timeoutMS) {
             return listTopics(Duration.ofMillis(timeoutMS));
+        }
+
+        @Override
+        public void commitOffsetSync(Map<TopicPartition, OffsetAndMetadata> offsets, Duration timeout) {
+            commitSync(offsets, timeout);
         }
     }
 }


### PR DESCRIPTION
Fixes #681 #687

### Motivation
#605 added a test framework for Kafka clients of different versions. However, it only added the basic e2e test, an important API commitOffset was not verified.

### Modifications
Add commit offset test in BasicEndToEndPulsarTest and BasicEndToEndKafkaTest in io.streamnative.pulsar.handlers.kop.compatibility package.

This feature belongs to the compatibility issue between different versions of kafka client and kop.