### PR TITLE
Fix the findBroker method may hang

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
@@ -68,7 +68,7 @@ public class KopBrokerLookupManager {
         getTopicBroker(topic)
                 .thenCompose(pair -> getProtocolDataToAdvertise(pair, TopicName.get(topic)))
                 .whenComplete((listeners, throwable) -> {
-                    if (!listeners.isPresent() || throwable != null) {
+                    if (listeners == null || !listeners.isPresent() || throwable != null) {
                         log.error("Not get advertise data for Kafka topic:{}. throwable", topic, throwable);
                         returnFuture.complete(null);
                         return;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
@@ -66,10 +66,11 @@ public class KopBrokerLookupManager {
 
         CompletableFuture<InetSocketAddress> returnFuture = new CompletableFuture<>();
         getTopicBroker(topic)
-                .thenCompose(pair -> getProtocolDataToAdvertise(pair, TopicName.get(topic)))
-                .whenComplete((listeners, throwable) -> {
-                    if (listeners == null || !listeners.isPresent() || throwable != null) {
-                        log.error("Not get advertise data for Kafka topic:{}. throwable", topic, throwable);
+                .thenApply(address -> getProtocolDataToAdvertise(address, TopicName.get(topic)))
+                .thenAccept(kopAddressFuture -> kopAddressFuture.thenAccept(listeners -> {
+                    if (!listeners.isPresent()) {
+                        log.error("Not get advertise data for Kafka topic:{}", topic);
+                        removeTopicManagerCache(topic);
                         returnFuture.complete(null);
                         return;
                     }
@@ -93,6 +94,12 @@ public class KopBrokerLookupManager {
                     }
 
                     checkTopicOwner(returnFuture, topic, endPoint);
+                })).exceptionally(throwable -> {
+                    log.error("Not get advertise data for Kafka topic:{}. throwable: [{}]",
+                            topic, throwable.getMessage());
+                    removeTopicManagerCache(topic);
+                    returnFuture.complete(null);
+                    return null;
                 });
         return returnFuture;
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
@@ -381,9 +381,7 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
     }
 
     // Unit test for unload / reload user topic bundle, verify it works well.
-    // NOTE: Currently the testMultiBrokerUnloadReload is flaky. If it ran after other tests, it would be easy to fail.
-    //   So we just change the priority to make it run first to avoid CI failing at this test for this moment.
-    @Test(timeOut = 30000, priority = -1)
+    @Test(timeOut = 30000)
     public void testMultiBrokerUnloadReload() throws Exception {
         int partitionNumber = 10;
         String kafkaTopicName = "kopMultiBrokerUnloadReload" + partitionNumber;


### PR DESCRIPTION
Fixes #682

## Motivation
The test unit `DistributedClusterTest#testMultiBrokerUnloadReload()` is flaky. 
If the`topicManager.getTopicBroker(topic.toString())` method has exception,  the `thenCompose` supplied function will never called, In this case `stringOptional` is null, will cause `NullPointerException`. 

See docs in : https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html#thenCompose-java.util.function.Function-

## Modification
Use `thenApply` to replase `thenCompose`