### PR TITLE
support multiple listeners with multiple endpoints

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/EndPoint.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/EndPoint.java
@@ -31,26 +31,45 @@ import org.apache.kafka.common.security.auth.SecurityProtocol;
 public class EndPoint {
 
     private static final String END_POINT_SEPARATOR = ",";
+    private static final String PROTOCOL_MAP_SEPARATOR = ",";
+    private static final String PROTOCOL_SEPARATOR = ":";
     private static final String REGEX = "^(.*)://\\[?([0-9a-zA-Z\\-%._:]*)\\]?:(-?[0-9]+)";
     private static final Pattern PATTERN = Pattern.compile(REGEX);
 
     @Getter
     private final String originalListener;
     @Getter
+    private final String listenerName;
+    @Getter
     private final SecurityProtocol securityProtocol;
     @Getter
     private final String hostname;
     @Getter
     private final int port;
+    @Getter
+    private final boolean multiListener;
 
-    public EndPoint(final String listener) {
+    public EndPoint(final String listener, final String kafkaProtocolMap) {
         this.originalListener = listener;
         final String errorMessage = "listener '" + listener + "' is invalid";
         final Matcher matcher = PATTERN.matcher(listener);
         checkState(matcher.find(), errorMessage);
         checkState(matcher.groupCount() == 3, errorMessage);
 
-        this.securityProtocol = SecurityProtocol.forName(matcher.group(1));
+        Map<String, SecurityProtocol> protocolMap = parseProtocolMap(kafkaProtocolMap);
+
+        this.listenerName = matcher.group(1);
+        if (protocolMap.isEmpty()) {
+            multiListener = false;
+            this.securityProtocol = SecurityProtocol.forName(matcher.group(1));
+        } else {
+            multiListener = true;
+            this.securityProtocol = protocolMap.get(this.listenerName);
+            if (this.securityProtocol == null) {
+                throw new IllegalStateException(this.listenerName + " is not set in kafkaProtocolMap");
+            }
+        }
+
         final String originalHostname = matcher.group(2);
         if (originalHostname.isEmpty()) {
             try {
@@ -65,19 +84,25 @@ public class EndPoint {
         checkState(port >= 0 && port <= 65535, errorMessage + ": port " + port + " is invalid");
     }
 
+
+
     public InetSocketAddress getInetAddress() {
         return new InetSocketAddress(hostname, port);
     }
 
-    public static Map<SecurityProtocol, EndPoint> parseListeners(final String listeners) {
-        final Map<SecurityProtocol, EndPoint> endPointMap = new HashMap<>();
+    public static Map<String, EndPoint> parseListeners(final String listeners) {
+        return parseListeners(listeners, null);
+    }
+
+    public static Map<String, EndPoint> parseListeners(final String listeners, final String kafkaProtocolMap) {
+        final Map<String, EndPoint> endPointMap = new HashMap<>();
         for (String listener : listeners.split(END_POINT_SEPARATOR)) {
-            final EndPoint endPoint = new EndPoint(listener);
-            if (endPointMap.containsKey(endPoint.securityProtocol)) {
+            final EndPoint endPoint = new EndPoint(listener, kafkaProtocolMap);
+            if (endPointMap.containsKey(endPoint.listenerName)) {
                 throw new IllegalStateException(
-                        listeners + " has multiple listeners whose protocol is " + endPoint.securityProtocol);
+                        listeners + " has multiple listeners whose listenerName is " + endPoint.listenerName);
             } else {
-                endPointMap.put(endPoint.securityProtocol, endPoint);
+                endPointMap.put(endPoint.listenerName, endPoint);
             }
         }
         return endPointMap;
@@ -87,7 +112,7 @@ public class EndPoint {
         for (String listener : listeners.split(END_POINT_SEPARATOR)) {
             if (listener.startsWith(SecurityProtocol.PLAINTEXT.name())
                     || listener.startsWith(SecurityProtocol.SASL_PLAINTEXT.name())) {
-                return new EndPoint(listener);
+                return new EndPoint(listener, null);
             }
         }
         throw new IllegalStateException(listeners + " has no plain text endpoint");
@@ -97,9 +122,31 @@ public class EndPoint {
         for (String listener : listeners.split(END_POINT_SEPARATOR)) {
             if (listener.startsWith(SecurityProtocol.SSL.name())
                     || listener.startsWith(SecurityProtocol.SASL_SSL.name())) {
-                return new EndPoint(listener);
+                return new EndPoint(listener, null);
             }
         }
         throw new IllegalStateException(listeners + " has no ssl endpoint");
+    }
+
+    public static Map<String, SecurityProtocol> parseProtocolMap(final String kafkaProtocolMap) {
+
+        final Map<String, SecurityProtocol> protocolMap = new HashMap<>();
+        if (kafkaProtocolMap == null) {
+            return protocolMap;
+        }
+
+        for (String protocolSet : kafkaProtocolMap.split(PROTOCOL_MAP_SEPARATOR)) {
+            String[] protocol = protocolSet.split(PROTOCOL_SEPARATOR);
+            if (protocol.length != 2) {
+                throw new IllegalStateException(
+                        "wrong format for kafkaProtocolMap " + kafkaProtocolMap);
+            }
+            if (protocolMap.containsKey(protocol[0])) {
+                throw new IllegalStateException(
+                        kafkaProtocolMap + " has multiple listeners whose listenerName is " + protocol[0]);
+            }
+            protocolMap.put(protocol[0], SecurityProtocol.forName(protocol[1]));
+        }
+        return protocolMap;
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/EndPoint.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/EndPoint.java
@@ -49,17 +49,15 @@ public class EndPoint {
     @Getter
     private final boolean multiListener;
 
-    public EndPoint(final String listener, final String kafkaProtocolMap) {
+    public EndPoint(final String listener, final Map<String, SecurityProtocol> protocolMap) {
         this.originalListener = listener;
         final String errorMessage = "listener '" + listener + "' is invalid";
         final Matcher matcher = PATTERN.matcher(listener);
         checkState(matcher.find(), errorMessage);
         checkState(matcher.groupCount() == 3, errorMessage);
 
-        Map<String, SecurityProtocol> protocolMap = parseProtocolMap(kafkaProtocolMap);
-
         this.listenerName = matcher.group(1);
-        if (protocolMap.isEmpty()) {
+        if (protocolMap == null || protocolMap.isEmpty()) {
             multiListener = false;
             this.securityProtocol = SecurityProtocol.forName(matcher.group(1));
         } else {
@@ -96,8 +94,9 @@ public class EndPoint {
 
     public static Map<String, EndPoint> parseListeners(final String listeners, final String kafkaProtocolMap) {
         final Map<String, EndPoint> endPointMap = new HashMap<>();
+        final Map<String, SecurityProtocol> protocolMap = parseProtocolMap(kafkaProtocolMap);
         for (String listener : listeners.split(END_POINT_SEPARATOR)) {
-            final EndPoint endPoint = new EndPoint(listener, kafkaProtocolMap);
+            final EndPoint endPoint = new EndPoint(listener, protocolMap);
             if (endPointMap.containsKey(endPoint.listenerName)) {
                 throw new IllegalStateException(
                         listeners + " has multiple listeners whose listenerName is " + endPoint.listenerName);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -321,7 +321,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
             KopVersion.getBuildHost(),
             KopVersion.getBuildTime());
 
-        // Currently each  time getMetadataCache() is called, a new MetadataCache<T> instance will be created, even for
+        // Currently each time getMetadataCache() is called, a new MetadataCache<T> instance will be created, even for
         // the same type. So we must reuse the same MetadataCache<LocalBrokerData> to avoid creating a lot of instances.
         localBrokerDataCache = brokerService.pulsar().getLocalMetadataStore().getMetadataCache(LocalBrokerData.class);
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -312,8 +312,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
         brokerService = service;
         kopBrokerLookupManager = new KopBrokerLookupManager(
                 brokerService.getPulsar(), false,
-                kafkaConfig.getKafkaAdvertisedListeners(),
-                kafkaConfig.getKafkaProtocolMap());
+                kafkaConfig.getKafkaAdvertisedListeners());
 
         log.info("Starting KafkaProtocolHandler, kop version is: '{}'", KopVersion.getVersion());
         log.info("Git Revision {}", KopVersion.getGitSha());
@@ -450,17 +449,15 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                     case SASL_PLAINTEXT:
                         builder.put(endPoint.getInetAddress(), new KafkaChannelInitializer(brokerService.getPulsar(),
                                 kafkaConfig, this, adminManager, false,
-                                advertisedEndPoint, rootStatsLogger.scope(SERVER_SCOPE), localBrokerDataCache));
-                                advertisedEndPoint, scopeStatsLogger, localBrokerDataCache));
-                                endPoint, rootStatsLogger.scope(SERVER_SCOPE), localBrokerDataCache));
+                                endPoint, scopeStatsLogger, localBrokerDataCache));
                         break;
                     case SSL:
                     case SASL_SSL:
                         builder.put(endPoint.getInetAddress(), new KafkaChannelInitializer(brokerService.getPulsar(),
                                 kafkaConfig, this, adminManager, true,
-                                endPoint, rootStatsLogger.scope(SERVER_SCOPE), localBrokerDataCache));
-                                advertisedEndPoint, scopeStatsLogger, localBrokerDataCache));
+                                endPoint, scopeStatsLogger, localBrokerDataCache));
                         break;
+                    default:
                 }
             });
             return builder.build();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -51,7 +51,6 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.kafka.common.internals.Topic;
 import org.apache.kafka.common.record.CompressionType;
-import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.Time;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
@@ -312,7 +311,9 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     public void start(BrokerService service) {
         brokerService = service;
         kopBrokerLookupManager = new KopBrokerLookupManager(
-                brokerService.getPulsar(), false, kafkaConfig.getKafkaAdvertisedListeners());
+                brokerService.getPulsar(), false,
+                kafkaConfig.getKafkaAdvertisedListeners(),
+                kafkaConfig.getKafkaProtocolMap());
 
         log.info("Starting KafkaProtocolHandler, kop version is: '{}'", KopVersion.getVersion());
         log.info("Git Revision {}", KopVersion.getGitSha());
@@ -321,7 +322,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
             KopVersion.getBuildHost(),
             KopVersion.getBuildTime());
 
-        // Currently each time getMetadataCache() is called, a new MetadataCache<T> instance will be created, even for
+        // Currently each  time getMetadataCache() is called, a new MetadataCache<T> instance will be created, even for
         // the same type. So we must reuse the same MetadataCache<LocalBrokerData> to avoid creating a lot of instances.
         localBrokerDataCache = brokerService.pulsar().getLocalMetadataStore().getMetadataCache(LocalBrokerData.class);
 
@@ -440,27 +441,24 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
 
         try {
             ImmutableMap.Builder<InetSocketAddress, ChannelInitializer<SocketChannel>> builder =
-                ImmutableMap.<InetSocketAddress, ChannelInitializer<SocketChannel>>builder();
+                    ImmutableMap.<InetSocketAddress, ChannelInitializer<SocketChannel>>builder();
 
-            final Map<SecurityProtocol, EndPoint> advertisedEndpointMap =
-                    EndPoint.parseListeners(kafkaConfig.getKafkaAdvertisedListeners());
-            EndPoint.parseListeners(kafkaConfig.getListeners()).forEach((protocol, endPoint) -> {
-                EndPoint advertisedEndPoint = advertisedEndpointMap.get(protocol);
-                if (advertisedEndPoint == null) {
-                    // Use the bind endpoint as the advertised endpoint.
-                    advertisedEndPoint = endPoint;
-                }
-                switch (protocol) {
+            EndPoint.parseListeners(kafkaConfig.getListeners(), kafkaConfig.getKafkaProtocolMap()).forEach((listener, endPoint) -> {
+
+                switch (endPoint.getSecurityProtocol()) {
                     case PLAINTEXT:
                     case SASL_PLAINTEXT:
                         builder.put(endPoint.getInetAddress(), new KafkaChannelInitializer(brokerService.getPulsar(),
                                 kafkaConfig, this, adminManager, false,
+                                advertisedEndPoint, rootStatsLogger.scope(SERVER_SCOPE), localBrokerDataCache));
                                 advertisedEndPoint, scopeStatsLogger, localBrokerDataCache));
+                                endPoint, rootStatsLogger.scope(SERVER_SCOPE), localBrokerDataCache));
                         break;
                     case SSL:
                     case SASL_SSL:
                         builder.put(endPoint.getInetAddress(), new KafkaChannelInitializer(brokerService.getPulsar(),
                                 kafkaConfig, this, adminManager, true,
+                                endPoint, rootStatsLogger.scope(SERVER_SCOPE), localBrokerDataCache));
                                 advertisedEndPoint, scopeStatsLogger, localBrokerDataCache));
                         break;
                 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -443,8 +443,8 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
             ImmutableMap.Builder<InetSocketAddress, ChannelInitializer<SocketChannel>> builder =
                     ImmutableMap.<InetSocketAddress, ChannelInitializer<SocketChannel>>builder();
 
-            EndPoint.parseListeners(kafkaConfig.getListeners(), kafkaConfig.getKafkaProtocolMap()).forEach((listener, endPoint) -> {
-
+            EndPoint.parseListeners(kafkaConfig.getListeners(), kafkaConfig.getKafkaProtocolMap()).
+                    forEach((listener, endPoint) -> {
                 switch (endPoint.getSecurityProtocol()) {
                     case PLAINTEXT:
                     case SASL_PLAINTEXT:

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -200,7 +200,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     private final MetadataCache<LocalBrokerData> localBrokerDataCache;
 
     private final Boolean tlsEnabled;
-    private final String kafkaProtocolMap;
     private final EndPoint advertisedEndPoint;
     private final String advertisedListeners;
     private final int defaultNumPartitions;
@@ -298,7 +297,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         this.localBrokerDataCache = localBrokerDataCache;
         this.tlsEnabled = tlsEnabled;
         this.advertisedEndPoint = advertisedEndPoint;
-        this.kafkaProtocolMap = kafkaConfig.getKafkaProtocolMap();
         this.advertisedListeners = kafkaConfig.getKafkaAdvertisedListeners();
         this.topicManager = new KafkaTopicManager(this);
         this.defaultNumPartitions = kafkaConfig.getDefaultNumPartitions();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -157,7 +157,6 @@ import org.apache.kafka.common.requests.TxnOffsetCommitRequest;
 import org.apache.kafka.common.requests.TxnOffsetCommitResponse;
 import org.apache.kafka.common.requests.WriteTxnMarkersRequest;
 import org.apache.kafka.common.requests.WriteTxnMarkersResponse;
-import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Utils;
@@ -179,7 +178,6 @@ import org.apache.pulsar.common.util.Murmur3_32Hash;
 import org.apache.pulsar.metadata.api.MetadataCache;
 import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
 import org.apache.pulsar.policies.data.loadbalancer.ServiceLookupData;
-import org.eclipse.jetty.util.StringUtil;
 
 /**
  * This class contains all the request handling methods.

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -189,17 +189,23 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
     private String kafkaListeners;
 
     @FieldContext(
-        category = CATEGORY_KOP,
-        doc = "Listeners to publish to ZooKeeper for clients to use.\n"
-                + "The format is the same as `kafkaListeners`.\n"
+            category = CATEGORY_KOP,
+            doc = "Comma-separated map of listener name and protocol.\n"
+                    + "e.g. PRIVATE:PLAINTEXT,PRIVATE_SSL:SSL,PUBLIC:PLAINTEXT,PUBLIC_SSL:SSL.\n"
+    )
+    private String kafkaProtocolMap;
+
+    @Deprecated
+    @FieldContext(
+            category = CATEGORY_KOP,
+            doc = "Use kafkaProtocolMap, kafkaListeners and advertisedAddress instead."
     )
     private String kafkaAdvertisedListeners;
 
+    @Deprecated
     @FieldContext(
             category = CATEGORY_KOP,
-            doc = "Specify the internal listener name for the broker.\n"
-                    + "The listener name must be contained in the advertisedListeners.\n"
-                    + "This config is used as the listener name in topic lookup."
+            doc = "Use kafkaProtocolMap, kafkaListeners and advertisedAddress instead."
     )
     private String kafkaListenerName;
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
@@ -67,7 +67,7 @@ public class KafkaTopicManager {
 
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
-    public static final ConcurrentHashMap<String, CompletableFuture<InetSocketAddress>>
+    public static final ConcurrentHashMap<String, ConcurrentHashMap<String, CompletableFuture<InetSocketAddress>>>
         LOOKUP_CACHE = new ConcurrentHashMap<>();
 
     public static final ConcurrentHashMap<String, CompletableFuture<Optional<String>>>
@@ -178,7 +178,7 @@ public class KafkaTopicManager {
     // call pulsarclient.lookup.getbroker to get and
     // own a topic.
     //    // when error happens, the returned future will complete with null.
-    public CompletableFuture<InetSocketAddress> getTopicBroker(String topicName) {
+    public CompletableFuture<InetSocketAddress> getTopicBroker(String topicName, String listenerName) {
         if (closed.get()) {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Return null for getTopicBroker({}) since channel closing",
@@ -186,16 +186,28 @@ public class KafkaTopicManager {
             }
             return CompletableFuture.completedFuture(null);
         }
-        return LOOKUP_CACHE.computeIfAbsent(topicName, t -> {
+
+        ConcurrentHashMap<String, CompletableFuture<InetSocketAddress>> topic_lookup_cache =
+                LOOKUP_CACHE.computeIfAbsent(topicName, t-> {
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}] topic {} not in Lookup_cache, call lookupBroker",
+                                requestHandler.ctx.channel(), topicName);
+                    }
+                    ConcurrentHashMap<String, CompletableFuture<InetSocketAddress>> cache = new ConcurrentHashMap<>();
+                    cache.put(listenerName == null ? "" : listenerName, lookupBroker(topicName, listenerName));
+                    return cache;
+                });
+
+        return topic_lookup_cache.computeIfAbsent(listenerName == null ? "" : listenerName, t-> {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] topic {} not in Lookup_cache, call lookupBroker",
-                    requestHandler.ctx.channel(), topicName);
+                        requestHandler.ctx.channel(), topicName);
             }
-            return lookupBroker(topicName);
+            return lookupBroker(topicName, listenerName);
         });
     }
 
-    private CompletableFuture<InetSocketAddress> lookupBroker(final String topic) {
+    private CompletableFuture<InetSocketAddress> lookupBroker(final String topic, String listenerName) {
         if (closed.get()) {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Return null for getTopic({}) since channel closing",
@@ -203,7 +215,7 @@ public class KafkaTopicManager {
             }
             return CompletableFuture.completedFuture(null);
         }
-        return lookupClient.getBrokerAddress(TopicName.get(topic));
+        return lookupClient.getBrokerAddress(TopicName.get(topic), listenerName);
     }
 
     // A wrapper of `BrokerService#getTopic` that is to find the topic's associated `PersistentTopic` instance

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
@@ -187,7 +187,7 @@ public class KafkaTopicManager {
             return CompletableFuture.completedFuture(null);
         }
 
-        ConcurrentHashMap<String, CompletableFuture<InetSocketAddress>> topic_lookup_cache =
+        ConcurrentHashMap<String, CompletableFuture<InetSocketAddress>> topicLookupCache =
                 LOOKUP_CACHE.computeIfAbsent(topicName, t-> {
                     if (log.isDebugEnabled()) {
                         log.debug("[{}] topic {} not in Lookup_cache, call lookupBroker",
@@ -198,7 +198,7 @@ public class KafkaTopicManager {
                     return cache;
                 });
 
-        return topic_lookup_cache.computeIfAbsent(listenerName == null ? "" : listenerName, t-> {
+        return topicLookupCache.computeIfAbsent(listenerName == null ? "" : listenerName, t-> {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] topic {} not in Lookup_cache, call lookupBroker",
                         requestHandler.ctx.channel(), topicName);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
@@ -45,6 +45,7 @@ public class KopBrokerLookupManager {
     private final PulsarService pulsarService;
     private final Boolean tlsEnabled;
     private final String advertisedListeners;
+    private final String kafkaProtocolMap;
     private final LookupClient lookupClient;
 
     public static final ConcurrentHashMap<String, CompletableFuture<InetSocketAddress>>
@@ -52,10 +53,11 @@ public class KopBrokerLookupManager {
     public static final ConcurrentHashMap<String, CompletableFuture<Optional<String>>>
             KOP_ADDRESS_CACHE = new ConcurrentHashMap<>();
 
-    public KopBrokerLookupManager(PulsarService pulsarService, Boolean tlsEnabled, String advertisedListeners) {
+    public KopBrokerLookupManager(PulsarService pulsarService, Boolean tlsEnabled, String advertisedListeners, String kafkaProtocolMap) {
         this.pulsarService = pulsarService;
         this.tlsEnabled = tlsEnabled;
         this.advertisedListeners = advertisedListeners;
+        this.kafkaProtocolMap = kafkaProtocolMap;
         this.lookupClient = KafkaProtocolHandler.getLookupClient(pulsarService);
     }
 
@@ -82,8 +84,8 @@ public class KopBrokerLookupManager {
 
                     // It's the `kafkaAdvertisedListeners` config that's written to ZK
                     final EndPoint endPoint =
-                            tlsEnabled ? EndPoint.getSslEndPoint(listeners.get())
-                                    : EndPoint.getPlainTextEndPoint(listeners.get());
+                            (tlsEnabled ? EndPoint.getSslEndPoint(listeners.get()) :
+                                    EndPoint.getPlainTextEndPoint(listeners.get()));
 
                     // here we found topic broker: broker2, but this is in broker1,
                     // how to clean the lookup cache?

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
@@ -53,7 +53,8 @@ public class KopBrokerLookupManager {
     public static final ConcurrentHashMap<String, CompletableFuture<Optional<String>>>
             KOP_ADDRESS_CACHE = new ConcurrentHashMap<>();
 
-    public KopBrokerLookupManager(PulsarService pulsarService, Boolean tlsEnabled, String advertisedListeners, String kafkaProtocolMap) {
+    public KopBrokerLookupManager(PulsarService pulsarService, Boolean tlsEnabled,
+                                  String advertisedListeners, String kafkaProtocolMap) {
         this.pulsarService = pulsarService;
         this.tlsEnabled = tlsEnabled;
         this.advertisedListeners = advertisedListeners;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
@@ -45,7 +45,6 @@ public class KopBrokerLookupManager {
     private final PulsarService pulsarService;
     private final Boolean tlsEnabled;
     private final String advertisedListeners;
-    private final String kafkaProtocolMap;
     private final LookupClient lookupClient;
 
     public static final ConcurrentHashMap<String, CompletableFuture<InetSocketAddress>>
@@ -54,11 +53,10 @@ public class KopBrokerLookupManager {
             KOP_ADDRESS_CACHE = new ConcurrentHashMap<>();
 
     public KopBrokerLookupManager(PulsarService pulsarService, Boolean tlsEnabled,
-                                  String advertisedListeners, String kafkaProtocolMap) {
+                                  String advertisedListeners) {
         this.pulsarService = pulsarService;
         this.tlsEnabled = tlsEnabled;
         this.advertisedListeners = advertisedListeners;
-        this.kafkaProtocolMap = kafkaProtocolMap;
         this.lookupClient = KafkaProtocolHandler.getLookupClient(pulsarService);
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/LookupClient.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/LookupClient.java
@@ -19,10 +19,13 @@ import java.io.Closeable;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.lookup.LookupResult;
@@ -46,10 +49,13 @@ public class LookupClient implements Closeable {
     @Getter
     private final PulsarClientImpl pulsarClient;
 
+    private ConcurrentHashMap<String, PulsarClientImpl> pulsarClientMap;
+
     public LookupClient(final PulsarService pulsarService, final KafkaServiceConfiguration kafkaConfig) {
         namespaceService = pulsarService.getNamespaceService();
         try {
-            pulsarClient = createPulsarClient(pulsarService, kafkaConfig);
+            pulsarClient = createPulsarClient(pulsarService, kafkaConfig, null);
+            pulsarClientMap = createPulsarClientMap(pulsarService, kafkaConfig);
         } catch (PulsarClientException e) {
             log.error("Failed to create PulsarClient", e);
             throw new IllegalStateException(e);
@@ -69,10 +75,14 @@ public class LookupClient implements Closeable {
     }
 
     public CompletableFuture<InetSocketAddress> getBrokerAddress(final TopicName topicName) {
+        return getBrokerAddress(topicName, null);
+    }
+
+    public CompletableFuture<InetSocketAddress> getBrokerAddress(final TopicName topicName, String listenerName) {
         // First try to use NamespaceService to find the broker directly.
         final LookupOptions options = LookupOptions.builder()
                 .authoritative(false)
-                .advertisedListenerName(pulsarClient.getConfiguration().getListenerName())
+                .advertisedListenerName(listenerName)
                 .loadTopicsInBundle(true)
                 .build();
         return namespaceService.getBrokerServiceUrlAsync(topicName, options).thenCompose(optLookupResult -> {
@@ -87,7 +97,8 @@ public class LookupClient implements Closeable {
             final LookupResult lookupResult = optLookupResult.get();
             if (lookupResult.isRedirect()) {
                 // Kafka client can't process redirect field, so here we fallback to PulsarClient
-                return pulsarClient.getLookup().getBroker(topicName).thenApply(Pair::getLeft);
+                return pulsarClientMap.getOrDefault(listenerName == null ? "" : listenerName, pulsarClient).
+                        getLookup().getBroker(topicName).thenApply(Pair::getLeft);
             } else {
                 return getAddressFutureFromBrokerUrl(lookupResult.getLookupData().getBrokerUrl());
             }
@@ -103,8 +114,21 @@ public class LookupClient implements Closeable {
         }
     }
 
+    private ConcurrentHashMap<String, PulsarClientImpl> createPulsarClientMap(PulsarService pulsarService, KafkaServiceConfiguration kafkaConfig) throws PulsarClientException {
+        ConcurrentHashMap<String, PulsarClientImpl> pulsarClientMap = new ConcurrentHashMap<>();
+        final Map<String, SecurityProtocol> protocolMap = EndPoint.parseProtocolMap(kafkaConfig.getKafkaProtocolMap());
+        if (protocolMap.isEmpty()) {
+            pulsarClientMap.put("", pulsarClient);
+        } else {
+            for (Map.Entry<String, SecurityProtocol> entry : protocolMap.entrySet()) {
+                pulsarClientMap.put(entry.getKey(), createPulsarClient(pulsarService, kafkaConfig, entry.getKey()));
+            }
+        }
+        return pulsarClientMap;
+    }
+
     private static PulsarClientImpl createPulsarClient(final PulsarService pulsarService,
-                                                       final KafkaServiceConfiguration kafkaConfig)
+                                                       final KafkaServiceConfiguration kafkaConfig, final String listenerName)
             throws PulsarClientException {
         // It's migrated from PulsarService#getClient() but it can configure listener name
         final ClientConfigurationData conf = new ClientConfigurationData();
@@ -137,7 +161,7 @@ public class LookupClient implements Closeable {
                     kafkaConfig.getBrokerClientAuthenticationParameters()));
         }
 
-        conf.setListenerName(kafkaConfig.getKafkaListenerName());
+        conf.setListenerName(listenerName);
         return new PulsarClientImpl(conf, pulsarService.getIoEventLoopGroup());
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/LookupClient.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/LookupClient.java
@@ -114,7 +114,8 @@ public class LookupClient implements Closeable {
         }
     }
 
-    private ConcurrentHashMap<String, PulsarClientImpl> createPulsarClientMap(PulsarService pulsarService, KafkaServiceConfiguration kafkaConfig) throws PulsarClientException {
+    private ConcurrentHashMap<String, PulsarClientImpl> createPulsarClientMap(
+            PulsarService pulsarService, KafkaServiceConfiguration kafkaConfig) throws PulsarClientException {
         ConcurrentHashMap<String, PulsarClientImpl> pulsarClientMap = new ConcurrentHashMap<>();
         final Map<String, SecurityProtocol> protocolMap = EndPoint.parseProtocolMap(kafkaConfig.getKafkaProtocolMap());
         if (protocolMap.isEmpty()) {
@@ -127,9 +128,9 @@ public class LookupClient implements Closeable {
         return pulsarClientMap;
     }
 
-    private static PulsarClientImpl createPulsarClient(final PulsarService pulsarService,
-                                                       final KafkaServiceConfiguration kafkaConfig, final String listenerName)
-            throws PulsarClientException {
+    private static PulsarClientImpl createPulsarClient(
+            final PulsarService pulsarService, final KafkaServiceConfiguration kafkaConfig,
+            final String listenerName) throws PulsarClientException {
         // It's migrated from PulsarService#getClient() but it can configure listener name
         final ClientConfigurationData conf = new ClientConfigurationData();
         conf.setServiceUrl(kafkaConfig.isTlsEnabled()

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/EndPointTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/EndPointTest.java
@@ -30,13 +30,13 @@ public class EndPointTest {
 
     @Test
     public void testValidListener() throws Exception {
-        EndPoint endPoint = new EndPoint("PLAINTEXT://192.168.0.1:9092");
+        EndPoint endPoint = new EndPoint("PLAINTEXT://192.168.0.1:9092", null);
         assertEquals(endPoint.getSecurityProtocol(), SecurityProtocol.PLAINTEXT);
         assertEquals(endPoint.getHostname(), "192.168.0.1");
         assertEquals(endPoint.getPort(), 9092);
 
         final String localhost = InetAddress.getLocalHost().getCanonicalHostName();
-        endPoint = new EndPoint("SSL://:9094");
+        endPoint = new EndPoint("SSL://:9094", null);
         assertEquals(endPoint.getSecurityProtocol(), SecurityProtocol.SSL);
         assertEquals(endPoint.getHostname(), localhost);
         assertEquals(endPoint.getPort(), 9094);
@@ -45,24 +45,24 @@ public class EndPointTest {
     @Test
     public void testInvalidListener() throws Exception {
         try {
-            new EndPoint("hello world");
+            new EndPoint("hello world", null);
         } catch (IllegalStateException e) {
             assertTrue(e.getMessage().contains("listener 'hello world' is invalid"));
         }
         try {
-            new EndPoint("pulsar://localhost:6650");
+            new EndPoint("pulsar://localhost:6650", null);
             fail();
         } catch (IllegalArgumentException e) {
             assertTrue(e.getMessage().contains("No enum constant"));
         }
         try {
-            new EndPoint("PLAINTEXT://localhost:65536");
+            new EndPoint("PLAINTEXT://localhost:65536", null);
             fail();
         } catch (IllegalStateException e) {
             assertTrue(e.getMessage().contains("port 65536 is invalid"));
         }
         try {
-            new EndPoint("PLAINTEXT://localhost:-1");
+            new EndPoint("PLAINTEXT://localhost:-1", null);
             fail();
         } catch (IllegalStateException e) {
             assertTrue(e.getMessage().contains("port -1 is invalid"));
@@ -71,17 +71,17 @@ public class EndPointTest {
 
     @Test
     public void testValidListeners() throws Exception {
-        final Map<SecurityProtocol, EndPoint> endPointMap =
+        final Map<String, EndPoint> endPointMap =
                 EndPoint.parseListeners("PLAINTEXT://localhost:9092,SSL://:9093");
         assertEquals(endPointMap.size(), 2);
 
-        final EndPoint plainEndPoint = endPointMap.get(SecurityProtocol.PLAINTEXT);
+        final EndPoint plainEndPoint = endPointMap.get("PLAINTEXT");
         assertNotNull(plainEndPoint);
         assertEquals(plainEndPoint.getSecurityProtocol(), SecurityProtocol.PLAINTEXT);
         assertEquals(plainEndPoint.getHostname(), "localhost");
         assertEquals(plainEndPoint.getPort(), 9092);
 
-        final EndPoint sslEndPoint = endPointMap.get(SecurityProtocol.SSL);
+        final EndPoint sslEndPoint = endPointMap.get("SSL");
         final String localhost = InetAddress.getLocalHost().getCanonicalHostName();
         assertNotNull(sslEndPoint);
         assertEquals(sslEndPoint.getSecurityProtocol(), SecurityProtocol.SSL);
@@ -90,12 +90,64 @@ public class EndPointTest {
     }
 
     @Test
+    public void testValidMultiListeners() throws Exception {
+        final String kafkaProtocolMap = "internal:PLAINTEXT,internal_ssl:SSL,external:PLAINTEXT,external_ssl:SSL";
+        final String kafkaListeners = "internal://localhost:9092,internal_ssl://localhost:9093," +
+                "external://externalhost:9094,external_ssl://externalhost:9095";
+        final Map<String, EndPoint> endPointMap = EndPoint.parseListeners(kafkaListeners, kafkaProtocolMap);
+        assertEquals(endPointMap.size(), 4);
+
+        final EndPoint internal = endPointMap.get("internal");
+        assertNotNull(internal);
+        assertEquals(internal.getSecurityProtocol(), SecurityProtocol.PLAINTEXT);
+        assertEquals(internal.getHostname(), "localhost");
+        assertEquals(internal.getPort(), 9092);
+
+        final EndPoint internal_ssl = endPointMap.get("internal_ssl");
+        assertNotNull(internal_ssl);
+        assertEquals(internal_ssl.getSecurityProtocol(), SecurityProtocol.SSL);
+        assertEquals(internal_ssl.getHostname(), "localhost");
+        assertEquals(internal_ssl.getPort(), 9093);
+
+        final EndPoint external = endPointMap.get("external");
+        assertNotNull(external);
+        assertEquals(external.getSecurityProtocol(), SecurityProtocol.PLAINTEXT);
+        assertEquals(external.getHostname(), "externalhost");
+        assertEquals(external.getPort(), 9094);
+
+        final EndPoint external_ssl = endPointMap.get("external_ssl");
+        assertNotNull(external_ssl);
+        assertEquals(external_ssl.getSecurityProtocol(), SecurityProtocol.SSL);
+        assertEquals(external_ssl.getHostname(), "externalhost");
+        assertEquals(external_ssl.getPort(), 9095);
+    }
+
+    @Test
+    public void testInvalidMultiListeners() throws Exception {
+        try {
+            EndPoint.parseListeners("internal://localhost:9092,internal_ssl://localhost:9093",
+                    "internal:PLAINTEXT,internal:SSL,internal_ssl:SSL");
+            fail();
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage().contains(" has multiple listeners whose listenerName is internal"));
+        }
+
+        try {
+            EndPoint.parseListeners("internal://localhost:9092,internal_ssl://localhost:9093",
+                    "internal:PLAINTEXT,external:SSL");
+            fail();
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage().contains("internal_ssl is not set in kafkaProtocolMap"));
+        }
+    }
+
+    @Test
     public void testRepeatedListeners() throws Exception {
         try {
             EndPoint.parseListeners("PLAINTEXT://localhost:9092,SSL://:9093,SSL://localhost:9094");
             fail();
         } catch (IllegalStateException e) {
-            assertTrue(e.getMessage().contains(" has multiple listeners whose protocol is SSL"));
+            assertTrue(e.getMessage().contains(" has multiple listeners whose listenerName is SSL"));
         }
     }
 
@@ -124,7 +176,7 @@ public class EndPointTest {
 
     @Test
     public void testOriginalUrl() throws Exception {
-        final EndPoint endPoint = new EndPoint("PLAINTEXT://:9092");
+        final EndPoint endPoint = new EndPoint("PLAINTEXT://:9092", null);
         assertEquals(endPoint.getHostname(), InetAddress.getLocalHost().getCanonicalHostName());
         assertEquals(endPoint.getOriginalListener(), "PLAINTEXT://:9092");
     }

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/EndPointTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/EndPointTest.java
@@ -92,8 +92,8 @@ public class EndPointTest {
     @Test
     public void testValidMultiListeners() throws Exception {
         final String kafkaProtocolMap = "internal:PLAINTEXT,internal_ssl:SSL,external:PLAINTEXT,external_ssl:SSL";
-        final String kafkaListeners = "internal://localhost:9092,internal_ssl://localhost:9093," +
-                "external://externalhost:9094,external_ssl://externalhost:9095";
+        final String kafkaListeners = "internal://localhost:9092,internal_ssl://localhost:9093,"
+                + "external://externalhost:9094,external_ssl://externalhost:9095";
         final Map<String, EndPoint> endPointMap = EndPoint.parseListeners(kafkaListeners, kafkaProtocolMap);
         assertEquals(endPointMap.size(), 4);
 
@@ -103,11 +103,11 @@ public class EndPointTest {
         assertEquals(internal.getHostname(), "localhost");
         assertEquals(internal.getPort(), 9092);
 
-        final EndPoint internal_ssl = endPointMap.get("internal_ssl");
-        assertNotNull(internal_ssl);
-        assertEquals(internal_ssl.getSecurityProtocol(), SecurityProtocol.SSL);
-        assertEquals(internal_ssl.getHostname(), "localhost");
-        assertEquals(internal_ssl.getPort(), 9093);
+        final EndPoint internalSSL = endPointMap.get("internal_ssl");
+        assertNotNull(internalSSL);
+        assertEquals(internalSSL.getSecurityProtocol(), SecurityProtocol.SSL);
+        assertEquals(internalSSL.getHostname(), "localhost");
+        assertEquals(internalSSL.getPort(), 9093);
 
         final EndPoint external = endPointMap.get("external");
         assertNotNull(external);
@@ -115,11 +115,11 @@ public class EndPointTest {
         assertEquals(external.getHostname(), "externalhost");
         assertEquals(external.getPort(), 9094);
 
-        final EndPoint external_ssl = endPointMap.get("external_ssl");
-        assertNotNull(external_ssl);
-        assertEquals(external_ssl.getSecurityProtocol(), SecurityProtocol.SSL);
-        assertEquals(external_ssl.getHostname(), "externalhost");
-        assertEquals(external_ssl.getPort(), 9095);
+        final EndPoint externalSSL = endPointMap.get("external_ssl");
+        assertNotNull(externalSSL);
+        assertEquals(externalSSL.getSecurityProtocol(), SecurityProtocol.SSL);
+        assertEquals(externalSSL.getHostname(), "externalhost");
+        assertEquals(externalSSL.getPort(), 9095);
     }
 
     @Test

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaListenerNameTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaListenerNameTest.java
@@ -13,17 +13,15 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
+import java.util.Properties;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.pulsar.broker.ServiceConfigurationUtils;
 import org.testng.annotations.Test;
 
-import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Test for kafkaListenerName config.
@@ -77,7 +75,8 @@ public class KafkaListenerNameTest extends KopProtocolHandlerTestBase {
         final String kafkaProtocolMap = "kafka:PLAINTEXT,kafka_external:PLAINTEXT";
         conf.setKafkaProtocolMap(kafkaProtocolMap);
         int externalPort = PortManager.nextFreePort();
-        final String kafkaListeners = "kafka://0.0.0.0:" + kafkaBrokerPort + ",kafka_external://0.0.0.0:" + externalPort;
+        final String kafkaListeners = "kafka://0.0.0.0:" + kafkaBrokerPort
+                + ",kafka_external://0.0.0.0:" + externalPort;
         conf.setKafkaListeners(kafkaListeners);
         final String advertisedListeners =
                 "pulsar:pulsar://" + localAddress + ":" + brokerPort

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -134,7 +134,7 @@ public abstract class KopProtocolHandlerTestBase {
     }
 
     protected EndPoint getPlainEndPoint() {
-        return new EndPoint(PLAINTEXT_PREFIX + "127.0.0.1:" + kafkaBrokerPort);
+        return new EndPoint(PLAINTEXT_PREFIX + "127.0.0.1:" + kafkaBrokerPort, null);
     }
 
     protected void resetConfig() {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/KafkaStreamsTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/KafkaStreamsTestBase.java
@@ -44,20 +44,17 @@ public abstract class KafkaStreamsTestBase extends KopProtocolHandlerTestBase {
         super("kafka");
     }
 
-    @BeforeClass
     @Override
     protected void setup() throws Exception {
         super.internalSetup();
         bootstrapServers = "localhost:" + getKafkaBrokerPort();
     }
 
-    @AfterClass
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();
     }
 
-    @BeforeMethod
     protected void setupTestCase() throws Exception {
         testNo++;
         createTopics();
@@ -80,7 +77,6 @@ public abstract class KafkaStreamsTestBase extends KopProtocolHandlerTestBase {
         extraSetup();
     }
 
-    @AfterMethod
     protected void cleanupTestCase() throws Exception {
         if (kafkaStreams != null) {
             kafkaStreams.close(3, TimeUnit.SECONDS);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/KafkaStreamsTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/KafkaStreamsTestBase.java
@@ -44,17 +44,20 @@ public abstract class KafkaStreamsTestBase extends KopProtocolHandlerTestBase {
         super("kafka");
     }
 
+    @BeforeClass
     @Override
     protected void setup() throws Exception {
         super.internalSetup();
         bootstrapServers = "localhost:" + getKafkaBrokerPort();
     }
 
+    @AfterClass
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();
     }
 
+    @BeforeMethod
     protected void setupTestCase() throws Exception {
         testNo++;
         createTopics();
@@ -77,6 +80,7 @@ public abstract class KafkaStreamsTestBase extends KopProtocolHandlerTestBase {
         extraSetup();
     }
 
+    @AfterMethod
     protected void cleanupTestCase() throws Exception {
         if (kafkaStreams != null) {
             kafkaStreams.close(3, TimeUnit.SECONDS);


### PR DESCRIPTION
Fixes #669
Fixes #574

To support multiple listeners with multiple protocols, we need to set follow configration, and deprecated `kafkaAdvertisedListeners` and `kafkaListenerName`.

> kafkaListeners=internal://0.0.0.0:9092,internal_ssl://0.0.0.0:9093,external://0.0.0.0:19002,external_ssl:0.0.0.0:19003
> kafkaProtocalMap=internal:PLAINTEXT,internal_ssl:SSL,external:PLAINTEXT,external_ssl:SSL
> advertisedListeners={pulsar's listeners},internal:pulsar//192.168.1.10:9092,internal_ssl:pulsar//192.168.1.10:9093,external:pulsar//172.16.1.10:19002,external_ssl:pulsar://172.16.1.10:19003

1. Define the listenerNames and port of each listenerName in `kafkaListeners`
2. Define the listenerNames and protocol of each listenerName in `kafkaProtocalMap`
3. Add listenerNames and advertised address of each listenerName into `advertisedListeners`

Kafka client should connect to the port of the listenerName according to KIP-103.