### PR TITLE
Refactor APIs to allow access from the Proxy module

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -548,6 +548,10 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
             this.remoteAddress = remoteAddress;
         }
 
+        public ByteBuf getBuffer() {
+            return buffer;
+        }
+
         public RequestHeader getHeader() {
             return this.header;
         }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
@@ -213,11 +213,12 @@ public class GroupMetadataManager {
             time,
             // Be same with kafka: abs(groupId.hashCode) % groupMetadataTopicPartitionCount
             // return a partitionId
-            groupId -> MathUtils.signSafeMod(
-                groupId.hashCode(),
-                offsetConfig.offsetsTopicNumPartitions()
-            )
+            groupId -> getPartitionId(groupId, offsetConfig.offsetsTopicNumPartitions())
         );
+    }
+
+    public static int getPartitionId(String groupId, int offsetsTopicNumPartitions) {
+        return MathUtils.signSafeMod(groupId.hashCode(), offsetsTopicNumPartitions);
     }
 
     GroupMetadataManager(OffsetConfig offsetConfig,
@@ -320,7 +321,11 @@ public class GroupMetadataManager {
     }
 
     public String getTopicPartitionName(int partitionId) {
-        return offsetConfig.offsetsTopicName() + PARTITIONED_TOPIC_SUFFIX + partitionId;
+        return getTopicPartitionName(offsetConfig.offsetsTopicName(), partitionId);
+    }
+
+    public static String getTopicPartitionName(String offsetsTopicName, int partitionId) {
+        return offsetsTopicName + PARTITIONED_TOPIC_SUFFIX + partitionId;
     }
 
     public int getGroupMetadataTopicPartitionCount() {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -105,9 +105,13 @@ public class TransactionCoordinator {
     }
 
     public int partitionFor(String transactionalId) {
+        return partitionFor(transactionalId, transactionConfig.getTransactionLogNumPartitions());
+    }
+
+    public static int partitionFor(String transactionalId, int transactionLogNumPartitions) {
         return MathUtils.signSafeMod(
                 transactionalId.hashCode(),
-                transactionConfig.getTransactionLogNumPartitions()
+                transactionLogNumPartitions
         );
     }
 
@@ -116,7 +120,11 @@ public class TransactionCoordinator {
     }
 
     public String getTopicPartitionName(int partitionId) {
-        return getTopicPartitionName() + PARTITIONED_TOPIC_SUFFIX + partitionId;
+        return getTopicPartitionName(getTopicPartitionName(), partitionId);
+    }
+
+    public static String getTopicPartitionName(String topicPartitionName, int partitionId) {
+        return topicPartitionName + PARTITIONED_TOPIC_SUFFIX + partitionId;
     }
 
     public void handleInitProducerId(String transactionalId, int transactionTimeoutMs,


### PR DESCRIPTION
This patch introduces a little refactor in order to support the implementation of a separate KOP Proxy Module:
- allow to access internal ByteBuf of KafkaHeaderAndRequest, in order to allow zero-copy request magement in the Proxy
- extract some static methods in order to use the same algorithm for mapping coordinators


Relates to #57 