### PR TITLE
Add Known Compatibility Issues docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Since Pulsar 2.6.2, KoP version changes with Pulsar version accordingly. The ver
 | [0.2.0](https://github.com/streamnative/kop/releases/tag/v0.2.0) |Pulsar 2.5.0|
 | [0.1.0](https://github.com/streamnative/kop/releases/tag/v0.1.0) |Pulsar 2.5.0|
 
+##Known Compatibility Issues
+KoP-2.8.0.13, 2.8.0.14, 2.8.0.15 and 2.8.0.16 minor versions with Pulsar-2.8.0 have a known compatibility issue [KoP-768](https://github.com/streamnative/kop/issues/768).
+
 # How to use KoP
 You can configure and manage KoP based on your requirements. Check the following guides for more details.
 - [Quick Start](docs/kop.md)


### PR DESCRIPTION
Some patch branches of KoP-2.8.0 have introduced a compatibility issue with Pulsar-2.8.0. Since the current major version is 2.8.1,  so add docs to mark the affected minor version.