### PR TITLE
Bump pulsar to 2.8.1.0

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/InternalServerCnx.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/InternalServerCnx.java
@@ -62,6 +62,7 @@ public class InternalServerCnx extends ServerCnx {
     // called after channel active
     public void updateCtx(final SocketAddress remoteAddress) {
         this.remoteAddress = remoteAddress;
+        this.ctx = kafkaRequestHandler.ctx;
     }
 
     @Override
@@ -77,5 +78,15 @@ public class InternalServerCnx extends ServerCnx {
     @Override
     public void cancelPublishBufferLimiting() {
         // do nothing is this mock
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
     <pulsar.group.id>io.streamnative</pulsar.group.id>
-    <pulsar.version>2.8.0.3</pulsar.version>
+    <pulsar.version>2.8.1.0</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testcontainers.version>1.15.1</testcontainers.version>


### PR DESCRIPTION
This PR migrates https://github.com/streamnative/kop/pull/692 for master branch.

Since we will upgrade Pulsar to 2.9.0 later, which might bring more incompatibilities, this PR migrates the fix for branch-2.8.1 first.