### PR TITLE
[Enhancement] Remove unnecessary lock

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManager.java
@@ -79,7 +79,7 @@ public class KopEventManager {
         this.deletionTopicsHandler = new DeletionTopicsHandler(this);
         this.brokersChangeHandler = new BrokersChangeHandler(this);
         this.metadataStore = metadataStore;
-        this.eventManagerStats = new KopEventManagerStats(statsLogger);
+        this.eventManagerStats = new KopEventManagerStats(statsLogger, queue);
         this.groupCoordinatorsByTenant = groupCoordinatorsByTenant;
     }
 
@@ -104,7 +104,6 @@ public class KopEventManager {
     public void put(KopEventWrapper eventWrapper) {
         try {
             queue.put(eventWrapper);
-            KopEventManagerStats.KOP_EVENT_QUEUE_SIZE_INSTANCE.set(queue.size());
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             log.error("Error put event {} to kop event queue",
@@ -136,7 +135,6 @@ public class KopEventManager {
             KopEventWrapper eventWrapper = null;
             try {
                 eventWrapper = queue.take();
-                KopEventManagerStats.KOP_EVENT_QUEUE_SIZE_INSTANCE.decrementAndGet();
                 registerEventQueuedLatency(eventWrapper);
 
                 if (eventWrapper.kopEvent instanceof ShutdownEventThread) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManagerStats.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManagerStats.java
@@ -18,7 +18,7 @@ import static io.streamnative.pulsar.handlers.kop.KopServerStats.KOP_EVENT_QUEUE
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.SERVER_SCOPE;
 
 import io.streamnative.pulsar.handlers.kop.stats.StatsLogger;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.BlockingQueue;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.stats.Gauge;
@@ -38,13 +38,13 @@ import org.apache.bookkeeper.stats.annotations.StatsDoc;
 @Slf4j
 public class KopEventManagerStats {
 
-    public static final AtomicInteger KOP_EVENT_QUEUE_SIZE_INSTANCE = new AtomicInteger(0);
-
+    private final BlockingQueue<KopEventManager.KopEventWrapper> eventQueue;
 
     private final StatsLogger statsLogger;
 
-    public KopEventManagerStats(StatsLogger statsLogger) {
+    public KopEventManagerStats(StatsLogger statsLogger, BlockingQueue<KopEventManager.KopEventWrapper> eventQueue) {
         this.statsLogger = statsLogger;
+        this.eventQueue = eventQueue;
 
         statsLogger.registerGauge(KOP_EVENT_QUEUE_SIZE, new Gauge<Number>() {
             @Override
@@ -54,7 +54,7 @@ public class KopEventManagerStats {
 
             @Override
             public Number getSample() {
-                return KOP_EVENT_QUEUE_SIZE_INSTANCE;
+                return eventQueue.size();
             }
         });
     }


### PR DESCRIPTION
### Motivation
`LinkedBlockingQueue` is thread-safe, there is no need to use `ReentrantLock` once more externally.