### PR TITLE
Fix name clash on RequestUtils

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelHandler.java
@@ -23,7 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.util.collections.ConcurrentLongHashMap;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.requests.RequestHeader;
-import org.apache.kafka.common.requests.RequestUtils;
+import org.apache.kafka.common.requests.KafkaRequestUtils;
 import org.apache.kafka.common.requests.ResponseHeader;
 import org.apache.kafka.common.requests.WriteTxnMarkersRequest;
 import org.apache.kafka.common.requests.WriteTxnMarkersResponse;
@@ -66,7 +66,7 @@ public class TransactionMarkerChannelHandler extends ChannelInboundHandlerAdapte
         public ByteBuf getRequestData() {
             RequestHeader requestHeader = new RequestHeader(
                     ApiKeys.WRITE_TXN_MARKERS, request.version(), "", (int) requestId);
-            return RequestUtils.serializeRequest(request.version(), requestHeader, request);
+            return KafkaRequestUtils.serializeRequest(request.version(), requestHeader, request);
         }
 
         public void onComplete(ByteBuffer nio) {

--- a/kafka-impl/src/main/java/org/apache/kafka/common/requests/KafkaRequestUtils.java
+++ b/kafka-impl/src/main/java/org/apache/kafka/common/requests/KafkaRequestUtils.java
@@ -23,7 +23,7 @@ import org.apache.kafka.common.protocol.types.Struct;
  * Provide util classes to access protected fields in kafka structures.
  */
 @Slf4j
-public class RequestUtils {
+public class KafkaRequestUtils {
 
     /**
      * Serialize a kafka request into a byte buf.


### PR DESCRIPTION
** Problem **
I am testing a Kafka IDE, [Conduktor](https://www.conduktor.io/) and I see the error below.
It happens because we created a org.apache.kafka.common.requests.RequestUtils class that clashes with the original class, that is used internally by the Kafka classes.

** Modifications **
Rename the class

```
11:56:15.128 [pulsar-io-29-11] ERROR io.streamnative.pulsar.handlers.kop.KafkaRequestHandler - Caught error in handler, closing channel
java.lang.NoSuchMethodError: 'org.apache.kafka.common.resource.ResourcePatternFilter org.apache.kafka.common.requests.RequestUtils.resourcePatternFilterFromStructFields(org.apache.kafka.common.protocol.types.Struct)'
	at org.apache.kafka.common.requests.DescribeAclsRequest.<init>(DescribeAclsRequest.java:97) ~[?:?]
	at org.apache.kafka.common.requests.AbstractRequest.parseRequest(AbstractRequest.java:200) ~[?:?]
	at io.streamnative.pulsar.handlers.kop.KafkaCommandDecoder.byteBufToRequest(KafkaCommandDecoder.java:147) ~[?:?]
	at io.streamnative.pulsar.handlers.kop.KafkaCommandDecoder.channelRead(KafkaCommandDecoder.java:222) ~[?:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [netty-transport-4.1.68.Final.jar:4.1.68.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [netty-transport-4.1.68.Final.jar:4.1.68.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) [netty-transport-4.1.68.Final.jar:4.1.68.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:324) [netty-codec-4.1.68.Final.jar:4.1.68.Final]
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296) [netty-codec-4.1.68.Final.jar:4.1.68.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [netty-transport-4.1.68.Final.jar:4.1.68.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [netty-transport-4.1.68.Final.jar:4.1.68.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) [netty-transport-4.1.68.Final.jar:4.1.68.Final]
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286) [netty-handler-4.1.68.Final.jar:4.1.68.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [netty-transport-4.1.68.Final.jar:4.1.68.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [netty-transport-4.1.68.Final.jar:4.1.68.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) [netty-transport-4.1.68.Final.jar:4.1.68.Final]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) [netty-transport-4.1.68.Final.jar:4.1.68
```