### PR TITLE
[CI] configure Maven for CI (batch-mode, no-download-progress)

### DIFF
--- a/.github/workflows/pr-impl-test.yml
+++ b/.github/workflows/pr-impl-test.yml
@@ -23,24 +23,24 @@ jobs:
         java-version: 1.8
 
     - name: License check
-      run: mvn license:check
+      run: mvn -ntp -B license:check
 
     - name: Build with Maven skipTests
-      run: mvn clean install -DskipTests
+      run: mvn clean install -ntp -B -DskipTests
 
     - name: Style check
-      run: mvn checkstyle:check
+      run: mvn -ntp -B checkstyle:check
 
     - name: Spotbugs check
-      run: mvn spotbugs:check
+      run: mvn -ntp -B spotbugs:check
 
     - name: kafka-impl test after build
-      run: mvn test -DfailIfNoTests=false -pl kafka-impl
+      run: mvn test -ntp -B -DfailIfNoTests=false -pl kafka-impl
 
     # The DistributedClusterTest is hard to pass in CI tests environment, we disable it first
     # the track issue: https://github.com/streamnative/kop/issues/184
 #    - name: DistributedClusterTest
-#      run: mvn test '-Dtest=DistributedClusterTest' -pl tests
+#      run: mvn test -ntp -B '-Dtest=DistributedClusterTest' -pl tests
 
     - name: package surefire artifacts
       if: failure()

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -23,10 +23,10 @@ jobs:
         java-version: 1.8
 
     - name: Build with Maven skipTests
-      run: mvn clean install -DskipTests
+      run: mvn clean install -ntp -B -DskipTests
 
     - name: kop integration test
-      run: mvn test '-Dtest=KafkaIntegration*Test' -pl tests
+      run: mvn test -ntp -B '-Dtest=KafkaIntegration*Test' -pl tests
 
     - name: package surefire artifacts
       if: failure()

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -23,10 +23,10 @@ jobs:
         java-version: 1.8
 
     - name: Build with Maven skipTests
-      run: mvn clean install -DskipTests
+      run: mvn clean install -ntp -B -DskipTests
 
     - name: tests module
-      run: mvn test -DfailIfNoTests=false '-Dtest=!KafkaIntegration*Test' -pl tests
+      run: mvn test -ntp -B -DfailIfNoTests=false '-Dtest=!KafkaIntegration*Test' -pl tests
       timeout-minutes: 60
 
     - name: package surefire artifacts


### PR DESCRIPTION
Best practice configuration for Maven in CI.  Shortens the log output.