### PR TITLE
Fix KafkaRequestHandler exceptionCaught should close handler

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -2594,7 +2594,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         log.error("Caught error in handler, closing channel", cause);
-        ctx.close();
+        this.close();
     }
 
     public CompletableFuture<PartitionMetadata> findBroker(TopicName topic) {


### PR DESCRIPTION
Currently, When `KafkaRequestHandler` has exception, it just close the `ChannelHandlerContext`, we should close KafkaRequestHandler instead. Otherwise, it will cause thread leak.