### PR TITLE
[FEATURE] Add authorization to create topic and delete topic requests

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
@@ -32,6 +32,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.Node;
@@ -213,20 +214,17 @@ class AdminManager {
         return resultFuture;
     }
 
-    public Map<String, Errors> deleteTopics(Set<String> topicsToDelete) {
-        Map<String, Errors> result = new ConcurrentHashMap<>();
-        topicsToDelete.forEach(topic -> {
-            try {
-                String topicFullName = new KopTopic(topic).getFullName();
-                admin.topics().deletePartitionedTopic(topicFullName);
-                result.put(topic, Errors.NONE);
-                log.info("delete topic {} successfully.", topicFullName);
-            } catch (PulsarAdminException e) {
-                log.error("delete topic {} failed, exception: ", topic, e);
-                result.put(topic, Errors.UNKNOWN_TOPIC_OR_PARTITION);
-            }
-        });
-        return result;
+    public void deleteTopic(String topicToDelete,
+                            Consumer<String> successConsumer,
+                            Consumer<String> errorConsumer) {
+        try {
+            admin.topics().deletePartitionedTopic(topicToDelete);
+            successConsumer.accept(topicToDelete);
+            log.info("delete topic {} successfully.", topicToDelete);
+        } catch (PulsarAdminException e) {
+            log.error("delete topic {} failed, exception: ", topicToDelete, e);
+            errorConsumer.accept(topicToDelete);
+        }
     }
 
     public Collection<? extends Node> getBrokers() {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -1909,6 +1909,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             authorize(AclOperation.CREATE, Resource.of(ResourceType.TOPIC, fullTopicName))
                     .whenComplete((isAuthorized, ex) -> {
                        if (ex != null) {
+                           log.error("CreateTopics authorize failed, topic - {}. {}",
+                                   fullTopicName, ex.getMessage());
                            completeOneErrorTopic
                                    .accept(topic, new ApiError(Errors.TOPIC_AUTHORIZATION_FAILED, ex.getMessage()));
                            return;
@@ -2175,7 +2177,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             authorize(AclOperation.DELETE, Resource.of(ResourceType.TOPIC, fullTopicName))
                     .whenComplete((isAuthorize, ex) -> {
                         if (ex != null) {
-                            log.error("Describe topic authorize failed, topic - {}. {}",
+                            log.error("DeleteTopics authorize failed, topic - {}. {}",
                                     fullTopicName, ex.getMessage());
                             completeOne.accept(topic, Errors.TOPIC_AUTHORIZATION_FAILED);
                             return;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -2577,7 +2577,9 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 break;
             case CREATE:
             case DELETE:
-                isAuthorizedFuture = authorizer.canAccessTopicAsync(session.getPrincipal(), resource);
+            case DESCRIBE_CONFIGS:
+            case ALTER_CONFIGS:
+                isAuthorizedFuture = authorizer.canManageTenantAsync(session.getPrincipal(), resource);
                 break;
             case ANY:
                 if (resource.getResourceType() == ResourceType.TENANT) {
@@ -2585,8 +2587,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 }
                 break;
             case CLUSTER_ACTION:
-            case DESCRIBE_CONFIGS:
-            case ALTER_CONFIGS:
             case ALTER:
             case UNKNOWN:
             case ALL:

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/Authorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/Authorizer.java
@@ -42,6 +42,15 @@ public interface Authorizer {
     CompletableFuture<Boolean> canAccessTenantAsync(KafkaPrincipal principal, Resource resource);
 
     /**
+     * Check whether the specified role can create or delete topic.
+     *
+     * @param principal login info
+     * @param resource resources to be authorized
+     * @return a boolean to determine whether authorized or not
+     */
+    CompletableFuture<Boolean> canAccessTopicAsync(KafkaPrincipal principal, Resource resource);
+
+    /**
      * Check whether the specified role can perform a produce for the specified topic.
      *
      * For that the caller needs to have producer permission.

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/Authorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/Authorizer.java
@@ -42,13 +42,14 @@ public interface Authorizer {
     CompletableFuture<Boolean> canAccessTenantAsync(KafkaPrincipal principal, Resource resource);
 
     /**
-     * Check whether the specified role can create or delete topic.
+     * Check whether the specified role can manage Pulsar tenant.
+     * This permission mapping to pulsar is Tenant Admin or Super Admin.
      *
      * @param principal login info
      * @param resource resources to be authorized
      * @return a boolean to determine whether authorized or not
      */
-    CompletableFuture<Boolean> canAccessTopicAsync(KafkaPrincipal principal, Resource resource);
+    CompletableFuture<Boolean> canManageTenantAsync(KafkaPrincipal principal, Resource resource);
 
     /**
      * Check whether the specified role can perform a produce for the specified topic.

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
@@ -263,6 +263,16 @@ public class SimpleAclAuthorizer implements Authorizer {
     }
 
     @Override
+    public CompletableFuture<Boolean> canAccessTopicAsync(KafkaPrincipal principal, Resource resource) {
+        checkArgument(resource.getResourceType() == ResourceType.TOPIC,
+                String.format("Expected resource type is TOPIC, but have [%s]", resource.getResourceType()));
+
+        TopicName topicName = TopicName.get(resource.getName());
+        NamespaceName namespace = topicName.getNamespaceObject();
+        return isSuperUserOrTenantAdmin(namespace.getTenant(), principal.getName());
+    }
+
+    @Override
     public CompletableFuture<Boolean> canLookupAsync(KafkaPrincipal principal, Resource resource) {
         checkArgument(resource.getResourceType() == ResourceType.TOPIC,
                 String.format("Expected resource type is TOPIC, but have [%s]", resource.getResourceType()));

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
@@ -263,7 +263,7 @@ public class SimpleAclAuthorizer implements Authorizer {
     }
 
     @Override
-    public CompletableFuture<Boolean> canAccessTopicAsync(KafkaPrincipal principal, Resource resource) {
+    public CompletableFuture<Boolean> canManageTenantAsync(KafkaPrincipal principal, Resource resource) {
         checkArgument(resource.getResourceType() == ResourceType.TOPIC,
                 String.format("Expected resource type is TOPIC, but have [%s]", resource.getResourceType()));
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationTestBase.java
@@ -35,7 +35,10 @@ import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.DeleteTopicsResult;
 import org.apache.kafka.clients.admin.ListTopicsResult;
+import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -275,15 +278,7 @@ public abstract class KafkaAuthorizationTestBase extends KopProtocolHandlerTestB
         assertTrue(result.containsKey(newTopic));
 
         // Check AdminClient use specific user to list topic
-        Properties props = new Properties();
-        props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getKafkaBrokerPort());
-        String jaasTemplate = "org.apache.kafka.common.security.plain.PlainLoginModule "
-                + "required username=\"%s\" password=\"%s\";";
-        String jaasCfg = String.format(jaasTemplate, TENANT + "/" + NAMESPACE, "token:" + anotherToken);
-        props.put("sasl.jaas.config", jaasCfg);
-        props.put("security.protocol", "SASL_PLAINTEXT");
-        props.put("sasl.mechanism", "PLAIN");
-        AdminClient adminClient = AdminClient.create(props);
+        AdminClient adminClient = createAdminClient(TENANT + "/" + NAMESPACE, anotherToken);
         ListTopicsResult listTopicsResult = adminClient.listTopics();
         Set<String> topics = listTopicsResult.names().get();
 
@@ -398,6 +393,103 @@ public abstract class KafkaAuthorizationTestBase extends KopProtocolHandlerTestB
             // Cleanup
             admin.topics().deletePartitionedTopic(testTopic);
         }
+    }
+
+    @Test(timeOut = 20000)
+    public void testCreateTopicSuccess() throws ExecutionException, InterruptedException, PulsarAdminException {
+        String newTopic = "testCreateTopicSuccess";
+        String fullNewTopicName = "persistent://" + TENANT + "/" + NAMESPACE + "/" + newTopic;
+
+        AdminClient adminClient = createAdminClient(TENANT + "/" + NAMESPACE, adminToken);
+        CreateTopicsResult result =
+                adminClient.createTopics(Collections.singleton(new NewTopic(fullNewTopicName, 1, (short) 1)));
+        result.all().get();
+
+        try {
+            admin.topics().createPartitionedTopic(fullNewTopicName, 1);
+        } catch (PulsarAdminException exception) {
+            assertTrue(exception.getMessage().contains("This topic already exists"));
+        }
+        admin.topics().deletePartitionedTopic(fullNewTopicName);
+        adminClient.close();
+    }
+
+    @Test(timeOut = 20000)
+    public void testCreateTopicFailed() throws PulsarAdminException {
+        String newTopic = "testCreateTopicFailed";
+        String fullNewTopicName = "persistent://" + TENANT + "/" + NAMESPACE + "/" + newTopic;
+
+        AdminClient adminClient = createAdminClient(TENANT + "/" + NAMESPACE, userToken);
+        CreateTopicsResult result =
+                adminClient.createTopics(Collections.singleton(new NewTopic(fullNewTopicName, 1, (short) 1)));
+        try {
+            result.all().get();
+        } catch (ExecutionException | InterruptedException ex) {
+            assertTrue(ex.getMessage().contains("TopicAuthorizationException"));
+        }
+        admin.topics().createPartitionedTopic(fullNewTopicName, 1);
+        admin.topics().deletePartitionedTopic(fullNewTopicName);
+        adminClient.close();
+    }
+
+    @Test(timeOut = 20000)
+    public void testDeleteTopicSuccess() throws PulsarAdminException, InterruptedException {
+        String newTopic = "testDeleteTopicSuccess";
+        String fullNewTopicName = "persistent://" + TENANT + "/" + NAMESPACE + "/" + newTopic;
+
+        admin.topics().createPartitionedTopic(fullNewTopicName, 1);
+
+        AdminClient adminClient = createAdminClient(TENANT + "/" + NAMESPACE, adminToken);
+        DeleteTopicsResult deleteTopicsResult = adminClient.deleteTopics(Collections.singletonList(newTopic));
+        try {
+            deleteTopicsResult.all().get();
+        } catch (ExecutionException ex) {
+            fail("Should success but have : " + ex.getMessage());
+        }
+        List<String> topicList = admin.topics().getList(TENANT + "/" + NAMESPACE);
+        topicList.forEach(topic -> {
+            if (topic.startsWith(fullNewTopicName)) {
+                fail("Delete topic failed!");
+            }
+        });
+
+        adminClient.close();
+    }
+
+    @Test(timeOut = 20000)
+    public void testDeleteTopicFailed() throws PulsarAdminException, InterruptedException {
+        String newTopic = "testDeleteTopicFailed";
+        String fullNewTopicName = "persistent://" + TENANT + "/" + NAMESPACE + "/" + newTopic;
+
+        admin.topics().createPartitionedTopic(fullNewTopicName, 1);
+
+        AdminClient adminClient = createAdminClient(TENANT + "/" + NAMESPACE, userToken);
+        DeleteTopicsResult deleteTopicsResult = adminClient.deleteTopics(Collections.singletonList(newTopic));
+        try {
+            deleteTopicsResult.all().get();
+            fail("Should delete failed!");
+        } catch (ExecutionException ex) {
+            assertTrue(ex.getMessage().contains("TopicAuthorizationException"));
+        }
+        try {
+            admin.topics().createPartitionedTopic(fullNewTopicName, 1);
+        } catch (PulsarAdminException exception) {
+            assertTrue(exception.getMessage().contains("This topic already exists"));
+        }
+        admin.topics().deletePartitionedTopic(fullNewTopicName);
+        adminClient.close();
+    }
+
+    private AdminClient createAdminClient(String username, String token) {
+        Properties props = new Properties();
+        props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getKafkaBrokerPort());
+        String jaasTemplate = "org.apache.kafka.common.security.plain.PlainLoginModule "
+                + "required username=\"%s\" password=\"%s\";";
+        String jaasCfg = String.format(jaasTemplate, username, "token:" + token);
+        props.put("sasl.jaas.config", jaasCfg);
+        props.put("security.protocol", "SASL_PLAINTEXT");
+        props.put("sasl.mechanism", "PLAIN");
+        return AdminClient.create(props);
     }
 
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizerTest.java
@@ -238,6 +238,11 @@ public class SimpleAclAuthorizerTest extends KopProtocolHandlerTestBase {
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertTrue(isAuthorized);
 
+        // TENANT_ADMIN_USER can create or delete Topic
+        isAuthorized = simpleAclAuthorizer.canAccessTopicAsync(
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TENANT_ADMIN_USER, null),
+                Resource.of(ResourceType.TOPIC, TOPIC)).get();
+        assertTrue(isAuthorized);
     }
 
     @Test

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizerTest.java
@@ -239,7 +239,7 @@ public class SimpleAclAuthorizerTest extends KopProtocolHandlerTestBase {
         assertTrue(isAuthorized);
 
         // TENANT_ADMIN_USER can create or delete Topic
-        isAuthorized = simpleAclAuthorizer.canAccessTopicAsync(
+        isAuthorized = simpleAclAuthorizer.canManageTenantAsync(
                 new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TENANT_ADMIN_USER, null),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertTrue(isAuthorized);


### PR DESCRIPTION
## Motivation
Currently KoP don't support authorization when users use adminClient to create topic or delete topic. So we need support this feature. 

In Pulsar, create or delete topic should have tenantAdmin or SuperAdmin permission, this implementation will follow the pulsar way.

## Modifications
* Add authorization to `handleCreateTopics`
* Add authorization to `handleDeleteTopics`
* Add new test units for create or delete topic permissions
* Add new test units for create topic with authorization
* Add new test units for delete topic with authorization
