### PR TITLE
Disable stats recorder for PulsarClient in group coordinator

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AbstractPulsarClient.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AbstractPulsarClient.java
@@ -1,0 +1,104 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import java.io.Closeable;
+import java.util.function.Consumer;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.PulsarServerException;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.client.api.AuthenticationFactory;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+
+
+/**
+ * The abstraction wrapper of {@link PulsarClientImpl}.
+ */
+@Slf4j
+@Getter
+public abstract class AbstractPulsarClient implements Closeable {
+
+    private final PulsarClientImpl pulsarClient;
+
+    public AbstractPulsarClient(@NonNull final PulsarClientImpl pulsarClient) {
+        this.pulsarClient = pulsarClient;
+    }
+
+    @Override
+    public void close() {
+        try {
+            pulsarClient.close();
+        } catch (PulsarClientException e) {
+            log.warn("Failed to close PulsarClient of LookupClient", e);
+        }
+    }
+
+    protected static PulsarClientImpl createPulsarClient(final PulsarService pulsarService) {
+        try {
+            return (PulsarClientImpl) pulsarService.getClient();
+        } catch (PulsarServerException e) {
+            log.error("Failed to create PulsarClient", e);
+            throw new IllegalStateException(e);
+        }
+    }
+
+    protected static PulsarClientImpl createPulsarClient(final PulsarService pulsarService,
+                                                         final KafkaServiceConfiguration kafkaConfig,
+                                                         final Consumer<ClientConfigurationData> customConfig) {
+        // It's migrated from PulsarService#getClient()
+        final ClientConfigurationData conf = new ClientConfigurationData();
+        conf.setServiceUrl(kafkaConfig.isTlsEnabled()
+                ? pulsarService.getBrokerServiceUrlTls()
+                : pulsarService.getBrokerServiceUrl());
+        conf.setTlsAllowInsecureConnection(kafkaConfig.isTlsAllowInsecureConnection());
+        conf.setTlsTrustCertsFilePath(kafkaConfig.getTlsCertificateFilePath());
+
+        if (kafkaConfig.isBrokerClientTlsEnabled()) {
+            if (kafkaConfig.isBrokerClientTlsEnabledWithKeyStore()) {
+                conf.setUseKeyStoreTls(true);
+                conf.setTlsTrustStoreType(kafkaConfig.getBrokerClientTlsTrustStoreType());
+                conf.setTlsTrustStorePath(kafkaConfig.getBrokerClientTlsTrustStore());
+                conf.setTlsTrustStorePassword(kafkaConfig.getBrokerClientTlsTrustStorePassword());
+            } else {
+                conf.setTlsTrustCertsFilePath(
+                        isNotBlank(kafkaConfig.getBrokerClientTrustCertsFilePath())
+                                ? kafkaConfig.getBrokerClientTrustCertsFilePath()
+                                : kafkaConfig.getTlsCertificateFilePath());
+            }
+        }
+
+        try {
+            if (isNotBlank(kafkaConfig.getBrokerClientAuthenticationPlugin())) {
+                conf.setAuthPluginClassName(kafkaConfig.getBrokerClientAuthenticationPlugin());
+                conf.setAuthParams(kafkaConfig.getBrokerClientAuthenticationParameters());
+                conf.setAuthParamMap(null);
+                conf.setAuthentication(AuthenticationFactory.create(
+                        kafkaConfig.getBrokerClientAuthenticationPlugin(),
+                        kafkaConfig.getBrokerClientAuthenticationParameters()));
+            }
+
+            customConfig.accept(conf);
+            return new PulsarClientImpl(conf);
+        } catch (PulsarClientException e) {
+            log.error("Failed to create PulsarClient", e);
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AbstractPulsarClient.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AbstractPulsarClient.java
@@ -46,7 +46,7 @@ public abstract class AbstractPulsarClient implements Closeable {
         try {
             pulsarClient.close();
         } catch (PulsarClientException e) {
-            log.warn("Failed to close PulsarClient of LookupClient", e);
+            log.warn("Failed to close PulsarClient of {}", getClass().getTypeName(), e);
         }
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -60,8 +60,6 @@ import org.apache.pulsar.broker.protocol.ProtocolHandler;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.client.admin.Lookup;
 import org.apache.pulsar.client.admin.PulsarAdmin;
-import org.apache.pulsar.client.api.PulsarClient;
-import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
@@ -86,6 +84,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     private KopBrokerLookupManager kopBrokerLookupManager;
     private AdminManager adminManager = null;
     private MetadataCache<LocalBrokerData> localBrokerDataCache;
+    private SystemTopicClient offsetTopicClient;
 
     @Getter
     private KafkaServiceConfiguration kafkaConfig;
@@ -343,9 +342,8 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
             throw new IllegalStateException(e);
         }
 
-        // Create PulsarClient for topic lookup, the listenerName will be set if kafkaListenerName is configured.
-        // After it's created successfully, this method won't throw any exception.
         LOOKUP_CLIENT_MAP.put(brokerService.pulsar(), new LookupClient(brokerService.pulsar(), kafkaConfig));
+        offsetTopicClient = new SystemTopicClient(brokerService.pulsar(), kafkaConfig);
 
         brokerService.pulsar()
                 .getNamespaceService()
@@ -398,7 +396,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                     clusterData, kafkaConfig);
 
             // init and start group coordinator
-            groupCoordinator = startGroupCoordinator(tenant, brokerService.getPulsar().getClient());
+            groupCoordinator = startGroupCoordinator(tenant, offsetTopicClient);
 
             // init KopEventManager
             KopEventManager kopEventManager = new KopEventManager(groupCoordinator,
@@ -470,6 +468,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     @Override
     public void close() {
         Optional.ofNullable(LOOKUP_CLIENT_MAP.remove(brokerService.pulsar())).ifPresent(LookupClient::close);
+        offsetTopicClient.close();
         adminManager.shutdown();
         for (Map.Entry<String, GroupCoordinator> groupCoordinator : groupCoordinatorsByTenant.entrySet()) {
             String tenant = groupCoordinator.getKey();
@@ -488,7 +487,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
         statsProvider.stop();
     }
 
-    private GroupCoordinator startGroupCoordinator(String tenant, PulsarClient pulsarClient) {
+    private GroupCoordinator startGroupCoordinator(String tenant, SystemTopicClient client) {
         GroupConfig groupConfig = new GroupConfig(
             kafkaConfig.getGroupMinSessionTimeoutMs(),
             kafkaConfig.getGroupMaxSessionTimeoutMs(),
@@ -507,7 +506,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
             .build();
 
         GroupCoordinator groupCoordinator = GroupCoordinator.of(
-            (PulsarClientImpl) pulsarClient,
+            client,
             groupConfig,
             offsetConfig,
             SystemTimer.builder()
@@ -579,5 +578,4 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     public static @NonNull LookupClient getLookupClient(final PulsarService pulsarService) {
         return LOOKUP_CLIENT_MAP.computeIfAbsent(pulsarService, ignored -> new LookupClient(pulsarService));
     }
-
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/LookupClient.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/LookupClient.java
@@ -13,29 +13,22 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
-
-import java.io.Closeable;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
-import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.lookup.LookupResult;
 import org.apache.pulsar.broker.namespace.LookupOptions;
 import org.apache.pulsar.broker.namespace.NamespaceService;
-import org.apache.pulsar.client.api.AuthenticationFactory;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.ClientCnx;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
-import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.common.api.proto.ServerError;
 import org.apache.pulsar.common.naming.TopicName;
 
@@ -43,18 +36,16 @@ import org.apache.pulsar.common.naming.TopicName;
  * The client that is responsible for topic lookup.
  */
 @Slf4j
-public class LookupClient implements Closeable {
+public class LookupClient extends AbstractPulsarClient {
 
     private final NamespaceService namespaceService;
-    @Getter
-    private final PulsarClientImpl pulsarClient;
 
     private ConcurrentHashMap<String, PulsarClientImpl> pulsarClientMap;
 
     public LookupClient(final PulsarService pulsarService, final KafkaServiceConfiguration kafkaConfig) {
+        super(createPulsarClient(pulsarService, kafkaConfig, conf -> {}));
         namespaceService = pulsarService.getNamespaceService();
         try {
-            pulsarClient = createPulsarClient(pulsarService, kafkaConfig, null);
             pulsarClientMap = createPulsarClientMap(pulsarService, kafkaConfig);
         } catch (PulsarClientException e) {
             log.error("Failed to create PulsarClient", e);
@@ -63,15 +54,10 @@ public class LookupClient implements Closeable {
     }
 
     public LookupClient(final PulsarService pulsarService) {
+        super(createPulsarClient(pulsarService));
         log.warn("This constructor should not be called, it's only called "
                 + "when the PulsarService doesn't exist in KafkaProtocolHandlers.LOOKUP_CLIENT_UP");
         namespaceService = pulsarService.getNamespaceService();
-        try {
-            pulsarClient = (PulsarClientImpl) pulsarService.getClient();
-        } catch (PulsarServerException e) {
-            log.error("Failed to create PulsarClient", e);
-            throw new IllegalStateException(e);
-        }
     }
 
     public CompletableFuture<InetSocketAddress> getBrokerAddress(final TopicName topicName) {
@@ -97,7 +83,7 @@ public class LookupClient implements Closeable {
             final LookupResult lookupResult = optLookupResult.get();
             if (lookupResult.isRedirect()) {
                 // Kafka client can't process redirect field, so here we fallback to PulsarClient
-                return pulsarClientMap.getOrDefault(listenerName == null ? "" : listenerName, pulsarClient).
+                return pulsarClientMap.getOrDefault(listenerName == null ? "" : listenerName, getPulsarClient()).
                         getLookup().getBroker(topicName).thenApply(Pair::getLeft);
             } else {
                 return getAddressFutureFromBrokerUrl(lookupResult.getLookupData().getBrokerUrl());
@@ -105,65 +91,19 @@ public class LookupClient implements Closeable {
         });
     }
 
-    @Override
-    public void close() {
-        try {
-            pulsarClient.close();
-        } catch (PulsarClientException e) {
-            log.warn("Failed to close PulsarClient of LookupClient", e);
-        }
-    }
-
     private ConcurrentHashMap<String, PulsarClientImpl> createPulsarClientMap(
             PulsarService pulsarService, KafkaServiceConfiguration kafkaConfig) throws PulsarClientException {
         ConcurrentHashMap<String, PulsarClientImpl> pulsarClientMap = new ConcurrentHashMap<>();
         final Map<String, SecurityProtocol> protocolMap = EndPoint.parseProtocolMap(kafkaConfig.getKafkaProtocolMap());
         if (protocolMap.isEmpty()) {
-            pulsarClientMap.put("", pulsarClient);
+            pulsarClientMap.put("", getPulsarClient());
         } else {
             for (Map.Entry<String, SecurityProtocol> entry : protocolMap.entrySet()) {
-                pulsarClientMap.put(entry.getKey(), createPulsarClient(pulsarService, kafkaConfig, entry.getKey()));
+                pulsarClientMap.put(entry.getKey(), createPulsarClient(
+                        pulsarService, kafkaConfig, conf -> conf.setListenerName(entry.getKey())));
             }
         }
         return pulsarClientMap;
-    }
-
-    private static PulsarClientImpl createPulsarClient(
-            final PulsarService pulsarService, final KafkaServiceConfiguration kafkaConfig,
-            final String listenerName) throws PulsarClientException {
-        // It's migrated from PulsarService#getClient() but it can configure listener name
-        final ClientConfigurationData conf = new ClientConfigurationData();
-        conf.setServiceUrl(kafkaConfig.isTlsEnabled()
-                ? pulsarService.getBrokerServiceUrlTls()
-                : pulsarService.getBrokerServiceUrl());
-        conf.setTlsAllowInsecureConnection(kafkaConfig.isTlsAllowInsecureConnection());
-        conf.setTlsTrustCertsFilePath(kafkaConfig.getTlsCertificateFilePath());
-
-        if (kafkaConfig.isBrokerClientTlsEnabled()) {
-            if (kafkaConfig.isBrokerClientTlsEnabledWithKeyStore()) {
-                conf.setUseKeyStoreTls(true);
-                conf.setTlsTrustStoreType(kafkaConfig.getBrokerClientTlsTrustStoreType());
-                conf.setTlsTrustStorePath(kafkaConfig.getBrokerClientTlsTrustStore());
-                conf.setTlsTrustStorePassword(kafkaConfig.getBrokerClientTlsTrustStorePassword());
-            } else {
-                conf.setTlsTrustCertsFilePath(
-                        isNotBlank(kafkaConfig.getBrokerClientTrustCertsFilePath())
-                                ? kafkaConfig.getBrokerClientTrustCertsFilePath()
-                                : kafkaConfig.getTlsCertificateFilePath());
-            }
-        }
-
-        if (isNotBlank(kafkaConfig.getBrokerClientAuthenticationPlugin())) {
-            conf.setAuthPluginClassName(kafkaConfig.getBrokerClientAuthenticationPlugin());
-            conf.setAuthParams(kafkaConfig.getBrokerClientAuthenticationParameters());
-            conf.setAuthParamMap(null);
-            conf.setAuthentication(AuthenticationFactory.create(
-                    kafkaConfig.getBrokerClientAuthenticationPlugin(),
-                    kafkaConfig.getBrokerClientAuthenticationParameters()));
-        }
-
-        conf.setListenerName(listenerName);
-        return new PulsarClientImpl(conf, pulsarService.getIoEventLoopGroup());
     }
 
     private static CompletableFuture<InetSocketAddress> getFailedAddressFuture(final Throwable throwable) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SystemTopicClient.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SystemTopicClient.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import java.nio.ByteBuffer;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.ProducerBuilder;
+import org.apache.pulsar.client.api.ReaderBuilder;
+import org.apache.pulsar.client.api.Schema;
+
+/**
+ * The client that is used to create producers and readers for system topics like __consumer_offsets.
+ */
+public class SystemTopicClient extends AbstractPulsarClient {
+
+    public SystemTopicClient(final PulsarService pulsarService, final KafkaServiceConfiguration kafkaConfig) {
+        // Disable stats recorder for producer and readers
+        super(createPulsarClient(pulsarService, kafkaConfig, conf -> conf.setStatsIntervalSeconds(0L)));
+    }
+
+    public ProducerBuilder<ByteBuffer> newProducerBuilder() {
+        return getPulsarClient().newProducer(Schema.BYTEBUFFER);
+    }
+
+    public ReaderBuilder<ByteBuffer> newReaderBuilder() {
+        return getPulsarClient().newReader(Schema.BYTEBUFFER)
+                .startMessageId(MessageId.earliest);
+    }
+}


### PR DESCRIPTION
### Motivation
The `PulsarClient` object returned by `PulsarService#getClient` doesn't change the default `statsIntervalSeconds` config, Therebefore, each producer or reader created in `GroupMetadataManager` will has an internal `ProducerStatsRecorderImpl` or `ConsumerStatsRecorderImpl` object, which triggers a `TimerTask` whose period is 60 seconds. It's a waste of CPU usage especially when the offset topic's partitions number is large.

### Modifications
Since we have already defined our own `PulsarClient` wrapper (`LookupClient`) for topic lookup, this PR adds a common abstract class `AbstractPulsarClient` to customize the client config. Then add a `SystemTopicClient` class that configures `statsIntervalSeconds` with zero value to disable stats recorder.