### PR TITLE
Disable transaction by default on units test

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -339,7 +339,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 log.debug("[{}] unLoad bundle: {}", brokerUrl, bundle);
             }
             // 1. get partitions owned by this pulsar service.
-            // 2. remove partitions by groupCoordinator.handleGroupEmigration.
+            // 2. remove partitions by TransactionCoordinator.handleTxnImmigration.
             service.pulsar().getNamespaceService().getOwnedTopicListForNamespaceBundle(bundle)
                     .whenComplete((topics, ex) -> {
                         if (ex == null) {
@@ -349,7 +349,6 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                                 TopicName name = TopicName.get(topic);
                                 String kafkaTopicName = getKafkaTopicNameFromPulsarTopicName(name);
 
-                                // Filter TRANSACTION_STATE_TOPIC
                                 if (Topic.TRANSACTION_STATE_TOPIC_NAME.equals(kafkaTopicName)
                                         && txnCoordinator != null) {
                                     checkState(name.isPartitioned(),

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CacheInvalidatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CacheInvalidatorTest.java
@@ -95,6 +95,7 @@ public class CacheInvalidatorTest extends KopProtocolHandlerTestBase {
     @BeforeClass
     @Override
     protected void setup() throws Exception {
+        conf.setEnableTransactionCoordinator(true);
         super.internalSetup();
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
@@ -30,6 +30,7 @@ import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupCoordinator;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
 import io.streamnative.pulsar.handlers.kop.stats.NullStatsLogger;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
+import io.streamnative.pulsar.handlers.kop.utils.MetadataUtils;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -46,8 +47,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
-import io.streamnative.pulsar.handlers.kop.utils.MetadataUtils;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedCursor;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
@@ -138,7 +138,6 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
     public void testGetTopicConsumerManager() throws Exception {
         String topicName = "persistent://public/default/testGetTopicConsumerManager";
         registerPartitionedTopic(topicName);
-        triggerTopicLookup(topicName);
         CompletableFuture<KafkaTopicConsumerManager> tcm = kafkaTopicManager.getTopicConsumerManager(topicName);
         KafkaTopicConsumerManager topicConsumerManager = tcm.get();
 
@@ -163,7 +162,6 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
     public void testTopicConsumerManagerRemoveAndAdd() throws Exception {
         String topicName = "persistent://public/default/testTopicConsumerManagerRemoveAndAdd";
         registerPartitionedTopic(topicName);
-        triggerTopicLookup(topicName);
         final Properties props = new Properties();
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getKafkaBrokerPort());
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopEventManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopEventManagerTest.java
@@ -91,7 +91,7 @@ public class KopEventManagerTest extends KopProtocolHandlerTestBase {
 
         final KafkaConsumer<String, String> kafkaConsumer1 = new KafkaConsumer<>(properties);
         kafkaConsumer1.subscribe(Collections.singletonList(topic1));
-        ConsumerRecords<String, String> records = kafkaConsumer1.poll(Duration.ofMillis(500));
+        ConsumerRecords<String, String> records = kafkaConsumer1.poll(Duration.ofSeconds(1));
         assertEquals(records.count(), 1);
 
         // 4. check group state must be Stable

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -213,7 +213,8 @@ public abstract class KopProtocolHandlerTestBase {
     }
 
     /**
-     * Trigger topic to lookup, it will load topic to namespace bundle.
+     * Trigger topic to lookup.
+     * It will load namespace bundle into {@link org.apache.pulsar.broker.namespace.OwnershipCache}.
      *
      * @param topicName topic to lookup.
      * @param numPartitions the topic partition nums.
@@ -226,7 +227,8 @@ public abstract class KopProtocolHandlerTestBase {
     }
 
     /**
-     * Trigger one topic to lookup, it will load topic to namespace bundle
+     * Trigger one topic to lookup.
+     * It will load namespace bundle into {@link org.apache.pulsar.broker.namespace.OwnershipCache}.
      *
      * @param topicName topic to lookup
      */

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -63,13 +63,16 @@ import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.pulsar.broker.BookKeeperClientFactory;
+import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.auth.SameThreadOrderedSafeExecutor;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.protocol.ProtocolHandler;
 import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.apache.pulsar.zookeeper.ZooKeeperClientFactory;
@@ -173,7 +176,7 @@ public abstract class KopProtocolHandlerTestBase {
         // kafka related settings.
         kafkaConfig.setOffsetsTopicNumPartitions(1);
 
-        kafkaConfig.setEnableTransactionCoordinator(true);
+        kafkaConfig.setEnableTransactionCoordinator(false);
         kafkaConfig.setTxnLogTopicNumPartitions(1);
 
         kafkaConfig.setKafkaListeners(
@@ -207,6 +210,35 @@ public abstract class KopProtocolHandlerTestBase {
     protected final void internalSetup() throws Exception {
         init();
         pulsarClient = KafkaProtocolHandler.getLookupClient(pulsar).getPulsarClient();
+    }
+
+    /**
+     * Trigger topic to lookup, it will load topic to namespace bundle.
+     *
+     * @param topicName topic to lookup.
+     * @param numPartitions the topic partition nums.
+     */
+    protected void triggerTopicLookup(String topicName, int numPartitions) {
+        for (int i = 0; i < numPartitions; ++i) {
+            String topicToLookup = topicName + TopicName.PARTITIONED_TOPIC_SUFFIX + i;
+            triggerTopicLookup(topicToLookup);
+        }
+    }
+
+    /**
+     * Trigger one topic to lookup, it will load topic to namespace bundle
+     *
+     * @param topicName topic to lookup
+     */
+    protected void triggerTopicLookup(String topicName) {
+        try {
+            String brokerUrl = pulsar.getAdminClient().lookups().lookupTopic(topicName);
+            if (log.isDebugEnabled()) {
+                log.debug("Topic [{}] brokerUrl: {}", topicName, brokerUrl);
+            }
+        } catch (PulsarAdminException | PulsarServerException e) {
+            log.error("Lookup topic: {} failed.", topicName, e);
+        }
     }
 
     protected void createAdmin() throws Exception {


### PR DESCRIPTION
### Motivation

Since most of units test don't depend of transaction, we can disable transaction by default.

### Modification

* Disable transaction by default on units test
* Modify some test, add new method called `triggerTopicLookup`, to make sure lookup call first, it will loading `NamespaceBundle` to the `OwnershipCache`, otherwise getTopic will failed in `OwnershipCache.getOwnedBundle()`.