### PR TITLE
Add error log when describe config authorize unsupported resource

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -2098,7 +2098,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                     // Current KoP don't support Broker Resource.
                 case UNKNOWN:
                 default:
-                    completeOne.accept(()->{});
+                    completeOne.accept(() -> log.error("KoP doesn't support resource type: " + configResource.type()));
                     break;
             }
         });


### PR DESCRIPTION
Related PR: #774
## Motivation
We should add error logs when describe config authorize a `BROKER` or `UNKNOWN` type.

## Modifications
Add error log.