### PR TITLE
Add Kafka client 2.8.0 tests

### DIFF
--- a/kafka-2-8/pom.xml
+++ b/kafka-2-8/pom.xml
@@ -24,9 +24,9 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>kafka-client-factory</artifactId>
-  <name>StreamNative :: Pulsar Protocol Handler :: Kafka Client Factory</name>
-  <description>The Kafka client factory to create different versions of Kafka clients</description>
+  <artifactId>kafka-2-8</artifactId>
+  <name>StreamNative :: Pulsar Protocol Handler :: Kafka Client 2.8.x</name>
+  <description>The Kafka client wrapper for 2.8.x</description>
 
   <dependencies>
     <dependency>
@@ -35,19 +35,39 @@
       <version>2.9.0-SNAPSHOT</version>
     </dependency>
     <dependency>
-      <groupId>io.streamnative.pulsar.handlers</groupId>
-      <artifactId>kafka-1-0</artifactId>
-      <version>2.9.0-SNAPSHOT</version>
-    </dependency>
-    <dependency>
-      <groupId>io.streamnative.pulsar.handlers</groupId>
-      <artifactId>kafka-0-10</artifactId>
-      <version>2.9.0-SNAPSHOT</version>
-    </dependency>
-    <dependency>
-      <groupId>io.streamnative.pulsar.handlers</groupId>
-      <artifactId>kafka-2-8</artifactId>
-      <version>2.9.0-SNAPSHOT</version>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>2.8.0</version>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${mavem-shade-plugin.version}</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <relocations>
+                <relocation>
+                  <pattern>org.apache.kafka.common</pattern>
+                  <shadedPattern>org.apache.kafka280.common</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.kafka.clients</pattern>
+                  <shadedPattern>org.apache.kafka280.clients</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/kafka-2-8/src/main/java/io/streamnative/kafka/client/two/eight/Consumer280Impl.java
+++ b/kafka-2-8/src/main/java/io/streamnative/kafka/client/two/eight/Consumer280Impl.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kafka.client.two.eight;
+
+import com.google.common.collect.Maps;
+import io.streamnative.kafka.client.api.Consumer;
+import io.streamnative.kafka.client.api.ConsumerConfiguration;
+import io.streamnative.kafka.client.api.ConsumerRecord;
+import io.streamnative.kafka.client.api.TopicOffsetAndMetadata;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+
+/**
+ * The implementation of Kafka consumer 1.0.0.
+ */
+public class Consumer280Impl<K, V> extends KafkaConsumer<K, V> implements Consumer<K, V> {
+
+    public Consumer280Impl(final ConsumerConfiguration conf) {
+        super(conf.toProperties());
+    }
+
+    @Override
+    public List<ConsumerRecord<K, V>> receive(long timeoutMs) {
+        final List<ConsumerRecord<K, V>> records = new ArrayList<>();
+        poll(timeoutMs).forEach(record -> records.add(ConsumerRecord.create(record)));
+        return records;
+    }
+
+    @Override
+    public Map<String, List<PartitionInfo>> listTopics(long timeoutMS) {
+        return listTopics();
+    }
+
+    @Override
+    public void commitOffsetSync(List<TopicOffsetAndMetadata> offsets, Duration timeout) {
+        HashMap<TopicPartition, OffsetAndMetadata> offsetsMap = Maps.newHashMap();
+        offsets.forEach(
+                offsetAndMetadata -> offsetsMap.put(
+                        offsetAndMetadata.createTopicPartition(TopicPartition.class),
+                        offsetAndMetadata.createOffsetAndMetadata(OffsetAndMetadata.class)
+                )
+        );
+        commitSync(offsetsMap);
+    }
+}

