### PR TITLE
[Issue 867]: Implement minimal DeleteRecords (KStreams support)

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
@@ -50,7 +50,6 @@ import org.apache.kafka.common.requests.CreateTopicsRequest;
 import org.apache.kafka.common.requests.DescribeConfigsResponse;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
-import org.apache.pulsar.common.util.ObjectMapperFactory;
 
 @Slf4j
 class AdminManager {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -338,6 +338,9 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
                     case DELETE_TOPICS:
                         handleDeleteTopics(kafkaHeaderAndRequest, responseFuture);
                         break;
+                    case DELETE_RECORDS:
+                        handleDeleteRecords(kafkaHeaderAndRequest, responseFuture);
+                        break;
                     case CREATE_PARTITIONS:
                         handleCreatePartitions(kafkaHeaderAndRequest, responseFuture);
                         break;
@@ -551,6 +554,9 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
 
     protected abstract void
     handleDeleteTopics(KafkaHeaderAndRequest kafkaHeaderAndRequest, CompletableFuture<AbstractResponse> response);
+
+    protected abstract void
+    handleDeleteRecords(KafkaHeaderAndRequest kafkaHeaderAndRequest, CompletableFuture<AbstractResponse> response);
 
     protected abstract void
     handleCreatePartitions(KafkaHeaderAndRequest kafkaHeaderAndRequest, CompletableFuture<AbstractResponse> response);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -173,7 +173,6 @@ import org.apache.pulsar.broker.service.Producer;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
-import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.common.api.proto.MarkerType;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.naming.NamespaceName;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManager.java
@@ -38,7 +38,6 @@ import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
-import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.common.util.FutureUtil;
 
 /**
@@ -277,7 +276,7 @@ public class KafkaTopicConsumerManager implements Closeable {
     }
 
     /**
-     * Returns the position in the ManagedLedger for the given offset
+     * Returns the position in the ManagedLedger for the given offset.
      * @param offset
      * @return null if not found, PositionImpl.latest if the offset matches the end of the topic
      */

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KafkaResponseUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KafkaResponseUtils.java
@@ -32,6 +32,7 @@ import org.apache.kafka.common.requests.ApiVersionsResponse;
 import org.apache.kafka.common.requests.CreatePartitionsResponse;
 import org.apache.kafka.common.requests.CreateTopicsResponse;
 import org.apache.kafka.common.requests.DeleteGroupsResponse;
+import org.apache.kafka.common.requests.DeleteRecordsResponse;
 import org.apache.kafka.common.requests.DeleteTopicsResponse;
 import org.apache.kafka.common.requests.DescribeGroupsResponse;
 import org.apache.kafka.common.requests.FindCoordinatorResponse;
@@ -76,6 +77,11 @@ public class KafkaResponseUtils {
 
     public static DeleteTopicsResponse newDeleteTopics(Map<String, Errors> topicToErrors) {
         return new DeleteTopicsResponse(topicToErrors);
+    }
+
+    public static DeleteRecordsResponse newDeleteRecords(Map<TopicPartition,
+            DeleteRecordsResponse.PartitionResponse> responseMap) {
+        return new DeleteRecordsResponse(-1, responseMap);
     }
 
     public static DescribeGroupsResponse newDescribeGroups(

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -56,7 +56,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import lombok.Cleanup;
@@ -419,7 +418,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
 
         AtomicInteger count = new AtomicInteger();
         final KafkaProducer<String, String> producer = new KafkaProducer<>(newKafkaProducerProperties());
-        topicToNumPartitions.forEach( (topic, numPartitions) -> {
+        topicToNumPartitions.forEach((topic, numPartitions) -> {
             for (int i = 0; i < numPartitions; i++) {
                 producer.send(new ProducerRecord<>(topic, i, count + "", count + ""));
                 count.incrementAndGet();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -401,7 +401,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
     @Test(timeOut = 10000)
     public void testDeleteRecords() throws Exception {
         Properties props = new Properties();
-        props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getClientPort());
+        props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getKafkaBrokerPort());
 
         @Cleanup
         AdminClient kafkaAdmin = AdminClient.create(props);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -43,6 +43,7 @@ import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -54,6 +55,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import lombok.Cleanup;
@@ -63,6 +66,7 @@ import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.ConsumerGroupDescription;
 import org.apache.kafka.clients.admin.NewPartitions;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.RecordsToDelete;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -327,6 +331,26 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
         }).collect(Collectors.toList())).all().get();
     }
 
+    private void deleteRecordsByKafkaAdmin(AdminClient admin, Map<String, Integer> topicToNumPartitions)
+            throws ExecutionException, InterruptedException {
+        Map<TopicPartition, RecordsToDelete> toDelete = new HashMap<>();
+        topicToNumPartitions.forEach((topic, numPartitions) -> {
+             try (KConsumer consumer = new KConsumer(topic, getKafkaBrokerPort());) {
+                    Collection<TopicPartition> topicPartitions = new ArrayList<>();
+                    for (int i = 0; i < numPartitions; i++) {
+                        topicPartitions.add(new TopicPartition(topic, i));
+                    }
+                 Map<TopicPartition, Long> map = consumer
+                         .getConsumer().endOffsets(topicPartitions);
+                 map.forEach((TopicPartition topicPartition, Long offset) -> {
+                        log.info("For {} we are truncating at {}", topicPartition, offset);
+                        toDelete.put(topicPartition, RecordsToDelete.beforeOffset(offset));
+                    });
+             }
+        });
+        admin.deleteRecords(toDelete).all().get();
+    }
+
     private void verifyTopicsCreatedByPulsarAdmin(Map<String, Integer> topicToNumPartitions)
             throws PulsarAdminException {
         for (Map.Entry<String, Integer> entry : topicToNumPartitions.entrySet()) {
@@ -373,6 +397,39 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
         // delete
         deleteTopicsByKafkaAdmin(kafkaAdmin, topicToNumPartitions.keySet());
         verifyTopicsDeletedByPulsarAdmin(topicToNumPartitions);
+    }
+
+    @Test(timeOut = 10000)
+    public void testDeleteRecords() throws Exception {
+        Properties props = new Properties();
+        props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getClientPort());
+
+        @Cleanup
+        AdminClient kafkaAdmin = AdminClient.create(props);
+        Map<String, Integer> topicToNumPartitions = new HashMap<String, Integer>(){{
+            put("testDeleteRecords-0", 1);
+            put("testDeleteRecords-1", 3);
+            put("my-tenant/my-ns/testDeleteRecords-2", 1);
+            put("persistent://my-tenant/my-ns/testDeleteRecords-3", 5);
+        }};
+        // create
+        createTopicsByKafkaAdmin(kafkaAdmin, topicToNumPartitions);
+        verifyTopicsCreatedByPulsarAdmin(topicToNumPartitions);
+
+
+        AtomicInteger count = new AtomicInteger();
+        final KafkaProducer<String, String> producer = new KafkaProducer<>(newKafkaProducerProperties());
+        topicToNumPartitions.forEach( (topic, numPartitions) -> {
+            for (int i = 0; i < numPartitions; i++) {
+                producer.send(new ProducerRecord<>(topic, i, count + "", count + ""));
+                count.incrementAndGet();
+            }
+        });
+
+        producer.close();
+
+        // delete
+        deleteRecordsByKafkaAdmin(kafkaAdmin, topicToNumPartitions);
     }
 
     @Test(timeOut = 20000)


### PR DESCRIPTION
KafkaStreams uses the DeleteRecords API to truncate topics to the very end of the topic.

https://github.com/apache/kafka/blob/ba0ebca7a516d4179b6327ddc60b0b49b1265347/streams/src/main/java/org/apache/kafka/streams/processor/internals/TaskManager.java#L441

This patch implements DeleteRecords, using the `truncateAsync` API in Pulsar introduced in 2.8.0.

we cannot make it work for arbitrary offsets, by the way this implementation is still useful, at least for KStreams or for Kafka Users who want to empty a topic.

Please note that Kafka Streams does not break without this feature, because it tries to delete the records in a best effort way.

Fixes #867
