### PR TITLE
KOP allowedNamespaces: allow to set ${tenant}/* placeholder to automatically allow all the namespaces

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -293,7 +293,8 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 throw new IllegalArgumentException(
                         "Invalid namespace '" + fullNamespace + "' in kopAllowedNamespaces config");
             }
-            NamespaceName.validateNamespaceName(tokens[0].replace(KafkaServiceConfiguration.TENANT_PLACEHOLDER, kafkaConfig.getKafkaTenant()),
+            NamespaceName.validateNamespaceName(
+                    tokens[0].replace(KafkaServiceConfiguration.TENANT_PLACEHOLDER, kafkaConfig.getKafkaTenant()),
                     tokens[1].replace("*", kafkaConfig.getKafkaNamespace()));
         }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -190,6 +190,7 @@ import org.apache.pulsar.policies.data.loadbalancer.ServiceLookupData;
 @Getter
 public class KafkaRequestHandler extends KafkaCommandDecoder {
     public static final long DEFAULT_TIMESTAMP = 0L;
+    private static final String POLICY_ROOT = "/admin/policies/";
 
     private final PulsarService pulsarService;
     private final KafkaTopicManager topicManager;
@@ -477,8 +478,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 || partitionedTopicName.endsWith("/" + TRANSACTION_STATE_TOPIC_NAME);
     }
 
-    private static final String POLICY_ROOT = "/admin/policies/";
-
     private static String path(String... parts) {
         StringBuilder sb = new StringBuilder();
         sb.append(POLICY_ROOT);
@@ -488,7 +487,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
 
     private CompletableFuture<Set<String>> expandAllowedNamespaces(Set<String> allowedNamespaces) {
         String currentTenant = getCurrentTenant(kafkaConfig.getKafkaTenant());
-        return expandAllowedNamespaces(allowedNamespaces,currentTenant, pulsarService);
+        return expandAllowedNamespaces(allowedNamespaces, currentTenant, pulsarService);
     }
 
     @VisibleForTesting
@@ -529,7 +528,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     private CompletableFuture<Map<String, List<TopicName>>> getAllTopicsAsync() {
         CompletableFuture<Map<String, List<TopicName>>> topicMapFuture = new CompletableFuture<>();
         final Map<String, List<TopicName>> topicMap = new ConcurrentHashMap<>();
-        final CompletableFuture<Set<String>> allowedNamespacesFuture = expandAllowedNamespaces(kafkaConfig.getKopAllowedNamespaces());
+        final CompletableFuture<Set<String>> allowedNamespacesFuture =
+                expandAllowedNamespaces(kafkaConfig.getKopAllowedNamespaces());
 
         allowedNamespacesFuture.thenAccept(allowedNamespaces -> {
             final AtomicInteger pendingNamespacesCount = new AtomicInteger(allowedNamespaces.size());

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -41,8 +41,8 @@ import org.apache.pulsar.common.configuration.FieldContext;
 @Setter
 public class KafkaServiceConfiguration extends ServiceConfiguration {
 
-    public static String TENANT_PLACEHOLDER = "${tenant}";
-    public static String TENANT_ALLNAMESPACES_PLACEHOLDER = "*";
+    public static final String TENANT_PLACEHOLDER = "${tenant}";
+    public static final String TENANT_ALLNAMESPACES_PLACEHOLDER = "*";
 
 
     // Group coordinator configuration

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
@@ -35,12 +35,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
-
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.api.DigestType;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
-import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.resources.NamespaceResources;
 import org.apache.pulsar.broker.resources.PulsarResources;
 import org.testng.annotations.Test;
@@ -200,23 +198,28 @@ public class KafkaServiceConfigurationTest {
         final KafkaServiceConfiguration conf = new KafkaServiceConfiguration();
         assertEquals(conf.getKopAllowedNamespaces(), Collections.singletonList("${tenant}/default"));
 
-        assertEquals(KafkaRequestHandler.expandAllowedNamespaces(conf.getKopAllowedNamespaces(), "my-tenant", null).get(),
+        assertEquals(KafkaRequestHandler.expandAllowedNamespaces(conf.getKopAllowedNamespaces(),
+                        "my-tenant", null).get(),
                 Collections.singletonList("my-tenant/default"));
         conf.setKafkaNamespace("my-ns");
 
-        assertEquals(KafkaRequestHandler.expandAllowedNamespaces(conf.getKopAllowedNamespaces(), "my-tenant", null).get(),
+        assertEquals(KafkaRequestHandler.expandAllowedNamespaces(conf.getKopAllowedNamespaces(),
+                        "my-tenant", null).get(),
                 Collections.singletonList("my-tenant/my-ns"));
 
         conf.setKopAllowedNamespaces(Collections.singleton("my-tenant-2/my-ns-2"));
-        assertEquals(KafkaRequestHandler.expandAllowedNamespaces(conf.getKopAllowedNamespaces(), "my-tenant", null).get(),
+        assertEquals(KafkaRequestHandler.expandAllowedNamespaces(conf.getKopAllowedNamespaces(),
+                        "my-tenant", null).get(),
                 Collections.singletonList("my-tenant-2/my-ns-2"));
 
         conf.setKopAllowedNamespaces(null);
-        assertEquals(KafkaRequestHandler.expandAllowedNamespaces(conf.getKopAllowedNamespaces(), "my-tenant", null).get(),
+        assertEquals(KafkaRequestHandler.expandAllowedNamespaces(conf.getKopAllowedNamespaces(),
+                        "my-tenant", null).get(),
                 Collections.singletonList("my-tenant/my-ns"));
 
         conf.setKopAllowedNamespaces(Sets.newHashSet("my-tenant/my-ns-0", "my-tenant/my-ns-1"));
-        assertEquals(KafkaRequestHandler.expandAllowedNamespaces(conf.getKopAllowedNamespaces(), "my-tenant", null).get(),
+        assertEquals(KafkaRequestHandler.expandAllowedNamespaces(conf.getKopAllowedNamespaces(),
+                        "my-tenant", null).get(),
                 Arrays.asList("my-tenant/my-ns-0", "my-tenant/my-ns-1"));
 
         conf.setKopAllowedNamespaces(Collections.singleton("${tenant}/*"));
@@ -226,8 +229,10 @@ public class KafkaServiceConfigurationTest {
         NamespaceResources namespaceResources = mock(NamespaceResources.class);
         when(pulsarService.getPulsarResources()).thenReturn(pulsarResources);
         when(pulsarResources.getNamespaceResources()).thenReturn(namespaceResources);
-        when(namespaceResources.getChildrenAsync(any(String.class))).thenReturn(CompletableFuture.completedFuture(Arrays.asList("one", "two")));
-        assertEquals(KafkaRequestHandler.expandAllowedNamespaces(conf.getKopAllowedNamespaces(), "logged", pulsarService).get(),
+        when(namespaceResources.getChildrenAsync(any(String.class)))
+                .thenReturn(CompletableFuture.completedFuture(Arrays.asList("one", "two")));
+        assertEquals(KafkaRequestHandler.expandAllowedNamespaces(conf.getKopAllowedNamespaces(),
+                        "logged", pulsarService).get(),
                 Arrays.asList("logged/one", "logged/two"));
 
     }


### PR DESCRIPTION
- allow to set ${tenant}/* placeholder to automatically allow all the namespaces
for the connected tenant
- ${tenant} is expanded to the current logged tenant if available (username of SASL authentication, see `kafkaEnableMultiTenantMetadata`), otherwise it maps to the `kafkaTenant` parameter

So if you configure allowedNamespaces to ${tenant}/* the user will be able to automatically list all the topics in all the namespaces for the tenant.

New default configuration will be ${tenant}/kafkaNamespace (where `kafkaNamespace` is the configuration parameter)
Previously the default was kafkaTenant/kafkaNamespace 