--- a/kafka-2-8/src/main/java/io/streamnative/kafka/client/two/eight/Consumer280Impl.java
+++ b/kafka-2-8/src/main/java/io/streamnative/kafka/client/two/eight/Consumer280Impl.java
@@ -29,7 +29,7 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 
 /**
- * The implementation of Kafka consumer 1.0.0.
+ * The implementation of Kafka consumer 2.8.0.
  */
 public class Consumer280Impl<K, V> extends KafkaConsumer<K, V> implements Consumer<K, V> {
 
@@ -40,7 +40,7 @@ public class Consumer280Impl<K, V> extends KafkaConsumer<K, V> implements Consum
     @Override
     public List<ConsumerRecord<K, V>> receive(long timeoutMs) {
         final List<ConsumerRecord<K, V>> records = new ArrayList<>();
-        poll(timeoutMs).forEach(record -> records.add(ConsumerRecord.create(record)));
+        poll(Duration.ofMillis(timeoutMs)).forEach(record -> records.add(ConsumerRecord.create(record)));
         return records;
     }
 

--- a/kafka-2-8/src/main/java/io/streamnative/kafka/client/two/eight/Producer280Impl.java
+++ b/kafka-2-8/src/main/java/io/streamnative/kafka/client/two/eight/Producer280Impl.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kafka.client.two.eight;
+
+import io.streamnative.kafka.client.api.ProduceContext;
+import io.streamnative.kafka.client.api.Producer;
+import io.streamnative.kafka.client.api.ProducerConfiguration;
+import io.streamnative.kafka.client.api.RecordMetadata;
+import java.util.concurrent.Future;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
+
+/**
+ * The implementation of Kafka producer 1.0.0.
+ */
+public class Producer280Impl<K, V> extends KafkaProducer<K, V> implements Producer<K, V> {
+
+    public Producer280Impl(final ProducerConfiguration conf) {
+        super(conf.toProperties());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Future<RecordMetadata> sendAsync(final ProduceContext<K, V> context) {
+        send(context.createProducerRecord(ProducerRecord.class, RecordHeader::new), context::complete);
+        return context.getFuture();
+    }
+}

--- a/kafka-2-8/src/main/java/io/streamnative/kafka/client/two/eight/Producer280Impl.java
+++ b/kafka-2-8/src/main/java/io/streamnative/kafka/client/two/eight/Producer280Impl.java
@@ -23,7 +23,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.internals.RecordHeader;
 
 /**
- * The implementation of Kafka producer 1.0.0.
+ * The implementation of Kafka producer 2.8.0.
  */
 public class Producer280Impl<K, V> extends KafkaProducer<K, V> implements Producer<K, V> {
 

--- a/kafka-2-8/src/main/java/io/streamnative/kafka/client/two/eight/package-info.java
+++ b/kafka-2-8/src/main/java/io/streamnative/kafka/client/two/eight/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.kafka.client.two.eight;

--- a/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/KafkaVersion.java
+++ b/kafka-client-api/src/main/java/io/streamnative/kafka/client/api/KafkaVersion.java
@@ -24,7 +24,7 @@ import lombok.Getter;
  */
 public enum KafkaVersion {
 
-    DEFAULT("default"), KAFKA_1_0_0("100"), KAFKA_0_10_0_0("010");
+    DEFAULT("default"), KAFKA_2_8_0("280"), KAFKA_1_0_0("100"), KAFKA_0_10_0_0("010");
 
     @Getter
     private String name;

--- a/kafka-client-factory/src/main/java/io/streamnative/kafka/client/api/KafkaClientFactoryImpl.java
+++ b/kafka-client-factory/src/main/java/io/streamnative/kafka/client/api/KafkaClientFactoryImpl.java
@@ -17,6 +17,8 @@ import io.streamnative.kafka.client.one.zero.ConsumerImpl;
 import io.streamnative.kafka.client.one.zero.ProducerImpl;
 import io.streamnative.kafka.client.zero.ten.Consumer010Impl;
 import io.streamnative.kafka.client.zero.ten.Producer010Impl;
+import io.streamnative.kafka.client.two.eight.Consumer280Impl;
+import io.streamnative.kafka.client.two.eight.Producer280Impl;
 
 /**
  * The factory class to create Kafka producers or consumers with a specific version.
@@ -35,6 +37,8 @@ public class KafkaClientFactoryImpl implements KafkaClientFactory {
             return new ProducerImpl<>(conf);
         } else if (kafkaVersion.equals(KafkaVersion.KAFKA_0_10_0_0)) {
             return new Producer010Impl<>(conf);
+        } else if (kafkaVersion.equals(KafkaVersion.KAFKA_2_8_0)) {
+            return new Producer280Impl<>(conf);
         }
         throw new IllegalArgumentException("No producer for version: " + kafkaVersion);
     }
@@ -45,6 +49,8 @@ public class KafkaClientFactoryImpl implements KafkaClientFactory {
             return new ConsumerImpl<>(conf);
         } else if (kafkaVersion.equals(KafkaVersion.KAFKA_0_10_0_0)) {
             return new Consumer010Impl<>(conf);
+        } else if (kafkaVersion.equals(KafkaVersion.KAFKA_2_8_0)) {
+            return new Consumer280Impl<>(conf);
         }
         throw new IllegalArgumentException("No consumer for version: " + kafkaVersion);
     }

--- a/kafka-client-factory/src/main/java/io/streamnative/kafka/client/api/KafkaClientFactoryImpl.java
+++ b/kafka-client-factory/src/main/java/io/streamnative/kafka/client/api/KafkaClientFactoryImpl.java
@@ -15,10 +15,10 @@ package io.streamnative.kafka.client.api;
 
 import io.streamnative.kafka.client.one.zero.ConsumerImpl;
 import io.streamnative.kafka.client.one.zero.ProducerImpl;
-import io.streamnative.kafka.client.zero.ten.Consumer010Impl;
-import io.streamnative.kafka.client.zero.ten.Producer010Impl;
 import io.streamnative.kafka.client.two.eight.Consumer280Impl;
 import io.streamnative.kafka.client.two.eight.Producer280Impl;
+import io.streamnative.kafka.client.zero.ten.Consumer010Impl;
+import io.streamnative.kafka.client.zero.ten.Producer010Impl;
 
 /**
  * The factory class to create Kafka producers or consumers with a specific version.

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
   <modules>
     <module>kafka-0-10</module>
     <module>kafka-1-0</module>
+    <module>kafka-2-8</module>
     <module>kafka-client-api</module>
     <module>kafka-client-factory</module>
     <module>kafka-impl</module>

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/saslplain/SaslPlainEndToEndTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/saslplain/SaslPlainEndToEndTestBase.java
@@ -345,8 +345,8 @@ public abstract class SaslPlainEndToEndTestBase extends KopProtocolHandlerTestBa
             } catch (Exception e) {
                 log.error("error", e);
                 if (version == KafkaVersion.KAFKA_2_8_0) {
-                    assertTrue(e.getMessage().contains("Topic " + KAFKA_TOPIC +
-                            " not present in metadata after " + metadataTimeoutMs + " ms."));
+                    assertTrue(e.getMessage().contains("Topic " + KAFKA_TOPIC
+                            + " not present in metadata after " + metadataTimeoutMs + " ms."));
                 } else {
                     assertTrue(e.getMessage().contains("Failed to update metadata"));
                 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/saslplain/SaslPlainEndToEndTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/saslplain/SaslPlainEndToEndTestBase.java
@@ -343,7 +343,6 @@ public abstract class SaslPlainEndToEndTestBase extends KopProtocolHandlerTestBa
                 producer.newContextBuilder(KAFKA_TOPIC, "hello").build().sendAsync().get();
                 fail("should have failed");
             } catch (Exception e) {
-                log.error("error", e);
                 if (version == KafkaVersion.KAFKA_2_8_0) {
                     assertTrue(e.getMessage().contains("Topic " + KAFKA_TOPIC
                             + " not present in metadata after " + metadataTimeoutMs + " ms."));

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/saslplain/SaslPlainEndToEndTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/compatibility/saslplain/SaslPlainEndToEndTestBase.java
@@ -147,12 +147,16 @@ public abstract class SaslPlainEndToEndTestBase extends KopProtocolHandlerTestBa
     @AfterClass
     protected void cleanup() throws Exception {
         super.internalCleanup();
-        jaasConfigFile.delete();
+        if (jaasConfigFile != null) {
+            jaasConfigFile.delete();
+        }
     }
 
     @AfterMethod
     protected void cleanJaasConf() {
-        jaasConfigFile.delete();
+        if (jaasConfigFile != null) {
+            jaasConfigFile.delete();
+        }
         Configuration.setConfiguration(null);
     }
 
@@ -339,7 +343,13 @@ public abstract class SaslPlainEndToEndTestBase extends KopProtocolHandlerTestBa
                 producer.newContextBuilder(KAFKA_TOPIC, "hello").build().sendAsync().get();
                 fail("should have failed");
             } catch (Exception e) {
-                assertTrue(e.getMessage().contains("Failed to update metadata"));
+                log.error("error", e);
+                if (version == KafkaVersion.KAFKA_2_8_0) {
+                    assertTrue(e.getMessage().contains("Topic " + KAFKA_TOPIC +
+                            " not present in metadata after " + metadataTimeoutMs + " ms."));
+                } else {
+                    assertTrue(e.getMessage().contains("Failed to update metadata"));
+                }
             }
         }
     }


### PR DESCRIPTION
This patch adds the Kafka 2.8.0 shaded client, and enables running compatibility tests using that version as well as with Kakfa 1.0, 1.1 and 0.10.
This way we will have more coverage of existing Kafka clients.
