### PR TITLE
Invalidate KopBrokerLookupManager  caches separately from GroupManagement listener

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -43,6 +43,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -104,6 +106,56 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     public TransactionCoordinator getTransactionCoordinator(String tenant) {
         return transactionCoordinatorByTenant.computeIfAbsent(tenant, this::createAndBootTransactionCoordinator);
     }
+
+    /**
+     * Listener for invalidating the global Broker ownership cache
+     */
+    @AllArgsConstructor
+    public static class CacheInvalidator implements NamespaceBundleOwnershipListener {
+        final BrokerService service;
+
+        @Override
+        public boolean test(NamespaceBundle namespaceBundle) {
+            // we are interested in every topic,
+            // because we do not know which topics are served by KOP
+            return true;
+        }
+
+        private void invalidateBundleCache(NamespaceBundle bundle) {
+            service.pulsar().getNamespaceService().getOwnedTopicListForNamespaceBundle(bundle)
+                    .whenComplete((topics, ex) -> {
+                        if (ex == null) {
+                            for (String topic : topics) {
+                                TopicName name = TopicName.get(topic);
+                                // deReference topic when unload
+                                KopBrokerLookupManager.removeTopicManagerCache(topic);
+                                KafkaTopicManager.deReference(topic);
+
+                                // For non-partitioned topic.
+                                if (!name.isPartitioned()) {
+                                    String partitionedZeroTopicName = name.getPartition(0).toString();
+                                    KafkaTopicManager.deReference(partitionedZeroTopicName);
+                                    KopBrokerLookupManager.removeTopicManagerCache(partitionedZeroTopicName);
+                                }
+                            }
+                        } else {
+                            log.error("Failed to get owned topic list for "
+                                            + "CacheInvalidator when triggering bundle ownership change {}.",
+                                    bundle, ex);
+                        }
+                    }
+                    );
+        }
+        @Override
+        public void onLoad(NamespaceBundle bundle) {
+            invalidateBundleCache(bundle);
+        }
+        @Override
+        public void unLoad(NamespaceBundle bundle) {
+            invalidateBundleCache(bundle);
+        }
+    }
+
     /**
      * Listener for the changing of topic that stores offsets of consumer group.
      */
@@ -152,16 +204,6 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                                 }
                                 groupCoordinator.handleGroupImmigration(name.getPartitionIndex());
                             }
-                            // deReference topic when unload
-                            KopBrokerLookupManager.removeTopicManagerCache(topic);
-                            KafkaTopicManager.deReference(topic);
-
-                            // For non-partitioned topic.
-                            if (!name.isPartitioned()) {
-                                String partitionedZeroTopicName = name.getPartition(0).toString();
-                                KafkaTopicManager.deReference(partitionedZeroTopicName);
-                                KopBrokerLookupManager.removeTopicManagerCache(partitionedZeroTopicName);
-                            }
                         }
                     } else {
                         log.error("Failed to get owned topic list for "
@@ -196,17 +238,6 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                                 }
                                 groupCoordinator.handleGroupEmigration(name.getPartitionIndex());
                             }
