### PR TITLE
[FEATURE] Add kop event manager stats for prometheus metrics

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManager.java
@@ -22,6 +22,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupCoordinator;
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupMetadata;
+import io.streamnative.pulsar.handlers.kop.stats.StatsLogger;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
 import io.streamnative.pulsar.handlers.kop.utils.ShutdownableThread;
 import java.nio.charset.StandardCharsets;
@@ -32,12 +33,16 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.BiConsumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.common.util.MathUtils;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.pulsar.broker.loadbalance.LoadManager;
@@ -52,7 +57,7 @@ public class KopEventManager {
 
     private static final String kopEventThreadName = "kop-event-thread";
     private final ReentrantLock putLock = new ReentrantLock();
-    private static final LinkedBlockingQueue<KopEvent> queue =
+    private static final LinkedBlockingQueue<KopEventWrapper> queue =
             new LinkedBlockingQueue<>();
     private final KopEventThread thread =
             new KopEventThread(kopEventThreadName);
@@ -61,15 +66,18 @@ public class KopEventManager {
     private final DeletionTopicsHandler deletionTopicsHandler;
     private final BrokersChangeHandler brokersChangeHandler;
     private final MetadataStore metadataStore;
+    private KopEventManagerStats eventManagerStats;
 
     public KopEventManager(GroupCoordinator coordinator,
                            AdminManager adminManager,
-                           MetadataStore metadataStore) {
+                           MetadataStore metadataStore,
+                           StatsLogger statsLogger) {
         this.coordinator = coordinator;
         this.adminManager = adminManager;
         this.deletionTopicsHandler = new DeletionTopicsHandler(this);
         this.brokersChangeHandler = new BrokersChangeHandler(this);
         this.metadataStore = metadataStore;
+        this.eventManagerStats = new KopEventManagerStats(statsLogger);
     }
 
     public void start() {
@@ -90,29 +98,49 @@ public class KopEventManager {
     }
 
 
-    public void put(KopEvent event) {
+    public void put(KopEventWrapper eventWrapper) {
         putLock.lock();
         try {
-            queue.put(event);
+            queue.put(eventWrapper);
+            KopEventManagerStats.KOP_EVENT_QUEUE_SIZE_INSTANCE.incrementAndGet();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            log.error("Error put event {} to coordinator event queue", event, e);
+            log.error("Error put event {} to coordinator event queue",
+                    eventWrapper.toString(), e);
         } finally {
             putLock.unlock();
         }
     }
 
-    public void clearAndPut(KopEvent event) {
+    public void clearAndPut(KopEventWrapper eventWrapper) {
         putLock.lock();
         try {
             queue.clear();
-            put(event);
+            KopEventManagerStats.KOP_EVENT_QUEUE_SIZE_INSTANCE.set(0);
+            put(eventWrapper);
+            KopEventManagerStats.KOP_EVENT_QUEUE_SIZE_INSTANCE.incrementAndGet();
         } finally {
             putLock.unlock();
         }
     }
 
-    static class KopEventThread extends ShutdownableThread {
+    public void registerEventQueuedLatency(KopEventWrapper eventWrapper) {
+        this.eventManagerStats.getStatsLogger()
+                .scopeLabel(KopServerStats.KOP_EVENT_SCOPE, eventWrapper.kopEvent.name())
+                .getOpStatsLogger(KopServerStats.KOP_EVENT_QUEUED_LATENCY)
+                .registerSuccessfulEvent(MathUtils.elapsedNanos(eventWrapper.getCreatedTime()),
+                        TimeUnit.NANOSECONDS);
+    }
+
+    public BiConsumer<String, Long> registerEventLatency = (eventName, createdTime) -> {
+        this.eventManagerStats.getStatsLogger()
+                .scopeLabel(KopServerStats.KOP_EVENT_SCOPE, eventName)
+                .getOpStatsLogger(KopServerStats.KOP_EVENT_LATENCY)
+                .registerSuccessfulEvent(MathUtils.elapsedNanos(createdTime),
+                        TimeUnit.NANOSECONDS);
+    };
+
+    class KopEventThread extends ShutdownableThread {
 
         public KopEventThread(String name) {
             super(name);
@@ -120,16 +148,19 @@ public class KopEventManager {
 
         @Override
         protected void doWork() {
-            KopEvent event = null;
+            KopEventWrapper eventWrapper = null;
             try {
-                event = queue.take();
-                if (event instanceof ShutdownEventThread) {
+                eventWrapper = queue.take();
+                KopEventManagerStats.KOP_EVENT_QUEUE_SIZE_INSTANCE.decrementAndGet();
+                registerEventQueuedLatency(eventWrapper);
+
+                if (eventWrapper.kopEvent instanceof ShutdownEventThread) {
                     log.info("Shutting down KopEventThread.");
                 } else {
-                    event.process();
+                    eventWrapper.kopEvent.process(registerEventLatency, MathUtils.nowInNano());
                 }
             } catch (InterruptedException e) {
-                log.error("Error processing event {}", event, e);
+                log.error("Error processing event {}", eventWrapper, e);
             }
         }
 
@@ -141,7 +172,8 @@ public class KopEventManager {
         // Really register ChildChange notification.
         metadataStore.getChildren(getDeleteTopicsPath());
         // init local kop brokers cache
-        getBrokers(metadataStore.getChildren(getBrokersChangePath()).join());
+        getBrokers(metadataStore.getChildren(getBrokersChangePath()).join(),
+                null, "", -1);
     }
 
     private void handleChildChangePathNotification(Notification notification) {
@@ -152,7 +184,10 @@ public class KopEventManager {
         }
     }
 
-    private void getBrokers(List<String> pulsarBrokers) {
+    private void getBrokers(List<String> pulsarBrokers,
+                            BiConsumer<String, Long> registerEventLatency,
+                            String name,
+                            long startProcessTime) {
         final Set<Node> kopBrokers = Sets.newConcurrentHashSet();
         final AtomicInteger pendingBrokers = new AtomicInteger(pulsarBrokers.size());
 
@@ -160,6 +195,9 @@ public class KopEventManager {
             metadataStore.get(getBrokersChangePath() + "/" + broker).whenComplete(
                     (brokerData, e) -> {
                         if (e != null) {
+                            if (registerEventLatency != null) {
+                                registerEventLatency.accept(name, startProcessTime);
+                            }
                             log.error("Get broker {} path data failed which have an error", broker, e);
                             return;
                         }
@@ -188,6 +226,9 @@ public class KopEventManager {
                         if (pendingBrokers.decrementAndGet() == 0) {
                             Collection<? extends Node> oldKopBrokers = adminManager.getBrokers();
                             adminManager.setBrokers(kopBrokers);
+                            if (registerEventLatency != null) {
+                                registerEventLatency.accept(name, startProcessTime);
+                            }
                             log.info("Refresh kop brokers new cache {}, old brokers cache {}",
                                     adminManager.getBrokers(), oldKopBrokers);
                         }
@@ -217,15 +258,38 @@ public class KopEventManager {
                 Integer.parseInt(port));
     }
 
+    @Getter
+    static class KopEventWrapper {
+        private final KopEvent kopEvent;
+        private final long createdTime;
+
+        public KopEventWrapper(KopEvent kopEvent) {
+            this.kopEvent = kopEvent;
+            this.createdTime = MathUtils.nowInNano();
+        }
+
+        @Override
+        public String toString() {
+            return "KopEventWrapper("
+                    + "kopEvent=" + ((kopEvent == null) ? "null" : "'" + kopEvent + "'")
+                    + ", createdTime=" + "'" + createdTime + "'"
+                    + ")";
+        }
+
+    }
 
     interface KopEvent {
-        void process();
+        void process(BiConsumer<String, Long> registerEventLatency,
+                     long startProcessTime);
+
+        String name();
     }
 
     class DeleteTopicsEvent implements KopEvent {
 
         @Override
-        public void process() {
+        public void process(BiConsumer<String, Long> registerEventLatency,
+                            long startProcessTime) {
             if (!coordinator.isActive()) {
                 return;
             }
@@ -273,42 +337,62 @@ public class KopEventManager {
 
             } catch (ExecutionException | InterruptedException e) {
                 log.error("DeleteTopicsEvent process have an error", e);
+            } finally {
+                registerEventLatency.accept(name(), startProcessTime);
             }
+        }
+
+        @Override
+        public String name() {
+            return "DeleteTopicsEvent";
         }
     }
 
     class BrokersChangeEvent implements KopEvent {
         @Override
-        public void process() {
+        public void process(BiConsumer<String, Long> registerEventLatency,
+                            long startProcessTime) {
             metadataStore.getChildren(getBrokersChangePath()).whenComplete(
                     (brokers, e) -> {
                         if (e != null) {
                             log.error("BrokersChangeEvent process have an error", e);
                             return;
                         }
-                        getBrokers(brokers);
+                        getBrokers(brokers, registerEventLatency, name(), startProcessTime);
                     });
+        }
+
+        @Override
+        public String name() {
+            return "BrokersChangeEvent";
         }
     }
 
     static class ShutdownEventThread implements KopEvent {
 
         @Override
-        public void process() {
+        public void process(BiConsumer<String, Long> registerEventLatency,
+                            long startProcessTime) {
             // Here is only record shutdown KopEventThread event.
+            registerEventLatency.accept(name(), startProcessTime);
+        }
+
+        @Override
+        public String name() {
+            return "ShutdownEventThread";
         }
     }
 
-    public DeleteTopicsEvent getDeleteTopicEvent() {
-        return new DeleteTopicsEvent();
+    public KopEventWrapper getDeleteTopicEvent() {
+        return new KopEventWrapper(new DeleteTopicsEvent());
     }
 
-    public BrokersChangeEvent getBrokersChangeEvent() {
-        return new BrokersChangeEvent();
+    public KopEventWrapper getBrokersChangeEvent() {
+        return new KopEventWrapper(new BrokersChangeEvent());
     }
 
-    public ShutdownEventThread getShutdownEventThread() {
-        return new ShutdownEventThread();
+    public KopEventWrapper getShutdownEventThread() {
+        return new KopEventWrapper(new ShutdownEventThread());
     }
 
     public static String getKopPath() {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManagerStats.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManagerStats.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import static io.streamnative.pulsar.handlers.kop.KopServerStats.CATEGORY_SERVER;
+import static io.streamnative.pulsar.handlers.kop.KopServerStats.KOP_EVENT_QUEUE_SIZE;
+import static io.streamnative.pulsar.handlers.kop.KopServerStats.SERVER_SCOPE;
+
+import io.streamnative.pulsar.handlers.kop.stats.StatsLogger;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.stats.Gauge;
+import org.apache.bookkeeper.stats.annotations.StatsDoc;
+
+
+/**
+ * Kop event manager stats for prometheus metrics.
+ */
+@StatsDoc(
+        name = SERVER_SCOPE,
+        category = CATEGORY_SERVER,
+        help = "KOP event manager stats"
+)
+
+@Getter
+@Slf4j
+public class KopEventManagerStats {
+
+    public static final AtomicInteger KOP_EVENT_QUEUE_SIZE_INSTANCE = new AtomicInteger(0);
+
+
+    private final StatsLogger statsLogger;
+
+    public KopEventManagerStats(StatsLogger statsLogger) {
+        this.statsLogger = statsLogger;
+
+        statsLogger.registerGauge(KOP_EVENT_QUEUE_SIZE, new Gauge<Number>() {
+            @Override
+            public Number getDefaultValue() {
+                return 0;
+            }
+
+            @Override
+            public Number getSample() {
+                return KOP_EVENT_QUEUE_SIZE_INSTANCE;
+            }
+        });
+    }
+
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopServerStats.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopServerStats.java
@@ -26,6 +26,8 @@ public interface KopServerStats {
     String PARTITION_SCOPE = "partition";
     String GROUP_SCOPE = "group";
 
+    String KOP_EVENT_SCOPE = "kop_event";
+
     /**
      * Request stats.
      */
@@ -79,4 +81,11 @@ public interface KopServerStats {
     String BYTES_OUT = "BYTES_OUT";
     String MESSAGE_OUT = "MESSAGE_OUT";
     String ENTRIES_OUT = "ENTRIES_OUT";
+
+    /**
+     * Kop event queue stats.
+     */
+    String KOP_EVENT_QUEUE_SIZE = "KOP_EVENT_QUEUE_SIZE";
+    String KOP_EVENT_QUEUED_LATENCY = "KOP_EVENT_QUEUED_LATENCY";
+    String KOP_EVENT_LATENCY = "KOP_EVENT_LATENCY";
 }


### PR DESCRIPTION
Fixes #739 

### Motivation
At present, we have not done some indicator collection work on kopEventManager, it will be very useful to add corresponding monitoring metrics

### Modifications
Add the following three metrics to monitor kopEventManager stats
KOP_EVENT_QUEUE_SIZE Represents the current number of events in kopEventQueue
KOP_EVENT_QUEUED_LATENCY Indicates the delay time for the event to wait in the queue to be formally processed
KOP_EVENT_LATENCY The time it takes for the event to be processed from the beginning to the completion of the processing