### PR TITLE
[MINOR] Print old client authentication session debug log

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
@@ -358,14 +358,15 @@ public class SaslAuthenticator {
                         if (!future.isSuccess()) {
                             log.error("[{}] Failed to write {}", ctx.channel(), future.cause());
                         } else {
-                            if (log.isDebugEnabled()) {
-                                log.debug("Send sasl response to SASL_HANDSHAKE v0 old client {} successfully",
-                                        ctx.channel());
-                            }
                             // This session is required for authorization.
                             this.session = new Session(
                                     new KafkaPrincipal(KafkaPrincipal.USER_TYPE, saslServer.getAuthorizationID()),
                                     "old-clientId");
+
+                            if (log.isDebugEnabled()) {
+                                log.debug("Send sasl response to SASL_HANDSHAKE v0 old client {} successfully, "
+                                        + "session {}", ctx.channel(), session);
+                            }
                         }
                     });
                 }


### PR DESCRIPTION
Fixes #706 

### Motivation
The current Kafka protocol header authentication of the high version will print the session debug log if the authentication is successful, but for the low version authentication, the session will be created after the debug log is printed.

### Modifications
Like the higher version of Kafka protocol header authentication, it is very useful to print the lower version of the authentication session debug log.