### PR TITLE
[Transaction] Migrate transaction coordinator handleInitProducerId tests and fix behavior

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/ErrorsAndData.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/ErrorsAndData.java
@@ -13,6 +13,7 @@
  */
 package io.streamnative.pulsar.handlers.kop.coordinator.transaction;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.apache.kafka.common.protocol.Errors;
 
@@ -20,6 +21,7 @@ import org.apache.kafka.common.protocol.Errors;
  * Errors and data.
  */
 @Data
+@AllArgsConstructor
 public class ErrorsAndData<T> {
 
     private Errors errors;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -269,7 +269,7 @@ public class TransactionCoordinator {
                 Optional<CoordinatorEpochAndTxnMetadata> data = epochAndTxnMeta.getData();
                 if (data.isPresent()) {
                     int coordinatorEpoch = data.get().getCoordinatorEpoch();
-                    TransactionMetadata txnMetadata = epochAndTxnMeta.getData().get().getTransactionMetadata();
+                    TransactionMetadata txnMetadata = data.get().getTransactionMetadata();
 
                     txnMetadata.inLock(() -> {
                         CompletableFuture<ErrorsAndData<EpochAndTxnTransitMetadata>> prepareInitProducerIdResult =
@@ -294,6 +294,7 @@ public class TransactionCoordinator {
                     responseCallback.accept(initTransactionError(Errors.UNKNOWN_SERVER_ERROR));
                 }
             }).exceptionally(ex -> {
+                log.error("Get epoch and TxnMetadata failed.", ex);
                 responseCallback.accept(initTransactionError(Errors.forException(ex.getCause())));
                 return null;
             });

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -19,8 +19,9 @@ import static io.streamnative.pulsar.handlers.kop.coordinator.transaction.Transa
 import static io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionState.PREPARE_EPOCH_FENCE;
 import static org.apache.pulsar.common.naming.TopicName.PARTITIONED_TOPIC_SUFFIX;
 
-import com.google.api.client.util.Sets;
+
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Sets;
 import io.streamnative.pulsar.handlers.kop.KopBrokerLookupManager;
 import io.streamnative.pulsar.handlers.kop.SystemTopicClient;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionMetadata.TxnTransitMetadata;
@@ -230,51 +231,71 @@ public class TransactionCoordinator {
 
             CompletableFuture<ErrorsAndData<Optional<CoordinatorEpochAndTxnMetadata>>>
                     epochAndTxnMetaFuture = new CompletableFuture<>();
-            if (existMeta.getData() == null || !existMeta.getData().isPresent()) {
-                producerIdManager.generateProducerId().whenComplete((pid, throwable) -> {
-                    short producerEpoch = 0;
-                    if (throwable != null) {
-                        responseCallback.accept(new InitProducerIdResult(
-                                -1L,
-                                producerEpoch
-                                , Errors.UNKNOWN_SERVER_ERROR));
-                        return;
-                    }
-                    TransactionMetadata newMetadata = TransactionMetadata.builder()
-                            .transactionalId(transactionalId)
-                            .producerId(pid)
-                            .lastProducerId(RecordBatch.NO_PRODUCER_ID)
-                            .producerEpoch(RecordBatch.NO_PRODUCER_EPOCH)
-                            .lastProducerEpoch(RecordBatch.NO_PRODUCER_EPOCH)
-                            .state(TransactionState.EMPTY)
-                            .topicPartitions(Sets.newHashSet())
-                            .txnLastUpdateTimestamp(time.milliseconds())
-                            .build();
-                    epochAndTxnMetaFuture.complete(txnManager.putTransactionStateIfNotExists(newMetadata));
-                });
+            if (!existMeta.getData().isPresent()) {
+                if (existMeta.hasErrors()) {
+                    epochAndTxnMetaFuture.complete(existMeta);
+                } else {
+                    producerIdManager.generateProducerId().whenComplete((pid, throwable) -> {
+                        short producerEpoch = 0;
+                        if (throwable != null) {
+                            responseCallback.accept(new InitProducerIdResult(
+                                    -1L,
+                                    producerEpoch
+                                    , Errors.UNKNOWN_SERVER_ERROR));
+                            return;
+                        }
+                        TransactionMetadata newMetadata = TransactionMetadata.builder()
+                                .transactionalId(transactionalId)
+                                .producerId(pid)
+                                .lastProducerId(RecordBatch.NO_PRODUCER_ID)
+                                .producerEpoch(RecordBatch.NO_PRODUCER_EPOCH)
+                                .lastProducerEpoch(RecordBatch.NO_PRODUCER_EPOCH)
+                                .state(TransactionState.EMPTY)
+                                .topicPartitions(Sets.newHashSet())
+                                .txnLastUpdateTimestamp(time.milliseconds())
+                                .build();
+                        epochAndTxnMetaFuture.complete(txnManager.putTransactionStateIfNotExists(newMetadata));
+                    });
+                }
             } else {
                 epochAndTxnMetaFuture.complete(existMeta);
             }
 
-            epochAndTxnMetaFuture.whenComplete((epochAndTxnMeta, throwable) -> {
-                int coordinatorEpoch = epochAndTxnMeta.getData().get().getCoordinatorEpoch();
-                TransactionMetadata txnMetadata = epochAndTxnMeta.getData().get().getTransactionMetadata();
+            epochAndTxnMetaFuture.thenAccept(epochAndTxnMeta -> {
+                if (epochAndTxnMeta.hasErrors()) {
+                    responseCallback.accept(initTransactionError(epochAndTxnMeta.getErrors()));
+                    return;
+                }
+                Optional<CoordinatorEpochAndTxnMetadata> data = epochAndTxnMeta.getData();
+                if (data.isPresent()) {
+                    int coordinatorEpoch = data.get().getCoordinatorEpoch();
+                    TransactionMetadata txnMetadata = epochAndTxnMeta.getData().get().getTransactionMetadata();
 
-                txnMetadata.inLock(() -> {
-                    CompletableFuture<ErrorsAndData<EpochAndTxnTransitMetadata>> prepareInitProducerIdResult =
-                            prepareInitProducerIdTransit(
-                                transactionalId,
-                                transactionTimeoutMs,
-                                coordinatorEpoch,
-                                txnMetadata,
-                                expectedProducerIdAndEpoch);
+                    txnMetadata.inLock(() -> {
+                        CompletableFuture<ErrorsAndData<EpochAndTxnTransitMetadata>> prepareInitProducerIdResult =
+                                prepareInitProducerIdTransit(
+                                        transactionalId,
+                                        transactionTimeoutMs,
+                                        coordinatorEpoch,
+                                        txnMetadata,
+                                        expectedProducerIdAndEpoch);
 
-                    prepareInitProducerIdResult.whenComplete((errorsAndData, prepareThrowable) -> {
-                        completeInitProducer(
-                                transactionalId, coordinatorEpoch, errorsAndData, prepareThrowable, responseCallback);
+                        prepareInitProducerIdResult.whenComplete((errorsAndData, prepareThrowable) -> {
+                            completeInitProducer(
+                                    transactionalId,
+                                    coordinatorEpoch,
+                                    errorsAndData,
+                                    prepareThrowable,
+                                    responseCallback);
+                        });
+                        return null;
                     });
-                    return null;
-                });
+                } else {
+                    responseCallback.accept(initTransactionError(Errors.UNKNOWN_SERVER_ERROR));
+                }
+            }).exceptionally(ex -> {
+                responseCallback.accept(initTransactionError(Errors.forException(ex.getCause())));
+                return null;
             });
 
         }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManager.java
@@ -458,7 +458,7 @@ public class TransactionStateManager {
             } else {
                 Map<String, TransactionMetadata> metadataMap = transactionMetadataCache.get(partitionId);
                 if (metadataMap == null) {
-                    return new ErrorsAndData<>(Errors.NOT_COORDINATOR);
+                    return new ErrorsAndData<>(Errors.NOT_COORDINATOR, Optional.empty());
                 }
                 Optional<TransactionMetadata> txnMetadata;
                 TransactionMetadata txnMetadataCache = metadataMap.get(transactionalId);
@@ -476,7 +476,7 @@ public class TransactionStateManager {
                 return txnMetadata
                         .map(metadata -> new ErrorsAndData<>(
                                 Optional.of(new CoordinatorEpochAndTxnMetadata(-1, metadata))))
-                        .orElseGet(() -> new ErrorsAndData<>(Optional.empty()));
+                        .orElseGet(() -> new ErrorsAndData<>(Errors.NONE, Optional.empty()));
             }
         });
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinatorTest.java
@@ -188,7 +188,7 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
     @Test(timeOut = defaultTestTimeout)
     public void shouldInitPidWithEpochZeroForNewTransactionalId() {
         initPidGenericMocks();
-        doReturn(new ErrorsAndData<>(Errors.NONE))
+        doReturn(new ErrorsAndData<>(Errors.NONE, Optional.empty()))
                 .when(transactionManager).getTransactionState(eq(transactionalId));
 
         doAnswer(__ -> {
@@ -221,7 +221,7 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
     @Test(timeOut = defaultTestTimeout)
     public void shouldGenerateNewProducerIdIfNoStateAndProducerIdAndEpochProvided() {
         initPidGenericMocks();
-        doReturn(new ErrorsAndData<>(Errors.NONE))
+        doReturn(new ErrorsAndData<>(Errors.NONE, Optional.empty()))
                 .when(transactionManager).getTransactionState(eq(transactionalId));
         doAnswer(__ -> {
             assertNotNull(capturedTxn.getValue());

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinatorTest.java
@@ -315,6 +315,22 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
     }
 
     @Test(timeOut = defaultTestTimeout)
+    public void shouldRespondWithCoordinatorLoadInProgressOnInitPidWhenCoordinatorLoading() {
+        initPidGenericMocks();
+        doReturn(new ErrorsAndData<>(Errors.COORDINATOR_LOAD_IN_PROGRESS, Optional.empty()))
+                .when(transactionManager).getTransactionState(eq(transactionalId));
+
+        transactionCoordinator.handleInitProducerId(
+                transactionalId,
+                txnTimeoutMs,
+                Optional.empty(),
+                initProducerIdMockCallback
+        );
+        assertEquals(new TransactionCoordinator
+                .InitProducerIdResult(-1L, (short) -1, Errors.COORDINATOR_LOAD_IN_PROGRESS), result);
+    }
+
+    @Test(timeOut = defaultTestTimeout)
     public void shouldAbortExpiredTransactionsInOngoingStateAndBumpEpoch() {
         long now = time.milliseconds();
         TransactionMetadata txnMetadata = new TransactionMetadata(


### PR DESCRIPTION
### Motivation

Currently, KoP support transaction but don't have units test to cover transaction coordinator code behavior, for future maintain, we should add units test from  Kafka.

### Modification
* Fix `handleInitProducerId` behavior.
* Add units test to ensure behavior same as Kafka.