### PR TITLE
Implement Tenant Aware Metadata Topics

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,8 +35,14 @@ Pulsar is a multi-tenant system that requires users to specify the [tenant and n
 | kafkaTenant            | The default tenant of Kafka topics             | public  |
 | kafkaNamespace         | The default namespace of Kafka topics          | default |
 | kafkaMetadataTenant    | The tenant used for storing Kafka metadata topics    | public  |
+| kafkaEnableMultitenantMetadata    | Use the SASL username as `kafkaMetadataTenant`  | true  |
 | kafkaMetadataNamespace | The namespace used for storing Kafka metadata topics | __kafka |
 | kopAllowedNamespaces   | The allowed namespace to list topics with a comma separator.<br>For example, "public/default,public/kafka".<br>If it's not set or empty, the allowed namespaces will be "<kafkaTenant>/<kafkaNamespace>". | |
+
+When you enable `kafkaEnableMultitenantMetadata` KOP uses separate tenants for handling system metadata.
+This will allow you to fully isolate your tenants in your Pulsar cluster.
+This is something that is not available in pure Kafka, because usually you share system metadata among all the users
+of the Kafka cluster.
 
 ## Performance
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,14 +35,13 @@ Pulsar is a multi-tenant system that requires users to specify the [tenant and n
 | kafkaTenant            | The default tenant of Kafka topics             | public  |
 | kafkaNamespace         | The default namespace of Kafka topics          | default |
 | kafkaMetadataTenant    | The tenant used for storing Kafka metadata topics    | public  |
-| kafkaEnableMultitenantMetadata    | Use the SASL username as `kafkaMetadataTenant`  | true  |
+| kafkaEnableMultiTenantMetadata    | Use the SASL username as `kafkaMetadataTenant`  | true  |
 | kafkaMetadataNamespace | The namespace used for storing Kafka metadata topics | __kafka |
 | kopAllowedNamespaces   | The allowed namespace to list topics with a comma separator.<br>For example, "public/default,public/kafka".<br>If it's not set or empty, the allowed namespaces will be "<kafkaTenant>/<kafkaNamespace>". | |
 
-When you enable `kafkaEnableMultitenantMetadata` KOP uses separate tenants for handling system metadata.
-This will allow you to fully isolate your tenants in your Pulsar cluster.
-This is something that is not available in pure Kafka, because usually you share system metadata among all the users
-of the Kafka cluster.
+When you enable `kafkaEnableMultiTenantMetadata`, KoP uses separate tenants for handling the system metadata.
+This enables you to fully isolate your tenants in your Pulsar cluster.
+This is not available in pure Kafka, because usually you share  the system metadata among all the users.
 
 ## Performance
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -79,7 +79,7 @@ If you want to enable the authentication feature for KoP using the `PLAIN` mecha
 
     Property | Description | Example value
     |---|---|---
-    `username` | `username` of Kafka JAAS is the `tenant/namespace`, where Kafka’s topics are stored in Pulsar. <br><br> **Note** In KoP 2.9.0 or above, the username is only used to be compatible with version history, has‘t actual function. |`public/default`
+    `username` | `username` of Kafka JAAS is the `tenant/namespace` or only `tenant`, where Kafka’s topics are stored in Pulsar. <br><br> **Note** In KoP 2.9.0 or above, the username can be used with `kafkaEnableMultitenantMetadata` to implement multi tenancy for metadata. | empty string
     `password`|`password` must be your token authentication parameters from Pulsar.<br><br>The token can be created by Pulsar token tools. The role is the `subject` for the token. It is embedded in the created token and the broker can get `role` by parsing this token.|`token:xxx`
 
     ```properties

--- a/docs/security.md
+++ b/docs/security.md
@@ -79,7 +79,7 @@ If you want to enable the authentication feature for KoP using the `PLAIN` mecha
 
     Property | Description | Example value
     |---|---|---
-    `username` | `username` of Kafka JAAS is the `tenant/namespace` or only `tenant`, where Kafka’s topics are stored in Pulsar. <br><br> **Note** In KoP 2.9.0 or above, the username can be used with `kafkaEnableMultitenantMetadata` to implement multi tenancy for metadata. | empty string
+    `username` | `username` | The `username` of Kafka JAAS is `tenant/namespace` or `tenant`, where Kafka’s topics are stored in Pulsar. <br><br> **Note** In KoP 2.9.0 or higher, the username can be used with `kafkaEnableMultiTenantMetadata` to implement multi-tenancy for metadata. | empty string
     `password`|`password` must be your token authentication parameters from Pulsar.<br><br>The token can be created by Pulsar token tools. The role is the `subject` for the token. It is embedded in the created token and the broker can get `role` by parsing this token.|`token:xxx`
 
     ```properties

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
@@ -21,8 +21,6 @@ import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.IdleStateHandler;
-import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupCoordinator;
-import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
 import io.streamnative.pulsar.handlers.kop.stats.StatsLogger;
 import io.streamnative.pulsar.handlers.kop.utils.ssl.SSLUtils;
 import java.util.concurrent.TimeUnit;
@@ -44,9 +42,8 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
     @Getter
     private final KafkaServiceConfiguration kafkaConfig;
     @Getter
-    private final GroupCoordinator groupCoordinator;
-    @Getter
-    private final TransactionCoordinator transactionCoordinator;
+    private final TenantContextManager tenantContextManager;
+
     private final AdminManager adminManager;
     @Getter
     private final boolean enableTls;
@@ -60,8 +57,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
 
     public KafkaChannelInitializer(PulsarService pulsarService,
                                    KafkaServiceConfiguration kafkaConfig,
-                                   GroupCoordinator groupCoordinator,
-                                   TransactionCoordinator transactionCoordinator,
+                                   TenantContextManager tenantContextManager,
                                    AdminManager adminManager,
                                    boolean enableTLS,
                                    EndPoint advertisedEndPoint,
@@ -70,8 +66,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
         super();
         this.pulsarService = pulsarService;
         this.kafkaConfig = kafkaConfig;
-        this.groupCoordinator = groupCoordinator;
-        this.transactionCoordinator = transactionCoordinator;
+        this.tenantContextManager = tenantContextManager;
         this.adminManager = adminManager;
         this.enableTls = enableTLS;
         this.advertisedEndPoint = advertisedEndPoint;
@@ -100,7 +95,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
             new LengthFieldBasedFrameDecoder(MAX_FRAME_LENGTH, 0, 4, 0, 4));
         ch.pipeline().addLast("handler",
                 new KafkaRequestHandler(pulsarService, kafkaConfig,
-                        groupCoordinator, transactionCoordinator, adminManager, localBrokerDataCache,
+                        tenantContextManager, adminManager, localBrokerDataCache,
                         enableTls, advertisedEndPoint, statsLogger));
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -365,7 +365,8 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
 
         GroupCoordinator groupCoordinator;
         try {
-            MetadataUtils.createOffsetMetadataIfMissing(tenant, brokerService.getPulsar().getAdminClient(), clusterData, kafkaConfig);
+            MetadataUtils.createOffsetMetadataIfMissing(tenant, brokerService.getPulsar().getAdminClient(),
+                    clusterData, kafkaConfig);
 
             // init and start group coordinator
             groupCoordinator = startGroupCoordinator(tenant, brokerService.getPulsar().getClient());
@@ -391,7 +392,8 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
 
         // init kafka namespaces
         try {
-            MetadataUtils.createKafkaNamespaceIfMissing(brokerService.getPulsar().getAdminClient(), clusterData, kafkaConfig);
+            MetadataUtils.createKafkaNamespaceIfMissing(brokerService.getPulsar().getAdminClient(),
+                    clusterData, kafkaConfig);
         } catch (Exception e) {
             // no need to throw exception since we can create kafka namespace later
             log.warn("init kafka failed, need to create it manually later", e);
@@ -494,7 +496,8 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
         return groupCoordinator;
     }
 
-    public TransactionCoordinator initTransactionCoordinator(String tenant, PulsarAdmin pulsarAdmin, ClusterData clusterData) throws Exception {
+    public TransactionCoordinator initTransactionCoordinator(String tenant, PulsarAdmin pulsarAdmin,
+                                                             ClusterData clusterData) throws Exception {
         TransactionConfig transactionConfig = TransactionConfig.builder()
                 .transactionLogNumPartitions(kafkaConfig.getTxnLogTopicNumPartitions())
                 .transactionMetadataTopicName(MetadataUtils.constructTxnLogTopicBaseName(tenant, kafkaConfig))

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -313,16 +313,6 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
         // After it's created successfully, this method won't throw any exception.
         LOOKUP_CLIENT_MAP.put(brokerService.pulsar(), new LookupClient(brokerService.pulsar(), kafkaConfig));
 
-
-        // Use the builtin PulsarClient for creating producers and readers in group coordinator
-        PulsarClient pulsarClient;
-        try {
-            pulsarClient = brokerService.getPulsar().getClient();
-        } catch (PulsarServerException e) {
-            log.error("Failed to create builtin PulsarClient", e);
-            throw new IllegalStateException(e);
-        }
-
         // initialize default Group Coordinator
         getGroupCoordinator(kafkaConfig.getKafkaMetadataTenant());
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -91,9 +91,9 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     @Getter
     private BrokerService brokerService;
 
-    private Map<String, GroupCoordinator> groupCoordinatorsByTenant = new ConcurrentHashMap<>();
-    private Map<String, TransactionCoordinator> transactionCoordinatorByTenant = new ConcurrentHashMap<>();
-    private Map<String, KopEventManager> kopEventManagerByTenant = new ConcurrentHashMap<>();
+    private final Map<String, GroupCoordinator> groupCoordinatorsByTenant = new ConcurrentHashMap<>();
+    private final Map<String, TransactionCoordinator> transactionCoordinatorByTenant = new ConcurrentHashMap<>();
+    private final Map<String, KopEventManager> kopEventManagerByTenant = new ConcurrentHashMap<>();
 
     @Override
     public GroupCoordinator getGroupCoordinator(String tenant) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -190,8 +190,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
 
     private final PulsarService pulsarService;
     private final KafkaTopicManager topicManager;
-    private final GroupCoordinator groupCoordinator;
-    private final TransactionCoordinator transactionCoordinator;
+    private final TenantContextManager groupCoordinatorAccessor;
 
     private final String clusterName;
     private final ScheduledExecutorService executor;
@@ -207,8 +206,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     private final int defaultNumPartitions;
     public final int maxReadEntriesNum;
     private final int failedAuthenticationDelayMs;
-    private final String offsetsTopicName;
-    private final String txnTopicName;
     private final Set<String> allowedNamespaces;
     // store the group name for current connected client.
     private final ConcurrentHashMap<String, String> currentConnectedGroup;
@@ -238,10 +235,37 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     private final AtomicLong pendingBytes = new AtomicLong(0);
     private volatile boolean autoReadDisabledPublishBufferLimiting = false;
 
+    private String getCurrentTenant() {
+        if (kafkaConfig.isKafkaEnableMultitenantMetadata()
+                && authenticator != null
+                && authenticator.session() != null
+                && authenticator.session().getPrincipal() != null) {
+            String username =  authenticator.session().getPrincipal().getUsername();
+            if (username != null && !username.isEmpty()) {
+                // username can be "tenant" or "tenant/namespace"
+                if (username.contains("/")) {
+                    username = username.substring(0, username.indexOf('/'));
+                }
+                log.debug("using {} as tenant", username);
+                return username;
+            }
+        }
+        // fallback to using system (default) tenant
+        log.debug("using {} as tenant", kafkaConfig.getKafkaMetadataTenant());
+        return kafkaConfig.getKafkaMetadataTenant();
+    }
+
+    public GroupCoordinator getGroupCoordinator() {
+        return groupCoordinatorAccessor.getGroupCoordinator(getCurrentTenant());
+    }
+
+    public TransactionCoordinator getTransactionCoordinator() {
+        return groupCoordinatorAccessor.getTransactionCoordinator(getCurrentTenant());
+    }
+
     public KafkaRequestHandler(PulsarService pulsarService,
                                KafkaServiceConfiguration kafkaConfig,
-                               GroupCoordinator groupCoordinator,
-                               TransactionCoordinator transactionCoordinator,
+                               TenantContextManager groupCoordinatorAccessor,
                                AdminManager adminManager,
                                MetadataCache<LocalBrokerData> localBrokerDataCache,
                                Boolean tlsEnabled,
@@ -249,8 +273,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                StatsLogger statsLogger) throws Exception {
         super(statsLogger, kafkaConfig);
         this.pulsarService = pulsarService;
-        this.groupCoordinator = groupCoordinator;
-        this.transactionCoordinator = transactionCoordinator;
+        this.groupCoordinatorAccessor = groupCoordinatorAccessor;
         this.clusterName = kafkaConfig.getClusterName();
         this.executor = pulsarService.getExecutor();
         this.admin = pulsarService.getAdminClient();
@@ -271,16 +294,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         this.topicManager = new KafkaTopicManager(this);
         this.defaultNumPartitions = kafkaConfig.getDefaultNumPartitions();
         this.maxReadEntriesNum = kafkaConfig.getMaxReadEntriesNum();
-        this.offsetsTopicName = new KopTopic(String.join("/",
-                kafkaConfig.getKafkaMetadataTenant(),
-                kafkaConfig.getKafkaMetadataNamespace(),
-                GROUP_METADATA_TOPIC_NAME)
-        ).getFullName();
-        this.txnTopicName = new KopTopic(String.join("/",
-                kafkaConfig.getKafkaMetadataTenant(),
-                kafkaConfig.getKafkaMetadataNamespace(),
-                TRANSACTION_STATE_TOPIC_NAME)
-        ).getFullName();
         this.allowedNamespaces = kafkaConfig.getKopAllowedNamespaces();
         this.entryFormatter = EntryFormatterFactory.create(kafkaConfig.getEntryFormat());
         this.currentConnectedGroup = new ConcurrentHashMap<>();
@@ -291,6 +304,22 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
 
         // update alive channel count stats
         RequestStats.ALIVE_CHANNEL_COUNT_INSTANCE.incrementAndGet();
+    }
+
+    private String getOffsetsTopicName() {
+        return new KopTopic(String.join("/",
+                getCurrentTenant(),
+                kafkaConfig.getKafkaMetadataNamespace(),
+                GROUP_METADATA_TOPIC_NAME)
+        ).getFullName();
+    }
+
+    private String getTxnTopicName() {
+        return new KopTopic(String.join("/",
+                getCurrentTenant(),
+                kafkaConfig.getKafkaMetadataNamespace(),
+                TRANSACTION_STATE_TOPIC_NAME)
+        ).getFullName();
     }
 
     @Override
@@ -438,7 +467,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     }
 
     private boolean isInternalTopic(final String fullTopicName) {
-        return fullTopicName.equals(offsetsTopicName) || fullTopicName.equals(txnTopicName);
+        return fullTopicName.equals(getOffsetsTopicName())
+                || fullTopicName.equals(getTxnTopicName());
     }
 
     // Get all topics in the configured allowed namespaces.
@@ -856,7 +886,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             byteBuf.release();
             if (e == null) {
                 if (batch.isTransactional()) {
-                    transactionCoordinator.addActivePidOffset(TopicName.get(partitionName), batch.producerId(), offset);
+                    getTransactionCoordinator().addActivePidOffset(TopicName.get(partitionName), batch.producerId(), offset);
                 }
                 requestStats.getMessagePublishStats().registerSuccessfulEvent(
                         MathUtils.elapsedNanos(beforePublish), TimeUnit.NANOSECONDS);
@@ -1030,11 +1060,12 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         int partition;
 
         if (request.coordinatorType() == FindCoordinatorRequest.CoordinatorType.TRANSACTION) {
+            TransactionCoordinator transactionCoordinator = getTransactionCoordinator();
             partition = transactionCoordinator.partitionFor(request.coordinatorKey());
             pulsarTopicName = transactionCoordinator.getTopicPartitionName(partition);
         } else if (request.coordinatorType() == FindCoordinatorRequest.CoordinatorType.GROUP) {
-            partition = groupCoordinator.partitionFor(request.coordinatorKey());
-            pulsarTopicName = groupCoordinator.getTopicPartitionName(partition);
+            partition = getGroupCoordinator().partitionFor(request.coordinatorKey());
+            pulsarTopicName = getGroupCoordinator().getTopicPartitionName(partition);
         } else {
             throw new NotImplementedException("FindCoordinatorRequest not support TRANSACTION type "
                 + request.coordinatorType());
@@ -1088,7 +1119,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                             CompletableFuture<AbstractResponse> resultFuture) {
         checkArgument(offsetFetch.getRequest() instanceof OffsetFetchRequest);
         OffsetFetchRequest request = (OffsetFetchRequest) offsetFetch.getRequest();
-        checkState(groupCoordinator != null,
+        checkState(getGroupCoordinator() != null,
             "Group Coordinator not started");
 
         CompletableFuture<List<TopicPartition>> authorizeFuture = new CompletableFuture<>();
@@ -1144,7 +1175,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
 
         authorizeFuture.whenComplete((partitionList, ex) -> {
             KeyValue<Errors, Map<TopicPartition, OffsetFetchResponse.PartitionData>> keyValue =
-                    groupCoordinator.handleFetchOffsets(
+                    getGroupCoordinator().handleFetchOffsets(
                             request.groupId(),
                             Optional.ofNullable(partitionList)
                     );
@@ -1516,7 +1547,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     protected void handleOffsetCommitRequest(KafkaHeaderAndRequest offsetCommit,
                                              CompletableFuture<AbstractResponse> resultFuture) {
         checkArgument(offsetCommit.getRequest() instanceof OffsetCommitRequest);
-        checkState(groupCoordinator != null,
+        checkState(getGroupCoordinator() != null,
                 "Group Coordinator not started");
 
         OffsetCommitRequest request = (OffsetCommitRequest) offsetCommit.getRequest();
@@ -1569,10 +1600,10 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                             request,
                             offsetCommit.getHeader().apiVersion(),
                             Time.SYSTEM.milliseconds(),
-                            groupCoordinator.offsetConfig().offsetsRetentionMs()
+                            getGroupCoordinator().offsetConfig().offsetsRetentionMs()
                     );
 
-            groupCoordinator.handleCommitOffsets(
+            getGroupCoordinator().handleCommitOffsets(
                     request.groupId(),
                     request.memberId(),
                     request.generationId(),
@@ -1613,7 +1644,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     protected void handleJoinGroupRequest(KafkaHeaderAndRequest joinGroup,
                                           CompletableFuture<AbstractResponse> resultFuture) {
         checkArgument(joinGroup.getRequest() instanceof JoinGroupRequest);
-        checkState(groupCoordinator != null,
+        checkState(getGroupCoordinator() != null,
             "Group Coordinator not started");
 
         JoinGroupRequest request = (JoinGroupRequest) joinGroup.getRequest();
@@ -1622,7 +1653,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         request.groupProtocols()
             .stream()
             .forEach(protocol -> protocols.put(protocol.name(), Utils.toArray(protocol.metadata())));
-        groupCoordinator.handleJoinGroup(
+        getGroupCoordinator().handleJoinGroup(
             request.groupId(),
             request.memberId(),
             joinGroup.getHeader().clientId(),
@@ -1661,7 +1692,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         SyncGroupRequest request = (SyncGroupRequest) syncGroup.getRequest();
 
         groupIds.add(request.groupId());
-        groupCoordinator.handleSyncGroup(
+        getGroupCoordinator().handleSyncGroup(
             request.groupId(),
             request.generationId(),
             request.memberId(),
@@ -1684,7 +1715,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         HeartbeatRequest request = (HeartbeatRequest) heartbeat.getRequest();
 
         // let the coordinator to handle heartbeat
-        groupCoordinator.handleHeartbeat(
+        getGroupCoordinator().handleHeartbeat(
             request.groupId(),
             request.memberId(),
             request.groupGenerationId()
@@ -1707,7 +1738,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         LeaveGroupRequest request = (LeaveGroupRequest) leaveGroup.getRequest();
 
         // let the coordinator to handle heartbeat
-        groupCoordinator.handleLeaveGroup(
+        getGroupCoordinator().handleLeaveGroup(
             request.groupId(),
             request.memberId()
         ).thenAccept(errors -> {
@@ -1726,7 +1757,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         // let the coordinator to handle heartbeat
         Map<String, GroupMetadata> groups = request.groupIds().stream()
             .map(groupId -> {
-                KeyValue<Errors, GroupSummary> describeResult = groupCoordinator
+                KeyValue<Errors, GroupSummary> describeResult = getGroupCoordinator()
                     .handleDescribeGroup(groupId);
                 GroupSummary summary = describeResult.getValue();
                 List<GroupMember> members = summary.members().stream()
@@ -1767,7 +1798,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     protected void handleListGroupsRequest(KafkaHeaderAndRequest listGroups,
                                            CompletableFuture<AbstractResponse> resultFuture) {
         checkArgument(listGroups.getRequest() instanceof ListGroupsRequest);
-        KeyValue<Errors, List<GroupOverview>> listResult = groupCoordinator.handleListGroups();
+        KeyValue<Errors, List<GroupOverview>> listResult = getGroupCoordinator().handleListGroups();
         ListGroupsResponse response = new ListGroupsResponse(
             listResult.getKey(),
             listResult.getValue().stream()
@@ -1784,7 +1815,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         checkArgument(deleteGroups.getRequest() instanceof DeleteGroupsRequest);
         DeleteGroupsRequest request = (DeleteGroupsRequest) deleteGroups.getRequest();
 
-        Map<String, Errors> deleteResult = groupCoordinator.handleDeleteGroups(request.groups());
+        Map<String, Errors> deleteResult = getGroupCoordinator().handleDeleteGroups(request.groups());
         DeleteGroupsResponse response = new DeleteGroupsResponse(
             deleteResult
         );
@@ -1856,6 +1887,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     protected void handleInitProducerId(KafkaHeaderAndRequest kafkaHeaderAndRequest,
                                         CompletableFuture<AbstractResponse> response) {
         InitProducerIdRequest request = (InitProducerIdRequest) kafkaHeaderAndRequest.getRequest();
+        TransactionCoordinator transactionCoordinator = getTransactionCoordinator();
         transactionCoordinator.handleInitProducerId(
                 request.transactionalId(), request.transactionTimeoutMs(), Optional.empty(), this, response);
     }
@@ -1864,6 +1896,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     protected void handleAddPartitionsToTxn(KafkaHeaderAndRequest kafkaHeaderAndRequest,
                                             CompletableFuture<AbstractResponse> response) {
         AddPartitionsToTxnRequest request = (AddPartitionsToTxnRequest) kafkaHeaderAndRequest.getRequest();
+        TransactionCoordinator transactionCoordinator = getTransactionCoordinator();
         transactionCoordinator.handleAddPartitionsToTransaction(request.transactionalId(),
                 request.producerId(), request.producerEpoch(), request.partitions(), response);
     }
@@ -1872,8 +1905,9 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     protected void handleAddOffsetsToTxn(KafkaHeaderAndRequest kafkaHeaderAndRequest,
                                          CompletableFuture<AbstractResponse> response) {
         AddOffsetsToTxnRequest request = (AddOffsetsToTxnRequest) kafkaHeaderAndRequest.getRequest();
-        int partition = groupCoordinator.partitionFor(request.consumerGroupId());
-        String offsetTopicName = groupCoordinator.getGroupManager().getOffsetConfig().offsetsTopicName();
+        int partition = getGroupCoordinator().partitionFor(request.consumerGroupId());
+        String offsetTopicName = getGroupCoordinator().getGroupManager().getOffsetConfig().offsetsTopicName();
+        TransactionCoordinator transactionCoordinator = getTransactionCoordinator();
         transactionCoordinator.handleAddPartitionsToTransaction(
                 request.transactionalId(),
                 request.producerId(),
@@ -1918,7 +1952,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         // update the request data
         request.offsets().putAll(convertedOffsetData);
 
-        groupCoordinator.handleTxnCommitOffsets(
+        getGroupCoordinator().handleTxnCommitOffsets(
                 request.consumerGroupId(),
                 request.producerId(),
                 request.producerEpoch(),
@@ -1956,6 +1990,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     protected void handleEndTxn(KafkaHeaderAndRequest kafkaHeaderAndRequest,
                                 CompletableFuture<AbstractResponse> response) {
         EndTxnRequest request = (EndTxnRequest) kafkaHeaderAndRequest.getRequest();
+        TransactionCoordinator transactionCoordinator = getTransactionCoordinator();
         transactionCoordinator.handleEndTransaction(
                 request.transactionalId(),
                 request.producerId(),
@@ -1971,6 +2006,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         WriteTxnMarkersRequest request = (WriteTxnMarkersRequest) kafkaHeaderAndRequest.getRequest();
         Map<Long, Map<TopicPartition, Errors>> resultMap = new HashMap<>();
         List<CompletableFuture<Void>> resultFutureList = new ArrayList<>();
+        TransactionCoordinator transactionCoordinator = getTransactionCoordinator();
         for (WriteTxnMarkersRequest.TxnMarkerEntry txnMarkerEntry : request.markers()) {
             Map<TopicPartition, Errors> partitionErrorsMap =
                     resultMap.computeIfAbsent(txnMarkerEntry.producerId(), pid -> new HashMap<>());
@@ -1995,7 +2031,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
 
                     CompletableFuture<Void> handleGroupFuture;
                     if (TopicName.get(topicPartition.topic()).getLocalName().equals(GROUP_METADATA_TOPIC_NAME)) {
-                        handleGroupFuture = groupCoordinator.scheduleHandleTxnCompletion(
+                        handleGroupFuture = getGroupCoordinator().scheduleHandleTxnCompletion(
                                 txnMarkerEntry.producerId(),
                                 Lists.newArrayList(topicPartition).stream(),
                                 txnMarkerEntry.transactionResult());
@@ -2013,6 +2049,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                         }
                         String fullPartitionName = KopTopic.toString(topicPartition);
                         TopicName topicName = TopicName.get(fullPartitionName);
+
                         long firstOffset = transactionCoordinator.removeActivePidOffset(
                                 topicName, txnMarkerEntry.producerId());
                         long lastStableOffset = transactionCoordinator.getLastStableOffset(topicName, offset);
@@ -2247,7 +2284,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     }
 
     protected boolean isOffsetTopic(String topic) {
-        String offsetsTopic = kafkaConfig.getKafkaMetadataTenant() + "/"
+        String offsetsTopic = getCurrentTenant() + "/"
             + kafkaConfig.getKafkaMetadataNamespace()
             + "/" + GROUP_METADATA_TOPIC_NAME;
 
@@ -2255,7 +2292,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     }
 
     protected boolean isTransactionTopic(String topic) {
-        String transactionTopic = kafkaConfig.getKafkaMetadataTenant() + "/"
+        String transactionTopic = getCurrentTenant() + "/"
             + kafkaConfig.getKafkaMetadataNamespace()
             + "/" + TRANSACTION_STATE_TOPIC_NAME;
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -886,7 +886,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             byteBuf.release();
             if (e == null) {
                 if (batch.isTransactional()) {
-                    getTransactionCoordinator().addActivePidOffset(TopicName.get(partitionName), batch.producerId(), offset);
+                    getTransactionCoordinator().addActivePidOffset(TopicName.get(partitionName), batch.producerId(),
+                                                                    offset);
                 }
                 requestStats.getMessagePublishStats().registerSuccessfulEvent(
                         MathUtils.elapsedNanos(beforePublish), TimeUnit.NANOSECONDS);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -237,7 +237,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     private volatile boolean autoReadDisabledPublishBufferLimiting = false;
 
     private String getCurrentTenant() {
-        if (kafkaConfig.isKafkaEnableMultitenantMetadata()
+        if (kafkaConfig.isKafkaEnableMultiTenantMetadata()
                 && authenticator != null
                 && authenticator.session() != null
                 && authenticator.session().getPrincipal() != null
@@ -2509,7 +2509,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
      */
     private boolean validateTenantAccessForSession(Session session)
             throws AuthenticationException {
-        if (!kafkaConfig.isKafkaEnableMultitenantMetadata()) {
+        if (!kafkaConfig.isKafkaEnableMultiTenantMetadata()) {
             // we are not leveraging lafkaEnableMultitenantMetadata feature
             // the client will access only system tenant
             return true;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -2502,7 +2502,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     }
 
     /**
-     * If we are using afkaEnableMultitenantMetadata we need to ensure
+     * If we are using kafkaEnableMultiTenantMetadata we need to ensure
      * that the TenantSpec refer to an existing tenant.
      * @param session
      * @return whether the tenant is accessible
@@ -2510,7 +2510,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     private boolean validateTenantAccessForSession(Session session)
             throws AuthenticationException {
         if (!kafkaConfig.isKafkaEnableMultiTenantMetadata()) {
-            // we are not leveraging lafkaEnableMultitenantMetadata feature
+            // we are not leveraging kafkaEnableMultiTenantMetadata feature
             // the client will access only system tenant
             return true;
         }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -460,8 +460,9 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     }
 
     private static boolean isInternalTopic(final String fullTopicName) {
-        return fullTopicName.endsWith("/" + GROUP_METADATA_TOPIC_NAME)
-                || fullTopicName.endsWith("/" + TRANSACTION_STATE_TOPIC_NAME);
+        String partitionedTopicName = TopicName.get(fullTopicName).getPartitionedTopicName();
+        return partitionedTopicName.endsWith("/" + GROUP_METADATA_TOPIC_NAME)
+                || partitionedTopicName.endsWith("/" + TRANSACTION_STATE_TOPIC_NAME);
     }
 
     // Get all topics in the configured allowed namespaces.

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -240,14 +240,14 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 && authenticator != null
                 && authenticator.session() != null
                 && authenticator.session().getPrincipal() != null) {
-            String username =  authenticator.session().getPrincipal().getTenantSpec();
-            if (username != null && !username.isEmpty()) {
+            String tenantSpec =  authenticator.session().getPrincipal().getTenantSpec();
+            if (tenantSpec != null && !tenantSpec.isEmpty()) {
                 // username can be "tenant" or "tenant/namespace"
-                if (username.contains("/")) {
-                    username = username.substring(0, username.indexOf('/'));
+                if (tenantSpec.contains("/")) {
+                    tenantSpec = tenantSpec.substring(0, tenantSpec.indexOf('/'));
                 }
-                log.debug("using {} as tenant", username);
-                return username;
+                log.debug("using {} as tenant", tenantSpec);
+                return tenantSpec;
             }
         }
         // fallback to using system (default) tenant

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -2454,7 +2454,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
 
     @VisibleForTesting
     protected CompletableFuture<Boolean> authorize(AclOperation operation, Resource resource) {
-        return authorize(operation, resource, authenticator.session());
+        Session session = authenticator != null ? authenticator.session() : null;
+        return authorize(operation, resource, session);
     }
 
     protected CompletableFuture<Boolean> authorize(AclOperation operation, Resource resource, Session session) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -190,7 +190,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
 
     private final PulsarService pulsarService;
     private final KafkaTopicManager topicManager;
-    private final TenantContextManager groupCoordinatorAccessor;
+    private final TenantContextManager tenantContextManager;
 
     private final String clusterName;
     private final ScheduledExecutorService executor;
@@ -240,7 +240,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 && authenticator != null
                 && authenticator.session() != null
                 && authenticator.session().getPrincipal() != null) {
-            String username =  authenticator.session().getPrincipal().getUsername();
+            String username =  authenticator.session().getPrincipal().getTenantSpec();
             if (username != null && !username.isEmpty()) {
                 // username can be "tenant" or "tenant/namespace"
                 if (username.contains("/")) {
@@ -256,16 +256,16 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     }
 
     public GroupCoordinator getGroupCoordinator() {
-        return groupCoordinatorAccessor.getGroupCoordinator(getCurrentTenant());
+        return tenantContextManager.getGroupCoordinator(getCurrentTenant());
     }
 
     public TransactionCoordinator getTransactionCoordinator() {
-        return groupCoordinatorAccessor.getTransactionCoordinator(getCurrentTenant());
+        return tenantContextManager.getTransactionCoordinator(getCurrentTenant());
     }
 
     public KafkaRequestHandler(PulsarService pulsarService,
                                KafkaServiceConfiguration kafkaConfig,
-                               TenantContextManager groupCoordinatorAccessor,
+                               TenantContextManager tenantContextManager,
                                AdminManager adminManager,
                                MetadataCache<LocalBrokerData> localBrokerDataCache,
                                Boolean tlsEnabled,
@@ -273,7 +273,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                StatsLogger statsLogger) throws Exception {
         super(statsLogger, kafkaConfig);
         this.pulsarService = pulsarService;
-        this.groupCoordinatorAccessor = groupCoordinatorAccessor;
+        this.tenantContextManager = tenantContextManager;
         this.clusterName = kafkaConfig.getClusterName();
         this.executor = pulsarService.getExecutor();
         this.admin = pulsarService.getAdminClient();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -2516,7 +2516,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         }
         String tenantSpec = session.getPrincipal().getTenantSpec();
         if (tenantSpec == null) {
-            // we are not leveraging kafkaEnableMultitenantMetadata feature
+            // we are not leveraging kafkaEnableMultiTenantMetadata feature
             // the client will access only system tenant
             return true;
         }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -93,6 +93,13 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
     private String kafkaMetadataTenant = "public";
 
     @FieldContext(
+            category = CATEGORY_KOP,
+            required = true,
+            doc = "Use the current tenant as namespace name for Metadata topics."
+    )
+    private boolean kafkaEnableMultitenantMetadata = true;
+
+    @FieldContext(
         category = CATEGORY_KOP,
         required = true,
         doc = "The namespace used for storing Kafka metadata topics"

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -97,7 +97,7 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
             required = true,
             doc = "Use the current tenant as namespace name for Metadata topics."
     )
-    private boolean kafkaEnableMultitenantMetadata = true;
+    private boolean kafkaEnableMultiTenantMetadata = true;
 
     @FieldContext(
         category = CATEGORY_KOP,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/TenantContextManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/TenantContextManager.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupCoordinator;
+import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
+
+/**
+ * Access Tenant level coordinators.
+ */
+public interface TenantContextManager {
+    /**
+     * Access the GroupCoordinator for the current Tenant.
+     * This method bootstraps a new GroupCoordinator if it is not started
+     * @param tenant
+     * @return the GroupCoordinator
+     */
+    GroupCoordinator getGroupCoordinator(String tenant);
+    /**
+     * Access the TransactionCoordinator for the current Tenant.
+     * This method bootstraps a new TransactionCoordinator if it is not started
+     * @param tenant
+     * @return the TransactionCoordinator
+     */
+    TransactionCoordinator getTransactionCoordinator(String tenant);
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/KafkaPrincipal.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/KafkaPrincipal.java
@@ -37,4 +37,8 @@ public class KafkaPrincipal implements Principal {
      */
     private final String name;
 
+    /**
+     * SASL username, mapped to Pulsar tenant
+     */
+    private final String username;
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/KafkaPrincipal.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/KafkaPrincipal.java
@@ -39,6 +39,7 @@ public class KafkaPrincipal implements Principal {
 
     /**
      * SASL username, mapped to Pulsar Tenant.
+     * It can be "tenant" or "tenant/namespace"
      */
-    private final String username;
+    private final String tenantSpec;
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/KafkaPrincipal.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/KafkaPrincipal.java
@@ -38,7 +38,7 @@ public class KafkaPrincipal implements Principal {
     private final String name;
 
     /**
-     * SASL username, mapped to Pulsar Tenant.
+     * Pulsar Tenant Specs.
      * It can be "tenant" or "tenant/namespace"
      */
     private final String tenantSpec;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/KafkaPrincipal.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/KafkaPrincipal.java
@@ -38,7 +38,7 @@ public class KafkaPrincipal implements Principal {
     private final String name;
 
     /**
-     * SASL username, mapped to Pulsar tenant
+     * SASL username, mapped to Pulsar Tenant.
      */
     private final String username;
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/PlainSaslServer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/PlainSaslServer.java
@@ -89,7 +89,8 @@ public class PlainSaslServer implements SaslServer {
                     username = authorizationId.substring(lastSlash + 1);
                     authorizationId = authorizationId.substring(0, lastSlash);
                 }
-                log.info("Authenticated Proxy role {} as user role {} tenant (username) {}", authState.getAuthRole(), authorizationId, username);
+                log.info("Authenticated Proxy role {} as user role {} tenant (username) {}", authState.getAuthRole(),
+                        authorizationId, username);
                 if (proxyRoles.contains(authorizationId)) {
                     throw new SaslException("The proxy (with role " + authState.getAuthRole()
                             + ") tried to forward another proxy user (with role " + authorizationId + ")");

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/PlainSaslServer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/PlainSaslServer.java
@@ -30,6 +30,8 @@ import org.apache.pulsar.broker.authentication.AuthenticationState;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.common.api.AuthData;
 
+import static io.streamnative.pulsar.handlers.kop.security.SaslAuthenticator.USER_NAME_PROP;
+
 /**
  * The SaslServer implementation for SASL/PLAIN.
  */
@@ -85,6 +87,7 @@ public class PlainSaslServer implements SaslServer {
                 authorizationId = saslAuth.getUsername();
                 username = null; // PULSAR TENANT
                 if (authorizationId.contains("/")) {
+                    // the proxy uses username/originalPrincipal as "username"
                     int lastSlash = authorizationId.lastIndexOf('/');
                     username = authorizationId.substring(lastSlash + 1);
                     authorizationId = authorizationId.substring(0, lastSlash);
@@ -131,13 +134,12 @@ public class PlainSaslServer implements SaslServer {
         }
         return Arrays.copyOfRange(outgoing, offset, offset + len);
     }
-
     @Override
     public Object getNegotiatedProperty(String propName) {
         if (!complete) {
             throw new IllegalStateException("Authentication exchange has not completed");
         }
-        if ("username".equals(propName)) {
+        if (USER_NAME_PROP.equals(propName)) {
             return username;
         }
         return null;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/PlainSaslServer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/PlainSaslServer.java
@@ -13,6 +13,8 @@
  */
 package io.streamnative.pulsar.handlers.kop.security;
 
+import static io.streamnative.pulsar.handlers.kop.security.SaslAuthenticator.USER_NAME_PROP;
+
 import io.streamnative.pulsar.handlers.kop.SaslAuth;
 import io.streamnative.pulsar.handlers.kop.utils.SaslUtils;
 import java.io.IOException;
@@ -29,8 +31,6 @@ import org.apache.pulsar.broker.authentication.AuthenticationService;
 import org.apache.pulsar.broker.authentication.AuthenticationState;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.common.api.AuthData;
-
-import static io.streamnative.pulsar.handlers.kop.security.SaslAuthenticator.USER_NAME_PROP;
 
 /**
  * The SaslServer implementation for SASL/PLAIN.

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
@@ -418,7 +418,7 @@ public class SaslAuthenticator {
                         } else {
                             // This session is required for authorization.
                             this.session = new Session(
-                                    new KafkaPrincipal(KafkaPrincipal.USER_TYPE, saslServer.getAuthorizationID()),
+                                    new KafkaPrincipal(KafkaPrincipal.USER_TYPE, saslServer.getAuthorizationID(), (String) saslServer.getNegotiatedProperty("username")),
                                     "old-clientId");
 
                             if (log.isDebugEnabled()) {
@@ -464,7 +464,7 @@ public class SaslAuthenticator {
                 ByteBuffer responseBuf = (responseToken == null) ? EMPTY_BUFFER : ByteBuffer.wrap(responseToken);
                 String pulsarRole = saslServer.getAuthorizationID();
                 this.session = new Session(
-                        new KafkaPrincipal(KafkaPrincipal.USER_TYPE, pulsarRole),
+                        new KafkaPrincipal(KafkaPrincipal.USER_TYPE, pulsarRole, (String) saslServer.getNegotiatedProperty("username")),
                         header.clientId());
                 registerRequestLatency.accept(apiKey.name, startProcessTime);
                 sendKafkaResponse(ctx,
@@ -473,8 +473,8 @@ public class SaslAuthenticator {
                         new SaslAuthenticateResponse(Errors.NONE, null, responseBuf),
                         null);
                 if (log.isDebugEnabled()) {
-                    log.debug("Authenticate successfully for client, header {}, request {}, session {}",
-                            header, saslAuthenticateRequest, session);
+                    log.debug("Authenticate successfully for client, header {}, request {}, session {} username {}",
+                            header, saslAuthenticateRequest, session, saslServer.getNegotiatedProperty("username"));
                 }
             } catch (SaslException e) {
                 registerRequestLatency.accept(apiKey.name, startProcessTime);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
@@ -66,6 +66,8 @@ import org.apache.pulsar.client.admin.PulsarAdmin;
 @Slf4j
 public class SaslAuthenticator {
 
+    public static final String USER_NAME_PROP = "username";
+
     private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocate(0);
 
     @Getter
@@ -419,7 +421,7 @@ public class SaslAuthenticator {
                             // This session is required for authorization.
                             this.session = new Session(
                                     new KafkaPrincipal(KafkaPrincipal.USER_TYPE, saslServer.getAuthorizationID(),
-                                            (String) saslServer.getNegotiatedProperty("username")),
+                                            (String) saslServer.getNegotiatedProperty(USER_NAME_PROP)),
                                     "old-clientId");
 
                             if (log.isDebugEnabled()) {
@@ -466,7 +468,7 @@ public class SaslAuthenticator {
                 String pulsarRole = saslServer.getAuthorizationID();
                 this.session = new Session(
                         new KafkaPrincipal(KafkaPrincipal.USER_TYPE, pulsarRole,
-                                (String) saslServer.getNegotiatedProperty("username")),
+                                (String) saslServer.getNegotiatedProperty(USER_NAME_PROP)),
                         header.clientId());
                 registerRequestLatency.accept(apiKey.name, startProcessTime);
                 sendKafkaResponse(ctx,
@@ -477,7 +479,7 @@ public class SaslAuthenticator {
                 if (log.isDebugEnabled()) {
                     log.debug("Authenticate successfully for client, header {}, request {}, session {} username {}",
                             header, saslAuthenticateRequest, session,
-                            saslServer.getNegotiatedProperty("username"));
+                            saslServer.getNegotiatedProperty(USER_NAME_PROP));
                 }
             } catch (SaslException e) {
                 registerRequestLatency.accept(apiKey.name, startProcessTime);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
 import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
@@ -175,7 +176,8 @@ public class SaslAuthenticator {
     public void authenticate(ChannelHandlerContext ctx,
                              ByteBuf requestBuf,
                              BiConsumer<Long, Throwable> registerRequestParseLatency,
-                             BiConsumer<String, Long> registerRequestLatency)
+                             BiConsumer<String, Long> registerRequestLatency,
+                             Function<Session, Boolean> tenantAccessValidationFunction)
             throws AuthenticationException {
         checkArgument(requestBuf.readableBytes() > 0);
         log.info("Authenticate {} {} {}", ctx, saslServer, state);
@@ -191,7 +193,8 @@ public class SaslAuthenticator {
                 handleKafkaRequest(ctx, requestBuf, registerRequestParseLatency, registerRequestLatency);
                 break;
             case AUTHENTICATE:
-                handleSaslToken(ctx, requestBuf, registerRequestParseLatency, registerRequestLatency);
+                handleSaslToken(ctx, requestBuf, registerRequestParseLatency, registerRequestLatency,
+                                                                            tenantAccessValidationFunction);
                 if (saslServer.isComplete()) {
                     setState(State.COMPLETE);
                 }
@@ -401,7 +404,8 @@ public class SaslAuthenticator {
     private void handleSaslToken(ChannelHandlerContext ctx,
                                  ByteBuf requestBuf,
                                  BiConsumer<Long, Throwable> registerRequestParseLatency,
-                                 BiConsumer<String, Long> registerRequestLatency)
+                                 BiConsumer<String, Long> registerRequestLatency,
+                                 Function<Session, Boolean> tenantAccessValidationFunction)
             throws AuthenticationException {
         final long timeBeforeParse = MathUtils.nowInNano();
         ByteBuffer nioBuffer = requestBuf.nioBuffer();
@@ -413,17 +417,22 @@ public class SaslAuthenticator {
                 nioBuffer.get(clientToken, 0, clientToken.length);
                 byte[] response = saslServer.evaluateResponse(clientToken);
                 if (response != null) {
+                    final Session newSession = new Session(
+                            new KafkaPrincipal(KafkaPrincipal.USER_TYPE, saslServer.getAuthorizationID(),
+                                    (String) saslServer.getNegotiatedProperty(USER_NAME_PROP)),
+                            "old-clientId");
+                    if (!tenantAccessValidationFunction.apply(newSession)) {
+                        AuthenticationException e =
+                                new AuthenticationException("User is not allowed to access this tenant");
+                        throw e;
+                    }
                     ByteBuf byteBuf = sizePrefixed(ByteBuffer.wrap(response));
                     ctx.channel().writeAndFlush(byteBuf).addListener(future -> {
                         if (!future.isSuccess()) {
                             log.error("[{}] Failed to write {}", ctx.channel(), future.cause());
                         } else {
                             // This session is required for authorization.
-                            this.session = new Session(
-                                    new KafkaPrincipal(KafkaPrincipal.USER_TYPE, saslServer.getAuthorizationID(),
-                                            (String) saslServer.getNegotiatedProperty(USER_NAME_PROP)),
-                                    "old-clientId");
-
+                            session = newSession;
                             if (log.isDebugEnabled()) {
                                 log.debug("Send sasl response to SASL_HANDSHAKE v0 old client {} successfully, "
                                         + "session {}", ctx.channel(), session);
@@ -471,6 +480,13 @@ public class SaslAuthenticator {
                                 (String) saslServer.getNegotiatedProperty(USER_NAME_PROP)),
                         header.clientId());
                 registerRequestLatency.accept(apiKey.name, startProcessTime);
+                if (!tenantAccessValidationFunction.apply(session)) {
+                    AuthenticationException e =
+                            new AuthenticationException("User is not allowed to access this tenant");
+                    registerRequestLatency.accept(apiKey.name, startProcessTime);
+                    buildResponseOnAuthenticateFailure(header, request, null, e);
+                    throw e;
+                }
                 sendKafkaResponse(ctx,
                         header,
                         request,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
@@ -418,7 +418,8 @@ public class SaslAuthenticator {
                         } else {
                             // This session is required for authorization.
                             this.session = new Session(
-                                    new KafkaPrincipal(KafkaPrincipal.USER_TYPE, saslServer.getAuthorizationID(), (String) saslServer.getNegotiatedProperty("username")),
+                                    new KafkaPrincipal(KafkaPrincipal.USER_TYPE, saslServer.getAuthorizationID(),
+                                            (String) saslServer.getNegotiatedProperty("username")),
                                     "old-clientId");
 
                             if (log.isDebugEnabled()) {
@@ -464,7 +465,8 @@ public class SaslAuthenticator {
                 ByteBuffer responseBuf = (responseToken == null) ? EMPTY_BUFFER : ByteBuffer.wrap(responseToken);
                 String pulsarRole = saslServer.getAuthorizationID();
                 this.session = new Session(
-                        new KafkaPrincipal(KafkaPrincipal.USER_TYPE, pulsarRole, (String) saslServer.getNegotiatedProperty("username")),
+                        new KafkaPrincipal(KafkaPrincipal.USER_TYPE, pulsarRole,
+                                (String) saslServer.getNegotiatedProperty("username")),
                         header.clientId());
                 registerRequestLatency.accept(apiKey.name, startProcessTime);
                 sendKafkaResponse(ctx,
@@ -474,7 +476,8 @@ public class SaslAuthenticator {
                         null);
                 if (log.isDebugEnabled()) {
                     log.debug("Authenticate successfully for client, header {}, request {}, session {} username {}",
-                            header, saslAuthenticateRequest, session, saslServer.getNegotiatedProperty("username"));
+                            header, saslAuthenticateRequest, session,
+                            saslServer.getNegotiatedProperty("username"));
                 }
             } catch (SaslException e) {
                 registerRequestLatency.accept(apiKey.name, startProcessTime);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
@@ -422,9 +422,7 @@ public class SaslAuthenticator {
                                     (String) saslServer.getNegotiatedProperty(USER_NAME_PROP)),
                             "old-clientId");
                     if (!tenantAccessValidationFunction.apply(newSession)) {
-                        AuthenticationException e =
-                                new AuthenticationException("User is not allowed to access this tenant");
-                        throw e;
+                        throw new AuthenticationException("User is not allowed to access this tenant");
                     }
                     ByteBuf byteBuf = sizePrefixed(ByteBuffer.wrap(response));
                     ctx.channel().writeAndFlush(byteBuf).addListener(future -> {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/Authorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/Authorizer.java
@@ -33,6 +33,15 @@ public interface Authorizer {
     CompletableFuture<Boolean> canLookupAsync(KafkaPrincipal principal, Resource resource);
 
     /**
+     * Check whether the specified role can access a Pulsar Tenant.
+     *
+     * @param principal login info
+     * @param resource resources to be authorized
+     * @return a boolean to determine whether authorized or not
+     */
+    CompletableFuture<Boolean> canAccessTenantAsync(KafkaPrincipal principal, Resource resource);
+
+    /**
      * Check whether the specified role can perform a produce for the specified topic.
      *
      * For that the caller needs to have producer permission.

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/ResourceType.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/ResourceType.java
@@ -33,12 +33,12 @@ public enum ResourceType {
     /**
      * A Pulsar topic.
      */
-    TOPIC((byte) 2),
+    TOPIC((byte) 1),
 
     /**
      * A Pulsar tenant.
      */
-    TENANT((byte) 3),
+    TENANT((byte) 2),
 
     ;
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/ResourceType.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/ResourceType.java
@@ -35,6 +35,11 @@ public enum ResourceType {
      */
     TOPIC((byte) 2),
 
+    /**
+     * A Pulsar tenant.
+     */
+    TENANT((byte) 3),
+
     ;
 
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.common.base.Joiner;
 import io.streamnative.pulsar.handlers.kop.security.KafkaPrincipal;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
@@ -27,6 +28,7 @@ import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.AuthAction;
+import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 
 /**
@@ -91,45 +93,7 @@ public class SimpleAclAuthorizer implements Authorizer {
                     .getNamespaceResources()
                     .getAsync(policiesPath)
                     .thenAccept(policies -> {
-                        if (!policies.isPresent()) {
-                            if (log.isDebugEnabled()) {
-                                log.debug("Policies node couldn't be found for namespace : {}", principal);
-                            }
-                        } else {
-                            String role = principal.getName();
-
-                            // Check Topic level policies
-                            Map<String, Set<AuthAction>> topicRoles = policies.get()
-                                    .auth_policies
-                                    .getTopicAuthentication()
-                                    .get(topicName.toString());
-                            if (topicRoles != null && role != null) {
-                                // Topic has custom policy
-                                Set<AuthAction> topicActions = topicRoles.get(role);
-                                if (topicActions != null && topicActions.contains(action)) {
-                                    permissionFuture.complete(true);
-                                    return;
-                                }
-                            }
-
-                            // Check Namespace level policies
-                            Map<String, Set<AuthAction>> namespaceRoles = policies.get().auth_policies
-                                    .getNamespaceAuthentication();
-                            Set<AuthAction> namespaceActions = namespaceRoles.get(role);
-                            if (namespaceActions != null && namespaceActions.contains(action)) {
-                                permissionFuture.complete(true);
-                                return;
-                            }
-
-                            // Check wildcard policies
-                            if (conf.isAuthorizationAllowWildcardsMatching()
-                                    && checkWildcardPermission(role, action, namespaceRoles)) {
-                                // The role has namespace level permission by wildcard match
-                                permissionFuture.complete(true);
-                                return;
-                            }
-                        }
-                        permissionFuture.complete(false);
+                        authoriseTopicOverNamespacePolicies(principal, action, permissionFuture, topicName, policies);
                     }).exceptionally(ex -> {
                         if (log.isDebugEnabled()) {
                             log.debug("Client with Principal - {} failed to get permissions for resource - {}. {}",
@@ -137,10 +101,54 @@ public class SimpleAclAuthorizer implements Authorizer {
                         }
                         permissionFuture.completeExceptionally(ex);
                         return null;
-                    });
+                    })
 
         });
         return permissionFuture;
+    }
+
+    private void authoriseTopicOverNamespacePolicies(KafkaPrincipal principal, AuthAction action,
+                                                     CompletableFuture<Boolean> permissionFuture,
+                                                     TopicName topicName, Optional<Policies> policies) {
+        if (!policies.isPresent()) {
+            if (log.isDebugEnabled()) {
+                log.debug("Policies node couldn't be found for namespace : {}", principal);
+            }
+        } else {
+            String role = principal.getName();
+
+            // Check Topic level policies
+            Map<String, Set<AuthAction>> topicRoles = policies.get()
+                    .auth_policies
+                    .getTopicAuthentication()
+                    .get(topicName.toString());
+            if (topicRoles != null && role != null) {
+                // Topic has custom policy
+                Set<AuthAction> topicActions = topicRoles.get(role);
+                if (topicActions != null && topicActions.contains(action)) {
+                    permissionFuture.complete(true);
+                    return;
+                }
+            }
+
+            // Check Namespace level policies
+            Map<String, Set<AuthAction>> namespaceRoles = policies.get().auth_policies
+                    .getNamespaceAuthentication();
+            Set<AuthAction> namespaceActions = namespaceRoles.get(role);
+            if (namespaceActions != null && namespaceActions.contains(action)) {
+                permissionFuture.complete(true);
+                return;
+            }
+
+            // Check wildcard policies
+            if (conf.isAuthorizationAllowWildcardsMatching()
+                    && checkWildcardPermission(role, action, namespaceRoles)) {
+                // The role has namespace level permission by wildcard match
+                permissionFuture.complete(true);
+                return;
+            }
+        }
+        permissionFuture.complete(false);
     }
 
     private CompletableFuture<Boolean> authorizeTenantPermission(KafkaPrincipal principal, Resource resource) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
@@ -19,7 +19,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.common.base.Joiner;
 import io.streamnative.pulsar.handlers.kop.security.KafkaPrincipal;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
@@ -100,7 +99,8 @@ public class SimpleAclAuthorizer implements Authorizer {
                             permissionFuture.complete(false);
                             return;
                         }
-                        authoriseTopicOverNamespacePolicies(principal, action, permissionFuture, topicName, policies.get());
+                        authoriseTopicOverNamespacePolicies(principal, action, permissionFuture, topicName,
+                                policies.get());
                     }).exceptionally(ex -> {
                         if (log.isDebugEnabled()) {
                             log.debug("Client with Principal - {} failed to get permissions for resource - {}. {}",

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
@@ -101,7 +101,7 @@ public class SimpleAclAuthorizer implements Authorizer {
                         }
                         permissionFuture.completeExceptionally(ex);
                         return null;
-                    })
+                    });
 
         });
         return permissionFuture;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
@@ -100,7 +100,7 @@ public class SimpleAclAuthorizer implements Authorizer {
                             permissionFuture.complete(false);
                             return;
                         }
-                        authoriseTopicOverNamespacePolicies(principal, action, permissionFuture, topicName, policies);
+                        authoriseTopicOverNamespacePolicies(principal, action, permissionFuture, topicName, policies.get());
                     }).exceptionally(ex -> {
                         if (log.isDebugEnabled()) {
                             log.debug("Client with Principal - {} failed to get permissions for resource - {}. {}",
@@ -116,10 +116,10 @@ public class SimpleAclAuthorizer implements Authorizer {
 
     private void authoriseTopicOverNamespacePolicies(KafkaPrincipal principal, AuthAction action,
                                                      CompletableFuture<Boolean> permissionFuture,
-                                                     TopicName topicName, Optional<Policies> policies) {
+                                                     TopicName topicName, Policies policies) {
         String role = principal.getName();
         // Check Topic level policies
-        Map<String, Set<AuthAction>> topicRoles = policies.get()
+        Map<String, Set<AuthAction>> topicRoles = policies
                 .auth_policies
                 .getTopicAuthentication()
                 .get(topicName.toString());
@@ -133,7 +133,7 @@ public class SimpleAclAuthorizer implements Authorizer {
         }
 
         // Check Namespace level policies
-        Map<String, Set<AuthAction>> namespaceRoles = policies.get().auth_policies
+        Map<String, Set<AuthAction>> namespaceRoles = policies.auth_policies
                 .getNamespaceAuthentication();
         Set<AuthAction> namespaceActions = namespaceRoles.get(role);
         if (namespaceActions != null && namespaceActions.contains(action)) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
@@ -89,8 +89,7 @@ public class MetadataUtils {
                                                      int partitionNum)
         throws PulsarAdminException {
         String cluster = conf.getClusterName();
-        String kafkaMetadataTenant = tenant;
-        String kafkaMetadataNamespace = kafkaMetadataTenant + "/" + conf.getKafkaMetadataNamespace();
+        String kafkaMetadataNamespace = tenant + "/" + conf.getKafkaMetadataNamespace();
 
         boolean clusterExists = false;
         boolean tenantExists = false;
@@ -118,30 +117,30 @@ public class MetadataUtils {
 
             // Check if the metadata tenant exists and create it if not
             Tenants tenants = pulsarAdmin.tenants();
-            if (!tenants.getTenants().contains(kafkaMetadataTenant)) {
-                log.info("Tenant: {} does not exist, creating it ...", kafkaMetadataTenant);
-                tenants.createTenant(kafkaMetadataTenant,
+            if (!tenants.getTenants().contains(tenant)) {
+                log.info("Tenant: {} does not exist, creating it ...", tenant);
+                tenants.createTenant(tenant,
                         TenantInfo.builder()
                                 .adminRoles(conf.getSuperUserRoles())
                                 .allowedClusters(Collections.singleton(cluster))
                                 .build());
             } else {
-                TenantInfo kafkaMetadataTenantInfo = tenants.getTenantInfo(kafkaMetadataTenant);
+                TenantInfo kafkaMetadataTenantInfo = tenants.getTenantInfo(tenant);
                 Set<String> allowedClusters = kafkaMetadataTenantInfo.getAllowedClusters();
                 if (!allowedClusters.contains(cluster)) {
                     log.info("Tenant: {} exists but cluster: {} is not in the allowedClusters list, updating it ...",
-                            kafkaMetadataTenant, cluster);
+                            tenant, cluster);
                     allowedClusters.add(cluster);
-                    tenants.updateTenant(kafkaMetadataTenant, kafkaMetadataTenantInfo);
+                    tenants.updateTenant(tenant, kafkaMetadataTenantInfo);
                 }
             }
             tenantExists = true;
 
             // Check if the metadata namespace exists and create it if not
             Namespaces namespaces = pulsarAdmin.namespaces();
-            if (!namespaces.getNamespaces(kafkaMetadataTenant).contains(kafkaMetadataNamespace)) {
+            if (!namespaces.getNamespaces(tenant).contains(kafkaMetadataNamespace)) {
                 log.info("Namespaces: {} does not exist in tenant: {}, creating it ...",
-                        kafkaMetadataNamespace, kafkaMetadataTenant);
+                        kafkaMetadataNamespace, tenant);
                 Set<String> replicationClusters = Sets.newHashSet(cluster);
                 namespaces.createNamespace(kafkaMetadataNamespace, replicationClusters);
                 namespaces.setNamespaceReplicationClusters(kafkaMetadataNamespace, replicationClusters);
@@ -191,7 +190,7 @@ public class MetadataUtils {
         } finally {
             log.info("Current state of kafka metadata, cluster: {} exists: {}, tenant: {} exists: {},"
                             + " namespace: {} exists: {}, topic: {} exists: {}",
-                    cluster, clusterExists, kafkaMetadataTenant, tenantExists, kafkaMetadataNamespace, namespaceExists,
+                    cluster, clusterExists, tenant, tenantExists, kafkaMetadataNamespace, namespaceExists,
                     kopTopic.getOriginalName(), offsetsTopicExists);
         }
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
@@ -53,7 +53,8 @@ public class MetadataUtils {
                                                      KafkaServiceConfiguration conf)
             throws PulsarAdminException {
         KopTopic kopTopic = new KopTopic(constructOffsetsTopicBaseName(tenant, conf));
-        createKafkaMetadataIfMissing(tenant, pulsarAdmin, clusterData, conf, kopTopic, conf.getOffsetsTopicNumPartitions());
+        createKafkaMetadataIfMissing(tenant, pulsarAdmin, clusterData, conf, kopTopic,
+                conf.getOffsetsTopicNumPartitions());
     }
 
     public static void createTxnMetadataIfMissing(String tenant,
@@ -62,7 +63,8 @@ public class MetadataUtils {
                                                   KafkaServiceConfiguration conf)
             throws PulsarAdminException {
         KopTopic kopTopic = new KopTopic(constructTxnLogTopicBaseName(tenant, conf));
-        createKafkaMetadataIfMissing(tenant, pulsarAdmin, clusterData, conf, kopTopic, conf.getTxnLogTopicNumPartitions());
+        createKafkaMetadataIfMissing(tenant, pulsarAdmin, clusterData, conf, kopTopic,
+                conf.getTxnLogTopicNumPartitions());
     }
 
     /**

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
@@ -38,30 +38,31 @@ public class MetadataUtils {
     // trigger compaction when the offset backlog reaches 100MB
     public static final int MAX_COMPACTION_THRESHOLD = 100 * 1024 * 1024;
 
-    public static String constructOffsetsTopicBaseName(KafkaServiceConfiguration conf) {
-        return conf.getKafkaMetadataTenant() + "/" + conf.getKafkaMetadataNamespace()
+    public static String constructOffsetsTopicBaseName(String tenant, KafkaServiceConfiguration conf) {
+        return tenant + "/" + conf.getKafkaMetadataNamespace()
             + "/" + Topic.GROUP_METADATA_TOPIC_NAME;
     }
 
-    public static String constructTxnLogTopicBaseName(KafkaServiceConfiguration conf) {
-        return conf.getKafkaMetadataTenant() + "/" + conf.getKafkaMetadataNamespace()
+    public static String constructTxnLogTopicBaseName(String tenant, KafkaServiceConfiguration conf) {
+        return tenant + "/" + conf.getKafkaMetadataNamespace()
                 + "/" + Topic.TRANSACTION_STATE_TOPIC_NAME;
     }
 
-    public static void createOffsetMetadataIfMissing(PulsarAdmin pulsarAdmin,
+    public static void createOffsetMetadataIfMissing(String tenant, PulsarAdmin pulsarAdmin,
                                                      ClusterData clusterData,
                                                      KafkaServiceConfiguration conf)
             throws PulsarAdminException {
-        KopTopic kopTopic = new KopTopic(constructOffsetsTopicBaseName(conf));
-        createKafkaMetadataIfMissing(pulsarAdmin, clusterData, conf, kopTopic, conf.getOffsetsTopicNumPartitions());
+        KopTopic kopTopic = new KopTopic(constructOffsetsTopicBaseName(tenant, conf));
+        createKafkaMetadataIfMissing(tenant, pulsarAdmin, clusterData, conf, kopTopic, conf.getOffsetsTopicNumPartitions());
     }
 
-    public static void createTxnMetadataIfMissing(PulsarAdmin pulsarAdmin,
+    public static void createTxnMetadataIfMissing(String tenant,
+                                                  PulsarAdmin pulsarAdmin,
                                                   ClusterData clusterData,
                                                   KafkaServiceConfiguration conf)
             throws PulsarAdminException {
-        KopTopic kopTopic = new KopTopic(constructTxnLogTopicBaseName(conf));
-        createKafkaMetadataIfMissing(pulsarAdmin, clusterData, conf, kopTopic, conf.getTxnLogTopicNumPartitions());
+        KopTopic kopTopic = new KopTopic(constructTxnLogTopicBaseName(tenant, conf));
+        createKafkaMetadataIfMissing(tenant, pulsarAdmin, clusterData, conf, kopTopic, conf.getTxnLogTopicNumPartitions());
     }
 
     /**
@@ -78,14 +79,15 @@ public class MetadataUtils {
      * <li>If the offset topic exists but some partitions are missing, the missing partitions will be created</li>
      * </ul>
      */
-    private static void createKafkaMetadataIfMissing(PulsarAdmin pulsarAdmin,
+    private static void createKafkaMetadataIfMissing(String tenant,
+                                                     PulsarAdmin pulsarAdmin,
                                                      ClusterData clusterData,
                                                      KafkaServiceConfiguration conf,
                                                      KopTopic kopTopic,
                                                      int partitionNum)
         throws PulsarAdminException {
         String cluster = conf.getClusterName();
-        String kafkaMetadataTenant = conf.getKafkaMetadataTenant();
+        String kafkaMetadataTenant = tenant;
         String kafkaMetadataNamespace = kafkaMetadataTenant + "/" + conf.getKafkaMetadataNamespace();
 
         boolean clusterExists = false;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
@@ -146,7 +146,8 @@ public class MetadataUtils {
         }
     }
 
-    private static void createTenantIfMissing(String tenant, KafkaServiceConfiguration conf, String cluster, Tenants tenants) throws PulsarAdminException {
+    private static void createTenantIfMissing(String tenant, KafkaServiceConfiguration conf,
+                                              String cluster, Tenants tenants) throws PulsarAdminException {
         if (!tenants.getTenants().contains(tenant)) {
             log.info("Tenant: {} does not exist, creating it ...", tenant);
             tenants.createTenant(tenant,
@@ -167,7 +168,8 @@ public class MetadataUtils {
     }
 
     private static void createNamespaceIfMissing(String tenant, KafkaServiceConfiguration conf, String cluster,
-                                                 String kafkaMetadataNamespace, Namespaces namespaces) throws PulsarAdminException {
+                                                 String kafkaMetadataNamespace, Namespaces namespaces)
+                                                 throws PulsarAdminException {
         if (!namespaces.getNamespaces(tenant).contains(kafkaMetadataNamespace)) {
             log.info("Namespaces: {} does not exist in tenant: {}, creating it ...",
                     kafkaMetadataNamespace, tenant);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
@@ -256,10 +256,9 @@ public class MetadataUtils {
             createTenantIfMissing(tenant, conf, cluster, tenants);
             tenantExists = true;
 
-            String kafkaMetadataNamespace = tenant + "/" + conf.getKafkaMetadataNamespace();
             Namespaces namespaces = pulsarAdmin.namespaces();
             // Check if the kafka namespace exists and create it if not
-            createNamespaceIfMissing(tenant, conf, cluster, kafkaMetadataNamespace, namespaces);
+            createNamespaceIfMissing(tenant, conf, cluster, kafkaNamespace, namespaces);
             namespaceExists = true;
 
         } catch (PulsarAdminException e) {

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtilsTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtilsTest.java
@@ -55,8 +55,10 @@ public class MetadataUtilsTest {
         conf.setSuperUserRoles(Sets.newHashSet("admin"));
         conf.setOffsetsTopicNumPartitions(8);
 
-        final KopTopic offsetsTopic = new KopTopic(MetadataUtils.constructOffsetsTopicBaseName(conf.getKafkaMetadataTenant(), conf));
-        final KopTopic txnTopic = new KopTopic(MetadataUtils.constructTxnLogTopicBaseName(conf.getKafkaMetadataTenant(), conf));
+        final KopTopic offsetsTopic = new KopTopic(MetadataUtils
+                .constructOffsetsTopicBaseName(conf.getKafkaMetadataTenant(), conf));
+        final KopTopic txnTopic = new KopTopic(MetadataUtils
+                .constructTxnLogTopicBaseName(conf.getKafkaMetadataTenant(), conf));
 
         List<String> emptyList = Lists.newArrayList();
 

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtilsTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtilsTest.java
@@ -55,8 +55,8 @@ public class MetadataUtilsTest {
         conf.setSuperUserRoles(Sets.newHashSet("admin"));
         conf.setOffsetsTopicNumPartitions(8);
 
-        final KopTopic offsetsTopic = new KopTopic(MetadataUtils.constructOffsetsTopicBaseName(conf));
-        final KopTopic txnTopic = new KopTopic(MetadataUtils.constructTxnLogTopicBaseName(conf));
+        final KopTopic offsetsTopic = new KopTopic(MetadataUtils.constructOffsetsTopicBaseName(conf.getKafkaMetadataTenant(), conf));
+        final KopTopic txnTopic = new KopTopic(MetadataUtils.constructTxnLogTopicBaseName(conf.getKafkaMetadataTenant(), conf));
 
         List<String> emptyList = Lists.newArrayList();
 
@@ -85,7 +85,7 @@ public class MetadataUtilsTest {
         TenantInfo partialTenant = TenantInfo.builder().build();
         doReturn(partialTenant).when(mockTenants).getTenantInfo(eq(conf.getKafkaMetadataTenant()));
 
-        MetadataUtils.createOffsetMetadataIfMissing(mockPulsarAdmin, clusterData, conf);
+        MetadataUtils.createOffsetMetadataIfMissing(conf.getKafkaMetadataTenant(), mockPulsarAdmin, clusterData, conf);
 
         // After call the createOffsetMetadataIfMissing, these methods should return expected data.
         doReturn(Lists.newArrayList(conf.getKafkaMetadataTenant())).when(mockTenants).getTenants();
@@ -94,7 +94,7 @@ public class MetadataUtilsTest {
         doReturn(Lists.newArrayList(conf.getClusterName())).when(mockNamespaces)
                 .getNamespaceReplicationClusters(eq(namespace));
 
-        MetadataUtils.createTxnMetadataIfMissing(mockPulsarAdmin, clusterData, conf);
+        MetadataUtils.createTxnMetadataIfMissing(conf.getKafkaMetadataTenant(), mockPulsarAdmin, clusterData, conf);
 
         verify(mockTenants, times(1)).createTenant(eq(conf.getKafkaMetadataTenant()), any(TenantInfo.class));
         verify(mockNamespaces, times(1)).createNamespace(eq(conf.getKafkaMetadataTenant() + "/"
@@ -144,8 +144,8 @@ public class MetadataUtilsTest {
         doReturn(incompletePartitionList).when(mockTopics).getList(eq(conf.getKafkaMetadataTenant()
             + "/" + conf.getKafkaMetadataNamespace()));
 
-        MetadataUtils.createOffsetMetadataIfMissing(mockPulsarAdmin, clusterData, conf);
-        MetadataUtils.createTxnMetadataIfMissing(mockPulsarAdmin, clusterData, conf);
+        MetadataUtils.createOffsetMetadataIfMissing(conf.getKafkaMetadataTenant(), mockPulsarAdmin, clusterData, conf);
+        MetadataUtils.createTxnMetadataIfMissing(conf.getKafkaMetadataTenant(), mockPulsarAdmin, clusterData, conf);
 
         verify(mockTenants, times(1)).updateTenant(eq(conf.getKafkaMetadataTenant()), any(TenantInfo.class));
         verify(mockNamespaces, times(2)).setNamespaceReplicationClusters(eq(conf.getKafkaMetadataTenant()

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/EntryPublishTimeTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/EntryPublishTimeTest.java
@@ -50,8 +50,10 @@ public class EntryPublishTimeTest extends KopProtocolHandlerTestBase {
         super.internalSetup();
 
         ProtocolHandler handler = pulsar.getProtocolHandlers().protocol("kafka");
-        GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler).getGroupCoordinator(conf.getKafkaMetadataTenant());
-        TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler).getTransactionCoordinator(conf.getKafkaMetadataTenant());
+        GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler)
+                .getGroupCoordinator(conf.getKafkaMetadataTenant());
+        TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler)
+                .getTransactionCoordinator(conf.getKafkaMetadataTenant());
 
         adminManager = new AdminManager(pulsar.getAdminClient(), conf);
         kafkaRequestHandler = new KafkaRequestHandler(

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/EntryPublishTimeTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/EntryPublishTimeTest.java
@@ -50,15 +50,24 @@ public class EntryPublishTimeTest extends KopProtocolHandlerTestBase {
         super.internalSetup();
 
         ProtocolHandler handler = pulsar.getProtocolHandlers().protocol("kafka");
-        GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler).getGroupCoordinator();
-        TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler).getTransactionCoordinator();
+        GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler).getGroupCoordinator(conf.getKafkaMetadataTenant());
+        TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler).getTransactionCoordinator(conf.getKafkaMetadataTenant());
 
         adminManager = new AdminManager(pulsar.getAdminClient(), conf);
         kafkaRequestHandler = new KafkaRequestHandler(
                 pulsar,
                 (KafkaServiceConfiguration) conf,
-                groupCoordinator,
-                transactionCoordinator,
+                new TenantContextManager() {
+                    @Override
+                    public GroupCoordinator getGroupCoordinator(String tenant) {
+                        return groupCoordinator;
+                    }
+
+                    @Override
+                    public TransactionCoordinator getTransactionCoordinator(String tenant) {
+                        return transactionCoordinator;
+                    }
+                },
                 adminManager,
                 pulsar.getLocalMetadataStore().getMetadataCache(LocalBrokerData.class),
                 false,

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
@@ -125,8 +125,10 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
         log.info("created namespaces, init handler");
 
         ProtocolHandler handler = pulsar.getProtocolHandlers().protocol("kafka");
-        GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler).getGroupCoordinator(conf.getKafkaMetadataTenant());
-        TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler).getTransactionCoordinator(conf.getKafkaMetadataTenant());
+        GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler)
+                .getGroupCoordinator(conf.getKafkaMetadataTenant());
+        TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler)
+                .getTransactionCoordinator(conf.getKafkaMetadataTenant());
 
         adminManager = new AdminManager(pulsar.getAdminClient(), conf);
         kafkaRequestHandler = new KafkaRequestHandler(

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationKafkaMultitenantTenantMetadataTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationKafkaMultitenantTenantMetadataTest.java
@@ -13,11 +13,11 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
+import static org.testng.Assert.assertFalse;
+
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
 
 /**
  * Unit test for Authorization with `KafkaEnableMultiTenantMetadata` = false.

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationKafkaMultitenantTenantMetadataTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationKafkaMultitenantTenantMetadataTest.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit test for Authorization with `KafkaEnableMultiTenantMetadata` = false.
+ */
+public class KafkaAuthorizationKafkaMultitenantTenantMetadataTest extends KafkaAuthorizationTestBase {
+    public KafkaAuthorizationKafkaMultitenantTenantMetadataTest() {
+        super("pulsar");
+    }
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        conf.setKafkaEnableMultiTenantMetadata(false);
+        super.setup();
+    }
+
+    @Test
+    void testKafkaEnableMultiTenantMetadataIsDisabled() {
+        // verify that the configuration is with KafkaEnableMultiTenantMetadata=false
+        // and the setup did not reset the value to the default
+        assertFalse(conf.isKafkaEnableMultiTenantMetadata());
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationTestBase.java
@@ -59,14 +59,14 @@ import org.testng.annotations.Test;
 @Slf4j
 public abstract class KafkaAuthorizationTestBase extends KopProtocolHandlerTestBase {
 
-    private static final String TENANT = "KafkaAuthorizationTest";
-    private static final String NAMESPACE = "ns1";
+    protected static final String TENANT = "KafkaAuthorizationTest";
+    protected static final String NAMESPACE = "ns1";
     private static final String SHORT_TOPIC = "topic1";
     private static final String TOPIC = "persistent://" + TENANT + "/" + NAMESPACE + "/" + SHORT_TOPIC;
 
-    private static final String SIMPLE_USER = "muggle_user";
-    private static final String ANOTHER_USER = "death_eater_user";
-    private static final String ADMIN_USER = "admin_user";
+    protected static final String SIMPLE_USER = "muggle_user";
+    protected static final String ANOTHER_USER = "death_eater_user";
+    protected static final String ADMIN_USER = "admin_user";
 
     private String adminToken;
     private String userToken;
@@ -150,12 +150,13 @@ public abstract class KafkaAuthorizationTestBase extends KopProtocolHandlerTestB
             kProducer.getProducer().send(new ProducerRecord<>(testTopic, 0, "")).get();
             fail("should have failed");
         } catch (Exception e) {
+            log.info("the error", e);
             assertTrue(e.getMessage().contains("TopicAuthorizationException"));
         } finally {
             // Cleanup
             admin.topics().deletePartitionedTopic(testTopic);
-            admin.namespaces().deleteNamespace(newTenant + "/" + NAMESPACE);
-            admin.tenants().deleteTenant(newTenant);
+            admin.namespaces().deleteNamespace(newTenant + "/" + NAMESPACE, true);
+            admin.tenants().deleteTenant(newTenant, true);
         }
     }
 
@@ -283,6 +284,7 @@ public abstract class KafkaAuthorizationTestBase extends KopProtocolHandlerTestB
         AdminClient adminClient = AdminClient.create(props);
         ListTopicsResult listTopicsResult = adminClient.listTopics();
         Set<String> topics = listTopicsResult.names().get();
+
         assertEquals(topics.size(), 1);
         assertTrue(topics.contains(newTopic));
 
@@ -353,8 +355,8 @@ public abstract class KafkaAuthorizationTestBase extends KopProtocolHandlerTestB
         } finally {
             // Cleanup
             admin.topics().deletePartitionedTopic(testTopic);
-            admin.namespaces().deleteNamespace(newTenant + "/" + NAMESPACE);
-            admin.tenants().deleteTenant(newTenant);
+            admin.namespaces().deleteNamespace(newTenant + "/" + NAMESPACE, true);
+            admin.tenants().deleteTenant(newTenant, true);
         }
     }
 
@@ -395,8 +397,8 @@ public abstract class KafkaAuthorizationTestBase extends KopProtocolHandlerTestB
         } finally {
             // Cleanup
             admin.topics().deletePartitionedTopic(testTopic);
-            admin.namespaces().deleteNamespace(newTenant + "/" + NAMESPACE);
-            admin.tenants().deleteTenant(newTenant);
+            admin.namespaces().deleteNamespace(newTenant + "/" + NAMESPACE, true);
+            admin.tenants().deleteTenant(newTenant, true);
         }
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationTestBase.java
@@ -16,6 +16,7 @@ package io.streamnative.pulsar.handlers.kop;
 import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.fail;
 
@@ -142,6 +143,9 @@ public abstract class KafkaAuthorizationTestBase extends KopProtocolHandlerTestB
                             .adminRoles(Collections.singleton(ADMIN_USER))
                             .allowedClusters(Collections.singleton(configClusterName))
                             .build());
+            TenantInfo tenantInfo = admin.tenants().getTenantInfo(TENANT);
+            log.info("tenantInfo for {} {} in test", TENANT, tenantInfo);
+            assertNotNull(tenantInfo);
             admin.namespaces().createNamespace(newTenant + "/" + NAMESPACE);
             admin.topics().createPartitionedTopic(testTopic, 1);
             @Cleanup

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationTestBase.java
@@ -93,8 +93,9 @@ public abstract class KafkaAuthorizationTestBase extends KopProtocolHandlerTestB
         userToken = AuthTokenUtils.createToken(secretKey, SIMPLE_USER, Optional.empty());
         adminToken = AuthTokenUtils.createToken(secretKey, ADMIN_USER, Optional.empty());
         anotherToken = AuthTokenUtils.createToken(secretKey, ANOTHER_USER, Optional.empty());
-
+        boolean originalKafkaEnableMultiTenantMetadata = conf.isKafkaEnableMultiTenantMetadata();
         super.resetConfig();
+        conf.setKafkaEnableMultiTenantMetadata(originalKafkaEnableMultiTenantMetadata);
         conf.setSaslAllowedMechanisms(Sets.newHashSet("PLAIN"));
         conf.setKafkaMetadataTenant("internal");
         conf.setKafkaMetadataNamespace("__kafka");

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -138,8 +138,10 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
         log.info("created namespaces, init handler");
 
         ProtocolHandler handler1 = pulsar.getProtocolHandlers().protocol("kafka");
-        GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler1).getGroupCoordinator(conf.getKafkaMetadataTenant());
-        TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler1).getTransactionCoordinator(conf.getKafkaMetadataTenant());
+        GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler1)
+                .getGroupCoordinator(conf.getKafkaMetadataTenant());
+        TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler1)
+                .getTransactionCoordinator(conf.getKafkaMetadataTenant());
 
         adminManager = new AdminManager(pulsar.getAdminClient(), conf);
         handler = new KafkaRequestHandler(

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -138,15 +138,24 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
         log.info("created namespaces, init handler");
 
         ProtocolHandler handler1 = pulsar.getProtocolHandlers().protocol("kafka");
-        GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler1).getGroupCoordinator();
-        TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler1).getTransactionCoordinator();
+        GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler1).getGroupCoordinator(conf.getKafkaMetadataTenant());
+        TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler1).getTransactionCoordinator(conf.getKafkaMetadataTenant());
 
         adminManager = new AdminManager(pulsar.getAdminClient(), conf);
         handler = new KafkaRequestHandler(
             pulsar,
             (KafkaServiceConfiguration) conf,
-            groupCoordinator,
-            transactionCoordinator,
+                new TenantContextManager() {
+                    @Override
+                    public GroupCoordinator getGroupCoordinator(String tenant) {
+                        return groupCoordinator;
+                    }
+
+                    @Override
+                    public TransactionCoordinator getTransactionCoordinator(String tenant) {
+                        return transactionCoordinator;
+                    }
+                },
             adminManager,
             pulsar.getLocalMetadataStore().getMetadataCache(LocalBrokerData.class),
             false,

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
@@ -152,15 +152,24 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
         log.info("created namespaces, init handler");
 
         ProtocolHandler handler1 = pulsar.getProtocolHandlers().protocol("kafka");
-        GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler1).getGroupCoordinator();
-        TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler1).getTransactionCoordinator();
+        GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler1).getGroupCoordinator(conf.getKafkaMetadataTenant());
+        TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler1).getTransactionCoordinator(conf.getKafkaMetadataTenant());
 
         adminManager = new AdminManager(pulsar.getAdminClient(), conf);
         handler = new KafkaRequestHandler(
                 pulsar,
                 (KafkaServiceConfiguration) conf,
-                groupCoordinator,
-                transactionCoordinator,
+                new TenantContextManager() {
+                    @Override
+                    public GroupCoordinator getGroupCoordinator(String tenant) {
+                        return groupCoordinator;
+                    }
+
+                    @Override
+                    public TransactionCoordinator getTransactionCoordinator(String tenant) {
+                        return transactionCoordinator;
+                    }
+                },
                 adminManager,
                 pulsar.getLocalMetadataStore().getMetadataCache(LocalBrokerData.class),
                 false,

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
@@ -152,8 +152,10 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
         log.info("created namespaces, init handler");
 
         ProtocolHandler handler1 = pulsar.getProtocolHandlers().protocol("kafka");
-        GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler1).getGroupCoordinator(conf.getKafkaMetadataTenant());
-        TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler1).getTransactionCoordinator(conf.getKafkaMetadataTenant());
+        GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler1)
+                .getGroupCoordinator(conf.getKafkaMetadataTenant());
+        TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler1)
+                .getTransactionCoordinator(conf.getKafkaMetadataTenant());
 
         adminManager = new AdminManager(pulsar.getAdminClient(), conf);
         handler = new KafkaRequestHandler(

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
@@ -76,8 +76,10 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
         super.internalSetup();
 
         ProtocolHandler handler = pulsar.getProtocolHandlers().protocol("kafka");
-        GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler).getGroupCoordinator(conf.getKafkaMetadataTenant());
-        TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler).getTransactionCoordinator(conf.getKafkaMetadataTenant());
+        GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler)
+                .getGroupCoordinator(conf.getKafkaMetadataTenant());
+        TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler)
+                .getTransactionCoordinator(conf.getKafkaMetadataTenant());
 
         adminManager = new AdminManager(pulsar.getAdminClient(), conf);
         kafkaRequestHandler = new KafkaRequestHandler(

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
@@ -76,15 +76,24 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
         super.internalSetup();
 
         ProtocolHandler handler = pulsar.getProtocolHandlers().protocol("kafka");
-        GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler).getGroupCoordinator();
-        TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler).getTransactionCoordinator();
+        GroupCoordinator groupCoordinator = ((KafkaProtocolHandler) handler).getGroupCoordinator(conf.getKafkaMetadataTenant());
+        TransactionCoordinator transactionCoordinator = ((KafkaProtocolHandler) handler).getTransactionCoordinator(conf.getKafkaMetadataTenant());
 
         adminManager = new AdminManager(pulsar.getAdminClient(), conf);
         kafkaRequestHandler = new KafkaRequestHandler(
             pulsar,
             (KafkaServiceConfiguration) conf,
-            groupCoordinator,
-            transactionCoordinator,
+                new TenantContextManager() {
+                    @Override
+                    public GroupCoordinator getGroupCoordinator(String tenant) {
+                        return groupCoordinator;
+                    }
+
+                    @Override
+                    public TransactionCoordinator getTransactionCoordinator(String tenant) {
+                        return transactionCoordinator;
+                    }
+                },
             adminManager,
             pulsar.getLocalMetadataStore().getMetadataCache(LocalBrokerData.class),
             false,

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -240,9 +240,9 @@ public abstract class KopProtocolHandlerTestBase {
 
         createAdmin();
 
-        MetadataUtils.createOffsetMetadataIfMissing(admin, clusterData, this.conf);
+        MetadataUtils.createOffsetMetadataIfMissing(conf.getKafkaMetadataTenant(), admin, clusterData, this.conf);
         if (conf.isEnableTransactionCoordinator()) {
-            MetadataUtils.createTxnMetadataIfMissing(admin, clusterData, this.conf);
+            MetadataUtils.createTxnMetadataIfMissing(conf.getKafkaMetadataTenant(), admin, clusterData, this.conf);
         }
 
         if (enableSchemaRegistry) {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -158,6 +158,9 @@ public abstract class KopProtocolHandlerTestBase {
         kafkaConfig.setAllowAutoTopicCreationType("partitioned");
         kafkaConfig.setBrokerDeleteInactiveTopicsEnabled(false);
 
+        kafkaConfig.setForceDeleteTenantAllowed(true);
+        kafkaConfig.setForceDeleteNamespaceAllowed(true);
+
         kafkaConfig.setKafkaMetadataTenant(tenant);
         kafkaConfig.setKafkaMetadataNamespace(namespace);
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
@@ -119,7 +119,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
             .build();
 
         ProtocolHandler handler = pulsar.getProtocolHandlers().protocol("kafka");
-        groupMetadataManager = ((KafkaProtocolHandler) handler).getGroupCoordinator().getGroupManager();
+        groupMetadataManager = ((KafkaProtocolHandler) handler).getGroupCoordinator(conf.getKafkaMetadataTenant()).getGroupManager();
     }
 
     @AfterMethod

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
@@ -119,7 +119,8 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
             .build();
 
         ProtocolHandler handler = pulsar.getProtocolHandlers().protocol("kafka");
-        groupMetadataManager = ((KafkaProtocolHandler) handler).getGroupCoordinator(conf.getKafkaMetadataTenant()).getGroupManager();
+        groupMetadataManager = ((KafkaProtocolHandler) handler)
+                .getGroupCoordinator(conf.getKafkaMetadataTenant()).getGroupManager();
     }
 
     @AfterMethod

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizerTest.java
@@ -130,32 +130,32 @@ public class SimpleAclAuthorizerTest extends KopProtocolHandlerTestBase {
     @Test
     public void testAuthorizeProduce() throws ExecutionException, InterruptedException {
         Boolean isAuthorized = simpleAclAuthorizer.canProduceAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER),
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER, null),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertTrue(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canProduceAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, PRODUCE_USER),
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, PRODUCE_USER, null),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertTrue(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canProduceAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, CONSUMER_USER),
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, CONSUMER_USER, null),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertFalse(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canProduceAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ANOTHER_USER),
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ANOTHER_USER, null),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertFalse(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canProduceAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER),
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER, null),
                 Resource.of(ResourceType.TOPIC, NOT_EXISTS_TENANT_TOPIC)).get();
         assertFalse(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canProduceAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ADMIN_USER),
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ADMIN_USER, null),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertTrue(isAuthorized);
     }
@@ -163,27 +163,27 @@ public class SimpleAclAuthorizerTest extends KopProtocolHandlerTestBase {
     @Test
     public void testAuthorizeConsume() throws ExecutionException, InterruptedException {
         Boolean isAuthorized = simpleAclAuthorizer.canConsumeAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER),
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER, null),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertTrue(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canConsumeAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, PRODUCE_USER),
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, PRODUCE_USER, null),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertFalse(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canConsumeAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, CONSUMER_USER),
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, CONSUMER_USER, null),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertTrue(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canConsumeAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ANOTHER_USER),
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ANOTHER_USER, null),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertFalse(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canConsumeAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER),
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER, null),
                 Resource.of(ResourceType.TOPIC, NOT_EXISTS_TENANT_TOPIC)).get();
         assertFalse(isAuthorized);
     }
@@ -191,27 +191,27 @@ public class SimpleAclAuthorizerTest extends KopProtocolHandlerTestBase {
     @Test
     public void testAuthorizeLookup() throws ExecutionException, InterruptedException {
         Boolean isAuthorized = simpleAclAuthorizer.canLookupAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER),
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER, null),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertTrue(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canLookupAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, PRODUCE_USER),
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, PRODUCE_USER, null),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertTrue(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canLookupAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, CONSUMER_USER),
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, CONSUMER_USER, null),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertTrue(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canLookupAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ANOTHER_USER),
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ANOTHER_USER, null),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertFalse(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canLookupAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER),
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER, null),
                 Resource.of(ResourceType.TOPIC, NOT_EXISTS_TENANT_TOPIC)).get();
         assertFalse(isAuthorized);
     }
@@ -222,19 +222,19 @@ public class SimpleAclAuthorizerTest extends KopProtocolHandlerTestBase {
         // TENANT_ADMIN_USER can't produce don't exist tenant's topic,
         // because tenant admin depend on exist tenant.
         Boolean isAuthorized = simpleAclAuthorizer.canProduceAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TENANT_ADMIN_USER),
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TENANT_ADMIN_USER, null),
                 Resource.of(ResourceType.TOPIC, NOT_EXISTS_TENANT_TOPIC)).get();
         assertFalse(isAuthorized);
 
         // ADMIN_USER can produce don't exist tenant's topic, because is superuser.
         isAuthorized = simpleAclAuthorizer.canProduceAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ADMIN_USER),
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ADMIN_USER, null),
                 Resource.of(ResourceType.TOPIC, NOT_EXISTS_TENANT_TOPIC)).get();
         assertTrue(isAuthorized);
 
         // TENANT_ADMIN_USER can produce.
         isAuthorized = simpleAclAuthorizer.canProduceAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TENANT_ADMIN_USER),
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TENANT_ADMIN_USER, null),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertTrue(isAuthorized);
 
@@ -247,22 +247,22 @@ public class SimpleAclAuthorizerTest extends KopProtocolHandlerTestBase {
         admin.topics().grantPermission(topic, TOPIC_LEVEL_PERMISSIONS_USER, Sets.newHashSet(AuthAction.produce));
 
         Boolean isAuthorized = simpleAclAuthorizer.canLookupAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TOPIC_LEVEL_PERMISSIONS_USER),
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TOPIC_LEVEL_PERMISSIONS_USER, null),
                 Resource.of(ResourceType.TOPIC, topic)).get();
         assertTrue(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canProduceAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TOPIC_LEVEL_PERMISSIONS_USER),
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TOPIC_LEVEL_PERMISSIONS_USER, null),
                 Resource.of(ResourceType.TOPIC, topic)).get();
         assertTrue(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canConsumeAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TOPIC_LEVEL_PERMISSIONS_USER),
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TOPIC_LEVEL_PERMISSIONS_USER, null),
                 Resource.of(ResourceType.TOPIC, topic)).get();
         assertFalse(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canProduceAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TOPIC_LEVEL_PERMISSIONS_USER),
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TOPIC_LEVEL_PERMISSIONS_USER, null),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertFalse(isAuthorized);
     }


### PR DESCRIPTION
This patch introduces a new  configuration flag `kafkaEnableMultitenantMetadata` that makes KOP use separate namespaces for Metadata Operations.

Motivation:
Currently KOP cannot be used in clusters where you need strong tenant isolation because we are sharing the system metadata topics.
We need a way to totally isolate the traffic and data storage per tenant.

High level overview:
The Client authenticates passing as username the Pulsar tenant for metadata operations.
We use such tenant for every metadata operation, and so we isolate the traffic of each tenant.


Summary of changes:
- Implement capture of "username" in SASL authentication
- Introduce the concept of "tenant" on KOP Hander: it is the "username" if authenticated otherwise it is `kafkaMetadataTenant` (if the username is in the form of tenant/namespace as in older KOP versions, then we strip away the /namespace part)
- Add `kafkaEnableMultitenantMetadata`, when this flag is enabled then the "username" is used instead of `kafkaMetadataTenant`  for every metadata operation and GroupCoordinator/TransactionCoordinator activity
- Lazily bootstrap new GroupCoordinator/TransactionCoordinator at first usage (but we eagerly start it for the `kafkaMetadataTenant` in order to preserve backward compatibility and perform basic sanity check at ProtocolHandler bootstrap
