### PR TITLE
[FEATURE] Add authorization to handle describe configs

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -72,7 +72,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
## Motivation
Currently KoP don't support authorization when admin client describe configs.

## Modifications
* Add authorization to `handleDescribeConfigs`.
* Add new units test in `KafkaAuthorizationTestBase` to test describe configs is success.
