### PR TITLE
support low version kafka client

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -368,7 +368,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                     switch (apiKey) {
                         case FETCH:
                             // V4 added MessageSets responses. We need to make sure RecordBatch format is not used
-                            versionList.add(new ApiVersionsResponse.ApiVersion((short) 1, (short) 4,
+                            versionList.add(new ApiVersionsResponse.ApiVersion((short) 1, (short) 0,
                                     apiKey.latestVersion()));
                             break;
                         case LIST_OFFSETS:


### PR DESCRIPTION
When I use a lower version of Kafka client to consume, an error is reported：
![image](https://user-images.githubusercontent.com/19296967/131657953-b73567bf-8031-4d9f-b455-51f20e10ef72.png)
