### PR TITLE
Support Kafka consumer for kafka format messages when entryFormat is pulsar

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/BaseEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/BaseEntryFormatter.java
@@ -1,0 +1,142 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.format;
+
+import static org.apache.kafka.common.record.Records.MAGIC_OFFSET;
+import static org.apache.kafka.common.record.Records.OFFSET_OFFSET;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.util.ReferenceCounted;
+import io.streamnative.pulsar.handlers.kop.exceptions.KoPMessageMetadataNotFoundException;
+import io.streamnative.pulsar.handlers.kop.utils.ByteBufUtils;
+import io.streamnative.pulsar.handlers.kop.utils.KopRecordsUtil;
+import io.streamnative.pulsar.handlers.kop.utils.MessageIdUtils;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.record.ConvertedRecords;
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
+import org.apache.pulsar.common.api.proto.KeyValue;
+import org.apache.pulsar.common.api.proto.MessageMetadata;
+import org.apache.pulsar.common.protocol.Commands;
+
+@Slf4j
+public class BaseEntryFormatter implements EntryFormatter{
+
+    // These key-value identifies the entry's format as kafka
+    public static final String IDENTITY_KEY = "entry.format";
+    public static final String IDENTITY_VALUE = EntryFormatterFactory.EntryFormat.KAFKA.name().toLowerCase();
+
+    @Override
+    public ByteBuf encode(MemoryRecords records, int numMessages) {
+        return null;
+    }
+
+    @Override
+    public DecodeResult decode(List<Entry> entries, byte magic) {
+        Optional<List<ByteBuf>> optionalByteBufs = Optional.empty();
+
+        // reset header information
+        final List<ByteBuf> orderedByteBuf = new ArrayList<>();
+
+        for (Entry entry : entries) {
+            try {
+                long startOffset = MessageIdUtils.peekBaseOffsetFromEntry(entry);
+                final ByteBuf byteBuf = entry.getDataBuffer();
+                final MessageMetadata metadata = Commands.parseMessageMetadata(byteBuf);
+                if (isKafkaEntryFormat(metadata)) {
+                    byte batchMagic = byteBuf.getByte(byteBuf.readerIndex() + MAGIC_OFFSET);
+                    byteBuf.setLong(byteBuf.readerIndex() + OFFSET_OFFSET, startOffset);
+
+                    // batch magic greater than the magic corresponding to the version requested by the client
+                    // need down converted
+                    if (batchMagic > magic || batchMagic != RecordBatch.MAGIC_VALUE_V2) {
+                        MemoryRecords memoryRecords = MemoryRecords.readableRecords(ByteBufUtils.getNioBuffer(byteBuf));
+                        //down converted, batch magic will be set to client magic
+                        ConvertedRecords<MemoryRecords> convertedRecords =
+                                KopRecordsUtil.convertAndAssignOffsets(memoryRecords.batches(), magic, startOffset);
+
+                        final ByteBuf kafkaBuffer = Unpooled.wrappedBuffer(convertedRecords.records().buffer());
+                        orderedByteBuf.add(kafkaBuffer);
+                        if (!optionalByteBufs.isPresent()) {
+                            optionalByteBufs = Optional.of(new ArrayList<>());
+                        }
+                        optionalByteBufs.ifPresent(byteBufs -> byteBufs.add(kafkaBuffer));
+
+                        if (log.isTraceEnabled()) {
+                            log.trace("[{}:{}] convertAndAssignOffsets record for down converted"
+                                            + " or assign offsets with v0 and v1 magic, start offset {},"
+                                            + " entry magic: {}, client magic: {}",
+                                    entry.getLedgerId(), entry.getEntryId(), startOffset, batchMagic, magic);
+                        }
+
+                    } else {
+                        //not need down converted, batch magic retains the magic value written in production
+                        orderedByteBuf.add(byteBuf.slice(byteBuf.readerIndex(), byteBuf.readableBytes()));
+                    }
+                } else {
+                    final DecodeResult decodeResult =
+                            ByteBufUtils.decodePulsarEntryToKafkaRecords(metadata, byteBuf, startOffset, magic);
+                    final ByteBuf kafkaBuffer = decodeResult.getOrCreateByteBuf();
+                    orderedByteBuf.add(kafkaBuffer);
+                    if (!optionalByteBufs.isPresent()) {
+                        optionalByteBufs = Optional.of(new ArrayList<>());
+                    }
+                    optionalByteBufs.ifPresent(byteBufs -> byteBufs.add(kafkaBuffer));
+                }
+                // Almost all exceptions in Kafka inherit from KafkaException and will be captured
+                // and processed in KafkaApis. Here, whether it is down-conversion or the IOException
+                // in builder.appendWithOffset in decodePulsarEntryToKafkaRecords will be caught by Kafka
+                // and the KafkaException will be thrown. So we need to catch KafkaException here.
+            } catch (KoPMessageMetadataNotFoundException | IOException | KafkaException e) { // skip failed decode entry
+                log.error("[{}:{}] Failed to decode entry. ", entry.getLedgerId(), entry.getEntryId(), e);
+                entry.release();
+            }
+        }
+
+        // batched ByteBuf should be released after sending to client
+        int totalSize = orderedByteBuf.stream().mapToInt(ByteBuf::readableBytes).sum();
+        ByteBuf batchedByteBuf = PulsarByteBufAllocator.DEFAULT.directBuffer(totalSize);
+
+        for (ByteBuf byteBuf : orderedByteBuf) {
+            batchedByteBuf.writeBytes(byteBuf);
+        }
+        optionalByteBufs.ifPresent(byteBufs -> byteBufs.forEach(ReferenceCounted::release));
+
+        // release entries
+        entries.forEach(Entry::release);
+        return new DecodeResult(
+                MemoryRecords.readableRecords(ByteBufUtils.getNioBuffer(batchedByteBuf)), batchedByteBuf);
+    }
+
+    private static boolean isKafkaEntryFormat(final MessageMetadata messageMetadata) {
+        final List<KeyValue> keyValues = messageMetadata.getPropertiesList();
+        for (KeyValue keyValue : keyValues) {
+            if (keyValue.hasKey()
+                    && keyValue.getKey().equals(IDENTITY_KEY)
+                    && keyValue.getValue().equals(IDENTITY_VALUE)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaEntryFormatter.java
@@ -13,28 +13,12 @@
  */
 package io.streamnative.pulsar.handlers.kop.format;
 
-import static org.apache.kafka.common.record.Records.MAGIC_OFFSET;
-import static org.apache.kafka.common.record.Records.OFFSET_OFFSET;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.util.ReferenceCounted;
-import io.streamnative.pulsar.handlers.kop.exceptions.KoPMessageMetadataNotFoundException;
-import io.streamnative.pulsar.handlers.kop.utils.ByteBufUtils;
-import io.streamnative.pulsar.handlers.kop.utils.KopRecordsUtil;
-import io.streamnative.pulsar.handlers.kop.utils.MessageIdUtils;
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Entry;
-import org.apache.kafka.common.KafkaException;
-import org.apache.kafka.common.record.ConvertedRecords;
 import org.apache.kafka.common.record.MemoryRecords;
-import org.apache.kafka.common.record.RecordBatch;
-import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
-import org.apache.pulsar.common.api.proto.KeyValue;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.protocol.Commands;
 
@@ -42,11 +26,7 @@ import org.apache.pulsar.common.protocol.Commands;
  * The entry formatter that uses Kafka's format.
  */
 @Slf4j
-public class KafkaEntryFormatter implements EntryFormatter {
-
-    // These key-value identifies the entry's format as kafka
-    private static final String IDENTITY_KEY = "entry.format";
-    private static final String IDENTITY_VALUE = EntryFormatterFactory.EntryFormat.KAFKA.name().toLowerCase();
+public class KafkaEntryFormatter extends BaseEntryFormatter {
 
     @Override
     public ByteBuf encode(MemoryRecords records, int numMessages) {
@@ -61,79 +41,7 @@ public class KafkaEntryFormatter implements EntryFormatter {
 
     @Override
     public DecodeResult decode(List<Entry> entries, byte magic) {
-        Optional<List<ByteBuf>> optionalByteBufs = Optional.empty();
-
-        // reset header information
-        final List<ByteBuf> orderedByteBuf = new ArrayList<>();
-
-        for (Entry entry : entries) {
-            try {
-                long startOffset = MessageIdUtils.peekBaseOffsetFromEntry(entry);
-                final ByteBuf byteBuf = entry.getDataBuffer();
-                final MessageMetadata metadata = Commands.parseMessageMetadata(byteBuf);
-                if (isKafkaEntryFormat(metadata)) {
-                    byte batchMagic = byteBuf.getByte(byteBuf.readerIndex() + MAGIC_OFFSET);
-                    byteBuf.setLong(byteBuf.readerIndex() + OFFSET_OFFSET, startOffset);
-
-                    // batch magic greater than the magic corresponding to the version requested by the client
-                    // need down converted
-                    if (batchMagic > magic || batchMagic != RecordBatch.MAGIC_VALUE_V2) {
-                        MemoryRecords memoryRecords = MemoryRecords.readableRecords(ByteBufUtils.getNioBuffer(byteBuf));
-                        //down converted, batch magic will be set to client magic
-                        ConvertedRecords<MemoryRecords> convertedRecords =
-                                KopRecordsUtil.convertAndAssignOffsets(memoryRecords.batches(), magic, startOffset);
-
-                        final ByteBuf kafkaBuffer = Unpooled.wrappedBuffer(convertedRecords.records().buffer());
-                        orderedByteBuf.add(kafkaBuffer);
-                        if (!optionalByteBufs.isPresent()) {
-                            optionalByteBufs = Optional.of(new ArrayList<>());
-                        }
-                        optionalByteBufs.ifPresent(byteBufs -> byteBufs.add(kafkaBuffer));
-
-                        if (log.isTraceEnabled()) {
-                            log.trace("[{}:{}] convertAndAssignOffsets record for down converted"
-                                            + " or assign offsets with v0 and v1 magic, start offset {},"
-                                            + " entry magic: {}, client magic: {}",
-                                    entry.getLedgerId(), entry.getEntryId(), startOffset, batchMagic, magic);
-                        }
-
-                    } else {
-                        //not need down converted, batch magic retains the magic value written in production
-                        orderedByteBuf.add(byteBuf.slice(byteBuf.readerIndex(), byteBuf.readableBytes()));
-                    }
-                } else {
-                    final DecodeResult decodeResult =
-                            ByteBufUtils.decodePulsarEntryToKafkaRecords(metadata, byteBuf, startOffset, magic);
-                    final ByteBuf kafkaBuffer = decodeResult.getOrCreateByteBuf();
-                    orderedByteBuf.add(kafkaBuffer);
-                    if (!optionalByteBufs.isPresent()) {
-                        optionalByteBufs = Optional.of(new ArrayList<>());
-                    }
-                    optionalByteBufs.ifPresent(byteBufs -> byteBufs.add(kafkaBuffer));
-                }
-                // Almost all exceptions in Kafka inherit from KafkaException and will be captured
-                // and processed in KafkaApis. Here, whether it is down-conversion or the IOException
-                // in builder.appendWithOffset in decodePulsarEntryToKafkaRecords will be caught by Kafka
-                // and the KafkaException will be thrown. So we need to catch KafkaException here.
-            } catch (KoPMessageMetadataNotFoundException | IOException | KafkaException e) { // skip failed decode entry
-                log.error("[{}:{}] Failed to decode entry. ", entry.getLedgerId(), entry.getEntryId(), e);
-                entry.release();
-            }
-        }
-
-        // batched ByteBuf should be released after sending to client
-        int totalSize = orderedByteBuf.stream().mapToInt(ByteBuf::readableBytes).sum();
-        ByteBuf batchedByteBuf = PulsarByteBufAllocator.DEFAULT.directBuffer(totalSize);
-
-        for (ByteBuf byteBuf : orderedByteBuf) {
-            batchedByteBuf.writeBytes(byteBuf);
-        }
-        optionalByteBufs.ifPresent(byteBufs -> byteBufs.forEach(ReferenceCounted::release));
-
-        // release entries
-        entries.forEach(Entry::release);
-        return new DecodeResult(
-                MemoryRecords.readableRecords(ByteBufUtils.getNioBuffer(batchedByteBuf)), batchedByteBuf);
+        return super.decode(entries, magic);
     }
 
     private static MessageMetadata getMessageMetadataWithNumberMessages(int numMessages) {
@@ -148,15 +56,4 @@ public class KafkaEntryFormatter implements EntryFormatter {
         return metadata;
     }
 
-    private static boolean isKafkaEntryFormat(final MessageMetadata messageMetadata) {
-        final List<KeyValue> keyValues = messageMetadata.getPropertiesList();
-        for (KeyValue keyValue : keyValues) {
-            if (keyValue.hasKey()
-                    && keyValue.getKey().equals(IDENTITY_KEY)
-                    && keyValue.getValue().equals(IDENTITY_VALUE)) {
-                return true;
-            }
-        }
-        return false;
-    }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/EntryFormatterTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/EntryFormatterTestBase.java
@@ -1,0 +1,129 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Properties;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+
+public class EntryFormatterTestBase extends KopProtocolHandlerTestBase{
+
+    private static final String group1 = "test-format-group1";
+    private static final String group2 = "test-format-group2";
+    private static final String topic = "test-format-topic";
+    private static final String offsetReset = "earliest";
+
+    public EntryFormatterTestBase(final String entryFormat) {
+        super(entryFormat);
+    }
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+    }
+
+    @AfterMethod
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    protected void testChangeEntryFormat(final String format) throws Exception {
+        // 1. create topic
+        int numPartitions = 1;
+        admin.topics().createPartitionedTopic(topic, numPartitions);
+
+        // 2. create producer
+        final KafkaProducer<String, String> producer = createKafkaProducer();
+        // 3. send messages
+        int total = 5;
+        for (int i = 0; i < total; i++) {
+            String key = "test-format-key-" + i;
+            String value = "test-format-value-" + i;
+            producer.send(new ProducerRecord<>(topic, key, value));
+        }
+        producer.close();
+
+        // 4. consume messages use group1 from earliest
+        KafkaConsumer<String, String> consumer1 = createKafkaConsumer(group1);
+        consumer1.subscribe(Collections.singleton(topic));
+        int consumedMessages = 0;
+        while (consumedMessages < total) {
+            ConsumerRecords<String, String> records = consumer1.poll(Duration.ofMillis(2000));
+            consumedMessages += records.count();
+        }
+        Assert.assertEquals(total, consumedMessages);
+        consumer1.close();
+
+        // 5. change entry format to pulsar from kafka
+        changeEntryFormatAndRestart(format);
+
+        // 6. consume messages use group2 from earliest
+        KafkaConsumer<String, String> consumer2 = createKafkaConsumer(group2);
+        consumer2.subscribe(Collections.singleton(topic));
+        consumedMessages = 0;
+        while (consumedMessages < total) {
+            ConsumerRecords<String, String> records = consumer2.poll(Duration.ofMillis(2000));
+            consumedMessages += records.count();
+        }
+        Assert.assertEquals(total, consumedMessages);
+        consumer2.close();
+    }
+
+    protected void testChangeKafkaEntryFormat() throws Exception {
+        testChangeEntryFormat("pulsar");
+    }
+
+    protected void testChangePulsarEntryFormat() throws Exception {
+        testChangeEntryFormat("kafka");
+    }
+
+    protected void changeEntryFormatAndRestart(final String entryFormat) throws Exception {
+        super.changeEntryFormat(entryFormat);
+        super.restartBroker();
+    }
+
+    protected KafkaProducer<String, String> createKafkaProducer() {
+        final Properties properties = new Properties();
+        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getKafkaBrokerPort());
+        properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                "org.apache.kafka.common.serialization.StringSerializer");
+        properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                "org.apache.kafka.common.serialization.StringSerializer");
+        return new KafkaProducer<>(properties);
+    }
+
+    protected KafkaConsumer<String, String> createKafkaConsumer(final String group) {
+        final Properties properties = new Properties();
+        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getKafkaBrokerPort());
+        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+                "org.apache.kafka.common.serialization.StringDeserializer");
+        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+                "org.apache.kafka.common.serialization.StringDeserializer");
+        properties.put(ConsumerConfig.GROUP_ID_CONFIG, group);
+        properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, offsetReset);
+        return new KafkaConsumer<>(properties);
+    }
+
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaEntryFormatterTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaEntryFormatterTestBase.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import org.testng.annotations.Test;
+
+public class KafkaEntryFormatterTestBase extends EntryFormatterTestBase {
+
+    public KafkaEntryFormatterTestBase() {
+        super("kafka");
+    }
+
+    @Test(timeOut = 20000)
+    public void testChangeKafkaEntryFormat() throws Exception {
+        super.testChangeKafkaEntryFormat();
+    }
+
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -118,17 +118,20 @@ public abstract class KopProtocolHandlerTestBase {
     protected Server restServer;
     protected String restConnect;
 
-    private final String entryFormat;
+    private String entryFormat;
 
     protected static final String PLAINTEXT_PREFIX = SecurityProtocol.PLAINTEXT.name() + "://";
     protected static final String SSL_PREFIX = SecurityProtocol.SSL.name() + "://";
 
     public KopProtocolHandlerTestBase() {
-        this.entryFormat = "pulsar";
-        resetConfig();
+        changeEntryFormat("pulsar");
     }
 
     public KopProtocolHandlerTestBase(final String entryFormat) {
+        changeEntryFormat(entryFormat);
+    }
+
+    protected void changeEntryFormat(final String entryFormat) {
         this.entryFormat = entryFormat;
         resetConfig();
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/PulsarEntryFormatterTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/PulsarEntryFormatterTestBase.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import org.testng.annotations.Test;
+
+public class PulsarEntryFormatterTestBase extends EntryFormatterTestBase {
+
+    public PulsarEntryFormatterTestBase() {
+        super("Pulsar");
+    }
+
+    @Test(timeOut = 20000)
+    public void testChangePulsarEntryFormat() throws Exception {
+        super.testChangePulsarEntryFormat();
+    }
+}


### PR DESCRIPTION
fixes #778 

### Motivation
Changing entryFormat from kafka to pulsar will cause old messages to fail to be consumed. This may happen in the process of changing entryFormat=pulsar and rolling restart kop, or resetting the consumption offset to the message written during entryFormat=kafka.

### Modifications
like #632 
Support Kafka consumer for kafka format messages when entryFormat is pulsar.
This may happen in the scenario described by Motivation above.
