### PR TITLE
KOP SchemaRegistry - First version

### DIFF
--- a/kafka-impl/pom.xml
+++ b/kafka-impl/pom.xml
@@ -32,7 +32,11 @@
 
   <!-- include the dependencies -->
   <dependencies>
-    <!-- runtime dependencies -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <version>${project.version}</version>
+      <artifactId>pulsar-kafka-schema-registry</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -63,6 +63,7 @@ import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.client.admin.Lookup;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
@@ -617,6 +618,10 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
         groupCoordinatorsByTenant.values().forEach(GroupCoordinator::shutdown);
         kopEventManager.close();
         transactionCoordinatorByTenant.values().forEach(TransactionCoordinator::shutdown);
+        if (schemaRegistryManager != null) {
+            schemaRegistryManager.close();
+        }
+        KafkaTopicManager.LOOKUP_CACHE.clear();
         KopBrokerLookupManager.clear();
         KafkaTopicManager.cancelCursorExpireTask();
         KafkaTopicConsumerManagerCache.getInstance().close();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -27,6 +27,7 @@ import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupCoordinator;
 import io.streamnative.pulsar.handlers.kop.coordinator.group.OffsetConfig;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionConfig;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryChannelInitializer;
 import io.streamnative.pulsar.handlers.kop.stats.PrometheusMetricsProvider;
 import io.streamnative.pulsar.handlers.kop.stats.StatsLogger;
 import io.streamnative.pulsar.handlers.kop.utils.ConfigurationUtils;
@@ -96,6 +97,8 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     private BrokerService brokerService;
     @Getter
     private KopEventManager kopEventManager;
+
+    private SchemaRegistryManager schemaRegistryManager;
 
     private final Map<String, GroupCoordinator> groupCoordinatorsByTenant = new ConcurrentHashMap<>();
     private final Map<String, TransactionCoordinator> transactionCoordinatorByTenant = new ConcurrentHashMap<>();
@@ -481,6 +484,9 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
             kafkaConfig.getKopPrometheusStatsLatencyRolloverSeconds());
         statsProvider.start(conf);
         brokerService.pulsar().addPrometheusRawMetricsProvider(statsProvider);
+
+        schemaRegistryManager = new SchemaRegistryManager(kafkaConfig, brokerService.getPulsar(),
+                brokerService.getAuthenticationService());
     }
 
     private TransactionCoordinator createAndBootTransactionCoordinator(String tenant) {
@@ -589,6 +595,12 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                             default:
                         }
             });
+
+            Optional<SchemaRegistryChannelInitializer> schemaRegistryChannelInitializer = schemaRegistryManager.build();
+            if (schemaRegistryChannelInitializer.isPresent()) {
+                builder.put(schemaRegistryManager.getAddress(), schemaRegistryChannelInitializer.get());
+            }
+
             return builder.build();
         } catch (Exception e){
             log.error("KafkaProtocolHandler newChannelInitializers failed with ", e);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -621,7 +621,6 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
         if (schemaRegistryManager != null) {
             schemaRegistryManager.close();
         }
-        KafkaTopicManager.LOOKUP_CACHE.clear();
         KopBrokerLookupManager.clear();
         KafkaTopicManager.cancelCursorExpireTask();
         KafkaTopicConsumerManagerCache.getInstance().close();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -388,6 +388,24 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
     )
     private Set<String> kopAllowedNamespaces;
 
