### PR TITLE
Fix flaky test: KafkaTopicConsumerManagerTest.testTopicManagerClose

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
@@ -486,6 +486,11 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
         assertFalse(originalTcmList.get(1).isClosed());
 
         consumers.get(1).close(); // trigger KafkaTopicManager#close, only the partition 1 related cache was removed
+        // Because the KafkaRequestHandler.close() is called by channelInActive, when channelInActive called,
+        // the tcp connect already closed. We need ensure topicManager.close() is called.
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(3))
+                .until(() -> originalTcmList.get(1).getNumCreatedCursors() == 0);
         assertSame(getTcmForPartition.apply(0), originalTcmList.get(0));
         assertFalse(originalTcmList.get(0).isClosed());
         // The tcm of partition 1 was closed and it was removed from cache
@@ -493,6 +498,9 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
         assertTrue(originalTcmList.get(1).isClosed());
 
         consumers.get(0).close(); // Now all TCM cache was cleared
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(3))
+                .until(() -> originalTcmList.get(0).getNumCreatedCursors() == 0);
         assertNull(getTcmForPartition.apply(0));
         assertNull(getTcmForPartition.apply(1));
         assertTrue(originalTcmList.get(0).isClosed());


### PR DESCRIPTION
Because the `KafkaRequestHandler.close()` is called by `channelInActive`, when `channelInActive` called, the tcp connection is already closed. We need ensure `topicManager.close()` is called. 

[channelInActive call root](https://github.com/netty/netty/blob/4.1/transport/src/main/java/io/netty/channel/AbstractChannel.java#L765)

We can easily reproduce by add some sleep in `KafkaRequestHandler.close()` like this:

```java
@Override
protected void close() {
    if (isActive.getAndSet(false)) {
        super.close();
        try {
            TimeUnit.SECONDS.sleep(1);
        } catch (InterruptedException e) {
            e.printStackTrace();
        }
        topicManager.close();
        String clientHost = ctx.channel().remoteAddress().toString();
        if (currentConnectedGroup.containsKey(clientHost)){
            log.info("currentConnectedGroup remove {}", clientHost);
            currentConnectedGroup.remove(clientHost);
        }
        producePurgatory.shutdown();
        fetchPurgatory.shutdown();

        // update alive channel count stat
        RequestStats.ALIVE_CHANNEL_COUNT_INSTANCE.decrementAndGet();
    }
}
```
