### PR TITLE
[BUGFIX] Fix go sarama client with v0 handshake can successful authenticated but will failed fresh metadata

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
@@ -324,7 +324,7 @@ public class SaslAuthenticator {
         });
     }
 
-    private static ByteBuf sizePrefixed(ByteBuffer buffer) {
+    public static ByteBuf sizePrefixed(ByteBuffer buffer) {
         ByteBuffer sizeBuffer = ByteBuffer.allocate(4);
         sizeBuffer.putInt(0, buffer.remaining());
         ByteBuf byteBuf = Unpooled.buffer(sizeBuffer.capacity() + buffer.remaining());

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
@@ -16,6 +16,7 @@ package io.streamnative.pulsar.handlers.kop.security;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.kafka.common.protocol.ApiKeys.API_VERSIONS;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
@@ -324,6 +325,7 @@ public class SaslAuthenticator {
         });
     }
 
+    @VisibleForTesting
     public static ByteBuf sizePrefixed(ByteBuffer buffer) {
         ByteBuffer sizeBuffer = ByteBuffer.allocate(4);
         sizeBuffer.putInt(0, buffer.remaining());

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
@@ -328,8 +328,11 @@ public class SaslAuthenticator {
         ByteBuffer sizeBuffer = ByteBuffer.allocate(4);
         sizeBuffer.putInt(0, buffer.remaining());
         ByteBuf byteBuf = Unpooled.buffer(sizeBuffer.capacity() + buffer.remaining());
+        // why we reset writer index? see https://github.com/streamnative/kop/issues/696
+        byteBuf.markWriterIndex();
         byteBuf.writeBytes(sizeBuffer);
         byteBuf.writeBytes(buffer);
+        byteBuf.resetWriterIndex();
         return byteBuf;
     }
 

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticatorTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticatorTest.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.security;
+
+import io.netty.buffer.ByteBuf;
+import java.nio.ByteBuffer;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Test SaslAuthenticator.
+ *
+ * @see SaslAuthenticator
+ */
+public class SaslAuthenticatorTest {
+
+    @Test
+    public void testSizePrefixed() {
+        final byte[] response = new byte[0];
+        final ByteBuf byteBuf = SaslAuthenticator.sizePrefixed(ByteBuffer.wrap(response));
+        Assert.assertEquals(byteBuf.readerIndex(), 0);
+        Assert.assertEquals(byteBuf.writerIndex(), 0);
+        Assert.assertEquals(byteBuf.capacity(), 4);
+    }
+
+}


### PR DESCRIPTION
fixes #696 

### Motivation
#696  describes a detailed investigation of the problem and root cause of the Go Sarama client's inability to process the metadata response after passing V0 authentication caused by LengthFieldPrepender
### Modifications
After the go sarama client passes the v0 version authenticate, it can process other data requests normally.