### PR TITLE
[FEATURE] Support close Idle connections when timeout

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,6 +53,7 @@ This section lists configurations that may affect the performance.
 | ----------------- | ------------------------------------------------------------ | ------- |
 | maxQueuedRequests | Limit the queue size for request, like `queued.max.requests` in Kafka server. | 500     |
 | requestTimeoutMs  | Limit the timeout in milliseconds for request, like `request.timeout.ms` in Kafka client.<br>If a request was not processed in the timeout, KoP would return an error response to client. | 30000   |
+| connectionMaxIdleMs | Idle connections timeout: the server handler close the connections that idle more than this. like `connections.max.idle.ms` in kafka server. | 600000 |
 | failedAuthenticationDelayMs | Connection close delay on failed authentication: this is the time (in milliseconds) by which connection close will be delayed on authentication failure, like `connection.failed.authentication.delay.ms` in Kafka server. | 300 |
 
 > **NOTE**

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,7 +53,7 @@ This section lists configurations that may affect the performance.
 | ----------------- | ------------------------------------------------------------ | ------- |
 | maxQueuedRequests | Limit the queue size for request, like `queued.max.requests` in Kafka server. | 500     |
 | requestTimeoutMs  | Limit the timeout in milliseconds for request, like `request.timeout.ms` in Kafka client.<br>If a request was not processed in the timeout, KoP would return an error response to client. | 30000   |
-| connectionMaxIdleMs | Idle connections timeout: the server handler close the connections that idle more than this. like `connections.max.idle.ms` in kafka server. | 600000 |
+| connectionMaxIdleMs | The idle connection timeout in milliseconds. If the idle connection timeout (such as `connections.max.idle.ms` used in the Kafka server) is reached, the server handler will close this idle connection.<br>**Note**: If it is set to `-1`, it indicates that the idle connection timeout is disabled. | 600000 |
 | failedAuthenticationDelayMs | Connection close delay on failed authentication: this is the time (in milliseconds) by which connection close will be delayed on authentication failure, like `connection.failed.authentication.delay.ms` in Kafka server. | 300 |
 
 > **NOTE**

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
@@ -20,10 +20,12 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
 import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.timeout.IdleStateHandler;
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupCoordinator;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
 import io.streamnative.pulsar.handlers.kop.stats.StatsLogger;
 import io.streamnative.pulsar.handlers.kop.utils.ssl.SSLUtils;
+import java.util.concurrent.TimeUnit;
 import lombok.Getter;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.metadata.api.MetadataCache;
@@ -75,7 +77,6 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
         this.advertisedEndPoint = advertisedEndPoint;
         this.statsLogger = statsLogger;
         this.localBrokerDataCache = localBrokerDataCache;
-
         if (enableTls) {
             sslContextFactory = SSLUtils.createSslContextFactory(kafkaConfig);
         } else {
@@ -85,6 +86,12 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
 
     @Override
     protected void initChannel(SocketChannel ch) throws Exception {
+        ch.pipeline().addLast("idleStateHandler",
+                new IdleStateHandler(
+                        kafkaConfig.getConnectionMaxIdleMs(),
+                        kafkaConfig.getConnectionMaxIdleMs(),
+                        0,
+                        TimeUnit.MILLISECONDS));
         if (this.enableTls) {
             ch.pipeline().addLast(TLS_HANDLER, new SslHandler(SSLUtils.createSslEngine(sslContextFactory)));
         }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -212,6 +212,13 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
 
     @FieldContext(
             category = CATEGORY_KOP,
+            doc = "Idle connections timeout: the server handler close the connections that idle more than this, \n"
+                    + "like connections.max.idle.ms in kafka server."
+    )
+    private long connectionMaxIdleMs = 10 * 60 * 1000L;
+
+    @FieldContext(
+            category = CATEGORY_KOP,
             doc = "Connection close delay on failed authentication: "
                     + "this is the time (in milliseconds) by which connection close "
                     + "will be delayed on authentication failure. "

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaIdleConnectionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaIdleConnectionTest.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
+
+import io.streamnative.kafka.client.api.KafkaVersion;
+import io.streamnative.kafka.client.api.ProducerConfiguration;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import org.apache.kafka.clients.ClientUtils;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.network.ChannelBuilder;
+import org.apache.kafka.common.network.KafkaChannel;
+import org.apache.kafka.common.network.Selector;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.common.utils.Time;
+import org.awaitility.Awaitility;
+import org.junit.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Unit test for KoP Idle connection close.
+ */
+public class KafkaIdleConnectionTest extends KopProtocolHandlerTestBase {
+
+    protected static final int BUFFER_SIZE = 4 * 1024;
+    private static final long DEFAULT_CONNECTION_MAX_IDLE_MS = 9 * 60 * 1000;
+    private static final long DEFAULT_BROKER_CONNECTION_MAX_IDLE_MS = 1000;
+
+    private Selector selector;
+    private Time time;
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        conf.setConnectionMaxIdleMs(DEFAULT_BROKER_CONNECTION_MAX_IDLE_MS);
+        super.internalSetup();
+
+        time = Time.SYSTEM;
+        Metrics metrics = new Metrics(time);
+        ProducerConfiguration producerConfiguration = ProducerConfiguration.builder()
+                .bootstrapServers("localhost:" + getKafkaBrokerPort())
+                .keySerializer(KafkaVersion.DEFAULT.getStringSerializer())
+                .valueSerializer(KafkaVersion.DEFAULT.getStringSerializer())
+                .build();
+        ChannelBuilder channelBuilder =
+                ClientUtils.createChannelBuilder(new ProducerConfig(producerConfiguration.toProperties()));
+        String clientId = "clientId";
+        selector = new Selector(
+                DEFAULT_CONNECTION_MAX_IDLE_MS,
+                metrics,
+                time,
+                "test-selector",
+                channelBuilder,
+                new LogContext(String.format("[Test Selector clientId=%s] ", clientId)));
+    }
+
+    @AfterClass
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testConnectionExceedMaxIdle() throws IOException {
+        String id = "0";
+        blockingConnect(id);
+        long startTimeMs = time.milliseconds();
+
+        assertEquals(selector.channels().size(), 1);
+        KafkaChannel channel = selector.channel(id);
+        assertTrue(channel.isConnected());
+
+        Awaitility.await().until(() -> {
+            poll(selector);
+            return !channel.isConnected();
+        });
+
+        assertTrue(time.milliseconds() >= (startTimeMs + DEFAULT_BROKER_CONNECTION_MAX_IDLE_MS));
+    }
+
+    // connect and wait for the connection to complete
+    private void blockingConnect(String node) throws IOException {
+        blockingConnect(node, new InetSocketAddress("localhost", getKafkaBrokerPort()));
+    }
+
+    protected void blockingConnect(String node, InetSocketAddress serverAddr) throws IOException {
+        selector.connect(node, serverAddr, BUFFER_SIZE, BUFFER_SIZE);
+        while (!selector.connected().contains(node)) {
+            selector.poll(10000L);
+        }
+        while (!selector.isChannelReady(node)) {
+            selector.poll(10000L);
+        }
+    }
+
+    private void poll(Selector selector) {
+        try {
+            selector.poll(50);
+        } catch (IOException e) {
+            Assert.fail("Caught unexpected exception " + e);
+        }
+    }
+
+}


### PR DESCRIPTION
#713

## Motivation
When there are too many idle connections on the server side, new client connections may not be created, so we need to clear idle connections over time.

## Modifications
Implemented using `IdleStateHandler`.