### PR TITLE
[FEATURE] Support non-partitioned Topic

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -143,8 +143,16 @@ public class KafkaProtocolHandler implements ProtocolHandler {
                                 }
                                 groupCoordinator.handleGroupImmigration(name.getPartitionIndex());
                             }
-                            KafkaTopicManager.removeTopicManagerCache(name.toString());
-                            KopBrokerLookupManager.removeTopicManagerCache(name.toString());
+                            // deReference topic when unload
+                            KopBrokerLookupManager.removeTopicManagerCache(topic);
+                            KafkaTopicManager.deReference(topic);
+
+                            // For non-partitioned topic.
+                            if (!name.isPartitioned()) {
+                                String partitionedZeroTopicName = name.getPartition(0).toString();
+                                KafkaTopicManager.deReference(partitionedZeroTopicName);
+                                KopBrokerLookupManager.removeTopicManagerCache(partitionedZeroTopicName);
+                            }
                         }
                     } else {
                         log.error("Failed to get owned topic list for "
@@ -180,8 +188,16 @@ public class KafkaProtocolHandler implements ProtocolHandler {
                                 groupCoordinator.handleGroupEmigration(name.getPartitionIndex());
                             }
                             // deReference topic when unload
-                            KopBrokerLookupManager.removeTopicManagerCache(name.toString());
-                            KafkaTopicManager.deReference(name.toString());
+                            KopBrokerLookupManager.removeTopicManagerCache(topic);
+                            KafkaTopicManager.deReference(topic);
+
+                            // For non-partitioned topic.
+                            if (!name.isPartitioned()) {
+                                String partitionedZeroTopicName = name.getPartition(0).toString();
+                                KafkaTopicManager.deReference(partitionedZeroTopicName);
+                                KopBrokerLookupManager.removeTopicManagerCache(partitionedZeroTopicName);
+                            }
+
                         }
                     } else {
                         log.error("Failed to get owned topic list for "

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
@@ -244,8 +244,9 @@ public class KafkaTopicManager {
                 brokerService.getTopicIfExists(nonPartitionedTopicName).whenComplete((nonPartitionedTopic, ex) -> {
                     if (ex != null) {
                         handleGetTopicEx(nonPartitionedTopicName, topicCompletableFuture, ex);
-                        // Failed to getTopic from current broker, remove cache, which added in getTopicBroker.
-                        removeTopicManagerCache(topicName);
+                        // Failed to getTopic from current broker, remove non-partitioned topic cache,
+                        // which added in getTopicBroker.
+                        removeTopicManagerCache(nonPartitionedTopicName);
                         return;
                     }
                     if (nonPartitionedTopic.isPresent()) {
@@ -254,7 +255,7 @@ public class KafkaTopicManager {
                     } else {
                         log.error("[{}]Get empty non-partitioned topic for name {}",
                                 requestHandler.ctx.channel(), nonPartitionedTopicName);
-                        removeTopicManagerCache(topicName);
+                        removeTopicManagerCache(nonPartitionedTopicName);
                         topicCompletableFuture.complete(Optional.empty());
                     }
                 });

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
@@ -218,9 +218,9 @@ public class KafkaTopicManager {
         }
         CompletableFuture<Optional<PersistentTopic>> topicCompletableFuture = new CompletableFuture<>();
         brokerService.getTopicIfExists(topicName).whenComplete((t2, throwable) -> {
-            boolean isPartitionZero = topicName.endsWith(PARTITIONED_ZERO_SUFFIX_NAME);
+            boolean isFirstPartition = topicName.endsWith(PARTITIONED_ZERO_SUFFIX_NAME);
             if (throwable != null) {
-                if (isPartitionZero) {
+                if (isFirstPartition) {
                     log.warn("Get partition-0 error [{}].", throwable.getMessage());
                 } else {
                     handleGetTopicEx(topicName, topicCompletableFuture, throwable);
@@ -230,12 +230,11 @@ public class KafkaTopicManager {
                 }
             }
             if (t2 != null && t2.isPresent()) {
-                PersistentTopic persistentTopic = (PersistentTopic) t2.get();
-                topicCompletableFuture.complete(Optional.of(persistentTopic));
+                topicCompletableFuture.complete(Optional.of((PersistentTopic) t2.get()));
                 return;
             }
             // Fallback try use non-partitioned topic
-            if (isPartitionZero) {
+            if (isFirstPartition) {
                 String nonPartitionedTopicName = TopicName.get(topicName).getPartitionedTopicName();
                 if (log.isDebugEnabled()) {
                     log.debug("[{}]Try to get non-partitioned topic for name {}",

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
@@ -25,6 +25,7 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -430,6 +431,147 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
         kProducer.close();
         kConsumer1.close();
         kConsumer2.close();
+    }
+
+
+    /**
+     * Unit test for test in distributed cluster env produce and consume non-partitioned topic,
+     * verify it works well.
+     */
+    @Test(timeOut = 30000)
+    public void testMultiBrokerProduceAndConsumeNonPartitionedTopic() throws Exception {
+        String kafkaTopicName = "kopMultiBrokerNonPartitionedTopic";
+        String pulsarTopicName = "persistent://public/default/" + kafkaTopicName;
+        String kopNamespace = "public/default";
+        int totalMsgs = 50;
+        List<TopicPartition> topicPartitions =
+                Collections.singletonList(new TopicPartition(pulsarTopicName, 0));
+        String messageStrPrefix = "Message_" + kafkaTopicName + "_";
+        KProducer kProducer1 = null;
+        KProducer kProducer2 = null;
+        KConsumer kConsumer1 = null;
+        KConsumer kConsumer2 = null;
+        // 0.  Preparing: create non-partitioned topic.
+        pulsarService1.getAdminClient().topics().createNonPartitionedTopic(kafkaTopicName);
+        try {
+            // 1. check lookup result.
+            String result = admin.lookups().lookupTopic(pulsarTopicName);
+            log.info("Server address:{}", result);
+            int kafkaPort;
+            if (result.endsWith(String.valueOf(primaryBrokerPort))) {
+                kafkaPort = secondaryKafkaBrokerPort;
+            } else {
+                kafkaPort = primaryKafkaBrokerPort;
+            }
+
+            // 2. produce consume message with Kafka producer.
+            kProducer1 = new KProducer(kafkaTopicName, false, kafkaPort, true);
+            kafkaPublishMessage(kProducer1, totalMsgs / 2, messageStrPrefix);
+
+            kProducer2 = new KProducer(kafkaTopicName, false, kafkaPort, true);
+            kafkaPublishMessage(kProducer2, totalMsgs / 2, messageStrPrefix);
+
+            kConsumer1 = new KConsumer(kafkaTopicName, kafkaPort, "consumer-group-1");
+            kConsumer2 = new KConsumer(kafkaTopicName, kafkaPort, "consumer-group-2");
+
+            log.info("Partition size: {}, will consume and commitOffset for 2 consumers",
+                    topicPartitions.size());
+            kafkaConsumeCommitMessage(kConsumer1, totalMsgs, messageStrPrefix, topicPartitions);
+            kafkaConsumeCommitMessage(kConsumer2, totalMsgs, messageStrPrefix, topicPartitions);
+
+            // 3. unload
+            log.info("Unload namespace, lookup will trigger another reload.");
+            pulsarService1.getAdminClient().namespaces().unload(kopNamespace);
+
+            // 4. publish consume again
+            log.info("Re Publish / Consume again.");
+            kafkaPublishMessage(kProducer1, totalMsgs, messageStrPrefix);
+            kafkaConsumeCommitMessage(kConsumer1, totalMsgs, messageStrPrefix, topicPartitions);
+            kafkaConsumeCommitMessage(kConsumer2, totalMsgs, messageStrPrefix, topicPartitions);
+
+        } finally {
+            if (kProducer1 != null) {
+                kProducer1.close();
+            }
+            if (kProducer2 != null) {
+                kProducer2.close();
+            }
+            if (kConsumer1 != null) {
+                kConsumer1.close();
+            }
+            if (kConsumer2 != null) {
+                kConsumer2.close();
+            }
+            pulsarService1.getAdminClient().topics().delete(pulsarTopicName);
+        }
+
+    }
+
+    /**
+     * Unit test for test in distributed cluster env produce and consume one partition topic,
+     * verify it works well.
+     */
+    @Test(timeOut = 20000, invocationCount = 50)
+    public void testMultiBrokerProduceAndConsumeOnePartitionedTopic() throws Exception {
+        String kafkaTopicName = "kopMultiBrokerOnePartitionedTopic";
+        String pulsarTopicName = "persistent://public/default/" + kafkaTopicName;
+        String kopNamespace = "public/default";
+        int totalMsgs = 50;
+        List<TopicPartition> topicPartitions =
+                Collections.singletonList(new TopicPartition(kafkaTopicName, 0));
+        String messageStrPrefix = "Message_" + kafkaTopicName + "_";
+        KProducer kProducer1 = null;
+        KProducer kProducer2 = null;
+        KConsumer kConsumer1 = null;
+        KConsumer kConsumer2 = null;
+        // 0.  Preparing: create non-partitioned topic.
+        pulsarService1.getAdminClient().topics().createPartitionedTopic(pulsarTopicName, 1);
+        try {
+            // 1. check lookup result.
+            String result = admin.lookups().lookupTopic(pulsarTopicName);
+            log.info("Server address:{}", result);
+
+            // 2. produce consume message with Kafka producer.
+            kProducer1 = new KProducer(kafkaTopicName, false, getKafkaBrokerPort(), true);
+            kafkaPublishMessage(kProducer1, totalMsgs / 2, messageStrPrefix);
+
+            kProducer2 = new KProducer(kafkaTopicName, false, getKafkaBrokerPort(), true);
+            kafkaPublishMessage(kProducer2, totalMsgs / 2, messageStrPrefix);
+
+            kConsumer1 = new KConsumer(kafkaTopicName, getKafkaBrokerPort(), "consumer-group-1");
+            kConsumer2 = new KConsumer(kafkaTopicName, getKafkaBrokerPort(), "consumer-group-2");
+
+            log.info("Partition size: {}, will consume and commitOffset for 2 consumers",
+                    topicPartitions.size());
+            kafkaConsumeCommitMessage(kConsumer1, totalMsgs, messageStrPrefix, topicPartitions);
+            kafkaConsumeCommitMessage(kConsumer2, totalMsgs, messageStrPrefix, topicPartitions);
+
+            // 3. unload
+            log.info("Unload namespace, lookup will trigger another reload.");
+            pulsarService1.getAdminClient().namespaces().unload(kopNamespace);
+
+            // 4. publish consume again
+            log.info("Re Publish / Consume again.");
+            kafkaPublishMessage(kProducer1, totalMsgs, messageStrPrefix);
+            kafkaConsumeCommitMessage(kConsumer1, totalMsgs, messageStrPrefix, topicPartitions);
+            kafkaConsumeCommitMessage(kConsumer2, totalMsgs, messageStrPrefix, topicPartitions);
+
+        } finally {
+            if (kProducer1 != null) {
+                kProducer1.close();
+            }
+            if (kProducer2 != null) {
+                kProducer2.close();
+            }
+            if (kConsumer1 != null) {
+                kConsumer1.close();
+            }
+            if (kConsumer2 != null) {
+                kConsumer2.close();
+            }
+            pulsarService1.getAdminClient().topics().deletePartitionedTopic(pulsarTopicName);
+        }
+
     }
 
     @Test(timeOut = 30000)

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaNonPartitionedTopicTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaNonPartitionedTopicTest.java
@@ -1,0 +1,108 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import lombok.Cleanup;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Test unit for non-partitioned topic.
+ */
+public class KafkaNonPartitionedTopicTest extends KopProtocolHandlerTestBase {
+
+    private static final String TENANT = "KafkaNonPartitionedTopicTest";
+    private static final String NAMESPACE = "ns1";
+
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        super.resetConfig();
+
+        conf.setKafkaTenant(TENANT);
+        conf.setKafkaNamespace(NAMESPACE);
+        conf.setKafkaMetadataTenant("internal");
+        conf.setKafkaMetadataNamespace("__kafka");
+        conf.setEnableTransactionCoordinator(true);
+
+        conf.setClusterName(super.configClusterName);
+        super.internalSetup();
+    }
+
+    @AfterClass
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test(timeOut = 30000)
+    public void testNonPartitionedTopic() throws PulsarAdminException {
+        String topic = "persistent://" + TENANT + "/" + NAMESPACE + "/" + "testNonPartitionedTopic";
+        admin.topics().createNonPartitionedTopic(topic);
+        try {
+            @Cleanup
+            KProducer kProducer = new KProducer(topic, false, getKafkaBrokerPort());
+
+            int totalMsgs = 50;
+            String messageStrPrefix = topic + "_message_";
+
+            for (int i = 0; i < totalMsgs; i++) {
+                String messageStr = messageStrPrefix + i;
+                kProducer.getProducer().send(new ProducerRecord<>(topic, i, messageStr));
+            }
+            @Cleanup
+            KConsumer kConsumer = new KConsumer(topic, getKafkaBrokerPort(), "DemoKafkaOnPulsarConsumer");
+
+            kConsumer.getConsumer().subscribe(Collections.singleton(topic));
+
+            int i = 0;
+            while (i < totalMsgs) {
+                ConsumerRecords<Integer, String> records = kConsumer.getConsumer().poll(Duration.ofSeconds(1));
+                for (ConsumerRecord<Integer, String> record : records) {
+                    Integer key = record.key();
+                    assertEquals(messageStrPrefix + key.toString(), record.value());
+                    i++;
+                }
+            }
+            assertEquals(i, totalMsgs);
+
+            // No more records
+            ConsumerRecords<Integer, String> records = kConsumer.getConsumer().poll(Duration.ofMillis(200));
+            assertTrue(records.isEmpty());
+
+            // Ensure that we can list the topic
+            Map<String, List<PartitionInfo>> result = kConsumer
+                    .getConsumer().listTopics(Duration.ofSeconds(1));
+            assertEquals(result.size(), 1);
+        } finally {
+            admin.topics().delete(topic);
+        }
+    }
+
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -708,7 +708,6 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
                 responseFuture);
         final MetadataResponse response = (MetadataResponse) responseFuture.get();
         assertEquals(response.topicMetadata().size(), 1);
-        assertEquals(response.errors().size(), 1);
-        assertEquals(response.errors().get(topic), Errors.INVALID_TOPIC_EXCEPTION);
+        assertEquals(response.errors().size(), 0);
     }
 }


### PR DESCRIPTION
Fix #674

## Motivation
Some users want to use exists non-partitioned topic in KoP, so we need support the feature.

## Modifications
**Note**: Current don't support transaction.

When KoP handle `METADATA` request, if the topic is non-partitioned topic, then treat as a single partitioned topic. And when we `KafkaTopicManager#getTopic`, add a fallback to get non-partitioned topic. Also when namespace `load` or `unload`, we need clear the cache.