### PR TITLE
[FEATURE] Add new pulsar message builder

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/PulsarEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/PulsarEntryFormatter.java
@@ -20,6 +20,7 @@ import io.netty.buffer.ByteBuf;
 import io.streamnative.pulsar.handlers.kop.exceptions.KoPMessageMetadataNotFoundException;
 import io.streamnative.pulsar.handlers.kop.utils.ByteBufUtils;
 import io.streamnative.pulsar.handlers.kop.utils.MessageIdUtils;
+import io.streamnative.pulsar.handlers.kop.utils.PulsarMessageBuilder;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -30,9 +31,7 @@ import org.apache.bookkeeper.mledger.Entry;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.Record;
-import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.MessageImpl;
-import org.apache.pulsar.client.impl.TypedMessageBuilderImpl;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.protocol.Commands;
@@ -141,8 +140,8 @@ public class PulsarEntryFormatter implements EntryFormatter {
     // convert kafka Record to Pulsar Message.
     // called when publish received Kafka Record into Pulsar.
     private static MessageImpl<byte[]> recordToEntry(Record record) {
-        @SuppressWarnings("unchecked")
-        TypedMessageBuilderImpl<byte[]> builder = new TypedMessageBuilderImpl(null, Schema.BYTES);
+
+        PulsarMessageBuilder builder = PulsarMessageBuilder.newBuilder();
 
         // key
         if (record.hasKey()) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/PulsarMessageBuilder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/PulsarMessageBuilder.java
@@ -1,0 +1,116 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.utils;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import io.netty.util.concurrent.FastThreadLocal;
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.Map;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.MessageImpl;
+import org.apache.pulsar.common.api.proto.MessageMetadata;
+
+/**
+ * Manually build {@link MessageImpl}.
+ */
+public class PulsarMessageBuilder {
+    private static final ByteBuffer EMPTY_CONTENT = ByteBuffer.allocate(0);
+    private static final Schema<byte[]> SCHEMA = Schema.BYTES;
+
+    private final transient MessageMetadata metadata;
+    private transient ByteBuffer content;
+
+    private static final FastThreadLocal<MessageMetadata> LOCAL_MESSAGE_METADATA =
+            new FastThreadLocal<MessageMetadata>() {
+                @Override
+                protected MessageMetadata initialValue() {
+                    return new MessageMetadata();
+                }
+            };
+
+    private PulsarMessageBuilder() {
+        metadata = LOCAL_MESSAGE_METADATA.get();
+        metadata.clear();
+        this.content = EMPTY_CONTENT;
+    }
+
+    public static PulsarMessageBuilder newBuilder() {
+        return new PulsarMessageBuilder();
+    }
+
+    public PulsarMessageBuilder keyBytes(byte[] key) {
+        metadata.setPartitionKey(Base64.getEncoder().encodeToString(key));
+        metadata.setPartitionKeyB64Encoded(true);
+        return this;
+    }
+
+    public PulsarMessageBuilder orderingKey(byte[] orderingKey) {
+        metadata.setOrderingKey(orderingKey);
+        return this;
+    }
+
+    public PulsarMessageBuilder value(byte[] value) {
+        if (value == null) {
+            metadata.setNullValue(true);
+            return this;
+        }
+        this.content = ByteBuffer.wrap(SCHEMA.encode(value));
+        return this;
+    }
+
+    public PulsarMessageBuilder property(String name, String value) {
+        checkArgument(name != null, "Need Non-Null name");
+        checkArgument(value != null, "Need Non-Null value for name: " + name);
+        metadata.addProperty()
+                .setKey(name)
+                .setValue(value);
+        return this;
+    }
+
+    public PulsarMessageBuilder properties(Map<String, String> properties) {
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            checkArgument(entry.getKey() != null, "Need Non-Null key");
+            checkArgument(entry.getValue() != null, "Need Non-Null value for key: " + entry.getKey());
+            metadata.addProperty()
+                    .setKey(entry.getKey())
+                    .setValue(entry.getValue());
+        }
+
+        return this;
+    }
+
+    public PulsarMessageBuilder eventTime(long timestamp) {
+        checkArgument(timestamp > 0, "Invalid timestamp : '%s'", timestamp);
+        metadata.setEventTime(timestamp);
+        return this;
+    }
+
+    public MessageMetadata getMetadataBuilder() {
+        return metadata;
+    }
+
+    public PulsarMessageBuilder sequenceId(long sequenceId) {
+        checkArgument(sequenceId >= 0);
+        metadata.setSequenceId(sequenceId);
+        return this;
+    }
+
+    public Message<byte[]> getMessage() {
+        return MessageImpl.create(metadata, content, SCHEMA);
+    }
+
+}


### PR DESCRIPTION
## Motivation
Currently, KoP use `TypedMessageBuilderImpl` to convert Kafka record to Pulsar entry, we shouldn’t be dependent on `TypedMessageBuilderImpl`, it's not designed to build messages for other systems, and if the API changed, might cause compatibility issue.

For future extensibility, this PR introduced a new `PulsarMessageBuilder` on KoP, and it add a `LOCAL_MESSAGE_METADATA` to reuse `MessageMetadata`, might reduce memory usage.

## Modifications
* Add a new `PulsarMessageBuilder` to replace original `TypedMessageBuilderImpl`
