### PR TITLE
Ensure created cursors can be deleted when TCM is closed

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
@@ -61,6 +61,7 @@ import org.apache.pulsar.broker.protocol.ProtocolHandler;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.policies.data.TopicStats;
+import org.awaitility.Awaitility;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -428,13 +429,15 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
                 KafkaTopicConsumerManagerCache.getInstance().getTopicConsumerManagers(partitionName);
         assertEquals(tcmList.size(), numConsumers);
 
+        // All TCMs share the same topic, so each internal PersistentTopic of TCM has `numConsumers` cursors.
         for (int i = 0; i < numConsumers; i++) {
-            assertEquals(tcmList.get(i).getNumCreatedCursors(), 1);
+            assertEquals(tcmList.get(i).getNumCreatedCursors(), numConsumers);
         }
 
         // Since consumer close will make connection disconnected and all TCMs will be cleared, we should call it after
         // the test is verified.
         consumers.forEach(KafkaConsumer::close);
+        Awaitility.await().atMost(Duration.ofSeconds(3)).until(() -> tcmList.get(0).getNumCreatedCursors() == 0);
         for (int i = 0; i < numConsumers; i++) {
             assertEquals(tcmList.get(i).getNumCreatedCursors(), 0);
         }


### PR DESCRIPTION
Fixes https://github.com/streamnative/kop/issues/838 https://github.com/streamnative/kop/issues/807

### Motivation

If a TCM (`KafkaTopicConsumerManager`) is closed, `deleteOneCursorAsync()` will do nothing. It's incorrect because the `closed` state will be set true in `close()` at first. Then the deletion for created cursors won't work.

### Modifications

Remove the unnecessary state check in `deleteOneCursorAsync`. In addition, instead of maintaining a `numCreatedCursors` field in TCM, just iterate the managed ledger's cursors to get the cursor count for tests. So it could also fix https://github.com/streamnative/kop/issues/807.