### PR TITLE
Update docs for multiple listeners and non-partitioned topic support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,9 +13,9 @@
 > 
 > Among all configurations, only `kafkaListeners` or `listeners` (deprecated) is required.
 
-To support multiple listeners, you need to specify different listener name in [`advertisedListeners`](https://pulsar.apache.org/docs/en/concepts-multiple-advertised-listeners/#use-multiple-advertised-listeners). Then map the listener name to the proper protocol in `kafkaProtocolMap`.
+To support multiple listeners, you need to specify different listener names in [`advertisedListeners`](https://pulsar.apache.org/docs/en/concepts-multiple-advertised-listeners/#use-multiple-advertised-listeners). Then map the listener name to the proper protocol in `kafkaProtocolMap`.
 
-For example, assuming you're going to listen on port 9092 and 19092 with the `PLAINTEXT` protocol, the associated names are `kafka_internal` and `kafka_external`. Then you need to add following configurations:
+For example, assuming you're going to listen on port 9092 and 19092 with the `PLAINTEXT` protocol, the associated names are `kafka_internal` and `kafka_external`. Then you need to add the following configurations:
 
 ```properties
 kafkaListeners=kafka_internal://localhost:9092,kafka_external://localhost:19092

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,7 +7,6 @@
 | kafkaListeners           | Comma-separated list of URIs that we will listen on and the listener names.<br>e.g. PLAINTEXT://localhost:9092,SSL://localhost:9093.<br>If the hostname is not set, the default interface is used. |
 | listeners                | Deprecated. `kafkaListeners` is used.                   |
 | kafkaAdvertisedListeners | Listeners published to the ZooKeeper for clients to use.<br>The format is the same as `kafkaListeners`. |
-| kafkaListenerName        | Specify the internal listener name for the broker.<br>The listener name must be contained in the advertisedListeners.<br>This config is used as the listener name in topic lookup. |
 
 > **NOTE**
 > 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,7 +15,7 @@
 
 To support multiple listeners, you need to specify different listener names in [`advertisedListeners`](https://pulsar.apache.org/docs/en/concepts-multiple-advertised-listeners/#use-multiple-advertised-listeners). Then map the listener name to the proper protocol in `kafkaProtocolMap`.
 
-For example, assuming you're going to listen on port 9092 and 19092 with the `PLAINTEXT` protocol, the associated names are `kafka_internal` and `kafka_external`. Then you need to add the following configurations:
+For example, assuming you need to listen on port 9092 and 19092 with the `PLAINTEXT` protocol, the associated names are `kafka_internal` and `kafka_external`. Then you need to add the following configurations:
 
 ```properties
 kafkaListeners=kafka_internal://localhost:9092,kafka_external://localhost:19092
@@ -23,10 +23,10 @@ kafkaProtocolMap=kafka_internal:PLAINTEXT,kafka_external:PLAINTEXT
 advertisedListeners=pulsar:pulsar://localhost:6650,kafka_internal:pulsar://localhost:9092,kafka_external:pulsar://localhost:19092
 ```
 
-In above example,
-- `kafkaListener` is split into multiple tokens by `,`, each token's format is `<listener-name>://<host>:<port>`.
-- `kafkaProtocolMap` is split into multiple tokens by `,`, each token's format is `<listener-name>:<protocol>`.
-- `advertisedListeners` is split into multiple tokens by `,`, each token's format is `<listener-name>:<scheme>://<host>:<port>`.
+In the above example,
+- `kafkaListener` is split into multiple tokens by a comma (`,`), the format of each token format is `<listener-name>://<host>:<port>`.
+- `kafkaProtocolMap` is split into multiple tokens by a comma (`,`), the format of each token format is `<listener-name>:<protocol>`.
+- `advertisedListeners` is split into multiple tokens by a comma(`,`), the format of each token format is `<listener-name>:<scheme>://<host>:<port>`.
 
 > **NOTE**
 >

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,12 +5,33 @@
 | Name                     | Description                                                  |
 | ------------------------ | ------------------------------------------------------------ |
 | kafkaListeners           | Comma-separated list of URIs that we will listen on and the listener names.<br>e.g. PLAINTEXT://localhost:9092,SSL://localhost:9093.<br>If the hostname is not set, the default interface is used. |
+| kafkaProtocolMap         | Comma-separated map of listener name and protocol.<br>e.g. PRIVATE:PLAINTEXT,PRIVATE_SSL:SSL,PUBLIC:PLAINTEXT,PUBLIC_SSL:SSL. |
 | listeners                | Deprecated. `kafkaListeners` is used.                   |
-| kafkaAdvertisedListeners | Listeners published to the ZooKeeper for clients to use.<br>The format is the same as `kafkaListeners`. |
+| kafkaAdvertisedListeners | Deprecated. Use kafkaProtocolMap, kafkaListeners and advertisedAddress instead. |
 
 > **NOTE**
 > 
 > Among all configurations, only `kafkaListeners` or `listeners` (deprecated) is required.
+
+To support multiple listeners, you need to specify different listener name in [`advertisedListeners`](https://pulsar.apache.org/docs/en/concepts-multiple-advertised-listeners/#use-multiple-advertised-listeners). Then map the listener name to the proper protocol in `kafkaProtocolMap`.
+
+For example, assuming you're going to listen on port 9092 and 19092 with the `PLAINTEXT` protocol, the associated names are `kafka_internal` and `kafka_external`. Then you need to add following configurations:
+
+```properties
+kafkaListeners=kafka_internal://localhost:9092,kafka_external://localhost:19092
+kafkaProtocolMap=kafka_internal:PLAINTEXT,kafka_external:PLAINTEXT
+advertisedListeners=pulsar:pulsar://localhost:6650,kafka_internal:pulsar://localhost:9092,kafka_external:pulsar://localhost:19092
+```
+
+In above example,
+- `kafkaListener` is split into multiple tokens by `,`, each token's format is `<listener-name>://<host>:<port>`.
+- `kafkaProtocolMap` is split into multiple tokens by `,`, each token's format is `<listener-name>:<protocol>`.
+- `advertisedListeners` is split into multiple tokens by `,`, each token's format is `<listener-name>:<scheme>://<host>:<port>`.
+
+> **NOTE**
+>
+> In Pulsar, the `scheme` part could be `pulsar` or `pulsar+ssl`, but in KoP, the `scheme` part must be `pulsar`.
+
 
 ## Logger
 

--- a/docs/kop.md
+++ b/docs/kop.md
@@ -75,7 +75,7 @@ After you copy the `.nar` file to your Pulsar `/protocols` directory, you need t
     | `protocolHandlerDirectory`|./protocols  | Location of KoP NAR file |
     | `allowAutoTopicCreationType`| non-partitioned | partitioned |
 
-    By default, `allowAutoTopicCreationType` is set to `non-partitioned`. You need to set `allowAutoTopicCreationType` to `partitioned` because KoP only supports partitioned topics. If not, topics automatically created by KoP are still partitioned topics, yet topics created automatically by the Pulsar broker are non-partitioned topics.
+    By default, `allowAutoTopicCreationType` is set to `non-partitioned`. Since topics are partitioned by default in Kafka, it's better to avoid creating non-partitioned topics for Kafka clients unless Kafka clients need to interact with existing non-partitioned topics.
 
 2. Set Kafka listeners.
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -202,13 +202,6 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
     )
     private String kafkaAdvertisedListeners;
 
-    @Deprecated
-    @FieldContext(
-            category = CATEGORY_KOP,
-            doc = "Use kafkaProtocolMap, kafkaListeners and advertisedAddress instead."
-    )
-    private String kafkaListenerName;
-
     @FieldContext(
             category = CATEGORY_KOP,
             doc = "limit the queue size for request, \n"

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
@@ -135,7 +135,6 @@ public class KafkaServiceConfigurationTest {
         assertEquals(kafkaServiceConfig.getManagedLedgerDigestType(), DigestType.CRC32C);
         assertEquals(
                 kafkaServiceConfig.getKopAllowedNamespaces(), Sets.newHashSet("public/default", "public/__kafka"));
-        assertEquals(kafkaServiceConfig.getKafkaListenerName(), "external");
     }
 
     @Test

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaListenerNameTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaListenerNameTest.java
@@ -52,7 +52,6 @@ public class KafkaListenerNameTest extends KopProtocolHandlerTestBase {
                 "pulsar:pulsar://" + localAddress + ":" + brokerPort
                         + ",kafka:pulsar://" + "localhost:" + kafkaBrokerPort;
         conf.setAdvertisedListeners(advertisedListeners);
-        conf.setKafkaListenerName("kafka");
         log.info("Set advertisedListeners to {}", advertisedListeners);
         super.internalSetup();
 


### PR DESCRIPTION
### Motivation

https://github.com/streamnative/kop/pull/690 supports non-partitioned topics and https://github.com/streamnative/kop/pull/742 supports multiple listeners and marks some configs as deprecated, so the current documents are outdated. 

### Modification
Even if KoP supports non-partitioned topics now, it's still better to configure `allowAutoTopicCreationType` with `partitioned` by default. This PR modified the explanation for the reason.

This PR also adds docs for how to enable multiple listeners and updates the related configuration docs.

In addition, https://github.com/streamnative/kop/pull/742 marks `kafkaListenerName` as deprecated, but it also makes this config not work anymore. So this PR removes the config and related tests.