### PR TITLE
[BUGFIX] Fix loadTxnLogTopics might crash in K8S environment

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -466,13 +466,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
         kopEventManager.start();
 
         if (kafkaConfig.isEnableTransactionCoordinator()) {
-//            TransactionCoordinator transactionCoordinator =
             getTransactionCoordinator(kafkaConfig.getKafkaMetadataTenant());
-//            try {
-//                loadTxnLogTopics(kafkaConfig.getKafkaMetadataTenant(), transactionCoordinator);
-//            } catch (Exception e) {
-//                log.error("Failed to load transaction log", e);
-//            }
         }
 
         Configuration conf = new PropertiesConfiguration();


### PR DESCRIPTION
Fixes: #761

### Motivation

In K8S environment, load transaction topics when start KafkaProtocolHandler might crash, because to start a KoP node might depend on a successful start of another KoP node.

See Related PR : #627

### Modification

The most important change is to remove the `loadTxnLogTopics ` method.
Addition change is add a method to wait txnLog load in units test.
