### PR TITLE
Adjust the log level

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -244,7 +244,9 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             return extractTenantFromTenantSpec(tenantSpec);
         }
         // fallback to using system (default) tenant
-        log.debug("using {} as tenant", kafkaConfig.getKafkaMetadataTenant());
+        if (log.isDebugEnabled()) {
+            log.debug("using {} as tenant", kafkaConfig.getKafkaMetadataTenant());
+        }
         return kafkaConfig.getKafkaMetadataTenant();
     }
 
@@ -255,7 +257,9 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             if (tenantSpec.contains("/")) {
                 tenant = tenantSpec.substring(0, tenantSpec.indexOf('/'));
             }
-            log.debug("using {} as tenant", tenant);
+            if (log.isDebugEnabled()) {
+                log.debug("using {} as tenant", tenant);
+            }
             return tenant;
         } else {
             return tenantSpec;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManager.java
@@ -303,7 +303,10 @@ public class KopEventManager {
                     topicsFullNameDeletionsSets.add(kopTopic.getFullName());
                 });
 
-                log.debug("Delete topics listener fired for topics {} to be deleted", topicsDeletions);
+                if (log.isDebugEnabled()) {
+                    log.debug("Delete topics listener fired for topics {} to be deleted", topicsDeletions);
+                }
+
                 Iterable<GroupMetadata> groupMetadataIterable = coordinator.getGroupManager().currentGroups();
                 HashSet<TopicPartition> topicPartitionsToBeDeletions = Sets.newHashSet();
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
@@ -180,7 +180,9 @@ public class SaslAuthenticator {
                              Function<Session, Boolean> tenantAccessValidationFunction)
             throws AuthenticationException {
         checkArgument(requestBuf.readableBytes() > 0);
-        log.info("Authenticate {} {} {}", ctx, saslServer, state);
+        if (log.isDebugEnabled()) {
+            log.debug("Authenticate {} {} {}", ctx, saslServer, state);
+        }
 
         this.ctx = ctx;
         if (saslServer != null && saslServer.isComplete()) {
@@ -504,8 +506,6 @@ public class SaslAuthenticator {
                     log.debug("Authenticate failed for client, header {}, request {}, reason {}",
                             header, saslAuthenticateRequest, e.getMessage());
                 }
-                log.error("Authenticate failed for client, header {}, request {}, reason {}",
-                        header, saslAuthenticateRequest, e.getMessage());
             }
         }
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/EntryPublishTimeKafkaFormatTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/EntryPublishTimeKafkaFormatTest.java
@@ -81,7 +81,9 @@ public class EntryPublishTimeKafkaFormatTest extends EntryPublishTimeTest {
                             i,
                             messageStr))
                     .get();
-            log.debug("Kafka Producer Sent message: ({}, {})", i, messageStr);
+            if (log.isDebugEnabled()) {
+                log.debug("Kafka Producer Sent message: ({}, {})", i, messageStr);
+            }
         }
 
         KConsumer kConsumer = new KConsumer(topicName, "localhost", getKafkaBrokerPort(), false,

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/EntryPublishTimePulsarFormatTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/EntryPublishTimePulsarFormatTest.java
@@ -67,7 +67,9 @@ public class EntryPublishTimePulsarFormatTest extends EntryPublishTimeTest {
                             i,
                             messageStr))
                     .get();
-            log.debug("Kafka Producer Sent message: ({}, {})", i, messageStr);
+            if (log.isDebugEnabled()) {
+                log.debug("Kafka Producer Sent message: ({}, {})", i, messageStr);
+            }
         }
 
         @Cleanup

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
@@ -259,7 +259,9 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
                     i,
                     messageStr))
                 .get();
-            log.debug("Kafka Producer Sent message: ({}, {})", i, messageStr);
+            if (log.isDebugEnabled()) {
+                log.debug("Kafka Producer Sent message: ({}, {})", i, messageStr);
+            }
         }
 
         // 2. real test, for ListOffset request verify Earliest get earliest
@@ -310,7 +312,9 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
                     i,
                     messageStr))
                 .get();
-            log.debug("Kafka Producer Sent message: ({}, {})", i, messageStr);
+            if (log.isDebugEnabled()) {
+                log.debug("Kafka Producer Sent message: ({}, {})", i, messageStr);
+            }
         }
 
         // 2. real test, for ListOffset request verify Earliest get earliest
@@ -477,7 +481,9 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
                             i,
                             messageStr))
                     .get();
-            log.debug("Kafka Producer Sent message: ({}, {})", i, messageStr);
+            if (log.isDebugEnabled()) {
+                log.debug("Kafka Producer Sent message: ({}, {})", i, messageStr);
+            }
         }
 
         // 2. real test, test earliest
@@ -838,14 +844,16 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
         // check metadata response
         Collection<TopicMetadata> topicMetadatas = metadataResponse.topicMetadata();
 
-        log.debug("a. dumpTopicMetadata: ");
-        topicMetadatas.forEach(topicMetadata -> {
-            log.debug("      topicMetadata: {}", topicMetadata);
-            log.debug("b.    dumpPartitionMetadata: ");
-            topicMetadata.partitionMetadata().forEach(partition -> {
-                log.debug("            PartitionMetadata: {}", partition);
+        if (log.isDebugEnabled()) {
+            log.debug("a. dumpTopicMetadata: ");
+            topicMetadatas.forEach(topicMetadata -> {
+                log.debug("      topicMetadata: {}", topicMetadata);
+                log.debug("b.    dumpPartitionMetadata: ");
+                topicMetadata.partitionMetadata().forEach(partition -> {
+                    log.debug("            PartitionMetadata: {}", partition);
+                });
             });
-        });
+        }
 
         assertEquals(topicMetadatas.size(), numberTopics);
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestTypeTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestTypeTest.java
@@ -395,8 +395,10 @@ public class KafkaRequestTypeTest extends KopProtocolHandlerTestBase {
             for (ConsumerRecord<Integer, String> record : records) {
                 Integer key = record.key();
                 assertEquals(messageStrPrefix + key.toString(), record.value());
-                log.debug("Kafka Consumer Received message: {}, {} at offset {}",
-                    record.key(), record.value(), record.offset());
+                if (log.isDebugEnabled()) {
+                    log.debug("Kafka Consumer Received message: {}, {} at offset {}",
+                            record.key(), record.value(), record.offset());
+                }
                 i++;
             }
         }


### PR DESCRIPTION
1. In SaslAuthenticator, we should keep the log level as debug, because authentication is a very frequent occurrence in high-traffic systems, which is often encountered in kafka, the connection and disconnection between the client and the server has been happening all the time . If we need to troubleshoot problems, we can dynamically adjust the log level.
2. Before executing the debug, keep judging whether to enable the debug, even if log4j2 writes the log asynchronously, it can avoid generating unnecessary LogEvent.