### PR TITLE
[branch-2.8.0] Bump Pulsar to 2.8.0.15

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/InternalServerCnx.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/InternalServerCnx.java
@@ -58,6 +58,7 @@ public class InternalServerCnx extends ServerCnx {
     // called after channel active
     public void updateCtx() {
         this.remoteAddress = kafkaRequestHandler.remoteAddress;
+        this.ctx = kafkaRequestHandler.ctx;
     }
 
     @Override
@@ -73,5 +74,15 @@ public class InternalServerCnx extends ServerCnx {
     @Override
     public void cancelPublishBufferLimiting() {
         // do nothing is this mock
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
     <pulsar.group.id>io.streamnative</pulsar.group.id>
-    <pulsar.version>2.8.0.3</pulsar.version>
+    <pulsar.version>2.8.0.15</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testcontainers.version>1.15.1</testcontainers.version>


### PR DESCRIPTION
### Motivation
https://github.com/apache/pulsar/pull/11804 added the custom implementations of `equals` and `hashCode` methods of `ServiceCnx`, which made KoP's spotbugs check fail with 

> Medium: io.streamnative.pulsar.handlers.kop.InternalServerCnx doesn't override org.apache.pulsar.broker.service.ServerCnx.equals(Object) [io.streamnative.pulsar.handlers.kop.InternalServerCnx] At InternalServerCnx.java:[line 1] EQ_DOESNT_OVERRIDE_EQUALS

### Modifications
This PR adds the overrided `equals` and `hashCode` methods by calling base class' same name methods simply. On the other hand, since the new `equals` and `hashCode` methods are based on `ctx` field and they are called when removing `Producer` from `Topic`, this PR also updates the `ctx` field of `InternalServerCnx`.