### PR TITLE
Kafka Streams - port more integration tests

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndTestBase.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 import io.streamnative.kafka.client.api.Header;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
@@ -25,6 +26,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -100,6 +102,22 @@ public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
 
         final KafkaConsumer<String, String> consumer = new KafkaConsumer<>(props);
         consumer.subscribe(Collections.singleton(topic));
+        return consumer;
+    }
+
+    protected KafkaConsumer<String, String> newKafkaConsumer(final Pattern pattern, final String group) {
+        final Properties props =  new Properties();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, (group == null) ? GROUP_ID : group);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+        // with Pattern subscription, we want to detect metadata changes to see new topic
+        props.put(ConsumerConfig.METADATA_MAX_AGE_CONFIG, 1000);
+
+        final KafkaConsumer<String, String> consumer = new KafkaConsumer<>(props);
+        consumer.subscribe(pattern);
         return consumer;
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/FineGrainedAutoResetIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/FineGrainedAutoResetIntegrationTest.java
@@ -1,0 +1,272 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.streams;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.regex.Pattern;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Produced;
+import org.junit.Assert;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class FineGrainedAutoResetIntegrationTest extends KafkaStreamsTestBase {
+
+    private static final String DEFAULT_OUTPUT_TOPIC = "outputTopic";
+    private static final String OUTPUT_TOPIC_0 = "outputTopic_0";
+    private static final String OUTPUT_TOPIC_1 = "outputTopic_1";
+    private static final String OUTPUT_TOPIC_2 = "outputTopic_2";
+
+    @Override
+    protected void createTopics() throws Exception {
+        String[] TOPICS =  new String[] {
+                TOPIC_1_0,
+                TOPIC_2_0,
+                TOPIC_A_0,
+                TOPIC_C_0,
+                TOPIC_Y_0,
+                TOPIC_Z_0,
+                TOPIC_1_1,
+                TOPIC_2_1,
+                TOPIC_A_1,
+                TOPIC_C_1,
+                TOPIC_Y_1,
+                TOPIC_Z_1,
+                TOPIC_1_2,
+                TOPIC_2_2,
+                TOPIC_A_2,
+                TOPIC_C_2,
+                TOPIC_Y_2,
+                TOPIC_Z_2,
+                NOOP,
+                DEFAULT_OUTPUT_TOPIC,
+                OUTPUT_TOPIC_0,
+                OUTPUT_TOPIC_1,
+                OUTPUT_TOPIC_2
+        };
+        createTopics(TOPICS);
+    }
+
+    private static final String TOPIC_1_0 = "topic-1_0";
+    private static final String TOPIC_2_0 = "topic-2_0";
+    private static final String TOPIC_A_0 = "topic-A_0";
+    private static final String TOPIC_C_0 = "topic-C_0";
+    private static final String TOPIC_Y_0 = "topic-Y_0";
+    private static final String TOPIC_Z_0 = "topic-Z_0";
+    private static final String TOPIC_1_1 = "topic-1_1";
+    private static final String TOPIC_2_1 = "topic-2_1";
+    private static final String TOPIC_A_1 = "topic-A_1";
+    private static final String TOPIC_C_1 = "topic-C_1";
+    private static final String TOPIC_Y_1 = "topic-Y_1";
+    private static final String TOPIC_Z_1 = "topic-Z_1";
+    private static final String TOPIC_1_2 = "topic-1_2";
+    private static final String TOPIC_2_2 = "topic-2_2";
+    private static final String TOPIC_A_2 = "topic-A_2";
+    private static final String TOPIC_C_2 = "topic-C_2";
+    private static final String TOPIC_Y_2 = "topic-Y_2";
+    private static final String TOPIC_Z_2 = "topic-Z_2";
+    private static final String NOOP = "noop";
+    private final Serde<String> stringSerde = Serdes.String();
+
+    private static final String STRING_SERDE_CLASSNAME = Serdes.String().getClass().getName();
+
+    private final String topic1TestMessage = "topic-1 test";
+    private final String topic2TestMessage = "topic-2 test";
+    private final String topicATestMessage = "topic-A test";
+    private final String topicCTestMessage = "topic-C test";
+    private final String topicYTestMessage = "topic-Y test";
+    private final String topicZTestMessage = "topic-Z test";
+
+    @Override
+    protected @NonNull String getApplicationIdPrefix() {
+        return "fine-grained";
+    }
+
+    @Override
+    protected void extraSetup() throws Exception {
+        streamsConfiguration.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
+        streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100L);
+        streamsConfiguration.put(ConsumerConfig.METADATA_MAX_AGE_CONFIG, "1000");
+        streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    }
+
+    @Override
+    protected Class<?> getKeySerdeClass() {
+        return null;
+    }
+
+    @Override
+    protected Class<?> getValueSerdeClass() {
+        return null;
+    }
+
+    @Test(enabled = false)
+    public void shouldOnlyReadRecordsWhereEarliestSpecifiedWithNoCommittedOffsetsWithGlobalAutoOffsetResetLatest() throws  Exception {
+        streamsConfiguration.put(StreamsConfig.consumerPrefix(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG), "latest");
+
+        final List<String> expectedReceivedValues = Arrays.asList(topic1TestMessage, topic2TestMessage);
+        shouldOnlyReadForEarliest("_0", TOPIC_1_0, TOPIC_2_0, TOPIC_A_0, TOPIC_C_0, TOPIC_Y_0, TOPIC_Z_0, OUTPUT_TOPIC_0, expectedReceivedValues);
+    }
+
+    @Test(enabled = false)
+    public void shouldOnlyReadRecordsWhereEarliestSpecifiedWithNoCommittedOffsetsWithDefaultGlobalAutoOffsetResetEarliest() throws  Exception {
+        final List<String> expectedReceivedValues = Arrays.asList(topic1TestMessage, topic2TestMessage, topicYTestMessage, topicZTestMessage);
+        shouldOnlyReadForEarliest("_1", TOPIC_1_1, TOPIC_2_1, TOPIC_A_1, TOPIC_C_1, TOPIC_Y_1, TOPIC_Z_1, OUTPUT_TOPIC_1, expectedReceivedValues);
+    }
+
+    @Test(enabled = false)
+    public void shouldOnlyReadRecordsWhereEarliestSpecifiedWithInvalidCommittedOffsets() throws  Exception {
+        commitInvalidOffsets();
+
+        final List<String> expectedReceivedValues = Arrays.asList(topic1TestMessage, topic2TestMessage, topicYTestMessage, topicZTestMessage);
+        shouldOnlyReadForEarliest("_2", TOPIC_1_2, TOPIC_2_2, TOPIC_A_2, TOPIC_C_2, TOPIC_Y_2, TOPIC_Z_2, OUTPUT_TOPIC_2, expectedReceivedValues);
+    }
+
+    private void shouldOnlyReadForEarliest(
+            final String topicSuffix,
+            final String topic1,
+            final String topic2,
+            final String topicA,
+            final String topicC,
+            final String topicY,
+            final String topicZ,
+            final String outputTopic,
+            final List<String> expectedReceivedValues) throws Exception {
+
+        final StreamsBuilder builder = new StreamsBuilder();
+
+
+        final KStream<String, String> pattern1Stream = builder.stream(Pattern.compile("topic-\\d" + topicSuffix), Consumed.<String, String>with(Topology.AutoOffsetReset.EARLIEST));
+        final KStream<String, String> pattern2Stream = builder.stream(Pattern.compile("topic-[A-D]" + topicSuffix), Consumed.<String, String>with(Topology.AutoOffsetReset.LATEST));
+        final KStream<String, String> namedTopicsStream = builder.stream(Arrays.asList(topicY, topicZ));
+
+        pattern1Stream.to(outputTopic, Produced.with(stringSerde, stringSerde));
+        pattern2Stream.to(outputTopic, Produced.with(stringSerde, stringSerde));
+        namedTopicsStream.to(outputTopic, Produced.with(stringSerde, stringSerde));
+
+        final Properties producerConfig = TestUtils.producerConfig(bootstrapServers, StringSerializer.class, StringSerializer.class);
+
+        IntegrationTestUtils.produceValuesSynchronously(topic1, Collections.singletonList(topic1TestMessage), producerConfig, mockTime);
+        IntegrationTestUtils.produceValuesSynchronously(topic2, Collections.singletonList(topic2TestMessage), producerConfig, mockTime);
+        IntegrationTestUtils.produceValuesSynchronously(topicA, Collections.singletonList(topicATestMessage), producerConfig, mockTime);
+        IntegrationTestUtils.produceValuesSynchronously(topicC, Collections.singletonList(topicCTestMessage), producerConfig, mockTime);
+        IntegrationTestUtils.produceValuesSynchronously(topicY, Collections.singletonList(topicYTestMessage), producerConfig, mockTime);
+        IntegrationTestUtils.produceValuesSynchronously(topicZ, Collections.singletonList(topicZTestMessage), producerConfig, mockTime);
+
+        final Properties consumerConfig = TestUtils.consumerConfig(bootstrapServers, StringDeserializer.class, StringDeserializer.class);
+
+        final KafkaStreams streams = new KafkaStreams(builder.build(), streamsConfiguration);
+        streams.start();
+
+        final List<KeyValue<String, String>> receivedKeyValues = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(consumerConfig, outputTopic, expectedReceivedValues.size());
+        final List<String> actualValues = new ArrayList<>(expectedReceivedValues.size());
+
+        for (final KeyValue<String, String> receivedKeyValue : receivedKeyValues) {
+            actualValues.add(receivedKeyValue.value);
+        }
+
+        streams.close();
+        Collections.sort(actualValues);
+        Collections.sort(expectedReceivedValues);
+        Assert.assertThat(actualValues, equalTo(expectedReceivedValues));
+    }
+
+    private void commitInvalidOffsets() {
+        final KafkaConsumer consumer = new KafkaConsumer(TestUtils.consumerConfig(
+                bootstrapServers,
+                streamsConfiguration.getProperty(StreamsConfig.APPLICATION_ID_CONFIG),
+                StringDeserializer.class,
+                StringDeserializer.class));
+
+        final Map<TopicPartition, OffsetAndMetadata> invalidOffsets = new HashMap<>();
+        invalidOffsets.put(new TopicPartition(TOPIC_1_2, 0), new OffsetAndMetadata(5, null));
+        invalidOffsets.put(new TopicPartition(TOPIC_2_2, 0), new OffsetAndMetadata(5, null));
+        invalidOffsets.put(new TopicPartition(TOPIC_A_2, 0), new OffsetAndMetadata(5, null));
+        invalidOffsets.put(new TopicPartition(TOPIC_C_2, 0), new OffsetAndMetadata(5, null));
+        invalidOffsets.put(new TopicPartition(TOPIC_Y_2, 0), new OffsetAndMetadata(5, null));
+        invalidOffsets.put(new TopicPartition(TOPIC_Z_2, 0), new OffsetAndMetadata(5, null));
+
+        consumer.commitSync(invalidOffsets);
+
+        consumer.close();
+    }
+
+    @Test
+    public void shouldThrowStreamsExceptionNoResetSpecified() throws InterruptedException {
+        final Properties props = new Properties();
+        props.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
+        props.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100);
+        props.put(ConsumerConfig.METADATA_MAX_AGE_CONFIG, "1000");
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "none");
+
+        final Properties localConfig = StreamsTestUtils.getStreamsConfig(
+                "testAutoOffsetWithNone",
+                bootstrapServers,
+                STRING_SERDE_CLASSNAME,
+                STRING_SERDE_CLASSNAME,
+                props);
+
+        final StreamsBuilder builder = new StreamsBuilder();
+        final KStream<String, String> exceptionStream = builder.stream(NOOP);
+
+        exceptionStream.to(DEFAULT_OUTPUT_TOPIC, Produced.with(stringSerde, stringSerde));
+
+        final KafkaStreams streams = new KafkaStreams(builder.build(), localConfig);
+
+        final TestingUncaughtExceptionHandler uncaughtExceptionHandler = new TestingUncaughtExceptionHandler();
+
+        streams.setUncaughtExceptionHandler(uncaughtExceptionHandler);
+        streams.start();
+        TestUtils.waitForCondition(() -> uncaughtExceptionHandler.correctExceptionThrown,
+                "The expected NoOffsetForPartitionException was never thrown");
+        streams.close();
+    }
+
+
+    private static final class TestingUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
+        boolean correctExceptionThrown = false;
+        @Override
+        public void uncaughtException(final Thread t, final Throwable e) {
+            assertThat(e.getClass().getSimpleName(), is("StreamsException"));
+            assertThat(e.getCause().getClass().getSimpleName(), is("NoOffsetForPartitionException"));
+            correctExceptionThrown = true;
+        }
+    }
+
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/IntegrationTestUtils.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/IntegrationTestUtils.java
@@ -1,0 +1,734 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.streams;
+
+import static io.streamnative.pulsar.handlers.kop.streams.TestUtils.retryOnExceptionWithTimeout;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.Assert.fail;
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.processor.internals.StreamThread;
+import org.apache.kafka.streams.processor.internals.ThreadStateTransitionValidator;
+import org.hamcrest.Matchers;
+
+@Slf4j
+public class IntegrationTestUtils {
+
+    public static final long DEFAULT_TIMEOUT = 60 * 1000L;
+
+    /*
+     * Records state transition for StreamThread
+     */
+    public static class StateListenerStub implements StreamThread.StateListener {
+        boolean toPendingShutdownSeen = false;
+
+        @Override
+        public void onChange(final Thread thread,
+                             final ThreadStateTransitionValidator newState,
+                             final ThreadStateTransitionValidator oldState) {
+            if (newState == StreamThread.State.PENDING_SHUTDOWN) {
+                toPendingShutdownSeen = true;
+            }
+        }
+
+        public boolean transitToPendingShutdownSeen() {
+            return toPendingShutdownSeen;
+        }
+    }
+
+    /**
+     * @param topic          Kafka topic to write the data records to
+     * @param records        Data records to write to Kafka
+     * @param producerConfig Kafka producer configuration
+     * @param time           Timestamp provider
+     * @param <K>            Key type of the data records
+     * @param <V>            Value type of the data records
+     */
+    public static <K, V> void produceKeyValuesSynchronously(
+            final String topic, final Collection<KeyValue<K, V>> records, final Properties producerConfig,
+            final Time time)
+            throws ExecutionException, InterruptedException {
+        produceKeyValuesSynchronously(topic, records, producerConfig, time, false);
+    }
+
+    /**
+     * @param topic          Kafka topic to write the data records to
+     * @param records        Data records to write to Kafka
+     * @param producerConfig Kafka producer configuration
+     * @param headers        {@link Headers} of the data records
+     * @param time           Timestamp provider
+     * @param <K>            Key type of the data records
+     * @param <V>            Value type of the data records
+     */
+    public static <K, V> void produceKeyValuesSynchronously(
+            final String topic, final Collection<KeyValue<K, V>> records, final Properties producerConfig,
+            final Headers headers, final Time time)
+            throws ExecutionException, InterruptedException {
+        produceKeyValuesSynchronously(topic, records, producerConfig, headers, time, false);
+    }
+
+    /**
+     * @param topic              Kafka topic to write the data records to
+     * @param records            Data records to write to Kafka
+     * @param producerConfig     Kafka producer configuration
+     * @param time               Timestamp provider
+     * @param enableTransactions Send messages in a transaction
+     * @param <K>                Key type of the data records
+     * @param <V>                Value type of the data records
+     */
+    public static <K, V> void produceKeyValuesSynchronously(
+            final String topic, final Collection<KeyValue<K, V>> records, final Properties producerConfig,
+            final Time time, final boolean enableTransactions)
+            throws ExecutionException, InterruptedException {
+        produceKeyValuesSynchronously(topic, records, producerConfig, null, time, enableTransactions);
+    }
+
+    /**
+     * @param topic              Kafka topic to write the data records to
+     * @param records            Data records to write to Kafka
+     * @param producerConfig     Kafka producer configuration
+     * @param headers            {@link Headers} of the data records
+     * @param time               Timestamp provider
+     * @param enableTransactions Send messages in a transaction
+     * @param <K>                Key type of the data records
+     * @param <V>                Value type of the data records
+     */
+    public static <K, V> void produceKeyValuesSynchronously(final String topic,
+                                                            final Collection<KeyValue<K, V>> records,
+                                                            final Properties producerConfig,
+                                                            final Headers headers,
+                                                            final Time time,
+                                                            final boolean enableTransactions)
+            throws ExecutionException, InterruptedException {
+        for (final KeyValue<K, V> record : records) {
+            produceKeyValuesSynchronouslyWithTimestamp(topic,
+                    Collections.singleton(record),
+                    producerConfig,
+                    headers,
+                    time.milliseconds(),
+                    enableTransactions);
+            time.sleep(1L);
+        }
+    }
+
+    /**
+     * @param topic          Kafka topic to write the data records to
+     * @param records        Data records to write to Kafka
+     * @param producerConfig Kafka producer configuration
+     * @param timestamp      Timestamp of the record
+     * @param <K>            Key type of the data records
+     * @param <V>            Value type of the data records
+     */
+    public static <K, V> void produceKeyValuesSynchronouslyWithTimestamp(final String topic,
+                                                                         final Collection<KeyValue<K, V>> records,
+                                                                         final Properties producerConfig,
+                                                                         final Long timestamp)
+            throws ExecutionException, InterruptedException {
+        produceKeyValuesSynchronouslyWithTimestamp(topic, records, producerConfig, timestamp, false);
+    }
+
+    /**
+     * @param topic              Kafka topic to write the data records to
+     * @param records            Data records to write to Kafka
+     * @param producerConfig     Kafka producer configuration
+     * @param timestamp          Timestamp of the record
+     * @param enableTransactions Send messages in a transaction
+     * @param <K>                Key type of the data records
+     * @param <V>                Value type of the data records
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static <K, V> void produceKeyValuesSynchronouslyWithTimestamp(final String topic,
+                                                                         final Collection<KeyValue<K, V>> records,
+                                                                         final Properties producerConfig,
+                                                                         final Long timestamp,
+                                                                         final boolean enableTransactions)
+            throws ExecutionException, InterruptedException {
+
+        produceKeyValuesSynchronouslyWithTimestamp(topic, records, producerConfig, null, timestamp, enableTransactions);
+    }
+
+    /**
+     * @param topic              Kafka topic to write the data records to
+     * @param records            Data records to write to Kafka
+     * @param producerConfig     Kafka producer configuration
+     * @param headers            {@link Headers} of the data records
+     * @param timestamp          Timestamp of the record
+     * @param enableTransactions Send messages in a transaction
+     * @param <K>                Key type of the data records
+     * @param <V>                Value type of the data records
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static <K, V> void produceKeyValuesSynchronouslyWithTimestamp(final String topic,
+                                                                         final Collection<KeyValue<K, V>> records,
+                                                                         final Properties producerConfig,
+                                                                         final Headers headers,
+                                                                         final Long timestamp,
+                                                                         final boolean enableTransactions)
+            throws ExecutionException, InterruptedException {
+
+        try (final Producer<K, V> producer = new KafkaProducer<>(producerConfig)) {
+            if (enableTransactions) {
+                producer.initTransactions();
+                producer.beginTransaction();
+            }
+            for (final KeyValue<K, V> record : records) {
+                final Future<RecordMetadata> f = producer.send(
+                        new ProducerRecord<>(topic, null, timestamp, record.key, record.value, headers));
+                f.get();
+            }
+            if (enableTransactions) {
+                producer.commitTransaction();
+            }
+            producer.flush();
+        }
+    }
+
+    /**
+     * @param topic          Kafka topic to write the data records to
+     * @param records        Data records to write to Kafka
+     * @param producerConfig Kafka producer configuration
+     * @param time           Timestamp provider
+     * @param <V>            Value type of the data records
+     */
+    public static <V> void produceValuesSynchronously(final String topic,
+                                                      final Collection<V> records,
+                                                      final Properties producerConfig,
+                                                      final Time time)
+            throws ExecutionException, InterruptedException {
+        produceValuesSynchronously(topic, records, producerConfig, time, false);
+    }
+
+    /**
+     * @param topic              Kafka topic to write the data records to
+     * @param records            Data records to write to Kafka
+     * @param producerConfig     Kafka producer configuration
+     * @param time               Timestamp provider
+     * @param enableTransactions Send messages in a transaction
+     * @param <V>                Value type of the data records
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static <V> void produceValuesSynchronously(final String topic,
+                                                      final Collection<V> records,
+                                                      final Properties producerConfig,
+                                                      final Time time,
+                                                      final boolean enableTransactions)
+            throws ExecutionException, InterruptedException {
+        final Collection<KeyValue<Object, V>> keyedRecords = new ArrayList<>();
+        for (final V value : records) {
+            final KeyValue<Object, V> kv = new KeyValue<>(null, value);
+            keyedRecords.add(kv);
+        }
+        produceKeyValuesSynchronously(topic, keyedRecords, producerConfig, time, enableTransactions);
+    }
+
+    /**
+     * Wait for streams to "finish", based on the consumer lag metric.
+     *
+     * Caveats:
+     * - Inputs must be finite, fully loaded, and flushed before this method is called
+     * - expectedPartitions is the total number of partitions to watch the lag on, including both input and internal.
+     * It's somewhat ok to get this wrong, as the main failure case would be an immediate return due to the clients
+     * not being initialized, which you can avoid with any non-zero value. But it's probably better to get it right ;)
+     */
+    public static void waitForCompletion(final KafkaStreams streams,
+                                         final int expectedPartitions,
+                                         final int timeoutMilliseconds) {
+        final long start = System.currentTimeMillis();
+        while (true) {
+            int lagMetrics = 0;
+            double totalLag = 0.0;
+            for (final Metric metric : streams.metrics().values()) {
+                if (metric.metricName().name().equals("records-lag")) {
+                    lagMetrics++;
+                    totalLag += ((Number) metric.metricValue()).doubleValue();
+                }
+            }
+            if (lagMetrics >= expectedPartitions && totalLag == 0.0) {
+                return;
+            }
+            if (System.currentTimeMillis() - start >= timeoutMilliseconds) {
+                throw new RuntimeException(String.format(
+                        "Timed out waiting for completion. lagMetrics=[%s/%s] totalLag=[%s]",
+                        lagMetrics, expectedPartitions, totalLag
+                ));
+            }
+        }
+    }
+
+    /**
+     * Wait until enough data (consumer records) has been consumed.
+     *
+     * @param consumerConfig     Kafka Consumer configuration
+     * @param topic              Kafka topic to consume from
+     * @param expectedNumRecords Minimum number of expected records
+     * @param <K>                Key type of the data records
+     * @param <V>                Value type of the data records
+     * @return All the records consumed, or null if no records are consumed
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static <K, V> List<ConsumerRecord<K, V>> waitUntilMinRecordsReceived(final Properties consumerConfig,
+                                                                                final String topic,
+                                                                                final int expectedNumRecords)
+            throws InterruptedException {
+        return waitUntilMinRecordsReceived(consumerConfig, topic, expectedNumRecords, DEFAULT_TIMEOUT);
+    }
+
+    /**
+     * Wait until enough data (consumer records) has been consumed.
+     *
+     * @param consumerConfig     Kafka Consumer configuration
+     * @param topic              Kafka topic to consume from
+     * @param expectedNumRecords Minimum number of expected records
+     * @param waitTime           Upper bound of waiting time in milliseconds
+     * @param <K>                Key type of the data records
+     * @param <V>                Value type of the data records
+     * @return All the records consumed, or null if no records are consumed
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static <K, V> List<ConsumerRecord<K, V>> waitUntilMinRecordsReceived(final Properties consumerConfig,
+                                                                                final String topic,
+                                                                                final int expectedNumRecords,
+                                                                                final long waitTime)
+            throws InterruptedException {
+        final List<ConsumerRecord<K, V>> accumData = new ArrayList<>();
+        final String reason =
+                String.format("Did not receive all %d records from topic %s within %d ms", expectedNumRecords, topic,
+                        waitTime);
+        try (final Consumer<K, V> consumer = createConsumer(consumerConfig)) {
+            retryOnExceptionWithTimeout(waitTime, () -> {
+                final List<ConsumerRecord<K, V>> readData =
+                        readRecords(topic, consumer, waitTime, expectedNumRecords);
+                accumData.addAll(readData);
+                assertThat(reason, accumData.size(), Matchers.is(greaterThanOrEqualTo(expectedNumRecords)));
+            });
+        }
+        return accumData;
+    }
+
+    /**
+     * Wait until enough data (key-value records) has been consumed.
+     *
+     * @param consumerConfig     Kafka Consumer configuration
+     * @param topic              Kafka topic to consume from
+     * @param expectedNumRecords Minimum number of expected records
+     * @param <K>                Key type of the data records
+     * @param <V>                Value type of the data records
+     * @return All the records consumed, or null if no records are consumed
+     */
+    public static <K, V> List<KeyValue<K, V>> waitUntilMinKeyValueRecordsReceived(final Properties consumerConfig,
+                                                                                  final String topic,
+                                                                                  final int expectedNumRecords)
+            throws InterruptedException {
+        return waitUntilMinKeyValueRecordsReceived(consumerConfig, topic, expectedNumRecords, DEFAULT_TIMEOUT);
+    }
+
+    /**
+     * Wait until enough data (key-value records) has been consumed.
+     *
+     * @param consumerConfig     Kafka Consumer configuration
+     * @param topic              Kafka topic to consume from
+     * @param expectedNumRecords Minimum number of expected records
+     * @param waitTime           Upper bound of waiting time in milliseconds
+     * @param <K>                Key type of the data records
+     * @param <V>                Value type of the data records
+     * @return All the records consumed, or null if no records are consumed
+     * @throws AssertionError if the given wait time elapses
+     */
+    public static <K, V> List<KeyValue<K, V>> waitUntilMinKeyValueRecordsReceived(final Properties consumerConfig,
+                                                                                  final String topic,
+                                                                                  final int expectedNumRecords,
+                                                                                  final long waitTime)
+            throws InterruptedException {
+        final List<KeyValue<K, V>> accumData = new ArrayList<>();
+        final String reason =
+                String.format("Did not receive all %d records from topic %s within %d ms", expectedNumRecords, topic,
+                        waitTime);
+        try (final Consumer<K, V> consumer = createConsumer(consumerConfig)) {
+            retryOnExceptionWithTimeout(waitTime, () -> {
+                final List<KeyValue<K, V>> readData =
+                        readKeyValues(topic, consumer, waitTime, expectedNumRecords);
+                accumData.addAll(readData);
+                assertThat(reason, accumData.size(), Matchers.is(greaterThanOrEqualTo(expectedNumRecords)));
+            });
+        }
+        return accumData;
+    }
+
+    /**
+     * Wait until enough data (value records) has been consumed.
+     *
+     * @param consumerConfig     Kafka Consumer configuration
+     * @param topic              Topic to consume from
+     * @param expectedNumRecords Minimum number of expected records
+     * @param waitTime           Upper bound of waiting time in milliseconds
+     * @return All the records consumed, or null if no records are consumed
+     * @throws AssertionError if the given wait time elapses
+     */
+    public static <V> List<V> waitUntilMinValuesRecordsReceived(final Properties consumerConfig,
+                                                                final String topic,
+                                                                final int expectedNumRecords,
+                                                                final long waitTime) throws InterruptedException {
+        final List<V> accumData = new ArrayList<>();
+        final String reason =
+                String.format("Did not receive all %d records from topic %s within %d ms", expectedNumRecords, topic,
+                        waitTime);
+        try (final Consumer<Object, V> consumer = createConsumer(consumerConfig)) {
+            retryOnExceptionWithTimeout(waitTime, () -> {
+                final List<V> readData =
+                        readValues(topic, consumer, waitTime, expectedNumRecords);
+                accumData.addAll(readData);
+                assertThat(reason, accumData.size(), Matchers.is(greaterThanOrEqualTo(expectedNumRecords)));
+            });
+        }
+        return accumData;
+    }
+
+    /**
+     * Starts the given {@link KafkaStreams} instances and waits for all of them to reach the
+     * {@link KafkaStreams.State#RUNNING} state at the same time. Note that states may change between the time
+     * that this method returns and the calling function executes its next statement.<p>
+     *
+     * When the application is already started use {@link #waitForApplicationState(List, KafkaStreams.State, Duration)}
+     * to wait for instances to reach {@link KafkaStreams.State#RUNNING} state.
+     *
+     * @param streamsList the list of streams instances to run.
+     * @param timeout     the time to wait for the streams to all be in {@link KafkaStreams.State#RUNNING} state.
+     */
+    public static void startApplicationAndWaitUntilRunning(final List<KafkaStreams> streamsList,
+                                                           final Duration timeout) throws InterruptedException {
+        final Lock stateLock = new ReentrantLock();
+        final Condition stateUpdate = stateLock.newCondition();
+        final Map<KafkaStreams, KafkaStreams.State> stateMap = new HashMap<>();
+        for (final KafkaStreams streams : streamsList) {
+            stateMap.put(streams, streams.state());
+            final KafkaStreams.StateListener prevStateListener = getStateListener(streams);
+            final KafkaStreams.StateListener newStateListener = (newState, oldState) -> {
+                stateLock.lock();
+                try {
+                    stateMap.put(streams, newState);
+                    if (newState == KafkaStreams.State.RUNNING) {
+                        if (stateMap.values().stream().allMatch(state -> state == KafkaStreams.State.RUNNING)) {
+                            stateUpdate.signalAll();
+                        }
+                    }
+                } finally {
+                    stateLock.unlock();
+                }
+            };
+
+            streams.setStateListener(prevStateListener != null
+                    ? new CompositeStateListener(prevStateListener, newStateListener)
+                    : newStateListener);
+        }
+
+        for (final KafkaStreams streams : streamsList) {
+            streams.start();
+        }
+
+        final long expectedEnd = System.currentTimeMillis() + timeout.toMillis();
+        stateLock.lock();
+        try {
+            // We use while true here because we want to run this test at least once, even if the
+            // timeout has expired
+            while (true) {
+                final Map<KafkaStreams, KafkaStreams.State> nonRunningStreams = new HashMap<>();
+                for (final Map.Entry<KafkaStreams, KafkaStreams.State> entry : stateMap.entrySet()) {
+                    if (entry.getValue() != KafkaStreams.State.RUNNING) {
+                        nonRunningStreams.put(entry.getKey(), entry.getValue());
+                    }
+                }
+
+                if (nonRunningStreams.isEmpty()) {
+                    return;
+                }
+
+                final long millisRemaining = expectedEnd - System.currentTimeMillis();
+                if (millisRemaining <= 0) {
+                    fail("Application did not reach a RUNNING state for all streams instances. Non-running instances: "
+                            +
+                            nonRunningStreams);
+                }
+
+                stateUpdate.await(millisRemaining, TimeUnit.MILLISECONDS);
+            }
+        } finally {
+            stateLock.unlock();
+        }
+    }
+
+    /**
+     * Waits for the given {@link KafkaStreams} instances to all be in a  {@link KafkaStreams.State#RUNNING}
+     * state. Prefer {@link #startApplicationAndWaitUntilRunning(List, Duration)} when possible
+     * because this method uses polling, which can be more error prone and slightly slower.
+     *
+     * @param streamsList the list of streams instances to run.
+     * @param timeout     the time to wait for the streams to all be in {@link KafkaStreams.State#RUNNING} state.
+     */
+    public static void waitForApplicationState(final List<KafkaStreams> streamsList,
+                                               final KafkaStreams.State state,
+                                               final Duration timeout) throws InterruptedException {
+        retryOnExceptionWithTimeout(timeout.toMillis(), () -> {
+            final Map<KafkaStreams, KafkaStreams.State> streamsToStates = streamsList
+                    .stream()
+                    .collect(Collectors.toMap(stream -> stream, KafkaStreams::state));
+
+            final Map<KafkaStreams, KafkaStreams.State> wrongStateMap = streamsToStates.entrySet()
+                    .stream()
+                    .filter(entry -> entry.getValue() != state)
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+            final String reason = String.format(
+                    "Expected all streams instances in %s to be %s within %d ms, but the following were not: %s",
+                    streamsList, state, timeout.toMillis(), wrongStateMap);
+            assertThat(reason, wrongStateMap.isEmpty());
+        });
+    }
+
+    private static KafkaStreams.StateListener getStateListener(final KafkaStreams streams) {
+        try {
+            final Field field = streams.getClass().getDeclaredField("stateListener");
+            field.setAccessible(true);
+            return (KafkaStreams.StateListener) field.get(streams);
+        } catch (final IllegalAccessException | NoSuchFieldException e) {
+            throw new RuntimeException("Failed to get StateListener through reflection", e);
+        }
+    }
+
+
+    private static <K, V> void compareKeyValueTimestamp(final ConsumerRecord<K, V> record,
+                                                        final K expectedKey,
+                                                        final V expectedValue,
+                                                        final long expectedTimestamp) {
+        Objects.requireNonNull(record);
+        final K recordKey = record.key();
+        final V recordValue = record.value();
+        final long recordTimestamp = record.timestamp();
+        final AssertionError error = new AssertionError(
+                "Expected <" + expectedKey + ", " + expectedValue + "> with timestamp=" + expectedTimestamp +
+                        " but was <" + recordKey + ", " + recordValue + "> with timestamp=" + recordTimestamp);
+        if (recordKey != null) {
+            if (!recordKey.equals(expectedKey)) {
+                throw error;
+            }
+        } else if (expectedKey != null) {
+            throw error;
+        }
+        if (recordValue != null) {
+            if (!recordValue.equals(expectedValue)) {
+                throw error;
+            }
+        } else if (expectedValue != null) {
+            throw error;
+        }
+        if (recordTimestamp != expectedTimestamp) {
+            throw error;
+        }
+    }
+
+    private static <K, V> String printRecords(final List<ConsumerRecord<K, V>> result) {
+        final StringBuilder resultStr = new StringBuilder();
+        resultStr.append("[\n");
+        for (final ConsumerRecord<?, ?> record : result) {
+            resultStr.append("  ").append(record.toString()).append("\n");
+        }
+        resultStr.append("]");
+        return resultStr.toString();
+    }
+
+    /**
+     * Returns up to `maxMessages` message-values from the topic.
+     *
+     * @param topic          Kafka topic to read messages from
+     * @param consumerConfig Kafka consumer config
+     * @param waitTime       Maximum wait time in milliseconds
+     * @param maxMessages    Maximum number of messages to read via the consumer.
+     * @return The values retrieved via the consumer.
+     */
+    public static <V> List<V> readValues(final String topic, final Properties consumerConfig,
+                                         final long waitTime, final int maxMessages) {
+        final List<V> returnList;
+        try (final Consumer<Object, V> consumer = createConsumer(consumerConfig)) {
+            returnList = readValues(topic, consumer, waitTime, maxMessages);
+        }
+        return returnList;
+    }
+
+    /**
+     * Returns up to `maxMessages` by reading via the provided consumer (the topic(s) to read from
+     * are already configured in the consumer).
+     *
+     * @param topic          Kafka topic to read messages from
+     * @param consumerConfig Kafka consumer config
+     * @param waitTime       Maximum wait time in milliseconds
+     * @param maxMessages    Maximum number of messages to read via the consumer
+     * @return The KeyValue elements retrieved via the consumer
+     */
+    public static <K, V> List<KeyValue<K, V>> readKeyValues(final String topic,
+                                                            final Properties consumerConfig, final long waitTime,
+                                                            final int maxMessages) {
+        final List<KeyValue<K, V>> consumedValues;
+        try (final Consumer<K, V> consumer = createConsumer(consumerConfig)) {
+            consumedValues = readKeyValues(topic, consumer, waitTime, maxMessages);
+        }
+        return consumedValues;
+    }
+
+    public static KafkaStreams getStartedStreams(final Properties streamsConfig, final StreamsBuilder builder,
+                                                 final boolean clean) {
+        final KafkaStreams driver = new KafkaStreams(builder.build(), streamsConfig);
+        if (clean) {
+            driver.cleanUp();
+        }
+        driver.start();
+        return driver;
+    }
+
+    /**
+     * Returns up to `maxMessages` message-values from the topic.
+     *
+     * @param topic       Kafka topic to read messages from
+     * @param consumer    Kafka consumer
+     * @param waitTime    Maximum wait time in milliseconds
+     * @param maxMessages Maximum number of messages to read via the consumer.
+     * @return The values retrieved via the consumer.
+     */
+    private static <V> List<V> readValues(final String topic,
+                                          final Consumer<Object, V> consumer,
+                                          final long waitTime,
+                                          final int maxMessages) {
+        final List<V> returnList = new ArrayList<>();
+        final List<KeyValue<Object, V>> kvs = readKeyValues(topic, consumer, waitTime, maxMessages);
+        for (final KeyValue<?, V> kv : kvs) {
+            returnList.add(kv.value);
+        }
+        return returnList;
+    }
+
+    /**
+     * Returns up to `maxMessages` by reading via the provided consumer (the topic(s) to read from
+     * are already configured in the consumer).
+     *
+     * @param topic       Kafka topic to read messages from
+     * @param consumer    Kafka consumer
+     * @param waitTime    Maximum wait time in milliseconds
+     * @param maxMessages Maximum number of messages to read via the consumer
+     * @return The KeyValue elements retrieved via the consumer
+     */
+    private static <K, V> List<KeyValue<K, V>> readKeyValues(final String topic,
+                                                             final Consumer<K, V> consumer,
+                                                             final long waitTime,
+                                                             final int maxMessages) {
+        final List<KeyValue<K, V>> consumedValues = new ArrayList<>();
+        final List<ConsumerRecord<K, V>> records = readRecords(topic, consumer, waitTime, maxMessages);
+        for (final ConsumerRecord<K, V> record : records) {
+            consumedValues.add(new KeyValue<>(record.key(), record.value()));
+        }
+        return consumedValues;
+    }
+
+    private static <K, V> List<ConsumerRecord<K, V>> readRecords(final String topic,
+                                                                 final Consumer<K, V> consumer,
+                                                                 final long waitTime,
+                                                                 final int maxMessages) {
+        final List<ConsumerRecord<K, V>> consumerRecords;
+        consumer.subscribe(Collections.singletonList(topic));
+        final int pollIntervalMs = 100;
+        consumerRecords = new ArrayList<>();
+        int totalPollTimeMs = 0;
+        while (totalPollTimeMs < waitTime &&
+                continueConsuming(consumerRecords.size(), maxMessages)) {
+            totalPollTimeMs += pollIntervalMs;
+            final ConsumerRecords<K, V> records = consumer.poll(Duration.ofMillis(pollIntervalMs));
+
+            for (final ConsumerRecord<K, V> record : records) {
+                log.info("readRecords received {}", record);
+                consumerRecords.add(record);
+            }
+        }
+        return consumerRecords;
+    }
+
+    private static boolean continueConsuming(final int messagesConsumed, final int maxMessages) {
+        return maxMessages <= 0 || messagesConsumed < maxMessages;
+    }
+
+    /**
+     * Sets up a {@link KafkaConsumer} from a copy of the given configuration that has
+     * {@link ConsumerConfig#AUTO_OFFSET_RESET_CONFIG} set to "earliest" and {@link
+     * ConsumerConfig#ENABLE_AUTO_COMMIT_CONFIG}
+     * set to "true" to prevent missing events as well as repeat consumption.
+     *
+     * @param consumerConfig Consumer configuration
+     * @return Consumer
+     */
+    private static <K, V> KafkaConsumer<K, V> createConsumer(final Properties consumerConfig) {
+        final Properties filtered = new Properties();
+        filtered.putAll(consumerConfig);
+        filtered.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        filtered.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
+        return new KafkaConsumer<>(filtered);
+    }
+
+    public static class CompositeStateListener implements KafkaStreams.StateListener {
+        private final List<KafkaStreams.StateListener> listeners;
+
+        public CompositeStateListener(final KafkaStreams.StateListener... listeners) {
+            this(Arrays.asList(listeners));
+        }
+
+        public CompositeStateListener(final Collection<KafkaStreams.StateListener> stateListeners) {
+            this.listeners = Collections.unmodifiableList(new ArrayList<>(stateListeners));
+        }
+
+        @Override
+        public void onChange(final KafkaStreams.State newState, final KafkaStreams.State oldState) {
+            for (final KafkaStreams.StateListener listener : listeners) {
+                listener.onChange(newState, oldState);
+            }
+        }
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/InternalTopicIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/InternalTopicIntegrationTest.java
@@ -1,0 +1,169 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.streams;
+
+import static io.streamnative.pulsar.handlers.kop.streams.IntegrationTestUtils.waitForCompletion;
+import static io.streamnative.pulsar.handlers.kop.streams.TestUtils.INTERNAL_LEAVE_GROUP_ON_CLOSE;
+import static io.streamnative.pulsar.handlers.kop.streams.TestUtils.purgeLocalStreamsState;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
+import lombok.NonNull;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.TimeWindows;
+import org.apache.kafka.streams.kstream.ValueMapper;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.WindowStore;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+public class InternalTopicIntegrationTest extends KafkaStreamsTestBase {
+    private static final String APP_ID = "internal-topics-integration-test";
+    private static final String DEFAULT_INPUT_TOPIC = "inputTopic";
+
+    @Override
+    protected void createTopics() throws Exception {
+        createTopics(DEFAULT_INPUT_TOPIC);
+    }
+
+    @Override
+    protected @NonNull String getApplicationIdPrefix() {
+        return APP_ID;
+    }
+
+    @Override
+    protected void extraSetup() throws Exception {
+        streamsConfiguration.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        streamsConfiguration.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+        streamsConfiguration.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+        streamsConfiguration.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
+        streamsConfiguration.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        streamsConfiguration.put(INTERNAL_LEAVE_GROUP_ON_CLOSE, true);
+        streamsConfiguration.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 100);
+        streamsConfiguration.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
+    }
+
+    @Override
+    protected Class<?> getKeySerdeClass() {
+        return null;
+    }
+
+    @Override
+    protected Class<?> getValueSerdeClass() {
+        return null;
+    }
+
+    @AfterMethod
+    public void after() throws IOException {
+        // Remove any state from previous test runs
+        purgeLocalStreamsState(streamsConfiguration);
+    }
+
+    private void produceData(final List<String> inputValues) throws Exception {
+        final Properties producerProp = new Properties();
+        producerProp.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        producerProp.put(ProducerConfig.ACKS_CONFIG, "all");
+        producerProp.put(ProducerConfig.RETRIES_CONFIG, 0);
+        producerProp.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        producerProp.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+        IntegrationTestUtils.produceValuesSynchronously(DEFAULT_INPUT_TOPIC, inputValues, producerProp, mockTime);
+    }
+
+    @Test
+    public void shouldCompactTopicsForKeyValueStoreChangelogs() throws Exception {
+        final String appID = APP_ID + "-compact";
+        streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
+
+        //
+        // Step 1: Configure and start a simple word count topology
+        //
+        final StreamsBuilder builder = new StreamsBuilder();
+        final KStream<String, String> textLines = builder.stream(DEFAULT_INPUT_TOPIC);
+
+        textLines.flatMapValues(new ValueMapper<String, Iterable<String>>() {
+                    @Override
+                    public Iterable<String> apply(final String value) {
+                        return Arrays.asList(value.toLowerCase(Locale.getDefault()).split("\\W+"));
+                    }
+                })
+                .groupBy(MockMapper.<String, String>selectValueMapper())
+                .count(Materialized.<String, Long, KeyValueStore<Bytes, byte[]>>as("Counts"));
+
+        final KafkaStreams streams = new KafkaStreams(builder.build(), streamsConfiguration);
+        streams.start();
+
+        //
+        // Step 2: Produce some input data to the input topic.
+        //
+        produceData(Arrays.asList("hello", "world", "world", "hello world"));
+
+        //
+        // Step 3: Verify the state changelog topics are compact
+        //
+        waitForCompletion(streams, 2, 30000);
+        streams.close();
+
+    }
+
+    @Test
+    public void shouldCompactAndDeleteTopicsForWindowStoreChangelogs() throws Exception {
+        final String appID = APP_ID + "-compact-delete";
+        streamsConfiguration.put(StreamsConfig.APPLICATION_ID_CONFIG, appID);
+
+        //
+        // Step 1: Configure and start a simple word count topology
+        //
+        StreamsBuilder builder = new StreamsBuilder();
+        KStream<String, String> textLines = builder.stream(DEFAULT_INPUT_TOPIC);
+
+        final int durationMs = 2000;
+
+        textLines.flatMapValues(new ValueMapper<String, Iterable<String>>() {
+                    @Override
+                    public Iterable<String> apply(final String value) {
+                        return Arrays.asList(value.toLowerCase(Locale.getDefault()).split("\\W+"));
+                    }
+                })
+                .groupBy(MockMapper.<String, String>selectValueMapper())
+                .windowedBy(TimeWindows.of(1000).until(2000))
+                .count(Materialized.<String, Long, WindowStore<Bytes, byte[]>>as("CountWindows"));
+
+        KafkaStreams streams = new KafkaStreams(builder.build(), streamsConfiguration);
+        streams.start();
+
+        //
+        // Step 2: Produce some input data to the input topic.
+        //
+        produceData(Arrays.asList("hello", "world", "world", "hello world"));
+
+        //
+        // Step 3: Verify the state changelog topics are compact
+        //
+        waitForCompletion(streams, 2, 30000);
+        streams.close();
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/KafkaStreamsTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/KafkaStreamsTestBase.java
@@ -23,6 +23,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
@@ -36,7 +37,7 @@ public abstract class KafkaStreamsTestBase extends KopProtocolHandlerTestBase {
     protected String bootstrapServers;
     @Getter
     private int testNo = 0; // the suffix of the prefix of test topic name or application id, etc.
-    private Properties streamsConfiguration;
+    protected Properties streamsConfiguration;
     protected StreamsBuilder builder; // the builder to build `kafkaStreams` and other objects of Kafka Streams
     protected KafkaStreams kafkaStreams;
 
@@ -55,6 +56,28 @@ public abstract class KafkaStreamsTestBase extends KopProtocolHandlerTestBase {
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();
+    }
+
+    protected void createTopics(String ... topics) throws Exception {
+        createTopics(1, topics);;
+    }
+    protected void createTopics(int partitions, String ... topics) throws Exception {
+        for (String topic : topics) {
+            try {
+                admin.topics().deletePartitionedTopic(topic, true, true);
+            } catch (PulsarAdminException.NotFoundException ok) {
+            }
+            admin.topics().createPartitionedTopic(topic, partitions);
+        }
+    }
+
+    protected void deleteTopic(String ... topics) throws Exception {
+        for (String topic : topics) {
+            try {
+                admin.topics().deletePartitionedTopic(topic, true, true);
+            } catch (PulsarAdminException.NotFoundException ok) {
+            }
+        }
     }
 
     @BeforeMethod

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/MockMapper.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/MockMapper.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.streams;
+
+import java.util.Collections;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.kstream.KeyValueMapper;
+import org.apache.kafka.streams.kstream.ValueMapper;
+
+public class MockMapper {
+
+    private static class NoOpKeyValueMapper<K, V> implements KeyValueMapper<K, V, KeyValue<K, V>> {
+        @Override
+        public KeyValue<K, V> apply(K key, V value) {
+            return KeyValue.pair(key, value);
+        }
+    }
+
+    private static class NoOpFlatKeyValueMapper<K, V> implements KeyValueMapper<K, V, Iterable<KeyValue<K, V>>> {
+        @Override
+        public Iterable<KeyValue<K, V>> apply(K key, V value) {
+            return Collections.singletonList(KeyValue.pair(key, value));
+        }
+    }
+
+    private static class SelectValueKeyValueMapper<K, V> implements KeyValueMapper<K, V, KeyValue<V, V>> {
+        @Override
+        public KeyValue<V, V> apply(K key, V value) {
+            return KeyValue.pair(value, value);
+        }
+    }
+
+    private static class SelectValueMapper<K, V> implements KeyValueMapper<K, V, V> {
+        @Override
+        public V apply(K key, V value) {
+            return value;
+        }
+    }
+
+    private static class SelectKeyMapper<K, V> implements KeyValueMapper<K, V, K> {
+        @Override
+        public K apply(K key, V value) {
+            return key;
+        }
+    }
+
+    private static class NoOpValueMapper<V> implements ValueMapper<V, V> {
+        @Override
+        public V apply(final V value) {
+            return value;
+        }
+    }
+
+    public static <K, V> KeyValueMapper<K, V, K> selectKeyKeyValueMapper() {
+        return new SelectKeyMapper<>();
+    }
+
+    public static <K, V> KeyValueMapper<K, V, Iterable<KeyValue<K, V>>> noOpFlatKeyValueMapper() {
+        return new NoOpFlatKeyValueMapper<>();
+    }
+
+    public static <K, V> KeyValueMapper<K, V, KeyValue<K, V>> noOpKeyValueMapper() {
+        return new NoOpKeyValueMapper<>();
+    }
+
+    public static <K, V> KeyValueMapper<K, V, KeyValue<V, V>> selectValueKeyValueMapper() {
+        return new SelectValueKeyValueMapper<>();
+    }
+
+    public static <K, V> KeyValueMapper<K, V, V> selectValueMapper() {
+        return new SelectValueMapper<>();
+    }
+
+    public static <V> ValueMapper<V, V> noOpValueMapper() {
+        return new NoOpValueMapper<>();
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/MockProcessor.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/MockProcessor.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.streams;
+
+import static org.junit.Assert.assertEquals;
+import java.util.ArrayList;
+import org.apache.kafka.streams.processor.AbstractProcessor;
+import org.apache.kafka.streams.processor.Cancellable;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.PunctuationType;
+import org.apache.kafka.streams.processor.Punctuator;
+
+public class MockProcessor<K, V> extends AbstractProcessor<K, V> {
+
+    public final ArrayList<String> processed = new ArrayList<>();
+    public final ArrayList<K> processedKeys = new ArrayList<>();
+    public final ArrayList<V> processedValues = new ArrayList<>();
+
+    public final ArrayList<Long> punctuatedStreamTime = new ArrayList<>();
+    public final ArrayList<Long> punctuatedSystemTime = new ArrayList<>();
+
+    public Cancellable scheduleCancellable;
+
+    private final PunctuationType punctuationType;
+    private final long scheduleInterval;
+
+    public MockProcessor(final PunctuationType punctuationType, final long scheduleInterval) {
+        this.punctuationType = punctuationType;
+        this.scheduleInterval = scheduleInterval;
+    }
+
+    public MockProcessor() {
+        this(PunctuationType.STREAM_TIME, -1);
+    }
+
+    @Override
+    public void init(final ProcessorContext context) {
+        super.init(context);
+        if (scheduleInterval > 0L) {
+            scheduleCancellable = context.schedule(scheduleInterval, punctuationType, new Punctuator() {
+                @Override
+                public void punctuate(final long timestamp) {
+                    if (punctuationType == PunctuationType.STREAM_TIME) {
+                        assertEquals(timestamp, context().timestamp());
+                    }
+                    assertEquals(-1, context().partition());
+                    assertEquals(-1L, context().offset());
+
+                    (punctuationType == PunctuationType.STREAM_TIME ? punctuatedStreamTime : punctuatedSystemTime)
+                            .add(timestamp);
+                }
+            });
+        }
+    }
+
+    @Override
+    public void process(final K key, final V value) {
+        processedKeys.add(key);
+        processedValues.add(value);
+        processed.add((key == null ? "null" : key) + ":" +
+                (value == null ? "null" : value));
+
+    }
+
+    public void checkAndClearProcessResult(final String... expected) {
+        assertEquals("the number of outputs:" + processed, expected.length, processed.size());
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals("output[" + i + "]:", expected[i], processed.get(i));
+        }
+
+        processed.clear();
+    }
+
+    public void checkEmptyAndClearProcessResult() {
+        assertEquals("the number of outputs:", 0, processed.size());
+        processed.clear();
+    }
+
+    public void checkAndClearPunctuateResult(final PunctuationType type, final long... expected) {
+        final ArrayList<Long> punctuated = type == PunctuationType.STREAM_TIME ? punctuatedStreamTime : punctuatedSystemTime;
+        assertEquals("the number of outputs:", expected.length, punctuated.size());
+
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals("output[" + i + "]:", expected[i], (long) punctuated.get(i));
+        }
+
+        processed.clear();
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/MockProcessorNode.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/MockProcessorNode.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.streams;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.kafka.streams.processor.PunctuationType;
+import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
+import org.apache.kafka.streams.processor.internals.ProcessorNode;
+
+public class MockProcessorNode<K, V> extends ProcessorNode<K, V> {
+
+    private static final String NAME = "MOCK-PROCESS-";
+    private static final AtomicInteger INDEX = new AtomicInteger(1);
+
+    public final MockProcessor<K, V> mockProcessor;
+
+    public boolean closed;
+    public boolean initialized;
+
+    public MockProcessorNode(long scheduleInterval) {
+        this(scheduleInterval, PunctuationType.STREAM_TIME);
+    }
+
+    public MockProcessorNode(long scheduleInterval, PunctuationType punctuationType) {
+        this(new MockProcessor<K, V>(punctuationType, scheduleInterval));
+    }
+
+    public MockProcessorNode() {
+        this(new MockProcessor<K, V>());
+    }
+
+    private MockProcessorNode(final MockProcessor<K, V> mockProcessor) {
+        super(NAME + INDEX.getAndIncrement(), mockProcessor, Collections.<String>emptySet());
+
+        this.mockProcessor = mockProcessor;
+    }
+
+    @Override
+    public void init(final InternalProcessorContext context) {
+        super.init(context);
+        initialized = true;
+    }
+
+    @Override
+    public void process(K key, V value) {
+        processor().process(key, value);
+    }
+
+    @Override
+    public void close() {
+        super.close();
+        this.closed = true;
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/MockProcessorSupplier.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/MockProcessorSupplier.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.streams;
+
+import static org.junit.Assert.assertEquals;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.kafka.streams.processor.Processor;
+import org.apache.kafka.streams.processor.ProcessorSupplier;
+import org.apache.kafka.streams.processor.PunctuationType;
+
+public class MockProcessorSupplier<K, V> implements ProcessorSupplier<K, V> {
+
+    private final long scheduleInterval;
+    private final PunctuationType punctuationType;
+    private final List<MockProcessor<K, V>> processors = new ArrayList<>();
+
+    public MockProcessorSupplier() {
+        this(-1L);
+    }
+
+    public MockProcessorSupplier(long scheduleInterval) {
+        this(scheduleInterval, PunctuationType.STREAM_TIME);
+    }
+
+    public MockProcessorSupplier(long scheduleInterval, PunctuationType punctuationType) {
+        this.scheduleInterval = scheduleInterval;
+        this.punctuationType = punctuationType;
+    }
+
+    @Override
+    public Processor<K, V> get() {
+        final MockProcessor<K, V> processor = new MockProcessor<>(punctuationType, scheduleInterval);
+        processors.add(processor);
+        return processor;
+    }
+
+    // get the captured processor assuming that only one processor gets returned from this supplier
+    public MockProcessor<K, V> theCapturedProcessor() {
+        return capturedProcessors(1).get(0);
+    }
+
+    // get the captured processors with the expected number
+    public List<MockProcessor<K, V>> capturedProcessors(final int expectedNumberOfProcessors) {
+        assertEquals(expectedNumberOfProcessors, processors.size());
+
+        return processors;
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/MockStateRestoreListener.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/MockStateRestoreListener.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.streamnative.pulsar.handlers.kop.streams;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.processor.AbstractNotifyingRestoreCallback;
+
+public class MockStateRestoreListener extends AbstractNotifyingRestoreCallback {
+
+    // verifies store name called for each state
+    public final Map<String, String> storeNameCalledStates = new HashMap<>();
+    public final List<KeyValue<byte[], byte[]>> restored = new ArrayList<>();
+    public long restoreStartOffset;
+    public long restoreEndOffset;
+    public long restoredBatchOffset;
+    public long numBatchRestored;
+    public long totalNumRestored;
+    public TopicPartition restoreTopicPartition;
+
+    public static final String RESTORE_START = "restore_start";
+    public static final String RESTORE_BATCH = "restore_batch";
+    public static final String RESTORE_END = "restore_end";
+
+    @Override
+    public void restore(byte[] key, byte[] value) {
+        restored.add(KeyValue.pair(key, value));
+    }
+
+    @Override
+    public void onRestoreStart(final TopicPartition topicPartition, final String storeName,
+                               final long startingOffset, final long endingOffset) {
+        restoreTopicPartition = topicPartition;
+        storeNameCalledStates.put(RESTORE_START, storeName);
+        restoreStartOffset = startingOffset;
+        restoreEndOffset = endingOffset;
+    }
+
+    @Override
+    public void onBatchRestored(final TopicPartition topicPartition, final String storeName,
+                                final long batchEndOffset, final long numRestored) {
+        restoreTopicPartition = topicPartition;
+        storeNameCalledStates.put(RESTORE_BATCH, storeName);
+        restoredBatchOffset = batchEndOffset;
+        numBatchRestored = numRestored;
+
+    }
+
+    @Override
+    public void onRestoreEnd(final TopicPartition topicPartition, final String storeName,
+                             final long totalRestored) {
+        restoreTopicPartition = topicPartition;
+        storeNameCalledStates.put(RESTORE_END, storeName);
+        totalNumRestored = totalRestored;
+    }
+
+    @Override
+    public String toString() {
+        return "MockStateRestoreListener{" +
+               "storeNameCalledStates=" + storeNameCalledStates +
+               ", restored=" + restored +
+               ", restoreStartOffset=" + restoreStartOffset +
+               ", restoreEndOffset=" + restoreEndOffset +
+               ", restoredBatchOffset=" + restoredBatchOffset +
+               ", numBatchRestored=" + numBatchRestored +
+               ", totalNumRestored=" + totalNumRestored +
+               ", restoreTopicPartition=" + restoreTopicPartition +
+               '}';
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/MockStateStore.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/MockStateStore.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.streams;
+
+import java.util.ArrayList;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.StateRestoreCallback;
+import org.apache.kafka.streams.processor.StateStore;
+
+public class MockStateStore implements StateStore {
+    private final String name;
+    private final boolean persistent;
+
+    public boolean initialized = false;
+    public boolean flushed = false;
+    public boolean closed = true;
+    public final ArrayList<Integer> keys = new ArrayList<>();
+
+    public MockStateStore(final String name,
+                          final boolean persistent) {
+        this.name = name;
+        this.persistent = persistent;
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public void init(final ProcessorContext context,
+                     final StateStore root) {
+        context.register(root, stateRestoreCallback);
+        initialized = true;
+        closed = false;
+    }
+
+    @Override
+    public void flush() {
+        flushed = true;
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+    }
+
+    @Override
+    public boolean persistent() {
+        return persistent;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return !closed;
+    }
+
+    public final StateRestoreCallback stateRestoreCallback = new StateRestoreCallback() {
+        private final Deserializer<Integer> deserializer = new IntegerDeserializer();
+
+        @Override
+        public void restore(final byte[] key,
+                            final byte[] value) {
+            keys.add(deserializer.deserialize("", key));
+        }
+    };
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/MockStoreBuilder.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/MockStoreBuilder.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.streams;
+
+import io.streamnative.pulsar.handlers.kop.utils.timer.MockTime;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.state.internals.AbstractStoreBuilder;
+
+public class MockStoreBuilder extends AbstractStoreBuilder<Integer, byte[], StateStore> {
+
+    private final boolean persistent;
+
+    public MockStoreBuilder(final String storeName, final boolean persistent) {
+        super(storeName, Serdes.Integer(), Serdes.ByteArray(), new MockTime());
+
+        this.persistent = persistent;
+    }
+
+    @Override
+    public StateStore build() {
+        return new MockStateStore(name, persistent);
+    }
+}
+

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/RegexSourceIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/RegexSourceIntegrationTest.java
@@ -1,0 +1,401 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.streams;
+
+import static io.streamnative.pulsar.handlers.kop.streams.TestUtils.INTERNAL_LEAVE_GROUP_ON_CLOSE;
+import static io.streamnative.pulsar.handlers.kop.streams.TestUtils.purgeLocalStreamsState;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+public class RegexSourceIntegrationTest extends KafkaStreamsTestBase {
+
+    private static final String TOPIC_1 = "topic-1";
+    private static final String TOPIC_2 = "topic-2";
+    private static final String TOPIC_A = "topic-A";
+    private static final String TOPIC_C = "topic-C";
+    private static final String TOPIC_Y = "topic-Y";
+    private static final String TOPIC_Z = "topic-Z";
+    private static final String FA_TOPIC = "fa";
+    private static final String FOO_TOPIC = "foo";
+    private static final String PARTITIONED_TOPIC_1 = "partitioned-1";
+    private static final String PARTITIONED_TOPIC_2 = "partitioned-2";
+
+    private static final String DEFAULT_OUTPUT_TOPIC = "outputTopic";
+    private static final String STRING_SERDE_CLASSNAME = Serdes.String().getClass().getName();
+    private static final String STREAM_TASKS_NOT_UPDATED = "Stream tasks not updated";
+    private KafkaStreams streams;
+
+    @Override
+    protected void createTopics() throws Exception {
+        createTopics(
+                TOPIC_1,
+                TOPIC_2,
+                TOPIC_A,
+                TOPIC_C,
+                TOPIC_Y,
+                TOPIC_Z,
+                FA_TOPIC,
+                FOO_TOPIC,
+                DEFAULT_OUTPUT_TOPIC);
+        createTopics(2, PARTITIONED_TOPIC_1);
+        createTopics(2, PARTITIONED_TOPIC_2);
+    }
+
+    @Override
+    protected @NonNull String getApplicationIdPrefix() {
+        return "app";
+    }
+
+    @Override
+    protected void extraSetup() throws Exception {
+        streamsConfiguration.put(INTERNAL_LEAVE_GROUP_ON_CLOSE, true);
+
+    }
+
+    @Override
+    protected Class<?> getKeySerdeClass() {
+        return null;
+    }
+
+    @Override
+    protected Class<?> getValueSerdeClass() {
+        return null;
+    }
+
+    @AfterMethod
+    public void tearDown() throws IOException {
+        if (streams != null) {
+            streams.close();
+        }
+        // Remove any state from previous test runs
+        purgeLocalStreamsState(streamsConfiguration);
+    }
+
+    @Test
+    public void testRegexMatchesTopicsAWhenCreated() throws Exception {
+
+        streamsConfiguration.put(ConsumerConfig.METADATA_MAX_AGE_CONFIG, 1000);
+
+        final Serde<String> stringSerde = Serdes.String();
+        final List<String> expectedFirstAssignment = Arrays.asList("TEST-TOPIC-1");
+        final List<String> expectedSecondAssignment = Arrays.asList("TEST-TOPIC-1", "TEST-TOPIC-2");
+
+        createTopics("TEST-TOPIC-1");
+
+        final StreamsBuilder builder = new StreamsBuilder();
+
+        final KStream<String, String> pattern1Stream = builder.stream(Pattern.compile("topic-\\d"));
+
+        pattern1Stream.to(DEFAULT_OUTPUT_TOPIC, Produced.with(stringSerde, stringSerde));
+        final List<String> assignedTopics = new CopyOnWriteArrayList<>();
+        streams = new KafkaStreams(builder.build(), streamsConfiguration, new DefaultKafkaClientSupplier() {
+            @Override
+            public Consumer<byte[], byte[]> getConsumer(final Map<String, Object> config) {
+                return new KafkaConsumer<byte[], byte[]>(config, new ByteArrayDeserializer(), new ByteArrayDeserializer()) {
+                    @Override
+                    public void subscribe(final Pattern topics, final ConsumerRebalanceListener listener) {
+                        super.subscribe(topics, new TheConsumerRebalanceListener(assignedTopics, listener));
+                    }
+                };
+
+            }
+        });
+
+
+        streams.start();
+        TestUtils.waitForCondition(new TestCondition() {
+            @Override
+            public boolean conditionMet() {
+                return assignedTopics.equals(expectedFirstAssignment);
+            }
+        }, STREAM_TASKS_NOT_UPDATED);
+
+        createTopics("TEST-TOPIC-2");
+
+        TestUtils.waitForCondition(new TestCondition() {
+            @Override
+            public boolean conditionMet() {
+                return assignedTopics.equals(expectedSecondAssignment);
+            }
+        }, STREAM_TASKS_NOT_UPDATED);
+
+    }
+
+    @Test
+    public void testRegexMatchesTopicsAWhenDeleted() throws Exception {
+
+        final Serde<String> stringSerde = Serdes.String();
+        final List<String> expectedFirstAssignment = Arrays.asList("TEST-TOPIC-A", "TEST-TOPIC-B");
+        final List<String> expectedSecondAssignment = Arrays.asList("TEST-TOPIC-B");
+
+        createTopics("TEST-TOPIC-A", "TEST-TOPIC-B");
+
+        final StreamsBuilder builder = new StreamsBuilder();
+
+        final KStream<String, String> pattern1Stream = builder.stream(Pattern.compile("TEST-TOPIC-[A-Z]"));
+
+        pattern1Stream.to(DEFAULT_OUTPUT_TOPIC, Produced.with(stringSerde, stringSerde));
+
+        final List<String> assignedTopics = new CopyOnWriteArrayList<>();
+        streams = new KafkaStreams(builder.build(), streamsConfiguration, new DefaultKafkaClientSupplier() {
+            @Override
+            public Consumer<byte[], byte[]> getConsumer(final Map<String, Object> config) {
+                return new KafkaConsumer<byte[], byte[]>(config, new ByteArrayDeserializer(), new ByteArrayDeserializer()) {
+                    @Override
+                    public void subscribe(final Pattern topics, final ConsumerRebalanceListener listener) {
+                        super.subscribe(topics, new TheConsumerRebalanceListener(assignedTopics, listener));
+                    }
+                };
+
+            }
+        });
+
+
+        streams.start();
+        TestUtils.waitForCondition(new TestCondition() {
+            @Override
+            public boolean conditionMet() {
+                return assignedTopics.equals(expectedFirstAssignment);
+            }
+        }, STREAM_TASKS_NOT_UPDATED);
+
+        deleteTopic("TEST-TOPIC-A");
+
+        TestUtils.waitForCondition(new TestCondition() {
+            @Override
+            public boolean conditionMet() {
+                return assignedTopics.equals(expectedSecondAssignment);
+            }
+        }, STREAM_TASKS_NOT_UPDATED);
+    }
+
+    @Test
+    public void testShouldReadFromRegexAndNamedTopics() throws Exception {
+
+        streamsConfiguration.put(ConsumerConfig.METADATA_MAX_AGE_CONFIG, 1000);
+
+        final String topic1TestMessage = "topic-1 test";
+        final String topic2TestMessage = "topic-2 test";
+        final String topicATestMessage = "topic-A test";
+        final String topicCTestMessage = "topic-C test";
+        final String topicYTestMessage = "topic-Y test";
+        final String topicZTestMessage = "topic-Z test";
+
+        final Serde<String> stringSerde = Serdes.String();
+
+        final KStream<String, String> pattern1Stream = builder.stream(Pattern.compile("topic-\\d"), Consumed.with(stringSerde, stringSerde));
+        final KStream<String, String> pattern2Stream = builder.stream(Pattern.compile("topic-[A-D]"), Consumed.with(stringSerde, stringSerde));
+        final KStream<String, String> namedTopicsStream = builder.stream(Arrays.asList(TOPIC_Y, TOPIC_Z), Consumed.with(stringSerde, stringSerde));
+
+        pattern1Stream.to(DEFAULT_OUTPUT_TOPIC, Produced.with(stringSerde, stringSerde));
+        pattern2Stream.to(DEFAULT_OUTPUT_TOPIC, Produced.with(stringSerde, stringSerde));
+        namedTopicsStream.to(DEFAULT_OUTPUT_TOPIC, Produced.with(stringSerde, stringSerde));
+
+        final Properties producerConfig = TestUtils.producerConfig(bootstrapServers, StringSerializer.class, StringSerializer.class);
+
+        streams = new KafkaStreams(builder.build(), streamsConfiguration);
+        streams.start();
+
+        IntegrationTestUtils.produceValuesSynchronously(TOPIC_1, Arrays.asList(topic1TestMessage), producerConfig, mockTime);
+        IntegrationTestUtils.produceValuesSynchronously(TOPIC_2, Arrays.asList(topic2TestMessage), producerConfig, mockTime);
+        IntegrationTestUtils.produceValuesSynchronously(TOPIC_A, Arrays.asList(topicATestMessage), producerConfig, mockTime);
+        IntegrationTestUtils.produceValuesSynchronously(TOPIC_C, Arrays.asList(topicCTestMessage), producerConfig, mockTime);
+        IntegrationTestUtils.produceValuesSynchronously(TOPIC_Y, Arrays.asList(topicYTestMessage), producerConfig, mockTime);
+        IntegrationTestUtils.produceValuesSynchronously(TOPIC_Z, Arrays.asList(topicZTestMessage), producerConfig, mockTime);
+
+        final Properties consumerConfig = TestUtils.consumerConfig(bootstrapServers, StringDeserializer.class, StringDeserializer.class);
+
+        final List<String> expectedReceivedValues = Arrays.asList(topicATestMessage, topic1TestMessage, topic2TestMessage, topicCTestMessage, topicYTestMessage, topicZTestMessage);
+        final List<KeyValue<String, String>> receivedKeyValues = IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(consumerConfig, DEFAULT_OUTPUT_TOPIC, 6);
+        final List<String> actualValues = new ArrayList<>(6);
+
+        for (final KeyValue<String, String> receivedKeyValue : receivedKeyValues) {
+            actualValues.add(receivedKeyValue.value);
+        }
+
+        Collections.sort(actualValues);
+        Collections.sort(expectedReceivedValues);
+        assertThat(actualValues, equalTo(expectedReceivedValues));
+    }
+
+    @Test
+    public void testMultipleConsumersCanReadFromPartitionedTopic() throws Exception {
+
+        KafkaStreams partitionedStreamsLeader = null;
+        KafkaStreams partitionedStreamsFollower = null;
+        try {
+            final Serde<String> stringSerde = Serdes.String();
+            final StreamsBuilder builderLeader = new StreamsBuilder();
+            final StreamsBuilder builderFollower = new StreamsBuilder();
+            final List<String> expectedAssignment = Arrays.asList(PARTITIONED_TOPIC_1,  PARTITIONED_TOPIC_2);
+
+            final KStream<String, String> partitionedStreamLeader = builderLeader.stream(Pattern.compile("partitioned-\\d"));
+            final KStream<String, String> partitionedStreamFollower = builderFollower.stream(Pattern.compile("partitioned-\\d"));
+
+
+            partitionedStreamLeader.to(DEFAULT_OUTPUT_TOPIC, Produced.with(stringSerde, stringSerde));
+            partitionedStreamFollower.to(DEFAULT_OUTPUT_TOPIC, Produced.with(stringSerde, stringSerde));
+
+            final List<String> leaderAssignment = new CopyOnWriteArrayList<>();
+            final List<String> followerAssignment = new CopyOnWriteArrayList<>();
+
+            partitionedStreamsLeader  = new KafkaStreams(builderLeader.build(), streamsConfiguration, new DefaultKafkaClientSupplier() {
+                @Override
+                public Consumer<byte[], byte[]> getConsumer(final Map<String, Object> config) {
+                    return new KafkaConsumer<byte[], byte[]>(config, new ByteArrayDeserializer(), new ByteArrayDeserializer()) {
+                        @Override
+                        public void subscribe(final Pattern topics, final ConsumerRebalanceListener listener) {
+                            super.subscribe(topics, new TheConsumerRebalanceListener(leaderAssignment, listener));
+                        }
+                    };
+
+                }
+            });
+            partitionedStreamsFollower  = new KafkaStreams(builderFollower.build(), streamsConfiguration, new DefaultKafkaClientSupplier() {
+                @Override
+                public Consumer<byte[], byte[]> getConsumer(final Map<String, Object> config) {
+                    return new KafkaConsumer<byte[], byte[]>(config, new ByteArrayDeserializer(), new ByteArrayDeserializer()) {
+                        @Override
+                        public void subscribe(final Pattern topics, final ConsumerRebalanceListener listener) {
+                            super.subscribe(topics, new TheConsumerRebalanceListener(followerAssignment, listener));
+                        }
+                    };
+
+                }
+            });
+
+
+            partitionedStreamsLeader.start();
+            partitionedStreamsFollower.start();
+            TestUtils.waitForCondition(new TestCondition() {
+                @Override
+                public boolean conditionMet() {
+                    return followerAssignment.equals(expectedAssignment) && leaderAssignment.equals(expectedAssignment);
+                }
+            }, "topic assignment not completed");
+        } finally {
+            if (partitionedStreamsLeader != null) {
+                partitionedStreamsLeader.close();
+            }
+            if (partitionedStreamsFollower != null) {
+                partitionedStreamsFollower.close();
+            }
+        }
+
+    }
+
+    @Test
+    public void testNoMessagesSentExceptionFromOverlappingPatterns() throws Exception {
+        final String fMessage = "fMessage";
+        final String fooMessage = "fooMessage";
+        final Serde<String> stringSerde = Serdes.String();
+        final StreamsBuilder builder = new StreamsBuilder();
+
+        // overlapping patterns here, no messages should be sent as TopologyException
+        // will be thrown when the processor topology is built.
+        final KStream<String, String> pattern1Stream = builder.stream(Pattern.compile("foo.*"));
+        final KStream<String, String> pattern2Stream = builder.stream(Pattern.compile("f.*"));
+
+        pattern1Stream.to(DEFAULT_OUTPUT_TOPIC, Produced.with(stringSerde, stringSerde));
+        pattern2Stream.to(DEFAULT_OUTPUT_TOPIC, Produced.with(stringSerde, stringSerde));
+
+        final AtomicBoolean expectError = new AtomicBoolean(false);
+
+        streams = new KafkaStreams(builder.build(), streamsConfiguration);
+        streams.setStateListener(new KafkaStreams.StateListener() {
+            @Override
+            public void onChange(KafkaStreams.State newState, KafkaStreams.State oldState) {
+                if (newState == KafkaStreams.State.ERROR)
+                    expectError.set(true);
+            }
+        });
+        streams.start();
+
+        final Properties producerConfig = TestUtils.producerConfig(bootstrapServers, StringSerializer.class, StringSerializer.class);
+
+        IntegrationTestUtils.produceValuesSynchronously(FA_TOPIC, Arrays.asList(fMessage), producerConfig, mockTime);
+        IntegrationTestUtils.produceValuesSynchronously(FOO_TOPIC, Arrays.asList(fooMessage), producerConfig, mockTime);
+
+        final Properties consumerConfig = TestUtils.consumerConfig(bootstrapServers, StringDeserializer.class, StringDeserializer.class);
+        try {
+            IntegrationTestUtils.waitUntilMinKeyValueRecordsReceived(consumerConfig, DEFAULT_OUTPUT_TOPIC, 2, 5000);
+            throw new IllegalStateException("This should not happen: an assertion error should have been thrown before this.");
+        } catch (final AssertionError e) {
+            // this is fine
+        }
+
+        assertThat(expectError.get(), is(true));
+    }
+
+    @Slf4j
+    private static class TheConsumerRebalanceListener implements ConsumerRebalanceListener {
+        private final List<String> assignedTopics;
+        private final ConsumerRebalanceListener listener;
+
+        TheConsumerRebalanceListener(final List<String> assignedTopics, final ConsumerRebalanceListener listener) {
+            this.assignedTopics = assignedTopics;
+            this.listener = listener;
+        }
+
+        @Override
+        public void onPartitionsRevoked(final Collection<TopicPartition> partitions) {
+            log.info("onPartitionsRevoked {} current {}", partitions, assignedTopics);
+            assignedTopics.clear();
+            listener.onPartitionsRevoked(partitions);
+        }
+
+        @Override
+        public void onPartitionsAssigned(final Collection<TopicPartition> partitions) {
+            for (final TopicPartition partition : partitions) {
+                assignedTopics.add(partition.topic());
+            }
+            log.info("onPartitionsAssigned {}", assignedTopics);
+            Collections.sort(assignedTopics);
+            listener.onPartitionsAssigned(partitions);
+        }
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/StreamsTestUtils.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/StreamsTestUtils.java
@@ -1,0 +1,139 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.streams;
+
+import static io.streamnative.pulsar.handlers.kop.streams.TestUtils.DEFAULT_MAX_WAIT_MS;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsConfig;
+
+public final class StreamsTestUtils {
+    private StreamsTestUtils() {
+    }
+
+    public static Properties getStreamsConfig(final String applicationId,
+                                              final String bootstrapServers,
+                                              final String keySerdeClassName,
+                                              final String valueSerdeClassName,
+                                              final Properties additional) {
+
+        final Properties props = new Properties();
+        props.put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
+        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, keySerdeClassName);
+        props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, valueSerdeClassName);
+        props.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
+        props.putAll(additional);
+        return props;
+    }
+
+    public static Properties getStreamsConfig(final Serde keyDeserializer,
+                                              final Serde valueDeserializer) {
+        return getStreamsConfig(
+                UUID.randomUUID().toString(),
+                "localhost:9091",
+                keyDeserializer.getClass().getName(),
+                valueDeserializer.getClass().getName(),
+                new Properties());
+    }
+
+    public static Properties getStreamsConfig(final String applicationId) {
+        return getStreamsConfig(applicationId, new Properties());
+    }
+
+    public static Properties getStreamsConfig(final String applicationId, final Properties additional) {
+        return getStreamsConfig(
+                applicationId,
+                "localhost:9091",
+                Serdes.ByteArraySerde.class.getName(),
+                Serdes.ByteArraySerde.class.getName(),
+                additional);
+    }
+
+    public static Properties getStreamsConfig() {
+        return getStreamsConfig(UUID.randomUUID().toString());
+    }
+
+    public static void startKafkaStreamsAndWaitForRunningState(final KafkaStreams kafkaStreams)
+            throws InterruptedException {
+        startKafkaStreamsAndWaitForRunningState(kafkaStreams, DEFAULT_MAX_WAIT_MS);
+    }
+
+    public static void startKafkaStreamsAndWaitForRunningState(final KafkaStreams kafkaStreams,
+                                                               final long timeoutMs) throws InterruptedException {
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        kafkaStreams.setStateListener((newState, oldState) -> {
+            if (newState == KafkaStreams.State.RUNNING) {
+                countDownLatch.countDown();
+            }
+        });
+
+        kafkaStreams.start();
+        assertThat(
+                "KafkaStreams did not transit to RUNNING state within " + timeoutMs + " milli seconds.",
+                countDownLatch.await(timeoutMs, TimeUnit.MILLISECONDS), equalTo(true));
+    }
+
+    public static <K, V> List<KeyValue<K, V>> toList(final Iterator<KeyValue<K, V>> iterator) {
+        final List<KeyValue<K, V>> results = new ArrayList<>();
+
+        while (iterator.hasNext()) {
+            results.add(iterator.next());
+        }
+        return results;
+    }
+
+    public static <K, V> Set<KeyValue<K, V>> toSet(final Iterator<KeyValue<K, V>> iterator) {
+        final Set<KeyValue<K, V>> results = new HashSet<>();
+
+        while (iterator.hasNext()) {
+            results.add(iterator.next());
+        }
+        return results;
+    }
+
+    public static <K, V> Set<V> valuesToSet(final Iterator<KeyValue<K, V>> iterator) {
+        final Set<V> results = new HashSet<>();
+
+        while (iterator.hasNext()) {
+            results.add(iterator.next().value);
+        }
+        return results;
+    }
+
+    public static <K> void verifyKeyValueList(final List<KeyValue<K, byte[]>> expected,
+                                              final List<KeyValue<K, byte[]>> actual) {
+        assertThat(actual.size(), equalTo(expected.size()));
+        for (int i = 0; i < actual.size(); i++) {
+            final KeyValue<K, byte[]> expectedKv = expected.get(i);
+            final KeyValue<K, byte[]> actualKv = actual.get(i);
+            assertThat(actualKv.key, equalTo(expectedKv.key));
+            assertThat(actualKv.value, equalTo(expectedKv.value));
+        }
+    }
+
+}


### PR DESCRIPTION
Modifications:
- port RegexSourceIntegrationTest integration test (fully passing)
- add a test about a KafkaConsumer with "pattern" subscription
- port InternalTopicIntegrationTest  integration test (fully passing)
- port FineGrainedAutoResetIntegrationTest integration test (but some methods do not pass, I have disabled them)
- port a few utility classes from Kafka codebase, to support the integration tests (from version 2.0)