### PR TITLE
[BUGFIX] Fix create delete topic in zookeeper might fail

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -52,6 +52,7 @@ import io.streamnative.pulsar.handlers.kop.utils.CoreUtils;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
 import io.streamnative.pulsar.handlers.kop.utils.MessageIdUtils;
 import io.streamnative.pulsar.handlers.kop.utils.OffsetFinder;
+import io.streamnative.pulsar.handlers.kop.utils.TopicNameUtils;
 import io.streamnative.pulsar.handlers.kop.utils.ZooKeeperUtils;
 import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperation;
 import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperationKey;
@@ -2158,7 +2159,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             if (errors == Errors.NONE) {
                 // create topic ZNode to trigger the coordinator DeleteTopicsEvent event
                 ZooKeeperUtils.tryCreatePath(pulsarService.getZkClient(),
-                        KopEventManager.getDeleteTopicsPath() + "/" + topic,
+                        KopEventManager.getDeleteTopicsPath() + "/"
+                                + TopicNameUtils.getTopicWithUrlEncoded(topic),
                         new byte[0]);
             }
             if (topicToDeleteCount.decrementAndGet() == 0) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManager.java
@@ -24,6 +24,7 @@ import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupMetadata;
 import io.streamnative.pulsar.handlers.kop.stats.StatsLogger;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
 import io.streamnative.pulsar.handlers.kop.utils.ShutdownableThread;
+import io.streamnative.pulsar.handlers.kop.utils.TopicNameUtils;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -313,7 +314,7 @@ public class KopEventManager {
                         HashSet<String> topicsFullNameDeletionsSets = Sets.newHashSet();
                         HashSet<KopTopic> kopTopicsSet = Sets.newHashSet();
                         topicsDeletions.forEach(topic -> {
-                            KopTopic kopTopic = new KopTopic(topic);
+                            KopTopic kopTopic = new KopTopic(TopicNameUtils.getTopicWithUrlDecoded(topic));
                             kopTopicsSet.add(kopTopic);
                             topicsFullNameDeletionsSets.add(kopTopic.getFullName());
                         });

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/TopicNameUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/TopicNameUtils.java
@@ -15,6 +15,11 @@ package io.streamnative.pulsar.handlers.kop.utils;
 
 import static org.apache.pulsar.common.naming.TopicName.PARTITIONED_TOPIC_SUFFIX;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import lombok.NonNull;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicDomain;
@@ -73,6 +78,32 @@ public class TopicNameUtils {
         String localName = topicName.getPartitionedTopicName();
         // remove persistent://tenant/ns
         return TopicName.get(localName).getLocalName();
+    }
+
+    /**
+     * Get an url encoded topic name.
+     */
+    public static @NonNull String getTopicWithUrlEncoded(String topicName) {
+        String encodedTopicName = "";
+        try {
+            encodedTopicName = URLEncoder.encode(topicName, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException ignore) {
+            // The exception will never happen, because the charset always exists.
+        }
+        return encodedTopicName;
+    }
+
+    /**
+     * Get an url decoded topic name.
+     */
+    public static @NonNull String getTopicWithUrlDecoded(String encodedTopicName) {
+        String topicName = "";
+        try {
+            topicName = URLDecoder.decode(encodedTopicName, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException ignore) {
+            // The exception will never happen, because the charset always exists.
+        }
+        return topicName;
     }
 
 }


### PR DESCRIPTION
Fixes: #775

## Motivation
When we in `handleDeleteTopics` to create a delete topic path, if the topic name like `persistent://tenant/ns/topic`, then the delete topic will create failed.

The reason is topic name contains /.

## Modifications
Use UrlEncoder to encode topic name when create path, and use UrlDecoder to decode when delete topic.