-                            // deReference topic when unload
-                            KopBrokerLookupManager.removeTopicManagerCache(topic);
-                            KafkaTopicManager.deReference(topic);
-
-                            // For non-partitioned topic.
-                            if (!name.isPartitioned()) {
-                                String partitionedZeroTopicName = name.getPartition(0).toString();
-                                KafkaTopicManager.deReference(partitionedZeroTopicName);
-                                KopBrokerLookupManager.removeTopicManagerCache(partitionedZeroTopicName);
-                            }
-
                         }
                     } else {
                         log.error("Failed to get owned topic list for "
@@ -253,6 +284,11 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
             kafkaConfig.setBindAddress(conf.getBindAddress());
         }
         KopTopic.initialize(kafkaConfig.getKafkaTenant() + "/" + kafkaConfig.getKafkaNamespace());
+
+        brokerService.pulsar()
+                .getNamespaceService()
+                .addNamespaceBundleOwnershipListener(
+                        new CacheInvalidator(brokerService));
 
         // Validate the namespaces
         for (String fullNamespace : kafkaConfig.getKopAllowedNamespaces()) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -121,12 +121,14 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
         }
 
         private void invalidateBundleCache(NamespaceBundle bundle) {
+            log.info("invalidateBundleCache for {}", bundle);
             service.pulsar().getNamespaceService().getOwnedTopicListForNamespaceBundle(bundle)
                     .whenComplete((topics, ex) -> {
                         if (ex == null) {
                             for (String topic : topics) {
                                 TopicName name = TopicName.get(topic);
-                                // deReference topic when unload
+
+                                log.info("invalidateBundleCache for topic {}", topic);
                                 KopBrokerLookupManager.removeTopicManagerCache(topic);
                                 KafkaTopicManager.deReference(topic);
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -43,7 +43,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
@@ -108,7 +107,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     }
 
     /**
-     * Listener for invalidating the global Broker ownership cache
+     * Listener for invalidating the global Broker ownership cache.
      */
     @AllArgsConstructor
     public static class CacheInvalidator implements NamespaceBundleOwnershipListener {
@@ -285,11 +284,6 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
         }
         KopTopic.initialize(kafkaConfig.getKafkaTenant() + "/" + kafkaConfig.getKafkaNamespace());
 
-        brokerService.pulsar()
-                .getNamespaceService()
-                .addNamespaceBundleOwnershipListener(
-                        new CacheInvalidator(brokerService));
-
         // Validate the namespaces
         for (String fullNamespace : kafkaConfig.getKopAllowedNamespaces()) {
             final String[] tokens = fullNamespace.split("/");
@@ -348,6 +342,11 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
         // Create PulsarClient for topic lookup, the listenerName will be set if kafkaListenerName is configured.
         // After it's created successfully, this method won't throw any exception.
         LOOKUP_CLIENT_MAP.put(brokerService.pulsar(), new LookupClient(brokerService.pulsar(), kafkaConfig));
+
+        brokerService.pulsar()
+                .getNamespaceService()
+                .addNamespaceBundleOwnershipListener(
+                        new CacheInvalidator(brokerService));
 
         // initialize default Group Coordinator
         getGroupCoordinator(kafkaConfig.getKafkaMetadataTenant());

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CacheInvalidatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CacheInvalidatorTest.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.time.Duration;
+import java.util.Collections;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.awaitility.Awaitility;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Validate CacheInvalidator.
+ */
+@Slf4j
+public class CacheInvalidatorTest extends KopProtocolHandlerTestBase {
+
+
+    @Test(timeOut = 20000, enabled = false)
+    public void testCacheInvalidatorIsTriggered() throws Exception {
+        String topic = "testCacheInvalidatorIsTriggered";
+        @Cleanup
+        KProducer kProducer = new KProducer(topic, false, getKafkaBrokerPort());
+        kProducer.getProducer().send(new ProducerRecord<>(topic, 1, "value"));
+
+        @Cleanup
+        KConsumer kConsumer = new KConsumer(topic, getKafkaBrokerPort(), true);
+        kConsumer.getConsumer().subscribe(Collections.singleton(topic));
+
+        ConsumerRecords<Integer, String> records = kConsumer.getConsumer().poll(Duration.ofSeconds(5));
+        assertNotNull(records);
+        assertEquals(1, records.count());
+        ConsumerRecord<Integer, String> record = records.iterator().next();
+        assertEquals(1, record.key().intValue());
+        assertEquals("value", record.value());
+
+        log.info("LOOKUP_CACHE {}", KopBrokerLookupManager.LOOKUP_CACHE);
+        log.info("KOP_ADDRESS_CACHE {}", KopBrokerLookupManager.KOP_ADDRESS_CACHE);
+
+        assertFalse(KopBrokerLookupManager.LOOKUP_CACHE.isEmpty());
+        assertFalse(KopBrokerLookupManager.KOP_ADDRESS_CACHE.isEmpty());
+
+        pulsar.getAdminClient().topics().unload(topic);
+
+        Awaitility.await().untilAsserted(() -> {
+            log.info("LOOKUP_CACHE {}", KopBrokerLookupManager.LOOKUP_CACHE);
+            log.info("KOP_ADDRESS_CACHE {}", KopBrokerLookupManager.KOP_ADDRESS_CACHE);
+            assertTrue(KopBrokerLookupManager.LOOKUP_CACHE.isEmpty());
+            assertTrue(KopBrokerLookupManager.KOP_ADDRESS_CACHE.isEmpty());
+        });
+
+    }
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+    }
+
+    @AfterClass
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CacheInvalidatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CacheInvalidatorTest.java
@@ -38,7 +38,7 @@ import org.testng.annotations.Test;
 public class CacheInvalidatorTest extends KopProtocolHandlerTestBase {
 
 
-    @Test(timeOut = 20000, enabled = false)
+    @Test(timeOut = 20000)
     public void testCacheInvalidatorIsTriggered() throws Exception {
         String topic = "testCacheInvalidatorIsTriggered";
         @Cleanup

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CacheInvalidatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CacheInvalidatorTest.java
@@ -23,8 +23,6 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
-
-import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -79,7 +77,8 @@ public class CacheInvalidatorTest extends KopProtocolHandlerTestBase {
         assertFalse(KopBrokerLookupManager.KOP_ADDRESS_CACHE.isEmpty());
         assertFalse(KopBrokerLookupManager.LOOKUP_CACHE.isEmpty());
 
-        BundlesData bundles = pulsar.getAdminClient().namespaces().getBundles(conf.getKafkaTenant() + "/" + conf.getKafkaNamespace());
+        BundlesData bundles = pulsar.getAdminClient().namespaces().getBundles(
+                conf.getKafkaTenant() + "/" + conf.getKafkaNamespace());
         List<String> boundaries = bundles.getBoundaries();
         for (int i = 0; i < boundaries.size() - 1; i++) {
             String bundle = String.format("%s_%s", boundaries.get(i), boundaries.get(i + 1));

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CacheInvalidatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CacheInvalidatorTest.java
@@ -57,14 +57,14 @@ public class CacheInvalidatorTest extends KopProtocolHandlerTestBase {
         producerProps.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 1000 * 10);
         producerProps.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId);
 
-        try (KafkaProducer<Integer, String> producer = new KafkaProducer<>(producerProps);) {
+        try (KafkaProducer<Integer, String> producer = new KafkaProducer<>(producerProps)) {
             producer.initTransactions();
             producer.beginTransaction();
             producer.send(new ProducerRecord<>(topicName, 1, "value")).get();
             producer.commitTransaction();
         }
 
-        try (KConsumer kConsumer = new KConsumer(topicName, getKafkaBrokerPort(), true);) {
+        try (KConsumer kConsumer = new KConsumer(topicName, getKafkaBrokerPort(), true)) {
             kConsumer.getConsumer().subscribe(Collections.singleton(topicName));
             ConsumerRecords<Integer, String> records = kConsumer.getConsumer().poll(Duration.ofSeconds(5));
             assertNotNull(records);


### PR DESCRIPTION
With the new Tenant Aware Metadata Topics feature (https://github.com/streamnative/kop/commit/d4f996039cb3f52bed5bd2cc59d626ecbb7984ee) now we initialise the OffsetAndTopicListener listener lazily.
Before this patch `OffsetAndTopicListener` was responsible for invalidating the `KopBrokerLookupManager` caches.
But as we initialise it lazily it would be possible to miss some cache invalidations.

This patch introduces a dedicated listener `CacheInvalidator` that invalidates the caches for every change that is detected.