### PR TITLE
[BUGFIX] Fix wrong default entryFormat

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,7 +69,7 @@ This section lists configurations that may affect the performance.
 
 | Name              | Description                                                  | Range             | Default |
 | ----------------- | ------------------------------------------------------------ | ----------------- | ------- |
-| entryFormat       | The format of an entry. If it is set to`kafka`, there is no unnecessary encoding and decoding work, which helps improve the performance. However, in this situation, a topic cannot be used by mixed Pulsar clients and Kafka clients. If it is set to `mixed_kafka`, Kafka clients (0.10.x) are supported. <br>- **Note**: Compared with performance for `mixed_kafka`, performance is improved by 2 to 3 times when the parameter is set to `kafka`. | kafka, <br> mixed_kafka,<br> pulsar | kafka   |
+| entryFormat       | The format of an entry. If it is set to`kafka`, there is no unnecessary encoding and decoding work, which helps improve the performance. However, in this situation, a topic cannot be used by mixed Pulsar clients and Kafka clients. If it is set to `mixed_kafka`, Kafka clients (0.10.x) are supported. <br>- **Note**: Compared with performance for `mixed_kafka`, performance is improved by 2 to 3 times when the parameter is set to `kafka`. | kafka, <br> mixed_kafka,<br> pulsar | pulsar   |
 | maxReadEntriesNum | The maximum number of entries that are read from the cursor once per time.<br>Increasing this value can make FETCH request read more bytes each time.<br>**NOTE**: Currently, KoP does not check the maximum byte limit. Therefore, if the value is too great, the response size may be over the network limit. |                   | 5       |
 
 ## Network

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -343,9 +343,9 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
 
     @FieldContext(
             category = CATEGORY_KOP,
-            doc = "The format of an entry. Default: kafka. Optional: [pulsar, kafka, mixed_kafka]"
+            doc = "The format of an entry. Default: pulsar. Optional: [pulsar, kafka, mixed_kafka]"
     )
-    private String entryFormat = "kafka";
+    private String entryFormat = "pulsar";
 
     @FieldContext(
         category = CATEGORY_KOP,


### PR DESCRIPTION

I found that the default `entryFormat` in the code is inconsistent with the default `entryFormat` marked in the documentation.

Since `entryFormat=kafka` has the best performance, maybe we should use `entryFormat=kafka` by default as indicated in the document.