### PR TITLE
Add support for passing OriginalPrincipal from Proxy

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/PlainSaslServer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/PlainSaslServer.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import javax.naming.AuthenticationException;
 import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
-
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.authentication.AuthenticationProvider;
@@ -84,7 +83,7 @@ public class PlainSaslServer implements SaslServer {
                 authorizationId = saslAuth.getUsername();
                 log.info("Authenticated Proxy role {} as user role {}", authState.getAuthRole(), authorizationId);
                 if (proxyRoles.contains(authorizationId)) {
-                    throw new SaslException("The proxy (with role "+authState.getAuthRole()
+                    throw new SaslException("The proxy (with role " + authState.getAuthRole()
                             + ") tried to forward another proxy user (with role " + authorizationId + ")");
                 }
             } else {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/PlainSaslServer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/PlainSaslServer.java
@@ -18,9 +18,12 @@ import io.streamnative.pulsar.handlers.kop.utils.SaslUtils;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Set;
 import javax.naming.AuthenticationException;
 import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
+
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.authentication.AuthenticationProvider;
 import org.apache.pulsar.broker.authentication.AuthenticationService;
@@ -31,6 +34,7 @@ import org.apache.pulsar.common.api.AuthData;
 /**
  * The SaslServer implementation for SASL/PLAIN.
  */
+@Slf4j
 public class PlainSaslServer implements SaslServer {
 
     public static final String PLAIN_MECHANISM = "PLAIN";
@@ -40,10 +44,12 @@ public class PlainSaslServer implements SaslServer {
 
     private boolean complete;
     private String authorizationId;
+    private Set<String> proxyRoles;
 
-    public PlainSaslServer(AuthenticationService authenticationService, PulsarAdmin admin) {
+    public PlainSaslServer(AuthenticationService authenticationService, PulsarAdmin admin, Set<String> proxyRoles) {
         this.authenticationService = authenticationService;
         this.admin = admin;
+        this.proxyRoles = proxyRoles;
     }
 
     @Override
@@ -73,8 +79,18 @@ public class PlainSaslServer implements SaslServer {
             if (StringUtils.isEmpty(role)) {
                 throw new AuthenticationException("Role cannot be empty.");
             }
-
-            authorizationId = authState.getAuthRole();
+            if (proxyRoles != null && proxyRoles.contains(authState.getAuthRole())) {
+                // the Proxy passes the OriginalPrincipal as "username"
+                authorizationId = saslAuth.getUsername();
+                log.info("Authenticated Proxy role {} as user role {}", authState.getAuthRole(), authorizationId);
+                if (proxyRoles.contains(authorizationId)) {
+                    throw new SaslException("The proxy (with role "+authState.getAuthRole()
+                            + ") tried to forward another proxy user (with role " + authorizationId + ")");
+                }
+            } else {
+                authorizationId = authState.getAuthRole();
+                log.info("Authenticated User {}", authorizationId);
+            }
             complete = true;
             return new byte[0];
         } catch (AuthenticationException e) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
@@ -22,7 +22,6 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -59,7 +58,6 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.authentication.AuthenticationService;
-import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 
 /**
@@ -438,8 +436,6 @@ public class SaslAuthenticator {
                     log.debug("Authenticate successfully for client, header {}, request {}, session {}",
                             header, saslAuthenticateRequest, session);
                 }
-                log.info("Authenticate successfully for client, header {}, request {}, session {} saslServerComplete {}",
-                        header, saslAuthenticateRequest, session, saslServer.isComplete());
             } catch (SaslException e) {
                 registerRequestLatency.accept(apiKey.name, startProcessTime);
                 sendKafkaResponse(ctx,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
@@ -108,12 +108,16 @@ public class SaslAuthenticator {
         }
     }
 
+    private static void setCurrentAuthenticationService(AuthenticationService authenticationService) {
+        if (SaslAuthenticator.authenticationService == null) {
+            SaslAuthenticator.authenticationService = authenticationService;
+        }
+    }
+
     public SaslAuthenticator(PulsarService pulsarService,
                              Set<String> allowedMechanisms,
                              KafkaServiceConfiguration config) throws PulsarServerException {
-        if (SaslAuthenticator.authenticationService == null) {
-            SaslAuthenticator.authenticationService = pulsarService.getBrokerService().getAuthenticationService();
-        }
+        setCurrentAuthenticationService(pulsarService.getBrokerService().getAuthenticationService())
         this.admin = pulsarService.getAdminClient();
         this.allowedMechanisms = allowedMechanisms;
         this.proxyRoles = config.getProxyRoles();
@@ -122,13 +126,19 @@ public class SaslAuthenticator {
         this.enableKafkaSaslAuthenticateHeaders = false;
     }
 
+    /**
+     * Used by external usages like KOP Proxy
+     * @param admin
+     * @param authenticationService
+     * @param allowedMechanisms
+     * @param config
+     * @throws PulsarServerException
+     */
     public SaslAuthenticator(PulsarAdmin admin,
                              AuthenticationService authenticationService,
                              Set<String> allowedMechanisms,
                              KafkaServiceConfiguration config) throws PulsarServerException {
-        if (SaslAuthenticator.authenticationService == null) {
-            SaslAuthenticator.authenticationService = authenticationService;
-        }
+        setCurrentAuthenticationService(authenticationService);
         this.proxyRoles = config.getProxyRoles();
         this.admin = admin;
         this.allowedMechanisms = allowedMechanisms;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
@@ -117,7 +117,7 @@ public class SaslAuthenticator {
     public SaslAuthenticator(PulsarService pulsarService,
                              Set<String> allowedMechanisms,
                              KafkaServiceConfiguration config) throws PulsarServerException {
-        setCurrentAuthenticationService(pulsarService.getBrokerService().getAuthenticationService())
+        setCurrentAuthenticationService(pulsarService.getBrokerService().getAuthenticationService());
         this.admin = pulsarService.getAdminClient();
         this.allowedMechanisms = allowedMechanisms;
         this.proxyRoles = config.getProxyRoles();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
@@ -127,7 +127,7 @@ public class SaslAuthenticator {
     }
 
     /**
-     * Used by external usages like KOP Proxy
+     * Used by external usages like KOP Proxy.
      * @param admin
      * @param authenticationService
      * @param allowedMechanisms

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/security/PlainSaslServerTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/security/PlainSaslServerTest.java
@@ -13,27 +13,23 @@
  */
 package io.streamnative.pulsar.handlers.kop.security;
 
-import io.netty.buffer.ByteBuf;
-import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
-import org.apache.pulsar.broker.authentication.AuthenticationProvider;
-import org.apache.pulsar.broker.authentication.AuthenticationService;
-import org.apache.pulsar.broker.authentication.AuthenticationState;
-import org.apache.pulsar.common.api.AuthData;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
-import javax.naming.AuthenticationException;
-import javax.security.sasl.SaslException;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.util.HashSet;
-import java.util.Set;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+import javax.naming.AuthenticationException;
+import javax.security.sasl.SaslException;
+import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
+import org.apache.pulsar.broker.authentication.AuthenticationProvider;
+import org.apache.pulsar.broker.authentication.AuthenticationService;
+import org.apache.pulsar.broker.authentication.AuthenticationState;
+import org.apache.pulsar.common.api.AuthData;
+import org.testng.annotations.Test;
 
 /**
  * Test SaslAuthenticator.
@@ -57,7 +53,8 @@ public class PlainSaslServerTest {
         testAssignPrincipal("proxy", "secondproxy", null);
     }
 
-    private void testAssignPrincipal(String username, String role, String expectedRole) throws AuthenticationException, SaslException {
+    private void testAssignPrincipal(String username, String role, String expectedRole)
+            throws AuthenticationException, SaslException {
         Set<String> proxyRoles = new HashSet<>();
         proxyRoles.add("proxy");
         proxyRoles.add("secondproxy");
@@ -88,7 +85,7 @@ public class PlainSaslServerTest {
         when(provider.newAuthState(any(AuthData.class), any(), any())).thenReturn(state);
         PlainSaslServer server = new PlainSaslServer(authenticationService, null, proxyRoles);
 
-        String challengeNoProxy = "XXXXX\000"+ username +"\000token:xxxxx";
+        String challengeNoProxy = "XXXXX\000" + username + "\000token:xxxxx";
         server.evaluateResponse(challengeNoProxy.getBytes(StandardCharsets.US_ASCII));
         String detectedRole = server.getAuthorizationID();
         assertEquals(detectedRole, expectedRole);

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/security/PlainSaslServerTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/security/PlainSaslServerTest.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.security;
+
+import io.netty.buffer.ByteBuf;
+import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
+import org.apache.pulsar.broker.authentication.AuthenticationProvider;
+import org.apache.pulsar.broker.authentication.AuthenticationService;
+import org.apache.pulsar.broker.authentication.AuthenticationState;
+import org.apache.pulsar.common.api.AuthData;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import javax.naming.AuthenticationException;
+import javax.security.sasl.SaslException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test SaslAuthenticator.
+ *
+ * @see SaslAuthenticator
+ */
+public class PlainSaslServerTest {
+
+    @Test
+    public void testSetPrincipalRegularUser() throws Exception {
+        testAssignPrincipal("I-DONT-CARE", "user", "user");
+    }
+
+    @Test
+    public void testSetPrincipalUsingProxyRole() throws Exception {
+        testAssignPrincipal("user", "proxy", "user");
+    }
+
+    @Test(expectedExceptions = SaslException.class)
+    public void testCannotUserProxyRoleOverProxyRole() throws Exception {
+        testAssignPrincipal("proxy", "secondproxy", null);
+    }
+
+    private void testAssignPrincipal(String username, String role, String expectedRole) throws AuthenticationException, SaslException {
+        Set<String> proxyRoles = new HashSet<>();
+        proxyRoles.add("proxy");
+        proxyRoles.add("secondproxy");
+        AuthenticationService authenticationService  = mock(AuthenticationService.class);
+        AuthenticationProvider provider = mock(AuthenticationProvider.class);
+        when(authenticationService.getAuthenticationProvider(eq("token"))).thenReturn(provider);
+        AuthenticationState state = new AuthenticationState() {
+            @Override
+            public String getAuthRole() throws AuthenticationException {
+                return role;
+            }
+
+            @Override
+            public AuthData authenticate(AuthData authData) throws AuthenticationException {
+                return authData;
+            }
+
+            @Override
+            public AuthenticationDataSource getAuthDataSource() {
+                return null;
+            }
+
+            @Override
+            public boolean isComplete() {
+                return true;
+            }
+        };
+        when(provider.newAuthState(any(AuthData.class), any(), any())).thenReturn(state);
+        PlainSaslServer server = new PlainSaslServer(authenticationService, null, proxyRoles);
+
+        String challengeNoProxy = "XXXXX\000"+ username +"\000token:xxxxx";
+        server.evaluateResponse(challengeNoProxy.getBytes(StandardCharsets.US_ASCII));
+        String detectedRole = server.getAuthorizationID();
+        assertEquals(detectedRole, expectedRole);
+    }
+
+}


### PR DESCRIPTION
- If the authenticated role is a proxyRole use the username as OriginalPrincipal
- remove dependency on "BrokerService" in SaslAuthenticator 