+    @FieldContext(
+            category = CATEGORY_KOP,
+            doc = "Start the Schema Registry service."
+    )
+    private boolean kopSchemaRegistryEnable = false;
+
+    @FieldContext(
+            category = CATEGORY_KOP,
+            doc = "The name of the topic used by the Schema Registry service."
+    )
+    private String kopSchemaRegistryTopicName = "__schema-registry";
+
+    @FieldContext(
+            category = CATEGORY_KOP,
+            doc = "Schema Registry port."
+    )
+    private int kopSchemaRegistryPort = 8001;
+
     private String checkAdvertisedListeners(String advertisedListeners) {
         StringBuilder listenersReBuilder = new StringBuilder();
         for (String listener : advertisedListeners.split(EndPoint.END_POINT_SEPARATOR)) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryManager.java
@@ -1,0 +1,196 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryChannelInitializer;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryHandler;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryRequestAuthenticator;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorageAccessor;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl.PulsarSchemaStorageAccessor;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl.SchemaStorageException;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.resources.SchemaResource;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.resources.SubjectResource;
+import io.streamnative.pulsar.handlers.kop.security.KafkaPrincipal;
+import io.streamnative.pulsar.handlers.kop.security.auth.Authorizer;
+import io.streamnative.pulsar.handlers.kop.security.auth.Resource;
+import io.streamnative.pulsar.handlers.kop.security.auth.ResourceType;
+import io.streamnative.pulsar.handlers.kop.security.auth.SimpleAclAuthorizer;
+import io.streamnative.pulsar.handlers.kop.utils.MetadataUtils;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.authentication.AuthenticationProvider;
+import org.apache.pulsar.broker.authentication.AuthenticationService;
+import org.apache.pulsar.broker.authentication.AuthenticationState;
+import org.apache.pulsar.broker.service.BrokerService;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.common.api.AuthData;
+import org.apache.pulsar.common.policies.data.ClusterData;
+
+@Slf4j
+public class SchemaRegistryManager {
+    private final KafkaServiceConfiguration kafkaConfig;
+    private final PulsarService pulsar;
+    private final AuthenticationService authenticationService;
+    private final SchemaRegistryRequestAuthenticator schemaRegistryRequestAuthenticator;
+    private final Authorizer authorizer;
+
+    public SchemaRegistryManager(KafkaServiceConfiguration kafkaConfig,
+                                 PulsarService pulsar,
+                                 AuthenticationService authenticationService) {
+        this.kafkaConfig = kafkaConfig;
+        this.pulsar = pulsar;
+        this.authenticationService = authenticationService;
+        this.schemaRegistryRequestAuthenticator = new HttpRequestAuthenticator();
+        this.authorizer = new SimpleAclAuthorizer(pulsar);
+    }
+
+    @AllArgsConstructor
+    private static final class UsernamePasswordPair {
+        final String username;
+        final String password;
+    }
+
+    private class HttpRequestAuthenticator implements SchemaRegistryRequestAuthenticator {
+        @Override
+        public String authenticate(FullHttpRequest request) throws Exception {
+            if (!kafkaConfig.isAuthenticationEnabled()) {
+                return kafkaConfig.getKafkaMetadataTenant();
+            }
+            String authenticationHeader = request.headers().get(HttpHeaderNames.AUTHORIZATION, "");
+            UsernamePasswordPair usernamePasswordPair = parseUsernamePassword(authenticationHeader);
+            String username = usernamePasswordPair.username;
+            String password = usernamePasswordPair.password;
+
+            AuthenticationProvider authenticationProvider = authenticationService
+                    .getAuthenticationProvider("token");
+            if (authenticationProvider == null) {
+                throw new SchemaStorageException("Pulsar is not configured for Token auth");
+            }
+            final AuthenticationState authState = authenticationProvider
+                    .newAuthState(AuthData.of(password.getBytes(StandardCharsets.UTF_8)), null, null);
+            final String role = authState.getAuthRole();
+
+            final String tenant;
+            if (kafkaConfig.isKafkaEnableMultiTenantMetadata()) {
+                // the tenant is the username
+                log.debug("SchemaRegistry Authenticated username {} role {} using tenant {} for data",
+                        username, role, username);
+                tenant =  username;
+            } else {
+                // use system tenant
+                log.debug("SchemaRegistry Authenticated username {} role {} using system tenant {} for data",
+                        username, role, kafkaConfig.getKafkaMetadataTenant());
+                tenant =  kafkaConfig.getKafkaMetadataTenant();
+            }
+
+            performAuthorizationValidation(username, role, tenant);
+
+            return tenant;
+        }
+
+        private void performAuthorizationValidation(String username, String role, String tenant)
+                throws InterruptedException, ExecutionException, SchemaStorageException {
+            if (kafkaConfig.isAuthorizationEnabled() && kafkaConfig.isKafkaEnableMultiTenantMetadata()) {
+                KafkaPrincipal kafkaPrincipal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, role, username);
+                String topicName = MetadataUtils.constructSchemaRegistryTopicName(tenant, kafkaConfig);
+                Boolean hasPermission = authorizer
+                        .canProduceAsync(kafkaPrincipal, Resource.of(ResourceType.TOPIC, topicName))
+                        .get();
+                if (hasPermission == null || !hasPermission) {
+                    log.debug("SchemaRegistry username {} role {} tenant {} cannot access topic {}",
+                            username, role, tenant, topicName);
+                    throw new SchemaStorageException("Role " + role + " cannot access topic " + topicName,
+                            HttpResponseStatus.FORBIDDEN.code());
+                }
+            }
+        }
+
+        private UsernamePasswordPair parseUsernamePassword(String authenticationHeader)
+                throws SchemaStorageException {
+            if (authenticationHeader.isEmpty()) {
+                // no auth
+                throw new SchemaStorageException("Missing AUTHORIZATION header",
+                        HttpResponseStatus.UNAUTHORIZED.code());
+            }
+
+            if (!authenticationHeader.startsWith("Basic ")) {
+                throw new SchemaStorageException("Bad authentication scheme, only Basic is supported",
+                        HttpResponseStatus.UNAUTHORIZED.code());
+            }
+            String strippedAuthenticationHeader = authenticationHeader.substring("Basic ".length());
+
+            String usernamePassword = new String(Base64.getDecoder()
+                    .decode(strippedAuthenticationHeader), StandardCharsets.UTF_8);
+            int colon = usernamePassword.indexOf(":");
+            if (colon <= 0) {
+                throw new SchemaStorageException("Bad authentication header", HttpResponseStatus.BAD_REQUEST.code());
+            }
+            String rawUsername = usernamePassword.substring(0, colon);
+            String rawPassword = usernamePassword.substring(colon + 1);
+            if (!rawPassword.startsWith("token:")) {
+                throw new SchemaStorageException("Password must start with 'token:'",
+                        HttpResponseStatus.UNAUTHORIZED.code());
+            }
+            String token = rawPassword.substring("token:".length());
+
+            UsernamePasswordPair usernamePasswordPair = new UsernamePasswordPair(rawUsername, token);
+            return usernamePasswordPair;
+        }
+    }
+
+    public InetSocketAddress getAddress() {
+        return new InetSocketAddress(kafkaConfig.getKopSchemaRegistryPort());
+    }
+
+    public Optional<SchemaRegistryChannelInitializer> build() throws Exception {
+        if (!kafkaConfig.isKopSchemaRegistryEnable()) {
+            return Optional.empty();
+        }
+        PulsarClient pulsarClient = pulsar.getClient();
+        PulsarAdmin pulsarAdmin = pulsar.getAdminClient();
+        SchemaRegistryHandler handler = new SchemaRegistryHandler();
+        SchemaStorageAccessor schemaStorage = new PulsarSchemaStorageAccessor((tenant) -> {
+            try {
+                BrokerService brokerService = pulsar.getBrokerService();
+                final ClusterData clusterData = ClusterData.builder()
+                        .serviceUrl(brokerService.getPulsar().getWebServiceAddress())
+                        .serviceUrlTls(brokerService.getPulsar().getWebServiceAddressTls())
+                        .brokerServiceUrl(brokerService.getPulsar().getBrokerServiceUrl())
+                        .brokerServiceUrlTls(brokerService.getPulsar().getBrokerServiceUrlTls())
+                        .build();
+                MetadataUtils.createSchemaRegistryMetadataIfMissing(tenant,
+                        pulsarAdmin,
+                        clusterData,
+                        kafkaConfig);
+                return pulsarClient;
+            } catch (Exception err) {
+                throw new IllegalStateException(err);
+            }
+        },
+                kafkaConfig.getKafkaMetadataNamespace(), kafkaConfig.getKopSchemaRegistryTopicName());
+        new SchemaResource(schemaStorage, schemaRegistryRequestAuthenticator).register(handler);
+        new SubjectResource(schemaStorage, schemaRegistryRequestAuthenticator).register(handler);
+        return Optional.of(new SchemaRegistryChannelInitializer(handler));
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
@@ -48,6 +48,11 @@ public class MetadataUtils {
                 + "/" + Topic.TRANSACTION_STATE_TOPIC_NAME;
     }
 
+    public static String constructSchemaRegistryTopicName(String tenant, KafkaServiceConfiguration conf) {
+        return tenant + "/" + conf.getKafkaMetadataNamespace()
+                + "/" + conf.getKopSchemaRegistryTopicName();
+    }
+
     public static void createOffsetMetadataIfMissing(String tenant, PulsarAdmin pulsarAdmin,
                                                      ClusterData clusterData,
                                                      KafkaServiceConfiguration conf)
@@ -63,6 +68,16 @@ public class MetadataUtils {
                                                   KafkaServiceConfiguration conf)
             throws PulsarAdminException {
         KopTopic kopTopic = new KopTopic(constructTxnLogTopicBaseName(tenant, conf));
+        createKafkaMetadataIfMissing(tenant, pulsarAdmin, clusterData, conf, kopTopic,
+                conf.getTxnLogTopicNumPartitions());
+    }
+
+    public static void createSchemaRegistryMetadataIfMissing(String tenant,
+                                                  PulsarAdmin pulsarAdmin,
+                                                  ClusterData clusterData,
+                                                  KafkaServiceConfiguration conf)
+            throws PulsarAdminException {
+        KopTopic kopTopic = new KopTopic(constructSchemaRegistryTopicName(tenant, conf));
         createKafkaMetadataIfMissing(tenant, pulsarAdmin, clusterData, conf, kopTopic,
                 conf.getTxnLogTopicNumPartitions());
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
@@ -59,7 +59,7 @@ public class MetadataUtils {
             throws PulsarAdminException {
         KopTopic kopTopic = new KopTopic(constructOffsetsTopicBaseName(tenant, conf));
         createKafkaMetadataIfMissing(tenant, pulsarAdmin, clusterData, conf, kopTopic,
-                conf.getOffsetsTopicNumPartitions());
+                true, conf.getOffsetsTopicNumPartitions());
     }
 
     public static void createTxnMetadataIfMissing(String tenant,
@@ -69,7 +69,7 @@ public class MetadataUtils {
             throws PulsarAdminException {
         KopTopic kopTopic = new KopTopic(constructTxnLogTopicBaseName(tenant, conf));
         createKafkaMetadataIfMissing(tenant, pulsarAdmin, clusterData, conf, kopTopic,
-                conf.getTxnLogTopicNumPartitions());
+                true, conf.getTxnLogTopicNumPartitions());
     }
 
     public static void createSchemaRegistryMetadataIfMissing(String tenant,
@@ -78,7 +78,7 @@ public class MetadataUtils {
                                                   KafkaServiceConfiguration conf)
             throws PulsarAdminException {
         KopTopic kopTopic = new KopTopic(constructSchemaRegistryTopicName(tenant, conf));
-        createKafkaMetadataIfMissing(tenant, pulsarAdmin, clusterData, conf, kopTopic, 1);
+        createKafkaMetadataIfMissing(tenant, pulsarAdmin, clusterData, conf, kopTopic, false, 1);
     }
 
     /**
@@ -100,6 +100,7 @@ public class MetadataUtils {
                                                      ClusterData clusterData,
                                                      KafkaServiceConfiguration conf,
                                                      KopTopic kopTopic,
+                                                     boolean partitioned,
                                                      int partitionNum)
         throws PulsarAdminException {
         String cluster = conf.getClusterName();
@@ -141,7 +142,7 @@ public class MetadataUtils {
             namespaceExists = true;
 
             // Check if the offsets topic exists and create it if not
-            createTopicIfNotExist(pulsarAdmin, kopTopic.getFullName(), partitionNum);
+            createTopicIfNotExist(pulsarAdmin, kopTopic.getFullName(), partitioned, partitionNum);
             offsetsTopicExists = true;
         } catch (PulsarAdminException e) {
             if (e instanceof ConflictException) {
@@ -293,8 +294,9 @@ public class MetadataUtils {
 
     private static void createTopicIfNotExist(final PulsarAdmin admin,
                                               final String topic,
+                                              boolean partitioned,
                                               final int numPartitions) throws PulsarAdminException {
-        if (numPartitions > 1) {
+        if (partitioned) {
             try {
                 admin.topics().createPartitionedTopic(topic, numPartitions);
             } catch (PulsarAdminException.ConflictException e) {

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
     <module>kafka-3-0</module>
     <module>kafka-client-api</module>
     <module>kafka-client-factory</module>
+    <module>schema-registry</module>
     <module>kafka-impl</module>
     <module>oauth-client</module>
     <module>tests</module>

--- a/schema-registry/README.md
+++ b/schema-registry/README.md
@@ -1,0 +1,6 @@
+# KOP Schema Registry
+
+This is an implementation of a Schema Registry with an API that is compatible
+with the most widely used Registries in the Kafka Ecosystem.
+
+For details, see [README](../README.md) for detail.

--- a/schema-registry/pom.xml
+++ b/schema-registry/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.streamnative.pulsar.handlers</groupId>
+    <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
+    <version>2.9.0-SNAPSHOT</version>
+  </parent>
+
+  <groupId>io.streamnative.pulsar.handlers</groupId>
+  <artifactId>pulsar-kafka-schema-registry</artifactId>
+  <name>StreamNative :: Pulsar Protocol Handler :: Schema Registry</name>
+  <description>Kafka Compatible Schema Registry</description>
+
+  <!-- include the dependencies -->
+  <dependencies>
+    <!-- runtime dependencies -->
+  </dependencies>
+
+</project>

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/HttpJsonRequestProcessor.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/HttpJsonRequestProcessor.java
@@ -89,7 +89,12 @@ public abstract class HttpJsonRequestProcessor <K, R> extends HttpRequestProcess
     }
 
     private List<String> detectGroups(FullHttpRequest request) {
-        Matcher matcher = pattern.matcher(request.uri());
+        String uri = request.uri();
+        int questionMark = uri.lastIndexOf('?');
+        if (questionMark > 0) {
+            uri = uri.substring(0, questionMark);
+        }
+        Matcher matcher = pattern.matcher(uri);
         if (!matcher.matches()) {
             return null;
         }

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/HttpJsonRequestProcessor.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/HttpJsonRequestProcessor.java
@@ -1,0 +1,113 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl.SchemaStorageException;
+import java.io.DataInput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public abstract class HttpJsonRequestProcessor <K, R> extends HttpRequestProcessor {
+
+    protected static final String RESPONSE_CONTENT_TYPE = "application/vnd.schemaregistry.v1+json";
+
+    private final Class<K> requestModel;
+    private final Pattern pattern;
+    private final String method;
+
+    public HttpJsonRequestProcessor(Class<K> requestModel, String uriPattern, String method) {
+        this.requestModel = requestModel;
+        this.pattern = Pattern.compile(uriPattern);
+        this.method = method;
+    }
+
+    @Override
+    FullHttpResponse processRequest(FullHttpRequest request) {
+        if (!request.method().name().equals(method)) {
+            return null;
+        }
+        List<String> groups = detectGroups(request);
+        if (groups == null) {
+            return null;
+        }
+
+        try (ByteBufInputStream  inputStream = new ByteBufInputStream(request.content());) {
+            K decodeRequest;
+            if (requestModel == Void.class) {
+                decodeRequest = null;
+            } else {
+                decodeRequest = MAPPER.readValue((DataInput) inputStream, requestModel);
+            }
+
+            R result = null;
+            try {
+                result = processRequest(decodeRequest, groups, request);
+            } catch (SchemaStorageException err) {
+                log.error("Error while processing request", err);
+                return buildJsonErrorResponse(err);
+            } catch (Exception err) {
+                log.error("Error while processing request", err);
+                return buildErrorResponse(INTERNAL_SERVER_ERROR,
+                        "Error while processing request", "text/plain");
+            }
+            if (result == null) {
+                return buildErrorResponse(NOT_FOUND, "Not found", "text/plain");
+            }
+            if (result.getClass() == String.class) {
+                return buildStringResponse(((String) result), RESPONSE_CONTENT_TYPE);
+            } else {
+                return buildJsonResponse(result, RESPONSE_CONTENT_TYPE);
+            }
+        } catch (IOException err) {
+            log.error("Error while processing request", err);
+            return buildErrorResponse(HttpResponseStatus.BAD_REQUEST,
+                    "Cannot decode request: " + err.getMessage(), "text/plain");
+        }
+    }
+
+    private List<String> detectGroups(FullHttpRequest request) {
+        Matcher matcher = pattern.matcher(request.uri());
+        if (!matcher.matches()) {
+            return null;
+        }
+        List<String> groups = new ArrayList<>(matcher.groupCount());
+        for (int i = 0; i < matcher.groupCount(); i++) {
+            groups.add(matcher.group(i + 1));
+        }
+        return groups;
+    }
+
+    protected abstract R processRequest(K payload, List<String> patternGroups,
+                                        FullHttpRequest request) throws Exception;
+
+    protected static int getInt(int position, List<String> queryStringGroups) {
+        return Integer.parseInt(queryStringGroups.get(position));
+    }
+
+    protected static String getString(int position, List<String> queryStringGroups) {
+        return queryStringGroups.get(position);
+    }
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/HttpRequestProcessor.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/HttpRequestProcessor.java
@@ -1,0 +1,105 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.CharsetUtil;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl.SchemaStorageException;
+import lombok.AllArgsConstructor;
+
+public abstract class HttpRequestProcessor {
+
+    protected static final ObjectMapper MAPPER = new ObjectMapper()
+            .configure(SerializationFeature.INDENT_OUTPUT, true);
+
+    abstract FullHttpResponse processRequest(FullHttpRequest request);
+
+    protected FullHttpResponse buildStringResponse(String body, String contentType) {
+        FullHttpResponse httpResponse = new DefaultFullHttpResponse(HTTP_1_1,  OK,
+                Unpooled.copiedBuffer(body, CharsetUtil.UTF_8));
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, contentType);
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, body.length());
+        return httpResponse;
+    }
+
+    protected FullHttpResponse buildErrorResponse(HttpResponseStatus error, String body, String contentType) {
+        FullHttpResponse httpResponse = new DefaultFullHttpResponse(HTTP_1_1,  error,
+                Unpooled.copiedBuffer(body, CharsetUtil.UTF_8));
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, contentType);
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, body.length());
+        return httpResponse;
+    }
+
+    @AllArgsConstructor
+    private static final class ErrorModel {
+        // https://docs.confluent.io/platform/current/schema-registry/develop/api.html#schemas
+
+        final int errorCode;
+        final String message;
+
+        @JsonProperty("error_code")
+        public int getErrorCode() {
+            return errorCode;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
+
+    protected FullHttpResponse buildJsonErrorResponse(SchemaStorageException err) {
+        HttpResponseStatus error = HttpResponseStatus.valueOf(err.getHttpStatusCode());
+
+        FullHttpResponse httpResponse = null;
+        try {
+            String body = MAPPER.writeValueAsString(new ErrorModel(err.getHttpStatusCode(), err.getMessage()));
+            httpResponse = new DefaultFullHttpResponse(HTTP_1_1,  error,
+                    Unpooled.copiedBuffer(body, CharsetUtil.UTF_8));
+            httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/vnd.schemaregistry.v1+json");
+            httpResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, body.length());
+        } catch (JsonProcessingException impossible) {
+            String body = "Error " + err;
+            httpResponse = new DefaultFullHttpResponse(HTTP_1_1,  error,
+                    Unpooled.copiedBuffer(body, CharsetUtil.UTF_8));
+            httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/plain");
+            httpResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, body.length());
+        }
+        return httpResponse;
+    }
+
+    protected FullHttpResponse buildJsonResponse(Object content, String contentType) {
+        try {
+            String body = MAPPER.writeValueAsString(content);
+            return buildStringResponse(body, contentType);
+        } catch (JsonProcessingException err) {
+            return buildErrorResponse(INTERNAL_SERVER_ERROR,
+                    "Internal server error - JSON Processing", "text/plain");
+        }
+    }
+
+
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/HttpRequestProcessor.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/HttpRequestProcessor.java
@@ -76,10 +76,7 @@ public abstract class HttpRequestProcessor {
         }
     }
 
-<<<<<<< HEAD
-    protected FullHttpResponse buildJsonErrorResponse(SchemaStorageException err) {
-        HttpResponseStatus error = HttpResponseStatus.valueOf(err.getHttpStatusCode());
-=======
+
     public static FullHttpResponse buildJsonErrorResponse(Throwable err) {
         while (err instanceof CompletionException) {
             err = err.getCause();
@@ -88,11 +85,9 @@ public abstract class HttpRequestProcessor {
                 ? ((SchemaStorageException) err).getHttpStatusCode()
                 : INTERNAL_SERVER_ERROR.code();
         HttpResponseStatus error = HttpResponseStatus.valueOf(httpStatusCode);
->>>>>>> cfc3733 (Make SchemaRegistry fully async)
-
         FullHttpResponse httpResponse = null;
         try {
-            String body = MAPPER.writeValueAsString(new ErrorModel(err.getHttpStatusCode(), err.getMessage()));
+            String body = MAPPER.writeValueAsString(new ErrorModel(httpStatusCode, err.getMessage()));
             httpResponse = new DefaultFullHttpResponse(HTTP_1_1,  error,
                     Unpooled.copiedBuffer(body, CharsetUtil.UTF_8));
             httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/vnd.schemaregistry.v1+json");

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryChannelInitializer.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryChannelInitializer.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry;
+
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpServerCodec;
+import lombok.AllArgsConstructor;
+
+/**
+ * A channel initializer that initialize channels for the Schema Registry service.
+ */
+@AllArgsConstructor
+public class SchemaRegistryChannelInitializer extends ChannelInitializer<SocketChannel> {
+
+    public static final int MAX_FRAME_LENGTH = 5 * 1024 * 1024; // 5MB
+
+    private SchemaRegistryHandler schemaRegistryHandler;
+
+    @Override
+    protected void initChannel(SocketChannel ch) throws Exception {
+        ChannelPipeline p = ch.pipeline();
+        p.addLast(new HttpServerCodec());
+        p.addLast(new HttpObjectAggregator(MAX_FRAME_LENGTH));
+        p.addLast(schemaRegistryHandler);
+    }
+
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryHandler.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryHandler.java
@@ -52,25 +52,21 @@ public class SchemaRegistryHandler extends SimpleChannelInboundHandler {
             log.debug("SchemaRegistry {}", msg);
         }
         FullHttpRequest request = (FullHttpRequest) msg;
-        try {
-            boolean done = false;
-            for (HttpRequestProcessor processor : processors) {
-                FullHttpResponse fullHttpResponse = processor.processRequest(request);
-                if (fullHttpResponse != null) {
-                    ctx.writeAndFlush(fullHttpResponse);
-                    done = true;
-                    break;
-                }
+        boolean done = false;
+        for (HttpRequestProcessor processor : processors) {
+            FullHttpResponse fullHttpResponse = processor.processRequest(request);
+            if (fullHttpResponse != null) {
+                ctx.writeAndFlush(fullHttpResponse);
+                done = true;
+                break;
             }
-            if (!done) {
-                FullHttpResponse httpResponse = new DefaultFullHttpResponse(HTTP_1_1,
-                        NOT_FOUND,
-                        Unpooled.copiedBuffer("Not found - " + request.uri(), CharsetUtil.UTF_8));
-                httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/plain; charset=UTF-8");
-                ctx.writeAndFlush(httpResponse);
-            }
-        } finally {
-            ReferenceCountUtil.safeRelease(msg);
+        }
+        if (!done) {
+            FullHttpResponse httpResponse = new DefaultFullHttpResponse(HTTP_1_1,
+                    NOT_FOUND,
+                    Unpooled.copiedBuffer("Not found - " + request.uri(), CharsetUtil.UTF_8));
+            httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/plain; charset=UTF-8");
+            ctx.writeAndFlush(httpResponse);
         }
     }
 

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryHandler.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryHandler.java
@@ -25,7 +25,6 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.util.CharsetUtil;
-import io.netty.util.ReferenceCountUtil;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryHandler.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryHandler.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.util.CharsetUtil;
+import io.netty.util.ReferenceCountUtil;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@ChannelHandler.Sharable
+public class SchemaRegistryHandler extends SimpleChannelInboundHandler {
+
+    private List<HttpRequestProcessor> processors = new ArrayList<>();
+
+    public SchemaRegistryHandler addProcessor(HttpRequestProcessor processor) {
+        this.processors.add(processor);
+        return this;
+    }
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) {
+        ctx.flush();
+    }
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, Object msg) {
+        if (log.isDebugEnabled()) {
+            log.debug("SchemaRegistry {}", msg);
+        }
+        FullHttpRequest request = (FullHttpRequest) msg;
+        try {
+            boolean done = false;
+            for (HttpRequestProcessor processor : processors) {
+                FullHttpResponse fullHttpResponse = processor.processRequest(request);
+                if (fullHttpResponse != null) {
+                    ctx.writeAndFlush(fullHttpResponse);
+                    done = true;
+                    break;
+                }
+            }
+            if (!done) {
+                FullHttpResponse httpResponse = new DefaultFullHttpResponse(HTTP_1_1,
+                        NOT_FOUND,
+                        Unpooled.copiedBuffer("Not found - " + request.uri(), CharsetUtil.UTF_8));
+                httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/plain; charset=UTF-8");
+                ctx.writeAndFlush(httpResponse);
+            }
+        } finally {
+            ReferenceCountUtil.safeRelease(msg);
+        }
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        log.error("Unhandled error, closing conection to {}", ctx.channel(), cause);
+        ctx.close();
+    }
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryHandler.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryHandler.java
@@ -51,6 +51,8 @@ public class SchemaRegistryHandler extends SimpleChannelInboundHandler {
             log.debug("SchemaRegistry {}", msg);
         }
         FullHttpRequest request = (FullHttpRequest) msg;
+        log.info("SchemaRegistry {} {} from {}", request.method(), request.uri(), ctx.channel().localAddress());
+
         boolean done = false;
         for (HttpRequestProcessor processor : processors) {
             FullHttpResponse fullHttpResponse = processor.processRequest(request);
@@ -65,12 +67,16 @@ public class SchemaRegistryHandler extends SimpleChannelInboundHandler {
             }
         }
         if (!done) {
-            String body = "Not found - " + request.uri();
+            String body = "{\n"
+                    + "  \"message\" : \"Not found\",\n"
+                    + "  \"error_code\" : 404\n"
+                    + "}";
             FullHttpResponse httpResponse = new DefaultFullHttpResponse(HTTP_1_1,
                     NOT_FOUND,
                     Unpooled.copiedBuffer(body, CharsetUtil.UTF_8));
-            httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/plain; charset=UTF-8");
+            httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/vnd.schemaregistry.v1+json");
             httpResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, body.length());
+            log.info("not found {} {} from {}", request.method(), request.uri(), ctx.channel().localAddress());
             if (log.isDebugEnabled()) {
                 log.debug("SchemaRegistry at {} request {} response {}", ctx.channel().localAddress(), msg,
                         httpResponse);

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryRequestAuthenticator.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryRequestAuthenticator.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry;
+
+import io.netty.handler.codec.http.FullHttpRequest;
+
+/**
+ * Authenticates a HTTP Request for the Schema Registry.
+ */
+public interface SchemaRegistryRequestAuthenticator {
+
+    /**
+     * Validates the HTTP Request.
+     * @param request
+     * @return a tenant name in case of valid request
+     * @throws Exception in case of authentication failure or other system error
+     */
+    String authenticate(FullHttpRequest request) throws Exception;
+
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/Schema.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/Schema.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@Data
+@AllArgsConstructor
+@Builder
+@EqualsAndHashCode
+@ToString
+public final class Schema {
+
+    public static final String TYPE_AVRO = "AVRO";
+    public static final String TYPE_JSON = "JSON";
+    public static final String TYPE_PROTOBUF = "PROTOBUF";
+    private static final List<String> ALL_TYPES =
+            Collections.unmodifiableList(Arrays.asList(TYPE_AVRO, TYPE_JSON, TYPE_PROTOBUF));
+
+    private final String tenant;
+    private final int id;
+    private final int version;
+    private final String schemaDefinition;
+    private final String subject;
+    private final String type;
+
+    public static List<String> getAllTypes() {
+        return ALL_TYPES;
+    }
+
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/SchemaStorage.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/SchemaStorage.java
@@ -15,6 +15,7 @@ package io.streamnative.pulsar.handlers.kop.schemaregistry.model;
 
 import io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl.SchemaStorageException;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 public interface SchemaStorage {
 
@@ -29,34 +30,34 @@ public interface SchemaStorage {
      * @param id the id
      * @return the Schema or null
      */
-    Schema findSchemaById(int id) throws SchemaStorageException;
+    CompletableFuture<Schema> findSchemaById(int id);
 
     /**
      * Find Schemas that have the same definition.
      * @param schemaDefinition the expected schema
      * @return the list of schemas
      */
-    List<Schema> findSchemaByDefinition(String schemaDefinition) throws SchemaStorageException;
+    CompletableFuture<List<Schema>> findSchemaByDefinition(String schemaDefinition);
 
     /**
      * Get all existing subjects.
      * @return
      */
-    List<String> getAllSubjects() throws SchemaStorageException;
+    CompletableFuture<List<String>> getAllSubjects();
 
     /**
      * Get all versions for a given subject.
      * @param subject the Subject
      * @return the list of versions
      */
-    List<Integer> getAllVersionsForSubject(String subject) throws SchemaStorageException;
+    CompletableFuture<List<Integer>> getAllVersionsForSubject(String subject);
 
     /**
      * Delete all the versions of a subject.
      * @param subject the Subject
      * @return the versions
      */
-    List<Integer> deleteSubject(String subject) throws SchemaStorageException;
+    CompletableFuture<List<Integer>> deleteSubject(String subject);
 
     /**
      * Lookup a schema by subject and version.
@@ -64,7 +65,7 @@ public interface SchemaStorage {
      * @param version the Version
      * @return the Schema
      */
-    Schema findSchemaBySubjectAndVersion(String subject, int version) throws SchemaStorageException;
+    CompletableFuture<Schema> findSchemaBySubjectAndVersion(String subject, int version);
 
     /**
      * Create a new schema.
@@ -74,6 +75,6 @@ public interface SchemaStorage {
      * @param forceCreate require to create a new version, without looking for an existing schema
      * @return the new Schema
      */
-    Schema createSchemaVersion(String subject, String schemaType, String schemaDefinition,
-                               boolean forceCreate) throws SchemaStorageException;
+    CompletableFuture<Schema> createSchemaVersion(String subject, String schemaType, String schemaDefinition,
+                               boolean forceCreate);
 }

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/SchemaStorage.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/SchemaStorage.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model;
+
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl.SchemaStorageException;
+import java.util.List;
+
+public interface SchemaStorage {
+
+    /**
+     * Get current tenant.
+     * @return
+     */
+    String getTenant();
+
+    /**
+     * Find a schema by unique id.
+     * @param id the id
+     * @return the Schema or null
+     */
+    Schema findSchemaById(int id) throws SchemaStorageException;
+
+    /**
+     * Find Schemas that have the same definition.
+     * @param schemaDefinition the expected schema
+     * @return the list of schemas
+     */
+    List<Schema> findSchemaByDefinition(String schemaDefinition) throws SchemaStorageException;
+
+    /**
+     * Get all existing subjects.
+     * @return
+     */
+    List<String> getAllSubjects() throws SchemaStorageException;
+
+    /**
+     * Get all versions for a given subject.
+     * @param subject the Subject
+     * @return the list of versions
+     */
+    List<Integer> getAllVersionsForSubject(String subject) throws SchemaStorageException;
+
+    /**
+     * Delete all the versions of a subject.
+     * @param subject the Subject
+     * @return the versions
+     */
+    List<Integer> deleteSubject(String subject) throws SchemaStorageException;
+
+    /**
+     * Lookup a schema by subject and version.
+     * @param subject the Subject
+     * @param version the Version
+     * @return the Schema
+     */
+    Schema findSchemaBySubjectAndVersion(String subject, int version) throws SchemaStorageException;
+
+    /**
+     * Create a new schema.
+     * @param subject the Subject
+     * @param schemaType the type
+     * @param schemaDefinition the schema
+     * @param forceCreate require to create a new version, without looking for an existing schema
+     * @return the new Schema
+     */
+    Schema createSchemaVersion(String subject, String schemaType, String schemaDefinition,
+                               boolean forceCreate) throws SchemaStorageException;
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/SchemaStorageAccessor.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/SchemaStorageAccessor.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model;
+
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl.SchemaStorageException;
+
+/**
+ * Accesses the SchemaStorage instance for a given tenant.
+ */
+public interface SchemaStorageAccessor extends Cloneable {
+
+    SchemaStorage getSchemaStorageForTenant(String tenant) throws SchemaStorageException;
+
+    void close();
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/MemorySchemaStorage.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/MemorySchemaStorage.java
@@ -1,0 +1,155 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl;
+
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.Schema;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorage;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+public class MemorySchemaStorage implements SchemaStorage {
+    private final ConcurrentHashMap<Integer, Schema> schemas = new ConcurrentHashMap<>();
+    private final AtomicInteger schemaIdGenerator = new AtomicInteger();
+    private final String tenant;
+
+    public MemorySchemaStorage(String tenant) {
+        this.tenant = tenant;
+    }
+
+    @Override
+    public String getTenant() {
+        return tenant;
+    }
+
+    @Override
+    public Schema findSchemaById(int id) throws SchemaStorageException {
+        return schemas.get(id);
+    }
+
+    @Override
+    public Schema findSchemaBySubjectAndVersion(String subject, int version) {
+        return schemas
+                .values()
+                .stream()
+                .filter(s -> s.getSubject().equals(subject)
+                        && s.getVersion() == version)
+                .findAny()
+                .orElse(null);
+    }
+
+    @Override
+    public List<Schema> findSchemaByDefinition(String schemaDefinition) {
+        return schemas
+                .values()
+                .stream()
+                .filter(s -> s.getSchemaDefinition().equals(schemaDefinition))
+                .sorted(Comparator.comparing(Schema::getId)) // this is good for unit tests
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<String> getAllSubjects() {
+        return schemas
+                .values()
+                .stream()
+                .map(Schema::getSubject)
+                .distinct()
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Integer> getAllVersionsForSubject(String subject) {
+        return schemas
+                .values()
+                .stream()
+                .filter(s -> s.getSubject().equals(subject))
+                .map(Schema::getVersion)
+                .sorted() // this is goodfor unit tests
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Integer> deleteSubject(String subject) {
+        // please note that this implementation is not meant to be fully
+        // thread safe, it is only for tests
+        List<Integer> keys = schemas
+                .values()
+                .stream()
+                .filter(s -> s.getSubject().equals(subject))
+                .map(s -> s.getId())
+                .collect(Collectors.toList());
+        List<Integer> versions = new ArrayList<>(keys.size());
+        keys.forEach(key -> {
+            Schema remove = schemas.remove(key);
+            if (remove != null) {
+                versions.add(remove.getVersion());
+            }
+        });
+        return versions;
+    }
+
+    @Override
+    public Schema createSchemaVersion(String subject, String schemaType,
+                                      String schemaDefinition, boolean forceCreate) {
+        // please note that this implementation is not meant to be fully
+        // thread safe, it is only for tests
+
+        if (!forceCreate) {
+            Schema found = schemas
+                    .values()
+                    .stream()
+                    .filter(s -> s.getSubject().equals(subject)
+                            && s.getSchemaDefinition().equals(schemaDefinition))
+                    .sorted(Comparator.comparing(Schema::getVersion).reversed())
+                    .findFirst()
+                    .orElse(null);
+            if (found != null) {
+                return found;
+            }
+        }
+
+        int newId = schemaIdGenerator.incrementAndGet();
+        int newVersion = schemas
+                .values()
+                .stream()
+                .filter(s -> s.getSubject().equals(subject))
+                .map(Schema::getVersion)
+                .sorted(Comparator.reverseOrder())
+                .findFirst()
+                .orElse(0) + 1;
+        Schema newSchema = Schema
+                .builder()
+                .id(newId)
+                .schemaDefinition(schemaDefinition)
+                .type(schemaType)
+                .subject(subject)
+                .version(newVersion)
+                .tenant(getTenant())
+                .build();
+        schemas.put(newSchema.getId(), newSchema);
+        return newSchema;
+    }
+
+    public void storeSchema(Schema schema) {
+        schemas.put(schema.getId(), schema);
+    }
+
+    public void clear() {
+        schemas.clear();
+    }
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/MemorySchemaStorage.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/MemorySchemaStorage.java
@@ -18,6 +18,7 @@ import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorage;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -37,54 +38,54 @@ public class MemorySchemaStorage implements SchemaStorage {
     }
 
     @Override
-    public Schema findSchemaById(int id) throws SchemaStorageException {
-        return schemas.get(id);
+    public CompletableFuture<Schema> findSchemaById(int id) {
+        return CompletableFuture.completedFuture(schemas.get(id));
     }
 
     @Override
-    public Schema findSchemaBySubjectAndVersion(String subject, int version) {
-        return schemas
+    public CompletableFuture<Schema> findSchemaBySubjectAndVersion(String subject, int version) {
+        return CompletableFuture.completedFuture(schemas
                 .values()
                 .stream()
                 .filter(s -> s.getSubject().equals(subject)
                         && s.getVersion() == version)
                 .findAny()
-                .orElse(null);
+                .orElse(null));
     }
 
     @Override
-    public List<Schema> findSchemaByDefinition(String schemaDefinition) {
-        return schemas
+    public CompletableFuture<List<Schema>> findSchemaByDefinition(String schemaDefinition) {
+        return CompletableFuture.completedFuture(schemas
                 .values()
                 .stream()
                 .filter(s -> s.getSchemaDefinition().equals(schemaDefinition))
                 .sorted(Comparator.comparing(Schema::getId)) // this is good for unit tests
-                .collect(Collectors.toList());
+                .collect(Collectors.toList()));
     }
 
     @Override
-    public List<String> getAllSubjects() {
-        return schemas
+    public CompletableFuture<List<String>> getAllSubjects() {
+        return CompletableFuture.completedFuture(schemas
                 .values()
                 .stream()
                 .map(Schema::getSubject)
                 .distinct()
-                .collect(Collectors.toList());
+                .collect(Collectors.toList()));
     }
 
     @Override
-    public List<Integer> getAllVersionsForSubject(String subject) {
-        return schemas
+    public CompletableFuture<List<Integer>> getAllVersionsForSubject(String subject) {
+        return CompletableFuture.completedFuture(schemas
                 .values()
                 .stream()
                 .filter(s -> s.getSubject().equals(subject))
                 .map(Schema::getVersion)
                 .sorted() // this is goodfor unit tests
-                .collect(Collectors.toList());
+                .collect(Collectors.toList()));
     }
 
     @Override
-    public List<Integer> deleteSubject(String subject) {
+    public CompletableFuture<List<Integer>> deleteSubject(String subject) {
         // please note that this implementation is not meant to be fully
         // thread safe, it is only for tests
         List<Integer> keys = schemas
@@ -100,11 +101,11 @@ public class MemorySchemaStorage implements SchemaStorage {
                 versions.add(remove.getVersion());
             }
         });
-        return versions;
+        return CompletableFuture.completedFuture(versions);
     }
 
     @Override
-    public Schema createSchemaVersion(String subject, String schemaType,
+    public CompletableFuture<Schema> createSchemaVersion(String subject, String schemaType,
                                       String schemaDefinition, boolean forceCreate) {
         // please note that this implementation is not meant to be fully
         // thread safe, it is only for tests
@@ -119,7 +120,7 @@ public class MemorySchemaStorage implements SchemaStorage {
                     .findFirst()
                     .orElse(null);
             if (found != null) {
-                return found;
+                return CompletableFuture.completedFuture(found);
             }
         }
 
@@ -142,7 +143,7 @@ public class MemorySchemaStorage implements SchemaStorage {
                 .tenant(getTenant())
                 .build();
         schemas.put(newSchema.getId(), newSchema);
-        return newSchema;
+        return CompletableFuture.completedFuture(newSchema);
     }
 
     public void storeSchema(Schema schema) {

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/MemorySchemaStorageAccessor.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/MemorySchemaStorageAccessor.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl;
+
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorageAccessor;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class MemorySchemaStorageAccessor implements SchemaStorageAccessor {
+    private final ConcurrentHashMap<String, MemorySchemaStorage> tenants = new ConcurrentHashMap<>();
+
+    @Override
+    public MemorySchemaStorage getSchemaStorageForTenant(String tenant) {
+        return tenants.computeIfAbsent(tenant != null ? tenant : "", t -> new MemorySchemaStorage(t));
+    }
+
+    public void clear() {
+        tenants.clear();
+    }
+
+    public void close() {
+        tenants.clear();
+    }
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorage.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorage.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -116,7 +117,7 @@ public class PulsarSchemaStorage implements SchemaStorage, Closeable {
                 reader = pulsarClient.newReader(avroSchema)
                         .topic(topic)
                         .startMessageId(MessageId.earliest)
-                        .subscriptionRolePrefix("kafak-schema-registry-")
+                        .subscriptionRolePrefix("kafka-schema-registry")
                         .create();
             }
             return reader;

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorage.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorage.java
@@ -1,0 +1,402 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl;
+
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.Schema;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorage;
+import java.io.Closeable;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerAccessMode;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Reader;
+
+@Slf4j
+public class PulsarSchemaStorage implements SchemaStorage, Closeable {
+
+    // Pulsar Schema instances are stateful, you cannot
+    // use them as constants
+    private final org.apache.pulsar.client.api.Schema<Op> avroSchema =
+                            org.apache.pulsar.client.api.Schema.AVRO(Op.class);
+
+    private final ConcurrentHashMap<Integer, SchemaEntry> schemas = new ConcurrentHashMap<>();
+    private final PulsarClient pulsarClient;
+    private final String topic;
+    private final String tenant;
+    private Reader<Op> reader;
+
+    private enum SchemaStatus {
+        ACTIVE,
+        DELETED
+    }
+
+    @Data
+    @Builder
+    private static final class SchemaEntry {
+        private int id;
+        private SchemaStatus status;
+        private String tenant;
+        private int version;
+        private String subject;
+        private String schemaDefinition;
+        private String type;
+    }
+
+    @Builder
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static final class Op {
+        int schemaId;
+        int schemaVersion;
+        String subject;
+        String tenant;
+        String schemaDefinition;
+        SchemaStatus status;
+        String type;
+
+
+        SchemaEntry toSchemaEntry() {
+            return SchemaEntry
+                    .builder()
+                    .id(schemaId)
+                    .version(schemaVersion)
+                    .subject(subject)
+                    .tenant(tenant)
+                    .schemaDefinition(schemaDefinition)
+                    .status(status)
+                    .type(type)
+                    .build();
+        }
+    }
+
+    PulsarSchemaStorage(String tenant, PulsarClient client, String topic) {
+        this.tenant = tenant;
+        this.pulsarClient = client;
+        this.topic = topic;
+    }
+
+    @Override
+    public String getTenant() {
+        return tenant;
+    }
+
+    private synchronized Reader<Op> getReader() throws SchemaStorageException {
+        try {
+            if (reader == null) {
+                reader = pulsarClient.newReader(avroSchema)
+                        .topic(topic)
+                        .startMessageId(MessageId.earliest)
+                        .subscriptionRolePrefix("kafak-schema-registry-")
+                        .create();
+            }
+            return reader;
+        } catch (PulsarClientException err) {
+            throw new SchemaStorageException(err);
+        }
+    }
+
+    private synchronized void ensureLatestData() throws SchemaStorageException {
+        Reader<Op> reader = getReader();
+        try {
+            while (reader.hasMessageAvailable()) {
+                Message<Op> opMessage = reader.readNext(1, TimeUnit.SECONDS);
+                if (opMessage != null) {
+                    Op value = opMessage.getValue();
+                    log.info("read {} from pulsar", value);
+                    SchemaEntry schemaEntry = value.toSchemaEntry();
+                    schemas.put(schemaEntry.id, schemaEntry);
+                }
+            }
+        } catch (PulsarClientException err) {
+            throw new SchemaStorageException(err);
+        }
+    }
+
+    @Override
+    public Schema findSchemaById(int id) throws SchemaStorageException {
+        return getSchemaFromSchemaEntry(fetchSchemaEntry(() -> schemas.get(id)));
+    }
+
+    private static Schema getSchemaFromSchemaEntry(SchemaEntry res) {
+        if (res == null) {
+            return null;
+        }
+        return Schema
+                .builder()
+                .tenant(res.tenant)
+                .id(res.id)
+                .version(res.version)
+                .subject(res.subject)
+                .schemaDefinition(res.schemaDefinition)
+                .type(res.type)
+                .build();
+    }
+
+    @Override
+    public Schema findSchemaBySubjectAndVersion(String subject, int version)
+                            throws SchemaStorageException {
+        return getSchemaFromSchemaEntry(fetchSchemaEntry(() ->schemas
+                .values()
+                .stream()
+                .filter(s-> s.getSubject().equals(subject)
+                        && s.getVersion() == version)
+                .findAny()
+                .orElse(null)));
+    }
+
+    private SchemaEntry fetchSchemaEntry(Supplier<SchemaEntry> procedure)
+            throws SchemaStorageException {
+        return fetch(procedure,
+                (schemaEntry) -> schemaEntry != null && schemaEntry.status == SchemaStatus.DELETED,
+                schemaEntry ->  schemaEntry == null);
+    }
+
+    private <T> T fetch(Supplier<T> procedure,
+                        Function<T, Boolean> isDeleted,
+                        Function<T, Boolean> requiresFetch)
+            throws SchemaStorageException {
+        T res = procedure.get();
+        if (isDeleted.apply(res)) {
+            return null;
+        }
+        if (requiresFetch.apply(res)) {
+            // ensure we are in sync with the latest write
+            ensureLatestData();
+            res = procedure.get();
+        }
+        if (isDeleted.apply(res)) {
+            return null;
+        }
+        return res;
+    }
+
+    @Override
+    public List<Schema> findSchemaByDefinition(String schemaDefinition) throws SchemaStorageException {
+        List<SchemaEntry> list = fetch(
+                () ->  schemas
+                    .values()
+                    .stream()
+                    .filter(s -> s.getSchemaDefinition().equals(schemaDefinition))
+                    .sorted(Comparator.comparing(SchemaEntry::getId)) // this is good for unit tests
+                    .collect(Collectors.toList())
+                , (res) -> false  // not applicable
+                , (res) -> res.isEmpty()); // fetch again if nothing found, useful for demos/testing
+        return list
+                .stream()
+                .map(PulsarSchemaStorage::getSchemaFromSchemaEntry)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<String> getAllSubjects() throws SchemaStorageException {
+        List<String> list = fetch(
+                () -> schemas
+                        .values()
+                        .stream()
+                        .map(SchemaEntry::getSubject)
+                        .distinct()
+                        .collect(Collectors.toList()),
+                (res) -> false, // not applicable
+                (res) -> res.isEmpty()); // fetch again if nothing found, useful for demos/testing
+        return list;
+    }
+
+    @Override
+    public List<Integer> getAllVersionsForSubject(String subject) throws SchemaStorageException {
+        List<Integer> list = fetch(
+                () -> schemas
+                .values()
+                .stream()
+                .filter(s -> s.getSubject().equals(subject) && s.status != SchemaStatus.DELETED)
+                .map(SchemaEntry::getVersion)
+                .sorted() // this is goodfor unit tests
+                .collect(Collectors.toList()),
+                (res) -> false,  // not applicable
+                (res) -> res.isEmpty()); // fetch again if nothing found, useful for demos/testing
+        return list;
+    }
+
+    private synchronized <T> List<T> executeWriteOp(Supplier<List<Map.Entry<Op, T>>> opBuilder)
+            throws SchemaStorageException {
+        try (Producer<Op> opProducer = pulsarClient.newProducer(avroSchema)
+                .enableBatching(false)
+                .topic(topic)
+                .accessMode(ProducerAccessMode.WaitForExclusive)
+                .blockIfQueueFull(true)
+                .create();) {
+            // nobody can write now to the topic
+            // wait for local cache to be up-to-date
+            ensureLatestData();
+
+            // build the Op, this will usually use the contents of the local cache
+            List<Map.Entry<Op, T>> ops = opBuilder.get();
+            List<T> res = new ArrayList<>();
+            // write to Pulsar
+            // if the write fails we lost the lock
+            for (Map.Entry<Op, T> action : ops) {
+                Op op = action.getKey();
+                // if "op" is null, then we do not have to write to Pulsar
+                if (op != null) {
+                    if (!op.tenant.equals(getTenant())) {
+                        throw new SchemaStorageException("Invalid tenant " + op.tenant + ", expected " + tenant);
+                    }
+                    opProducer.send(op);
+                    // write to local memory
+                    SchemaEntry schemaEntry = op.toSchemaEntry();
+                    schemas.put(schemaEntry.id, schemaEntry);
+                }
+                res.add(action.getValue());
+            }
+
+            return res;
+        } catch (PulsarClientException err) {
+            throw new SchemaStorageException(err);
+        }
+    }
+
+    @Override
+    public List<Integer> deleteSubject(String subject) throws SchemaStorageException {
+        List<Integer> versionsRes = executeWriteOp(() -> {
+            List<SchemaEntry> entriesToDelete = schemas
+                    .values()
+                    .stream()
+                    .filter(s->s.getTenant().equals(tenant) && s.getSubject().equals(subject))
+                    .collect(Collectors.toList());
+
+                List<Map.Entry<Op, Integer>> operationsAndResults =
+                        entriesToDelete
+                                .stream()
+                                .map(schemaEntry -> {
+                                    return new AbstractMap.SimpleImmutableEntry<>(
+                                            Op.builder()
+                                                    .schemaId(schemaEntry.id)
+                                                    .subject(schemaEntry.subject)
+                                                    .schemaDefinition(null)
+                                                    .schemaVersion(schemaEntry.version)
+                                                    .status(SchemaStatus.DELETED)
+                                                    .tenant(schemaEntry.tenant)
+                                                    .build(),
+                                            schemaEntry.getVersion()
+                                    );
+                                })
+                                .collect(Collectors.toList());
+
+                return operationsAndResults;
+        });
+        return versionsRes;
+    }
+
+    @Override
+    public Schema createSchemaVersion(String subject, String schemaType, String schemaDefinition,
+                                      boolean forceCreate) throws SchemaStorageException {
+        if (!forceCreate) {
+            // read from cache, this is the most common case
+            SchemaEntry found = fetchSchemaEntry(() -> schemas
+                    .values()
+                    .stream()
+                    .filter(s -> s.getTenant().equals(tenant)
+                            && s.getSubject().equals(subject)
+                            && s.getSchemaDefinition().equals(schemaDefinition))
+                    .sorted(Comparator.comparing(SchemaEntry::getVersion).reversed())
+                    .findFirst()
+                    .orElse(null));
+            if (found != null) {
+                return getSchemaFromSchemaEntry(found);
+            }
+        }
+
+        // enter the lock
+        List<SchemaEntry> schemaRes = executeWriteOp(buildWriteSchemaOp(subject,
+                schemaType, schemaDefinition, forceCreate));
+
+        // this function will always return something
+        return getSchemaFromSchemaEntry(schemaRes.get(0));
+    }
+
+    private Supplier<List<Map.Entry<Op, SchemaEntry>>> buildWriteSchemaOp(String subject,
+                                                                          String schemaType,
+                                                                          String schemaDefinition,
+                                                                          boolean forceCreate) {
+        return () -> {
+
+            if (!forceCreate) {
+                SchemaEntry found = schemas
+                        .values()
+                        .stream()
+                        .filter(s -> s.getSubject().equals(subject)
+                                && s.getSchemaDefinition().equals(schemaDefinition))
+                        .sorted(Comparator.comparing(SchemaEntry::getVersion).reversed())
+                        .findFirst()
+                        .orElse(null);
+
+                if (found != null) {
+                    List<Map.Entry<Op, SchemaEntry>> cachedRes =
+                     Arrays.asList(new AbstractMap.SimpleImmutableEntry<>((Op) null, found));
+                    return cachedRes;
+                }
+            }
+
+            // select new id, we are inside the write lock
+            // also we are sure that the local cache is up-to-date
+            int newId = schemas
+                    .keySet()
+                    .stream()
+                    .mapToInt(s -> s)
+                    .max()
+                    .orElse(0) + 1;
+            int newVersion = schemas
+                    .values()
+                    .stream()
+                    .filter(s -> s.getSubject().equals(subject))
+                    .map(SchemaEntry::getVersion)
+                    .sorted(Comparator.reverseOrder())
+                    .findFirst()
+                    .orElse(0) + 1;
+            Op newSchema = Op
+                    .builder()
+                    .schemaId(newId)
+                    .schemaDefinition(schemaDefinition)
+                    .type(schemaType)
+                    .subject(subject)
+                    .schemaVersion(newVersion)
+                    .tenant(tenant)
+                    .build();
+
+            return Arrays.asList(new AbstractMap.SimpleImmutableEntry<>(newSchema, newSchema.toSchemaEntry()));
+        };
+    }
+
+    public void close() {
+        // we are not owning the PulsarClient
+    }
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorage.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorage.java
@@ -132,8 +132,7 @@ public class PulsarSchemaStorage implements SchemaStorage, Closeable {
                         return CompletableFuture.completedFuture(null);
                     } else {
                         CompletableFuture<Message<Op>> opMessage = reader.readNextAsync();
-                        // here we use thenApplyAsync in order to detach from the current thread
-                        return opMessage.thenApplyAsync(msg -> {
+                        return opMessage.thenCompose(msg -> {
                             Op value = msg.getValue();
                             log.info("read {} from pulsar", value);
                             SchemaEntry schemaEntry = value.toSchemaEntry();

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorage.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorage.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorageAccessor.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorageAccessor.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl;
+
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorageAccessor;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.PulsarClient;
+
+@AllArgsConstructor
+@Slf4j
+public class PulsarSchemaStorageAccessor implements SchemaStorageAccessor {
+    private final ConcurrentHashMap<String, PulsarSchemaStorage> tenants = new ConcurrentHashMap<>();
+    private final Function<String, PulsarClient> authenticatedClientBuilder;
+    private final String namespaceName;
+    private final String topicName;
+
+    @Override
+    public PulsarSchemaStorage getSchemaStorageForTenant(String tenant) throws SchemaStorageException {
+        if (tenant == null) {
+            throw new SchemaStorageException("Invalid Tenant null");
+        }
+        return tenants.computeIfAbsent(tenant, t -> {
+            String fullTopicName = "persistent://" + t + "/" + namespaceName + "/" + topicName;
+            log.info("Building Pulsar Client for Schema Registry for Tenant {}, data topic {}", tenant, fullTopicName);
+            PulsarClient pulsarClient = authenticatedClientBuilder.apply(t);
+            return new PulsarSchemaStorage(t, pulsarClient, fullTopicName);
+        });
+    }
+
+    public void clear() {
+        tenants.clear();
+    }
+
+    public void close() {
+        tenants.clear();
+    }
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/SchemaStorageException.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/SchemaStorageException.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class SchemaStorageException extends Exception {
+
+    private final int httpStatusCode;
+
+    public SchemaStorageException(Throwable cause) {
+        super(cause);
+        this.httpStatusCode = HttpResponseStatus.INTERNAL_SERVER_ERROR.code();
+    }
+
+    public SchemaStorageException(String message) {
+        super(message);
+        this.httpStatusCode = HttpResponseStatus.INTERNAL_SERVER_ERROR.code();
+    }
+
+    public SchemaStorageException(String message, int httpStatusCode) {
+        super(message);
+        this.httpStatusCode = httpStatusCode;
+    }
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/package-info.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl;

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/package-info.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model;

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/package-info.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry;

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/AbstractResource.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/AbstractResource.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.resources;
+
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryHandler;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryRequestAuthenticator;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorage;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorageAccessor;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl.SchemaStorageException;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public abstract class AbstractResource {
+
+    public static final String INT_PATTERN = "([0-9]+)";
+    public static final String STRING_PATTERN = "(.+)";
+
+    public static final String GET = "GET";
+    public static final String POST = "POST";
+    public static final String DELETE = "DELETE";
+
+    public static final String DEFAULT_TENANT = "public";
+
+    protected final SchemaStorageAccessor schemaStorageAccessor;
+    protected final SchemaRegistryRequestAuthenticator schemaRegistryRequestAuthenticator;
+
+    protected String getCurrentTenant(FullHttpRequest request) throws Exception {
+        return schemaRegistryRequestAuthenticator.authenticate(request);
+    }
+
+    protected SchemaStorage getSchemaStorage(FullHttpRequest request) throws SchemaStorageException {
+        String currentTenant;
+        try {
+            currentTenant = getCurrentTenant(request);
+        } catch (SchemaStorageException e) {
+            throw e;
+        }  catch (Exception e) {
+            throw new SchemaStorageException(e);
+        }
+        if (currentTenant == null) {
+            throw new SchemaStorageException("Missing or failed authentication",
+                    HttpResponseStatus.UNAUTHORIZED.code());
+        }
+        return schemaStorageAccessor.getSchemaStorageForTenant(currentTenant);
+    }
+
+    /**
+     * Register all processors.
+     * @param schemaRegistryHandler
+     */
+    public abstract void register(SchemaRegistryHandler schemaRegistryHandler);
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SchemaResource.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SchemaResource.java
@@ -1,0 +1,126 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.resources;
+
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.HttpJsonRequestProcessor;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryHandler;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryRequestAuthenticator;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.Schema;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorage;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorageAccessor;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class SchemaResource extends AbstractResource {
+
+    public SchemaResource(SchemaStorageAccessor schemaStorageAccessor,
+                          SchemaRegistryRequestAuthenticator schemaRegistryRequestAuthenticator) {
+        super(schemaStorageAccessor, schemaRegistryRequestAuthenticator);
+    }
+
+    /**
+     * Register all processors.
+     * @param schemaRegistryHandler
+     */
+    public void register(SchemaRegistryHandler schemaRegistryHandler) {
+        schemaRegistryHandler.addProcessor(new GetSchemaById());
+        schemaRegistryHandler.addProcessor(new GetSchemaTypes());
+        schemaRegistryHandler.addProcessor(new GetSchemaAliases());
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static final class GetSchemaResponse {
+        private String schema;
+    }
+
+    // GET /schemas/ids/{int: id}
+    public class GetSchemaById extends HttpJsonRequestProcessor<Void, GetSchemaResponse> {
+
+        public GetSchemaById() {
+            super(Void.class, "/schemas/ids/" + INT_PATTERN, GET);
+        }
+
+        @Override
+        protected GetSchemaResponse processRequest(Void payload, List<String> patternGroups, FullHttpRequest request)
+                                    throws Exception{
+            int id = getInt(0, patternGroups);
+            SchemaStorage schemaStorage = getSchemaStorage(request);
+            Schema schemaById = schemaStorage.findSchemaById(id);
+            if (schemaById == null) {
+                return null;
+            }
+            return new GetSchemaResponse(schemaById.getSchemaDefinition());
+        }
+
+    }
+
+
+    // /schemas/types
+    public static class GetSchemaTypes extends HttpJsonRequestProcessor<Void, List<String>> {
+
+        public GetSchemaTypes() {
+            super(Void.class, "/schemas/types", GET);
+        }
+
+        @Override
+        protected List<String> processRequest(Void payload, List<String> patternGroups, FullHttpRequest request) {
+           return Schema.getAllTypes();
+        }
+
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+     public static final class SubjectVersionPair {
+        private String subject;
+        private int version;
+    }
+
+
+    // /schemas/ids/{int: id}/versions
+    public class GetSchemaAliases extends HttpJsonRequestProcessor<Void, List<SubjectVersionPair>> {
+
+        public GetSchemaAliases() {
+            super(Void.class, "/schemas/ids/" + INT_PATTERN + "/versions", GET);
+        }
+
+        @Override
+        protected List<SubjectVersionPair> processRequest(Void payload,
+                                                          List<String> patternGroups, FullHttpRequest request)
+                                throws Exception {
+            SchemaStorage schemaStorage = getSchemaStorage(request);
+            int id = getInt(0, patternGroups);
+            Schema schema =  schemaStorage.findSchemaById(id);
+            if (schema == null) {
+                return null;
+            }
+            List<Schema> schemaAliases = schemaStorage.findSchemaByDefinition(schema.getSchemaDefinition());
+            return schemaAliases
+                    .stream()
+                    .map(s -> new SubjectVersionPair(schema.getSubject(), schema.getVersion()))
+                    .collect(Collectors.toList());
+
+        }
+
+    }
+
+
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SubjectResource.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SubjectResource.java
@@ -1,0 +1,226 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.resources;
+
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.HttpJsonRequestProcessor;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryHandler;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryRequestAuthenticator;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.Schema;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorage;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorageAccessor;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+
+public class SubjectResource extends AbstractResource {
+
+    public SubjectResource(SchemaStorageAccessor schemaStorageAccessor,
+                           SchemaRegistryRequestAuthenticator schemaRegistryRequestAuthenticator) {
+        super(schemaStorageAccessor, schemaRegistryRequestAuthenticator);
+    }
+
+    @Override
+    public void register(SchemaRegistryHandler schemaRegistryHandler) {
+        schemaRegistryHandler.addProcessor(new CreateNewSchema());
+        schemaRegistryHandler.addProcessor(new GetAllSubjects());
+        schemaRegistryHandler.addProcessor(new GetAllVersions());
+        schemaRegistryHandler.addProcessor(new DeleteSubject());
+        schemaRegistryHandler.addProcessor(new GetSchemaBySubjectAndVersion());
+        schemaRegistryHandler.addProcessor(new GetRawSchemaBySubjectAndVersion());
+        schemaRegistryHandler.addProcessor(new CreateOrUpdateSchema());
+    }
+
+    // GET /subjects
+    public class GetAllSubjects extends HttpJsonRequestProcessor<Void, List<String>> {
+
+        public GetAllSubjects() {
+            super(Void.class, "/subjects", GET);
+        }
+
+        @Override
+        protected List<String> processRequest(Void payload, List<String> patternGroups, FullHttpRequest request)
+                throws Exception {
+            SchemaStorage schemaStorage = getSchemaStorage(request);
+            List<String> subjects = schemaStorage.getAllSubjects();
+            return subjects;
+        }
+
+    }
+
+    // GET /subjects/test/versions
+    public class GetAllVersions extends HttpJsonRequestProcessor<Void, List<Integer>> {
+
+        public GetAllVersions() {
+            super(Void.class, "/subjects/" + STRING_PATTERN + "/versions", GET);
+        }
+
+        @Override
+        protected List<Integer> processRequest(Void payload, List<String> patternGroups, FullHttpRequest request)
+                throws Exception {
+            SchemaStorage schemaStorage = getSchemaStorage(request);
+            String subject = getString(0, patternGroups);
+            List<Integer> versions = schemaStorage.getAllVersionsForSubject(subject);
+            if (versions.isEmpty()) {
+                return null;
+            }
+            return versions;
+        }
+
+    }
+
+    // DELETE /subjects/(string: subject)
+    public class DeleteSubject extends HttpJsonRequestProcessor<Void, List<Integer>> {
+
+        public DeleteSubject() {
+            super(Void.class, "/subjects/" + STRING_PATTERN, DELETE);
+        }
+
+        @Override
+        protected List<Integer> processRequest(Void payload, List<String> patternGroups, FullHttpRequest request)
+                throws Exception {
+            SchemaStorage schemaStorage = getSchemaStorage(request);
+            String subject = getString(0, patternGroups);
+
+            List<Integer> versions = schemaStorage.deleteSubject(subject);
+            if (versions.isEmpty()) {
+                return null;
+            }
+            return versions;
+        }
+
+    }
+
+    @AllArgsConstructor
+    @Getter
+    public static class GetSchemaBySubjectAndVersionResponse {
+        private String name;
+        private int version;
+        private String schema;
+    }
+
+    // GET /subjects/(string: subject)/versions/(versionId: version)
+    public class GetSchemaBySubjectAndVersion
+            extends HttpJsonRequestProcessor<Void, GetSchemaBySubjectAndVersionResponse> {
+
+        public GetSchemaBySubjectAndVersion() {
+            super(Void.class, "/subjects/" + STRING_PATTERN + "/versions/" + INT_PATTERN, GET);
+        }
+
+        @Override
+        protected GetSchemaBySubjectAndVersionResponse processRequest(Void payload,
+                                                                      List<String> patternGroups,
+                                                                      FullHttpRequest request)
+                throws Exception {
+            String subject = getString(0, patternGroups);
+            int version = getInt(1, patternGroups);
+            SchemaStorage schemaStorage = getSchemaStorage(request);
+            Schema schema = schemaStorage.findSchemaBySubjectAndVersion(subject, version);
+            if (schema == null) {
+                return null;
+            }
+            return new GetSchemaBySubjectAndVersionResponse(schema.getSubject(),
+                    schema.getVersion(), schema.getSchemaDefinition());
+        }
+
+    }
+
+    // GET /subjects/(string: subject)/versions/(versionId: version)
+    public class GetRawSchemaBySubjectAndVersion extends HttpJsonRequestProcessor<Void, String> {
+
+        public GetRawSchemaBySubjectAndVersion() {
+            super(Void.class, "/subjects/" + STRING_PATTERN + "/versions/" + INT_PATTERN + "/schema", GET);
+        }
+
+        @Override
+        protected String processRequest(Void payload, List<String> patternGroups, FullHttpRequest request)
+                throws Exception {
+            String subject = getString(0, patternGroups);
+            int version = getInt(1, patternGroups);
+            SchemaStorage schemaStorage = getSchemaStorage(request);
+            Schema schema = schemaStorage.findSchemaBySubjectAndVersion(subject, version);
+            if (schema == null) {
+                return null;
+            }
+            return schema.getSchemaDefinition();
+        }
+
+    }
+
+
+
+    @Data
+    public static final class CreateSchemaRequest {
+        String schema;
+        String schemaType = "AVRO";
+        List<SchemaReference> references = new ArrayList<>();
+
+        @Data
+        public static final class SchemaReference {
+            String name;
+            String subject;
+            String version;
+        }
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static final class CreateSchemaResponse {
+        int id;
+    }
+
+
+    // POST /subjects/(string: subject)/versions
+    public class CreateNewSchema extends HttpJsonRequestProcessor<CreateSchemaRequest, CreateSchemaResponse> {
+
+        public CreateNewSchema() {
+            super(CreateSchemaRequest.class, "/subjects/" + STRING_PATTERN + "/versions", POST);
+        }
+
+        @Override
+        protected CreateSchemaResponse processRequest(CreateSchemaRequest payload, List<String> patternGroups,
+                                                      FullHttpRequest request)
+                throws Exception {
+            String subject = getString(0, patternGroups);
+            SchemaStorage schemaStorage = getSchemaStorage(request);
+            Schema schema = schemaStorage.createSchemaVersion(subject,
+                    payload.schemaType, payload.schema, true);
+            return new CreateSchemaResponse(schema.getId());
+        }
+
+    }
+
+
+    // POST /subjects/(string: subject)
+    public class CreateOrUpdateSchema extends HttpJsonRequestProcessor<CreateSchemaRequest, CreateSchemaResponse> {
+
+        public CreateOrUpdateSchema() {
+            super(CreateSchemaRequest.class, "/subjects/" + STRING_PATTERN, POST);
+        }
+
+        @Override
+        protected CreateSchemaResponse processRequest(CreateSchemaRequest payload, List<String> patternGroups,
+                                                      FullHttpRequest request)
+                throws Exception {
+            String subject = getString(0, patternGroups);
+            SchemaStorage schemaStorage = getSchemaStorage(request);
+            Schema schema = schemaStorage.createSchemaVersion(subject,
+                    payload.schemaType, payload.schema, false);
+            return new CreateSchemaResponse(schema.getId());
+        }
+
+    }
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/package-info.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.resources;

--- a/schema-registry/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryHandlerTest.java
+++ b/schema-registry/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryHandlerTest.java
@@ -1,0 +1,173 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry;
+
+import static org.testng.Assert.assertEquals;
+
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl.SchemaStorageException;
+import java.io.FileNotFoundException;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class SchemaRegistryHandlerTest {
+
+    private SimpleAPIServer server = new SimpleAPIServer(new SchemaRegistryHandler()
+            .addProcessor(new DemoHandler())
+            .addProcessor(new JsonBodyHandler())
+            .addProcessor(new JsonHandler()));
+
+    @BeforeClass(alwaysRun = true)
+    public void startServer() throws Exception {
+        server.startServer();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void stopServer() throws Exception {
+        server.stopServer();
+    }
+
+    private static class DemoHandler extends HttpRequestProcessor {
+
+        @Override
+        public FullHttpResponse processRequest(FullHttpRequest request) {
+            if (!request.uri().startsWith("/demo")) {
+                return null;
+            }
+            return buildStringResponse("ok", "text/plain; charset=UTF-8");
+        }
+    }
+
+    private static class JsonHandler extends HttpRequestProcessor {
+
+        @Data
+        @AllArgsConstructor
+        private static class SchemaPojo {
+            String value;
+        }
+
+        @Override
+        public FullHttpResponse processRequest(FullHttpRequest request) {
+            if (!request.uri().startsWith("/json")) {
+                return null;
+            }
+            String content = request.uri();
+            return buildJsonResponse(new SchemaPojo(content), "application/json; charset=UTF-8");
+        }
+    }
+
+
+    @Data
+    private static class RequestPojo {
+        String value;
+    }
+
+    @Data
+    @AllArgsConstructor
+    private static class ResponsePojo {
+        String subject;
+        String value;
+    }
+
+    private static class JsonBodyHandler extends HttpJsonRequestProcessor<RequestPojo, ResponsePojo> {
+
+        public JsonBodyHandler() {
+            super(RequestPojo.class, "/subjects/(.*)", "POST");
+        }
+
+        @Override
+        protected ResponsePojo processRequest(RequestPojo payload, List<String> groups, FullHttpRequest request)
+                                                        throws Exception {
+            String subject = groups.get(0);
+            if (subject.equals("errorsubject401")) {
+                throw new SchemaStorageException("Bad auth", HttpResponseStatus.UNAUTHORIZED.code());
+            }
+            if (subject.equals("errorsubject403")) {
+                throw new SchemaStorageException("Forbidden", HttpResponseStatus.FORBIDDEN.code());
+            }
+            if (subject.equals("errorsubject500")) {
+                throw new SchemaStorageException("Error");
+            }
+            return new ResponsePojo(subject, payload.value);
+        }
+
+    }
+
+    @Test
+    public void testBasicGet() throws Exception {
+        assertEquals("ok", server.executeGet("/demo/ok"));
+    }
+
+    @Test
+    public void testBasicJson() throws Exception {
+        assertEquals("{\n"
+                + "  \"value\" : \"/json/test\"\n"
+                + "}", server.executeGet("/json/test"));
+    }
+
+    @Test
+    public void testBasicJsonApi() throws Exception {
+        assertEquals("{\n"
+                        + "  \"subject\" : \"testsubject\",\n"
+                        + "  \"value\" : \"/json/test\"\n"
+                + "}",
+                server.executePost("/subjects/testsubject", "{\n"
+                        + "  \"value\" : \"/json/test\"\n"
+                        + "}", "application/json"));
+    }
+
+    @Test
+    public void testBasicJsonApiError401() throws Exception {
+        assertEquals("{\n"
+                        + "  \"message\" : \"Bad auth\",\n"
+                        + "  \"error_code\" : 401\n"
+                        + "}",
+                server.executePost("/subjects/errorsubject401", "{\n"
+                        + "  \"value\" : \"/json/test\"\n"
+                        + "}", "application/json", 401));
+    }
+
+    @Test
+    public void testBasicJsonApiError403() throws Exception {
+        assertEquals("{\n"
+                        + "  \"message\" : \"Forbidden\",\n"
+                        + "  \"error_code\" : 403\n"
+                        + "}",
+                server.executePost("/subjects/errorsubject403", "{\n"
+                        + "  \"value\" : \"/json/test\"\n"
+                        + "}", "application/json", 403));
+    }
+
+    @Test
+    public void testBasicJsonApiError500() throws Exception {
+        assertEquals("{\n"
+                        + "  \"message\" : \"Error\",\n"
+                        + "  \"error_code\" : 500\n"
+                        + "}",
+                server.executePost("/subjects/errorsubject500", "{\n"
+                        + "  \"value\" : \"/json/test\"\n"
+                        + "}", "application/json", 500));
+    }
+
+    @Test(expectedExceptions = FileNotFoundException.class)
+    public void testBasicNotFound() throws Exception {
+        server.executeGet("/notfound");
+    }
+}

--- a/schema-registry/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SimpleAPIServer.java
+++ b/schema-registry/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SimpleAPIServer.java
@@ -1,0 +1,138 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.ServerSocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.IOUtils;
+
+public class SimpleAPIServer {
+    private EventLoopGroup group;
+    private ServerSocketChannel serverChannel;
+
+    private final SchemaRegistryHandler schemaRegistryHandler;
+
+    public SimpleAPIServer(SchemaRegistryHandler schemaRegistryHandler) {
+        this.schemaRegistryHandler = schemaRegistryHandler;
+    }
+
+    public void startServer() throws Exception {
+        group = new NioEventLoopGroup();
+        ServerBootstrap b = new ServerBootstrap();
+        b.group(group, group)
+                .channel(NioServerSocketChannel.class)
+                .handler(new LoggingHandler(LogLevel.INFO))
+                .childHandler(new ChannelInitializer() {
+
+                    @Override
+                    protected void initChannel(Channel ch) throws Exception {
+                        ChannelPipeline p = ch.pipeline();
+                        p.addLast(new HttpServerCodec());
+                        p.addLast(new HttpObjectAggregator(5 * 1024 * 1024 * 1024));
+                        p.addLast(schemaRegistryHandler);
+                    }
+                });
+        ChannelFuture bind = b.bind(0);
+        bind.get();
+        serverChannel = (ServerSocketChannel) bind.channel();
+    }
+
+    public void stopServer() throws Exception {
+        if (serverChannel != null) {
+            serverChannel.close().get();
+        }
+        if (group != null) {
+            group.shutdownGracefully().await();
+            group = null;
+        }
+    }
+
+    public URL url(String base) throws Exception {
+        return new URL("http://localhost:"
+                + serverChannel.localAddress().getPort() + base);
+    }
+
+    public String executeGet(String base) throws Exception {
+        URL url = url(base);
+        Object content = url.getContent();
+        if (content instanceof InputStream) {
+            content = IOUtils.toString((InputStream) content, "utf-8");
+        }
+        return content.toString();
+    }
+
+    public String executePost(String base, String requestContent, String requestContentType) throws Exception {
+        return executePost(base, requestContent, requestContentType, null);
+    }
+
+    public String executePost(String base, String requestContent,
+                              String requestContentType, Integer expectedError) throws Exception {
+        URL url = url(base);
+        HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
+        try {
+            urlConnection.setDoOutput(true);
+            urlConnection.setRequestProperty("Content-Type", requestContentType);
+            urlConnection.setRequestProperty("Content-Length", requestContent.length() + "");
+            urlConnection.getOutputStream().write(requestContent.getBytes(StandardCharsets.UTF_8));
+            urlConnection.getOutputStream().close();
+            Object content = urlConnection.getContent();
+            if (content instanceof InputStream) {
+                content = IOUtils.toString((InputStream) content, "utf-8");
+            }
+            return content.toString();
+        } catch (IOException err) {
+            if (expectedError == null) {
+                throw err;
+            }
+            if (urlConnection.getResponseCode() != expectedError.intValue()) {
+                throw new IOException("Unexpecter error code "
+                        + urlConnection.getResponseCode() + ", expected " + expectedError);
+            }
+            return IOUtils.toString(urlConnection.getErrorStream(), "utf-8");
+        } finally {
+            urlConnection.disconnect();
+        }
+    }
+
+    public String executeDelete(String base) throws Exception {
+        URL url = url(base);
+        HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
+        try {
+            urlConnection.setRequestMethod("DELETE");
+            Object content = urlConnection.getContent();
+            if (content instanceof InputStream) {
+                content = IOUtils.toString((InputStream) content, "utf-8");
+            }
+            return content.toString();
+        } finally {
+            urlConnection.disconnect();
+        }
+    }
+}

--- a/schema-registry/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SchemaResourceTest.java
+++ b/schema-registry/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SchemaResourceTest.java
@@ -101,6 +101,16 @@ public class SchemaResourceTest {
                 + "}");
     }
 
+    @Test
+    public void getSchemaByIdWithQueryStringTest() throws Exception {
+        putSchema(1, "{SCHEMA-1}");
+        String result = server.executeGet("/schemas/ids/1?fetchMaxId=false");
+        log.info("result {}", result);
+        assertEquals(result, "{\n"
+                + "  \"schema\" : \"{SCHEMA-1}\"\n"
+                + "}");
+    }
+
     @Test(expectedExceptions = FileNotFoundException.class)
     public void getSchemaByIdNotFoundTest() throws Exception {
         server.executeGet("/schemas/ids/1");

--- a/schema-registry/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SchemaResourceTest.java
+++ b/schema-registry/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SchemaResourceTest.java
@@ -131,7 +131,7 @@ public class SchemaResourceTest {
         assertEquals(result, "{SCHEMA-1}");
     }
 
-    @Test(expectedExceptions = java.io.FileNotFoundException.class)
+    @Test(expectedExceptions = FileNotFoundException.class)
     public void getRawSchemaBySubjectAndVersionNotFound() throws Exception {
         server.executeGet("/subjects/aaa/versions/1/schema");
     }
@@ -143,7 +143,7 @@ public class SchemaResourceTest {
         assertEquals(result, "[ \"AVRO\", \"JSON\", \"PROTOBUF\" ]");
     }
 
-    @Test(expectedExceptions = java.io.FileNotFoundException.class)
+    @Test(expectedExceptions = FileNotFoundException.class)
     public void getSchemaAliasesByIdNotFoundTest() throws Exception {
         String result = server.executeGet("/schemas/ids/1/versions");
         log.info("result {}", result);

--- a/schema-registry/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SchemaResourceTest.java
+++ b/schema-registry/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SchemaResourceTest.java
@@ -1,0 +1,296 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.resources;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertThrows;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryHandler;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryRequestAuthenticator;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SimpleAPIServer;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.Schema;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl.MemorySchemaStorageAccessor;
+import java.io.FileNotFoundException;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+@Slf4j
+public class SchemaResourceTest {
+
+    private static final String TEST_SCHEMA = "{\n"
+            + "  \"schema\":"
+            + "    \"{"
+            + "       \\\"type\\\": \\\"record\\\","
+            + "       \\\"name\\\": \\\"test\\\","
+            + "       \\\"fields\\\":"
+            + "         ["
+            + "           {"
+            + "             \\\"type\\\": \\\"string\\\","
+            + "             \\\"name\\\": \\\"field1\\\""
+            + "           },"
+            + "           {"
+            + "             \\\"type\\\": \\\"com.acme.Referenced\\\","
+            + "             \\\"name\\\": \\\"int\\\""
+            + "           }"
+            + "          ]"
+            + "     }\",\n"
+            + "  \"schemaType\": \"AVRO\",\n"
+            + "  \"references\": [\n"
+            + "    {\n"
+            + "       \"name\": \"com.acme.Referenced\",\n"
+            + "       \"subject\":  \"childSubject\",\n"
+            + "       \"version\": 1\n"
+            + "    }\n"
+            + "  ]\n"
+            + "}";
+
+    private SimpleAPIServer server;
+    private MemorySchemaStorageAccessor schemaStorage = new MemorySchemaStorageAccessor();
+    private SchemaRegistryRequestAuthenticator schemaRegistryRequestAuthenticator =
+                                                            (r) -> SchemaResource.DEFAULT_TENANT;
+
+    @BeforeClass(alwaysRun = true)
+    public void startServer() throws Exception {
+
+        SchemaResource schemaResource = new SchemaResource(schemaStorage, schemaRegistryRequestAuthenticator);
+        SubjectResource subjectResource = new SubjectResource(schemaStorage, schemaRegistryRequestAuthenticator);
+        SchemaRegistryHandler schemaRegistryHandler = new SchemaRegistryHandler();
+        schemaResource.register(schemaRegistryHandler);
+        subjectResource.register(schemaRegistryHandler);
+        server = new SimpleAPIServer(schemaRegistryHandler);
+        server.startServer();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void stopServer() throws Exception {
+        if (server != null) {
+            server.stopServer();
+        }
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    public void reset() {
+        schemaStorage.clear();
+    }
+
+    @Test
+    public void getSchemaByIdTest() throws Exception {
+        putSchema(1, "{SCHEMA-1}");
+        String result = server.executeGet("/schemas/ids/1");
+        log.info("result {}", result);
+        assertEquals(result, "{\n"
+                + "  \"schema\" : \"{SCHEMA-1}\"\n"
+                + "}");
+    }
+
+    @Test(expectedExceptions = FileNotFoundException.class)
+    public void getSchemaByIdNotFoundTest() throws Exception {
+        server.executeGet("/schemas/ids/1");
+    }
+
+    @Test
+    public void getSchemaBySubjectAndVersion() throws Exception {
+        putSchema(1, "aaa", "{SCHEMA-1}", 17);
+        String result = server.executeGet("/subjects/aaa/versions/17");
+
+        assertEquals(result, "{\n"
+                + "  \"name\" : \"aaa\",\n"
+                + "  \"version\" : 17,\n"
+                + "  \"schema\" : \"{SCHEMA-1}\"\n"
+                + "}");
+    }
+
+    @Test(expectedExceptions = FileNotFoundException.class)
+    public void getSchemaBySubjectAndVersionNotFound() throws Exception {
+        server.executeGet("/subjects/aaa/versions/1");
+    }
+
+    @Test
+    public void getRawSchemaBySubjectAndVersion() throws Exception {
+        putSchema(1, "aaa", "{SCHEMA-1}", 17);
+        String result = server.executeGet("/subjects/aaa/versions/17/schema");
+        log.info("result {}", result);
+        assertEquals(result, "{SCHEMA-1}");
+    }
+
+    @Test(expectedExceptions = java.io.FileNotFoundException.class)
+    public void getRawSchemaBySubjectAndVersionNotFound() throws Exception {
+        server.executeGet("/subjects/aaa/versions/1/schema");
+    }
+
+    @Test
+    public void getAllSchemaTypesTest() throws Exception {
+        String result = server.executeGet("/schemas/types");
+        log.info("result {}", result);
+        assertEquals(result, "[ \"AVRO\", \"JSON\", \"PROTOBUF\" ]");
+    }
+
+    @Test(expectedExceptions = java.io.FileNotFoundException.class)
+    public void getSchemaAliasesByIdNotFoundTest() throws Exception {
+        String result = server.executeGet("/schemas/ids/1/versions");
+        log.info("result {}", result);
+    }
+
+    @Test
+    public void getSchemaAliasesById() throws Exception {
+        putSchema(1, "{SCHEMA}");
+        putSchema(2, "{SCHEMA}");
+        putSchema(3, "{SCHEMA-OTHER}");
+        String result = server.executeGet("/schemas/ids/1/versions");
+        log.info("result {}", result);
+        assertEquals(result, "[ {\n"
+                + "  \"subject\" : \"test-subject\",\n"
+                + "  \"version\" : 1\n"
+                + "}, {\n"
+                + "  \"subject\" : \"test-subject\",\n"
+                + "  \"version\" : 1\n"
+                + "} ]");
+    }
+
+    @Test
+    public void getAllVersionsSubjects() throws Exception {
+        putSchema(1, "subject1", "{SCHEMA1}", 6);
+        putSchema(2, "subject2", "{SCHEMA2}", 7);
+        putSchema(3, "subject1", "{SCHEMA3}", 8);
+
+        String result = server.executeGet("/subjects/subject1/versions");
+        log.info("result {}", result);
+        assertEquals(result, "[ 6, 8 ]");
+    }
+
+    @Test
+    public void createSchemaTest() throws Exception {
+
+        log.info("body {}", TEST_SCHEMA);
+        String jsonResult = server.executePost("/subjects/mysub/versions", TEST_SCHEMA, "application/json");
+        Map<String, Object> parsed = new ObjectMapper().readValue(jsonResult, Map.class);
+        int schemaId = Integer.parseInt(parsed.get("id") + "");
+        String result = server.executeGet("/subjects/mysub/versions");
+        log.info("result {}", result);
+        assertEquals(result, "[ 1 ]");
+
+        result = server.executeGet("/schemas/ids/" + schemaId);
+        log.info("result {}", result);
+        assertEquals(result, "{\n"
+                + "  \"schema\" : \"{       \\\"type\\\": \\\"record\\\",       \\\"name\\\": \\\"test\\\",  "
+                + "     \\\"fields\\\":         [           {             \\\"type\\\": \\\"string\\\",       "
+                + "      \\\"name\\\": \\\"field1\\\"           },         "
+                + "  {             \\\"type\\\": \\\"com.acme.Referenced\\\",   "
+                + "          \\\"name\\\": \\\"int\\\"           }          ]     }\"\n"
+                + "}");
+    }
+
+    @Test
+    public void createOrUpdateSchemaTest() throws Exception {
+
+        log.info("body {}", TEST_SCHEMA);
+        String jsonResult = server.executePost("/subjects/mysub", TEST_SCHEMA, "application/json");
+        Map<String, Object> parsed = new ObjectMapper().readValue(jsonResult, Map.class);
+        int schemaId = Integer.parseInt(parsed.get("id") + "");
+        String result = server.executeGet("/subjects/mysub/versions");
+        log.info("result {}", result);
+        assertEquals(result, "[ 1 ]");
+
+
+        jsonResult = server.executePost("/subjects/mysub", TEST_SCHEMA, "application/json");
+        parsed = new ObjectMapper().readValue(jsonResult, Map.class);
+        int secondSchemaId = Integer.parseInt(parsed.get("id") + "");
+        assertEquals(secondSchemaId, schemaId);
+
+        // new subject
+        jsonResult = server.executePost("/subjects/mysub2", TEST_SCHEMA, "application/json");
+        parsed = new ObjectMapper().readValue(jsonResult, Map.class);
+        int thirdSchemaId = Integer.parseInt(parsed.get("id") + "");
+        assertNotEquals(secondSchemaId, thirdSchemaId);
+
+        result = server.executeGet("/schemas/ids/" + schemaId);
+        log.info("result {}", result);
+        assertEquals(result, "{\n"
+                + "  \"schema\" : \"{       \\\"type\\\": \\\"record\\\",       \\\"name\\\": \\\"test\\\","
+                + "       \\\"fields\\\":         "
+                + "[           { "
+                + "            \\\"type\\\": \\\"string\\\",             \\\"name\\\": \\\"field1\\\"           },  "
+                + "         {             \\\"type\\\": \\\"com.acme.Referenced\\\",         "
+                + "    \\\"name\\\": \\\"int\\\"    "
+                + "       }          ]     }\"\n"
+                + "}");
+    }
+
+    @Test
+    public void deleteSubjects() throws Exception {
+        putSchema(1, "subject1", "{SCHEMA1}", 6);
+        putSchema(2, "subject2", "{SCHEMA2}", 7);
+        putSchema(3, "subject1", "{SCHEMA3}", 8);
+
+        String result = server.executeDelete("/subjects/subject1");
+        log.info("result {}", result);
+        assertEquals(result, "[ 6, 8 ]");
+
+        assertThrows(FileNotFoundException.class, () -> {
+            server.executeGet("/subjects/subject1/versions");
+        });
+        String result2 = server.executeGet("/subjects/subject2/versions");
+        assertEquals(result2, "[ 7 ]");
+    }
+
+    @Test(expectedExceptions = FileNotFoundException.class)
+    public void getAllVersionsSubjectsNotFound() throws Exception {
+        server.executeGet("/subjects/subject1/versions");
+    }
+
+    @Test(expectedExceptions = FileNotFoundException.class)
+    public void getDeleteSubjectsNotFound() throws Exception {
+        server.executeDelete("/subjects/subject1/versions");
+    }
+
+    @Test
+    public void getAllSubjects() throws Exception {
+        putSchema(1, "subject1", "{SCHEMA1}");
+        putSchema(2, "subject2", "{SCHEMA2}");
+        putSchema(3, "subject1", "{SCHEMA3}");
+
+        String result = server.executeGet("/subjects");
+        log.info("result {}", result);
+        assertEquals(result, "[ \"subject1\", \"subject2\" ]");
+    }
+
+
+    protected void putSchema(int id, String definition) throws Exception {
+        putSchema(id, "test-subject", definition);
+    }
+
+    protected void putSchema(int id, String subject, String definition) throws Exception {
+        putSchema(id, subject, definition, 1);
+    }
+
+    protected void putSchema(int id, String subject, String definition, int version) throws Exception {
+        Schema schema = Schema.builder()
+                .id(id)
+                .version(version)
+                .schemaDefinition(definition)
+                .subject(subject)
+                .type(Schema.TYPE_AVRO)
+                .tenant(SchemaResource.DEFAULT_TENANT)
+                .build();
+        schemaStorage.getSchemaStorageForTenant(SchemaResource.DEFAULT_TENANT).storeSchema(schema);
+    }
+
+}

--- a/schema-registry/src/test/resources/log4j2.xml
+++ b/schema-registry/src/test/resources/log4j2.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<Configuration status="INFO">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t:%C@%L] %-5level %logger{36} - %msg%n" />
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="warn">
+            <AppenderRef ref="Console" />
+        </Root>
+        <Logger name="org.eclipse.jetty" level="info"/>
+        <Logger name="io.streamnative" level="trace"/>
+        <Logger name="io.streamnative.pulsar.handlers.kop.format" level="error"/>
+        <Logger name="org.apache.pulsar" level="info"/>
+        <Logger name="org.apache.bookkeeper" level="info"/>
+        <Logger name="org.apache.kafka" level="debug"/>
+    </Loggers>
+</Configuration>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -52,11 +52,19 @@
       <version>${kafka.version}</version>
     </dependency>
     <!-- test dependencies -->
+
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-mapper-asl</artifactId>
+      <version>1.9.13</version>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>io.streamnative.pulsar.handlers</groupId>
       <artifactId>pulsar-protocol-handler-kafka</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
+
     </dependency>
 
     <dependency>

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationTestBase.java
@@ -21,6 +21,9 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.fail;
 
 import com.google.common.collect.Sets;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;
 import io.jsonwebtoken.SignatureAlgorithm;
 import java.time.Duration;
 import java.util.Collections;
@@ -33,6 +36,10 @@ import java.util.concurrent.ExecutionException;
 import javax.crypto.SecretKey;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.Config;
@@ -41,12 +48,18 @@ import org.apache.kafka.clients.admin.DeleteTopicsResult;
 import org.apache.kafka.clients.admin.DescribeConfigsResult;
 import org.apache.kafka.clients.admin.ListTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationProviderToken;
 import org.apache.pulsar.broker.authentication.utils.AuthTokenUtils;
@@ -55,6 +68,7 @@ import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.impl.auth.AuthenticationToken;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -85,6 +99,10 @@ public abstract class KafkaAuthorizationTestBase extends KopProtocolHandlerTestB
     @BeforeClass
     @Override
     protected void setup() throws Exception {
+
+        // this is for SchemaRegistry testing with Authentication and Authorization
+        enableSchemaRegistry = true;
+
         SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
 
         AuthenticationProviderToken provider = new AuthenticationProviderToken();
@@ -590,6 +608,108 @@ public abstract class KafkaAuthorizationTestBase extends KopProtocolHandlerTestB
         props.put("security.protocol", "SASL_PLAINTEXT");
         props.put("sasl.mechanism", "PLAIN");
         return AdminClient.create(props);
+    }
+
+    private IndexedRecord createAvroRecord() {
+        String userSchema = "{\"namespace\": \"example.avro\", \"type\": \"record\", "
+                + "\"name\": \"User\", \"fields\": [{\"name\": \"name\", \"type\": \"string\"}]}";
+        Schema.Parser parser = new Schema.Parser();
+        Schema schema = parser.parse(userSchema);
+        GenericRecord avroRecord = new GenericData.Record(schema);
+        avroRecord.put("name", "testUser");
+        return avroRecord;
+    }
+
+    private KafkaProducer<Integer, Object> createAvroProducer() {
+        Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getKafkaBrokerPort());
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class);
+        props.put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, restConnect);
+
+        String username = TENANT;
+        String password = "token:" + userToken;
+
+        String jaasTemplate = "org.apache.kafka.common.security.plain.PlainLoginModule "
+                + "required username=\"%s\" password=\"%s\";";
+        String jaasCfg = String.format(jaasTemplate, username, password);
+        props.put("sasl.jaas.config", jaasCfg);
+        props.put("security.protocol", "SASL_PLAINTEXT");
+        props.put("sasl.mechanism", "PLAIN");
+
+
+        props.put(KafkaAvroSerializerConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO");
+
+        props.put(KafkaAvroSerializerConfig.USER_INFO_CONFIG, username + ":" + password);
+
+        return new KafkaProducer<>(props);
+    }
+
+    private KafkaConsumer<Integer, Object> createAvroConsumer() {
+        Properties props = new Properties();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getKafkaBrokerPort());
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "avroGroup");
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class);
+        props.put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, restConnect);
+
+        props.put(KafkaAvroSerializerConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO");
+        String username = TENANT;
+        String password = "token:" + userToken;
+
+        String jaasTemplate = "org.apache.kafka.common.security.plain.PlainLoginModule "
+                + "required username=\"%s\" password=\"%s\";";
+        String jaasCfg = String.format(jaasTemplate, username, password);
+        props.put("sasl.jaas.config", jaasCfg);
+        props.put("security.protocol", "SASL_PLAINTEXT");
+        props.put("sasl.mechanism", "PLAIN");
+        props.put(KafkaAvroSerializerConfig.USER_INFO_CONFIG, username + ":" + password);
+        return new KafkaConsumer<>(props);
+    }
+
+    @Test(timeOut = 40000)
+    public void testAvroProduceAndConsumeWithAuth() throws Exception {
+
+        if (conf.isKafkaEnableMultiTenantMetadata()) {
+            // ensure that the KOP metadata namespace exists and that the user can write to it
+            // because we require "produce" permissions on the Schema Registry Topic
+            // while working in Multi Tenant mode
+            admin.namespaces().createNamespace(TENANT + "/" + conf.getKafkaMetadataNamespace());
+            admin.namespaces().grantPermissionOnNamespace(TENANT + "/" + conf.getKafkaMetadataNamespace(), SIMPLE_USER,
+                    Sets.newHashSet(AuthAction.produce, AuthAction.consume));
+        }
+
+        String topic = "SchemaRegistryTest-testAvroProduceAndConsumeWithAuth";
+        IndexedRecord avroRecord = createAvroRecord();
+        Object[] objects = new Object[]{ avroRecord, true, 130, 345L, 1.23f, 2.34d, "abc", "def".getBytes() };
+        @Cleanup
+        KafkaProducer<Integer, Object> producer = createAvroProducer();
+        for (int i = 0; i < objects.length; i++) {
+            final Object object = objects[i];
+            producer.send(new ProducerRecord<>(topic, i, object), (metadata, e) -> {
+                if (e != null) {
+                    log.error("Failed to send {}: {}", object, e.getMessage());
+                    Assert.fail("Failed to send " + object + ": " + e.getMessage());
+                }
+                log.info("Success send {} to {}-partition-{}@{}",
+                        object, metadata.topic(), metadata.partition(), metadata.offset());
+            }).get();
+        }
+        producer.close();
+
+        @Cleanup
+        KafkaConsumer<Integer, Object> consumer = createAvroConsumer();
+        consumer.subscribe(Collections.singleton(topic));
+        int i = 0;
+        while (i < objects.length) {
+            for (ConsumerRecord<Integer, Object> record : consumer.poll(Duration.ofSeconds(3))) {
+                assertEquals(record.key().intValue(), i);
+                assertEquals(record.value(), objects[i]);
+                i++;
+            }
+        }
+        consumer.close();
     }
 
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationTestBase.java
@@ -668,7 +668,8 @@ public abstract class KafkaAuthorizationTestBase extends KopProtocolHandlerTestB
         return new KafkaConsumer<>(props);
     }
 
-    @Test(timeOut = 40000)
+    // this test creates the schema registry topic, and this may interfere with other tests
+    @Test(timeOut = 30000, priority = 1000)
     public void testAvroProduceAndConsumeWithAuth() throws Exception {
 
         if (conf.isKafkaEnableMultiTenantMetadata()) {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -19,9 +19,6 @@ import static org.mockito.Mockito.spy;
 
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.MoreExecutors;
-import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
-import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
-import io.confluent.kafka.schemaregistry.rest.SchemaRegistryRestApplication;
 import io.netty.channel.EventLoopGroup;
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupCoordinator;
 import io.streamnative.pulsar.handlers.kop.utils.MetadataUtils;
@@ -78,7 +75,6 @@ import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.MockZooKeeper;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.ACL;
-import org.eclipse.jetty.server.Server;
 
 /**
  * Unit test to test KoP handler.
@@ -114,11 +110,8 @@ public abstract class KopProtocolHandlerTestBase {
     private SameThreadOrderedSafeExecutor sameThreadOrderedSafeExecutor;
     private OrderedExecutor bkExecutor;
 
-    // Fields about Confluent Schema Registry
+    // Fields about Schema Registry
     protected boolean enableSchemaRegistry = false;
-    private static final String KAFKASTORE_TOPIC = SchemaRegistryConfig.DEFAULT_KAFKASTORE_TOPIC;
-    protected SchemaRegistryRestApplication restApp;
-    protected Server restServer;
     protected String restConnect;
 
     private String entryFormat;
@@ -245,6 +238,14 @@ public abstract class KopProtocolHandlerTestBase {
             brokerServiceUrlTls);
         mockBookKeeper = createMockBookKeeper(bkExecutor);
 
+
+        if (enableSchemaRegistry) {
+
+            conf.setKopSchemaRegistryEnable(true);
+            conf.setKopSchemaRegistryPort(getKafkaSchemaRegistryPort());
+            restConnect = "http://localhost:" + getKafkaSchemaRegistryPort();
+        }
+
         startBroker();
 
         createAdmin();
@@ -254,37 +255,12 @@ public abstract class KopProtocolHandlerTestBase {
             MetadataUtils.createTxnMetadataIfMissing(conf.getKafkaMetadataTenant(), admin, clusterData, this.conf);
         }
 
-        if (enableSchemaRegistry) {
-            admin.topics().createPartitionedTopic(KAFKASTORE_TOPIC, 1);
-            final Properties props = new Properties();
-            props.put(SchemaRegistryConfig.PORT_CONFIG, Integer.toString(getKafkaSchemaRegistryPort()));
-            // Increase the kafkastore.timeout.ms (default: 500) to avoid test failure in CI
-            props.put(SchemaRegistryConfig.KAFKASTORE_TIMEOUT_CONFIG, 3000);
-            // NOTE: KoP doesn't support kafkastore.connection.url
-            props.put(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG,
-                    "PLAINTEXT://localhost:" + getKafkaBrokerPort());
-            props.put(SchemaRegistryConfig.KAFKASTORE_TOPIC_CONFIG, KAFKASTORE_TOPIC);
-            props.put(SchemaRegistryConfig.COMPATIBILITY_CONFIG, AvroCompatibilityLevel.NONE.name);
-            props.put(SchemaRegistryConfig.MASTER_ELIGIBILITY, true);
-
-            restApp = new SchemaRegistryRestApplication(props);
-            restServer = restApp.createServer();
-            restServer.start();
-            restConnect = restServer.getURI().toString();
-            if (restConnect.endsWith("/")) {
-                restConnect = restConnect.substring(0, restConnect.length() - 1);
-            }
-        }
     }
 
     protected final void internalCleanup() throws Exception {
         try {
             // if init fails, some of these could be null, and if so would throw
             // an NPE in shutdown, obscuring the real error
-            if (restServer != null) {
-                restServer.stop();
-                restServer.join();
-            }
             if (admin != null) {
                 admin.close();
             }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryTest.java
@@ -37,8 +37,6 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Factory;
-import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
 /**
@@ -49,16 +47,8 @@ public class SchemaRegistryTest extends KopProtocolHandlerTestBase {
 
     private String bootstrapServers;
 
-    public SchemaRegistryTest(final String entryFormat) {
-        super(entryFormat);
-    }
-
-    @Factory
-    public static Object[] instances() {
-        return new Object[] {
-                new SchemaRegistryTest("pulsar"),
-                new SchemaRegistryTest("kafka")
-        };
+    public SchemaRegistryTest() {
+        super("pulsar");
     }
 
     @BeforeMethod
@@ -69,7 +59,7 @@ public class SchemaRegistryTest extends KopProtocolHandlerTestBase {
         bootstrapServers = "localhost:" + getKafkaBrokerPort();
     }
 
-    @BeforeMethod
+    @BeforeMethod(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         this.internalCleanup();
@@ -105,7 +95,6 @@ public class SchemaRegistryTest extends KopProtocolHandlerTestBase {
         return new KafkaConsumer<>(props);
     }
 
-    @Ignore
     @Test(timeOut = 40000)
     public void testAvroProduceAndConsume() throws Exception {
         String topic = "SchemaRegistryTest-testAvroProduceAndConsume";
@@ -122,8 +111,9 @@ public class SchemaRegistryTest extends KopProtocolHandlerTestBase {
                 }
                 log.info("Success send {} to {}-partition-{}@{}",
                         object, metadata.topic(), metadata.partition(), metadata.offset());
-            });
+            }).get();
         }
+        producer.close();
 
         @Cleanup
         KafkaConsumer<Integer, Object> consumer = createAvroConsumer();
@@ -136,5 +126,6 @@ public class SchemaRegistryTest extends KopProtocolHandlerTestBase {
                 i++;
             }
         }
+        consumer.close();
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/MemorySchemaStorageTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/MemorySchemaStorageTest.java
@@ -1,0 +1,20 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl;
+
+public class MemorySchemaStorageTest extends SchemaStorageTestsBase {
+    public MemorySchemaStorageTest() {
+        super(new MemorySchemaStorageAccessor());
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorageTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorageTest.java
@@ -56,14 +56,14 @@ public class PulsarSchemaStorageTest extends KopProtocolHandlerTestBase {
                     "persistent://public/default/__schemaregistry-2");) {
             // writing using instance1
             Schema schemaVersion = instance1.createSchemaVersion(subject1,
-                    Schema.TYPE_AVRO, "{test}", true);
+                    Schema.TYPE_AVRO, "{test}", true).get();
 
             // read using instance2
-            Schema lookup2 = instance2.findSchemaById(schemaVersion.getId());
+            Schema lookup2 = instance2.findSchemaById(schemaVersion.getId()).get();
             assertEquals(schemaVersion, lookup2);
 
             // read using instance1
-            Schema lookup1 = instance2.findSchemaById(schemaVersion.getId());
+            Schema lookup1 = instance2.findSchemaById(schemaVersion.getId()).get();
             assertEquals(schemaVersion, lookup1);
         }
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorageTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorageTest.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl;
+
+import static org.testng.Assert.assertEquals;
+
+import io.streamnative.pulsar.handlers.kop.KopProtocolHandlerTestBase;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.Schema;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorage;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorageAccessor;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class PulsarSchemaStorageTest extends KopProtocolHandlerTestBase {
+
+
+    @Test
+    public void testUsingSchemaStorageTestsBase() throws Exception {
+        SchemaStorageTestsBase tester = new SchemaStorageTestsBase(new SchemaStorageAccessor() {
+            @Override
+            public SchemaStorage getSchemaStorageForTenant(String tenant) throws SchemaStorageException {
+                return new PulsarSchemaStorage(tenant, pulsarClient,
+                        "persistent://public/default/__schemaregistry");
+            }
+
+            @Override
+            public void close() {
+                // nothing to do
+            }
+        });
+        try {
+            tester.testWriteGet();
+        } finally {
+            tester.stopAll();
+        }
+    }
+
+    @Test
+    public void testTwoInstances() throws Exception {
+        String subject1 = "cccc";
+        try (PulsarSchemaStorage instance1 = new PulsarSchemaStorage(tenant, pulsarClient,
+                "persistent://public/default/__schemaregistry-2");
+            PulsarSchemaStorage instance2 = new PulsarSchemaStorage(tenant, pulsarClient,
+                    "persistent://public/default/__schemaregistry-2");) {
+            // writing using instance1
+            Schema schemaVersion = instance1.createSchemaVersion(subject1,
+                    Schema.TYPE_AVRO, "{test}", true);
+
+            // read using instance2
+            Schema lookup2 = instance2.findSchemaById(schemaVersion.getId());
+            assertEquals(schemaVersion, lookup2);
+
+            // read using instance1
+            Schema lookup1 = instance2.findSchemaById(schemaVersion.getId());
+            assertEquals(schemaVersion, lookup1);
+        }
+    }
+
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+    }
+
+    @AfterClass
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorageTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorageTest.java
@@ -28,6 +28,7 @@ public class PulsarSchemaStorageTest extends KopProtocolHandlerTestBase {
 
     @Test
     public void testUsingSchemaStorageTestsBase() throws Exception {
+        admin.topics().createNonPartitionedTopic("persistent://public/default/__schemaregistry");
         SchemaStorageTestsBase tester = new SchemaStorageTestsBase(new SchemaStorageAccessor() {
             @Override
             public SchemaStorage getSchemaStorageForTenant(String tenant) throws SchemaStorageException {
@@ -50,6 +51,7 @@ public class PulsarSchemaStorageTest extends KopProtocolHandlerTestBase {
     @Test
     public void testTwoInstances() throws Exception {
         String subject1 = "cccc";
+        admin.topics().createNonPartitionedTopic("persistent://public/default/__schemaregistry-2");
         try (PulsarSchemaStorage instance1 = new PulsarSchemaStorage(tenant, pulsarClient,
                 "persistent://public/default/__schemaregistry-2");
             PulsarSchemaStorage instance2 = new PulsarSchemaStorage(tenant, pulsarClient,

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/SchemaStorageTestsBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/SchemaStorageTestsBase.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNull;
+
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.Schema;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorage;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorageAccessor;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+@AllArgsConstructor
+public class SchemaStorageTestsBase {
+    private SchemaStorageAccessor storageAccessor;
+
+    @Test
+    public void testWriteGet() throws SchemaStorageException {
+        SchemaStorage storage = storageAccessor.getSchemaStorageForTenant("test-tenant");
+        String subject1 = "aa";
+        Schema schemaVersion = storage.createSchemaVersion(subject1, Schema.TYPE_AVRO, "{test}", true);
+        Schema lookup = storage.findSchemaById(schemaVersion.getId());
+        assertEquals(schemaVersion, lookup);
+        List<Integer> versions = storage.deleteSubject(subject1);
+        assertEquals(1, versions.size());
+        lookup = storage.findSchemaById(schemaVersion.getId());
+        assertNull(lookup);
+
+        String subject2 = "bb";
+        Schema schemaVersion2 = storage.createSchemaVersion(subject2, Schema.TYPE_AVRO, "{test}", true);
+        Schema lookup2 = storage.findSchemaById(schemaVersion2.getId());
+        assertEquals(schemaVersion2, lookup2);
+
+
+        Schema schemaVersion3 = storage.createSchemaVersion(subject2, Schema.TYPE_AVRO, "{test}", false);
+        Schema lookup3 = storage.findSchemaById(schemaVersion3.getId());
+        assertEquals(schemaVersion3, lookup3);
+
+        // we must have received the same schema id
+        assertEquals(lookup2, lookup3);
+
+        Schema schemaVersion4 = storage.createSchemaVersion(subject2, Schema.TYPE_AVRO, "{test}", true);
+        Schema lookup4 = storage.findSchemaById(schemaVersion4.getId());
+        assertEquals(schemaVersion4, lookup4);
+
+        assertNotEquals(lookup3.getId(), lookup4.getId());
+
+        Schema lookupNonExistingSchema = storage.findSchemaById(-10);
+        assertNull(lookupNonExistingSchema);
+
+    }
+
+    @AfterClass
+    public void stopAll() {
+        storageAccessor.close();
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/SchemaStorageTestsBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/SchemaStorageTestsBase.java
@@ -30,37 +30,37 @@ public class SchemaStorageTestsBase {
     private SchemaStorageAccessor storageAccessor;
 
     @Test
-    public void testWriteGet() throws SchemaStorageException {
+    public void testWriteGet() throws Exception {
         SchemaStorage storage = storageAccessor.getSchemaStorageForTenant("test-tenant");
         String subject1 = "aa";
-        Schema schemaVersion = storage.createSchemaVersion(subject1, Schema.TYPE_AVRO, "{test}", true);
-        Schema lookup = storage.findSchemaById(schemaVersion.getId());
+        Schema schemaVersion = storage.createSchemaVersion(subject1, Schema.TYPE_AVRO, "{test}", true).get();
+        Schema lookup = storage.findSchemaById(schemaVersion.getId()).get();
         assertEquals(schemaVersion, lookup);
-        List<Integer> versions = storage.deleteSubject(subject1);
+        List<Integer> versions = storage.deleteSubject(subject1).get();
         assertEquals(1, versions.size());
-        lookup = storage.findSchemaById(schemaVersion.getId());
+        lookup = storage.findSchemaById(schemaVersion.getId()).get();
         assertNull(lookup);
 
         String subject2 = "bb";
-        Schema schemaVersion2 = storage.createSchemaVersion(subject2, Schema.TYPE_AVRO, "{test}", true);
-        Schema lookup2 = storage.findSchemaById(schemaVersion2.getId());
+        Schema schemaVersion2 = storage.createSchemaVersion(subject2, Schema.TYPE_AVRO, "{test}", true).get();
+        Schema lookup2 = storage.findSchemaById(schemaVersion2.getId()).get();
         assertEquals(schemaVersion2, lookup2);
 
 
-        Schema schemaVersion3 = storage.createSchemaVersion(subject2, Schema.TYPE_AVRO, "{test}", false);
-        Schema lookup3 = storage.findSchemaById(schemaVersion3.getId());
+        Schema schemaVersion3 = storage.createSchemaVersion(subject2, Schema.TYPE_AVRO, "{test}", false).get();
+        Schema lookup3 = storage.findSchemaById(schemaVersion3.getId()).get();
         assertEquals(schemaVersion3, lookup3);
 
         // we must have received the same schema id
         assertEquals(lookup2, lookup3);
 
-        Schema schemaVersion4 = storage.createSchemaVersion(subject2, Schema.TYPE_AVRO, "{test}", true);
-        Schema lookup4 = storage.findSchemaById(schemaVersion4.getId());
+        Schema schemaVersion4 = storage.createSchemaVersion(subject2, Schema.TYPE_AVRO, "{test}", true).get();
+        Schema lookup4 = storage.findSchemaById(schemaVersion4.getId()).get();
         assertEquals(schemaVersion4, lookup4);
 
         assertNotEquals(lookup3.getId(), lookup4.getId());
 
-        Schema lookupNonExistingSchema = storage.findSchemaById(-10);
+        Schema lookupNonExistingSchema = storage.findSchemaById(-10).get();
         assertNull(lookupNonExistingSchema);
 
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/package-info.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl;


### PR DESCRIPTION
This Pull Request implements a Schema Registry compatible with the API required by the most used Kafka Avro serializer/deserializer.

Reference API
https://docs.confluent.io/platform/current/schema-registry/develop/api.html#schemas 

Features:
- start a Netty endpoint, from the KOP protocol handler
- integrate with KOP Authentication and Authorization mechanisms
- support Full multi-tenant environment (HTTP Basic Auth username is the tenant name, as in KOP)
- support Token based Authentication
- store data on a Pulsar topic, use Pulsar Exclusive Producer in order to manage concurrent writes
- The topic is by default on the Metadata Tenant/Metadata Namespace, but we use the logged Tenant in case of multi tenant configuration 

Non-goals:
- write another general purpose Schema Registry, we what something that works with KOP and can be used easily by KOP users
- share the Pulsar schema registry with Kafka (this is not possible because we have very different conventions)

Contents of the patch:
- new Schema Registry Module
- Simple Netty based framework to implement the Schema Registry REST API
- Implementation of REST APIs compatible with the Confluent® Schema Registry
- Replace the Confluence Schema Registry in the tests with using the KOP Schema Registry
- Activate AVRO tests, that were disabled, now they work
- Add tests about the Schema Registry with Authentication and Authorization enabled, with Multi tenancy mode and Non Multitenancy mode

Future works:
- add support for TLS
- schema compatibility validation
- support for "Referenced schemas"
- cache eviction (we are now holding all the schema in memory)
- do not rely on infinite retention of the Schema registry topic

