### PR TITLE
[BUG] Fix unit test logs has multiple SLF4J bindings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,12 +160,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <version>${log4j2.version}</version>
-    </dependency>
-
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>
@@ -193,6 +187,13 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>${commons-lang3.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${log4j2.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
`log4j-slf4j-impl` is duplicate in `kafka-0-10` and `kafka-1-0`, because `log4j-slf4j-impl` only use by unit test, so we just change the `log4j-slf4j-impl` dependency scope to `test`.