### PR TITLE
[BUGFIX] Shut down KopEventManager when closing kop

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -410,6 +410,7 @@ public class KafkaProtocolHandler implements ProtocolHandler {
     @Override
     public void close() {
         Optional.ofNullable(LOOKUP_CLIENT_MAP.remove(brokerService.pulsar())).ifPresent(LookupClient::close);
+        kopEventManager.close();
         adminManager.shutdown();
         groupCoordinator.shutdown();
         KafkaTopicManager.LOOKUP_CACHE.clear();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManager.java
@@ -291,11 +291,11 @@ public class KopEventManager {
         }
     }
 
-    class ShutdownEventThread implements KopEvent {
+    static class ShutdownEventThread implements KopEvent {
 
         @Override
         public void process() {
-
+            // Here is only record shutdown KopEventThread event.
         }
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManager.java
@@ -79,7 +79,9 @@ public class KopEventManager {
 
     public void close() {
         try {
-            thread.shutdown();
+            thread.initiateShutdown();
+            clearAndPut(getShutdownEventThread());
+            thread.awaitShutdown();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             log.error("Interrupted at shutting down {}", kopEventThreadName);
@@ -121,7 +123,11 @@ public class KopEventManager {
             KopEvent event = null;
             try {
                 event = queue.take();
-                event.process();
+                if (event instanceof ShutdownEventThread) {
+                    log.info("Shutting down KopEventThread.");
+                } else {
+                    event.process();
+                }
             } catch (InterruptedException e) {
                 log.error("Error processing event {}", event, e);
             }
@@ -285,12 +291,24 @@ public class KopEventManager {
         }
     }
 
+    class ShutdownEventThread implements KopEvent {
+
+        @Override
+        public void process() {
+
+        }
+    }
+
     public DeleteTopicsEvent getDeleteTopicEvent() {
         return new DeleteTopicsEvent();
     }
 
     public BrokersChangeEvent getBrokersChangeEvent() {
         return new BrokersChangeEvent();
+    }
+
+    public ShutdownEventThread getShutdownEventThread() {
+        return new ShutdownEventThread();
     }
 
     public static String getKopPath() {


### PR DESCRIPTION
Fixes #732 

### Modifications
When exiting kop, kopEventManager should be closed.