### PR TITLE
[FEATURE] Add authorization to handle offset commit requests

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -1632,7 +1632,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 return;
             }
             String fullTopicName = kopTopic.getFullName();
-            authorize(AclOperation.WRITE, Resource.of(ResourceType.TOPIC, fullTopicName))
+            authorize(AclOperation.READ, Resource.of(ResourceType.TOPIC, fullTopicName))
                     .whenComplete((isAuthorized, ex) -> {
                         if (ex != null) {
                             log.error("OffsetCommit authorize failed, topic - {}. {}",


### PR DESCRIPTION
## Motivation
Currently KoP don't support authorization when consumer commit offset.

## Modifications
* Add authorization to `handleOffsetCommitRequest`
* Add new units test in `KafkaRequestHandlerWithAuthorizationTest`
