### PR TITLE
Change CI tests timeout to 60 minutes

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -27,6 +27,7 @@ jobs:
 
     - name: tests module
       run: mvn test -DfailIfNoTests=false '-Dtest=!KafkaIntegration*Test' -pl tests
+      timeout-minutes: 60
 
     - name: package surefire artifacts
       if: failure()


### PR DESCRIPTION
## Motivation
Some PR test might stuck forever, but in normal conditions CI tests doesn't last longer than 40 minutes.

## Modifications
Set CI tests timeout to 60 minutes.