### PR TITLE
Fix flaky test: KafkaAuthorizationPulsarTest.testConsumeFailed

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationTestBase.java
@@ -306,7 +306,7 @@ public abstract class KafkaAuthorizationTestBase extends KopProtocolHandlerTestB
                 TENANT + "/" + NAMESPACE, "token:" + anotherToken, "DemoAnotherKafkaOnPulsarConsumer");
         anotherConsumer.getConsumer().subscribe(Collections.singleton(fullNewTopicName));
         try {
-            anotherConsumer.getConsumer().poll(Duration.ofSeconds(2));
+            anotherConsumer.getConsumer().poll(Duration.ofSeconds(10));
             fail("expected TopicAuthorizationException");
         } catch (TopicAuthorizationException ignore) {
             log.info("Has TopicAuthorizationException.");
@@ -529,7 +529,7 @@ public abstract class KafkaAuthorizationTestBase extends KopProtocolHandlerTestB
                     newTenant + "/" + NAMESPACE, "token:" + userToken, "DemoKafkaOnPulsarConsumer");
             kConsumer.getConsumer().subscribe(Collections.singleton(testTopic));
             try {
-                kConsumer.getConsumer().poll(Duration.ofSeconds(1));
+                kConsumer.getConsumer().poll(Duration.ofSeconds(10));
                 fail("expected TopicAuthorizationException");
             } catch (TopicAuthorizationException ignore) {
                 log.info("Has TopicAuthorizationException.");


### PR DESCRIPTION
Fixes: #847

In this tests, some time the consumer might poll timeout in 1 ~ 2 seconds, In this changes, we just add timeout to 10 seconds. In this way, the timeout will not be triggered most of the time.