### PR TITLE
Fix testProduceConsumeMultiLedger might fail when consumer receive message timeout

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MultiLedgerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MultiLedgerTest.java
@@ -123,7 +123,9 @@ public class MultiLedgerTest extends KopProtocolHandlerTestBase {
             while (i < totalMsgs) {
                 Message<byte[]> msg = consumer.receive(100, TimeUnit.MILLISECONDS);
                 if (msg == null) {
-                    log.info("Message is null.");
+                    if (log.isDebugEnabled()) {
+                        log.debug("Received Message is null, because receive timeout. Skipped.");
+                    }
                     continue;
                 }
                 Integer key = kafkaIntDeserialize(Base64.getDecoder().decode(msg.getKey()));


### PR DESCRIPTION
Fixes: #842 
## Motivation
When `consumer.receive(100, TimeUnit.MILLISECONDS)` timeout, the message is null, this is a normal situation, because sometimes there are network fluctuations or other situation. We should skip the null messages.

## Modification
Skip all null messages, since we added timeout in test method, it won't cause the test get stuck be here.