### PR TITLE
Use MessageMetadataUtils instead of raw use of Commands API

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -54,7 +54,7 @@ import io.streamnative.pulsar.handlers.kop.utils.GroupIdUtils;
 import io.streamnative.pulsar.handlers.kop.utils.KafkaRequestUtils;
 import io.streamnative.pulsar.handlers.kop.utils.KafkaResponseUtils;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
-import io.streamnative.pulsar.handlers.kop.utils.MessageIdUtils;
+import io.streamnative.pulsar.handlers.kop.utils.MessageMetadataUtils;
 import io.streamnative.pulsar.handlers.kop.utils.OffsetFinder;
 import io.streamnative.pulsar.handlers.kop.utils.TopicNameUtils;
 import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperation;
@@ -1071,7 +1071,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 final EncodeRequest encodeRequest = EncodeRequest.get(validRecords);
                 if (entryFormatter instanceof KafkaMixedEntryFormatter) {
                     final ManagedLedger managedLedger = persistentTopicOpt.get().getManagedLedger();
-                    final long logEndOffset = MessageIdUtils.getLogEndOffset(managedLedger);
+                    final long logEndOffset = MessageMetadataUtils.getLogEndOffset(managedLedger);
                     encodeRequest.setBaseOffset(logEndOffset);
                 }
 
@@ -1298,7 +1298,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                     log.debug("Get latest position for topic {} time {}. result: {}",
                         perTopic.getName(), timestamp, position);
                 }
-                long offset = MessageIdUtils.getLogEndOffset(managedLedger);
+                long offset = MessageMetadataUtils.getLogEndOffset(managedLedger);
                 partitionData.complete(Pair.of(Errors.NONE, offset));
 
             } else if (timestamp == ListOffsetRequest.EARLIEST_TIMESTAMP) {
@@ -1308,11 +1308,11 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                     log.debug("Get earliest position for topic {} time {}. result: {}",
                         perTopic.getName(), timestamp, position);
                 }
-                if (position.compareTo(lac) > 0 || MessageIdUtils.getCurrentOffset(managedLedger) < 0) {
-                    long offset = Math.max(0, MessageIdUtils.getCurrentOffset(managedLedger));
+                if (position.compareTo(lac) > 0 || MessageMetadataUtils.getCurrentOffset(managedLedger) < 0) {
+                    long offset = Math.max(0, MessageMetadataUtils.getCurrentOffset(managedLedger));
                     partitionData.complete(Pair.of(Errors.NONE, offset));
                 } else {
-                    MessageIdUtils.getOffsetOfPosition(managedLedger, position, false, timestamp)
+                    MessageMetadataUtils.getOffsetOfPosition(managedLedger, position, false, timestamp)
                             .whenComplete((offset, throwable) -> {
                                 if (throwable != null) {
                                     log.error("[{}] Failed to get offset for position {}",
@@ -1362,11 +1362,11 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                             topic, timestamp, finalPosition);
                 }
 
-                if (finalPosition.compareTo(lac) > 0 || MessageIdUtils.getCurrentOffset(managedLedger) < 0) {
-                    long offset = Math.max(0, MessageIdUtils.getCurrentOffset(managedLedger));
+                if (finalPosition.compareTo(lac) > 0 || MessageMetadataUtils.getCurrentOffset(managedLedger) < 0) {
+                    long offset = Math.max(0, MessageMetadataUtils.getCurrentOffset(managedLedger));
                     partitionData.complete(Pair.of(Errors.NONE, offset));
                 } else {
-                    MessageIdUtils.getOffsetOfPosition(managedLedger, finalPosition, true, timestamp)
+                    MessageMetadataUtils.getOffsetOfPosition(managedLedger, finalPosition, true, timestamp)
                             .whenComplete((offset, throwable) -> {
                                 if (throwable != null) {
                                     log.error("[{}] Failed to get offset for position {}",

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessagePublishContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessagePublishContext.java
@@ -16,13 +16,13 @@ package io.streamnative.pulsar.handlers.kop;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
+import io.streamnative.pulsar.handlers.kop.exceptions.KoPMessageMetadataNotFoundException;
+import io.streamnative.pulsar.handlers.kop.utils.MessageMetadataUtils;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.Topic.PublishContext;
-import org.apache.pulsar.common.api.proto.BrokerEntryMetadata;
-import org.apache.pulsar.common.protocol.Commands;
 
 /**
  * Implementation for PublishContext.
@@ -33,26 +33,15 @@ public final class MessagePublishContext implements PublishContext {
     private CompletableFuture<Long> offsetFuture;
     private Topic topic;
     private long startTimeNs;
-    private long numberOfMessages;
+    private int numberOfMessages;
     private long baseOffset = -1L;
 
     @Override
     public void setMetadataFromEntryData(ByteBuf entryData) {
         try {
-            final BrokerEntryMetadata brokerEntryMetadata = Commands.peekBrokerEntryMetadataIfExist(entryData);
-            if (brokerEntryMetadata == null) {
-                throw new IllegalStateException("There's no BrokerEntryData, "
-                        + "check if your broker has configured brokerEntryMetadataInterceptors");
-            }
-            if (!brokerEntryMetadata.hasIndex()) {
-                throw new IllegalStateException("The BrokerEntryData has no 'index' field, check if "
-                        + "your broker configured AppendIndexMetadataInterceptor");
-            }
-            baseOffset = brokerEntryMetadata.getIndex() - (numberOfMessages - 1);
-        } catch (IllegalStateException e) {
-            throw e;
-        } catch (Exception e) {
-            log.error("Failed to set metadata from entry", e);
+            baseOffset = MessageMetadataUtils.peekBaseOffset(entryData, numberOfMessages);
+        } catch (KoPMessageMetadataNotFoundException e) {
+            log.error("Failed to set metadata from entry: {}", e.getMessage());
         }
     }
 
@@ -87,7 +76,7 @@ public final class MessagePublishContext implements PublishContext {
     // recycler
     public static MessagePublishContext get(CompletableFuture<Long> offsetFuture,
                                             Topic topic,
-                                            long numberOfMessages,
+                                            int numberOfMessages,
                                             long startTimeNs) {
         MessagePublishContext callback = RECYCLER.get();
         callback.offsetFuture = offsetFuture;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
@@ -33,7 +33,7 @@ import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupMetadata.Commi
 import io.streamnative.pulsar.handlers.kop.offset.OffsetAndMetadata;
 import io.streamnative.pulsar.handlers.kop.utils.CoreUtils;
 import io.streamnative.pulsar.handlers.kop.utils.KafkaResponseUtils;
-import io.streamnative.pulsar.handlers.kop.utils.MessageIdUtils;
+import io.streamnative.pulsar.handlers.kop.utils.MessageMetadataUtils;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -541,7 +541,7 @@ public class GroupMetadataManager {
             .thenApplyAsync(messageId -> {
                 if (!group.is(GroupState.Dead)) {
                     MessageIdImpl lastMessageId = (MessageIdImpl) messageId;
-                    long baseOffset = MessageIdUtils.getMockOffset(
+                    long baseOffset = MessageMetadataUtils.getMockOffset(
                         lastMessageId.getLedgerId(),
                         lastMessageId.getEntryId()
                     );

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/AbstractEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/AbstractEntryFormatter.java
@@ -20,7 +20,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.streamnative.pulsar.handlers.kop.exceptions.KoPMessageMetadataNotFoundException;
 import io.streamnative.pulsar.handlers.kop.utils.ByteBufUtils;
-import io.streamnative.pulsar.handlers.kop.utils.MessageIdUtils;
+import io.streamnative.pulsar.handlers.kop.utils.MessageMetadataUtils;
 import java.io.IOException;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -32,7 +32,6 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.api.proto.KeyValue;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
-import org.apache.pulsar.common.protocol.Commands;
 
 @Slf4j
 public abstract class AbstractEntryFormatter implements EntryFormatter {
@@ -50,9 +49,9 @@ public abstract class AbstractEntryFormatter implements EntryFormatter {
         ByteBuf batchedByteBuf = PulsarByteBufAllocator.DEFAULT.directBuffer(totalSize);
         for (Entry entry : entries) {
             try {
-                long startOffset = MessageIdUtils.peekBaseOffsetFromEntry(entry);
+                long startOffset = MessageMetadataUtils.peekBaseOffsetFromEntry(entry);
                 final ByteBuf byteBuf = entry.getDataBuffer();
-                final MessageMetadata metadata = Commands.parseMessageMetadata(byteBuf);
+                final MessageMetadata metadata = MessageMetadataUtils.parseMessageMetadata(byteBuf);
                 if (isKafkaEntryFormat(metadata)) {
                     byte batchMagic = byteBuf.getByte(byteBuf.readerIndex() + MAGIC_OFFSET);
                     byteBuf.setLong(byteBuf.readerIndex() + OFFSET_OFFSET, startOffset);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/OffsetFinder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/OffsetFinder.java
@@ -62,7 +62,7 @@ public class OffsetFinder implements AsyncCallbacks.FindEntryCallback {
                     return false;
                 }
                 try {
-                    return MessageIdUtils.getPublishTime(entry.getDataBuffer()) <= timestamp;
+                    return MessageMetadataUtils.getPublishTime(entry.getDataBuffer()) <= timestamp;
                 } catch (Exception e) {
                     log.error("[{}] Error deserialize message for message position find", managedLedger.getName(), e);
                 } finally {


### PR DESCRIPTION
### Motivation

The `Commands` class contains some static methods but the API design is bad. For the methods that parse metadata from a buffer. Sometimes it prints logs and then returns null, like `peekMessageMetadata`. Sometimes it just returns a parsed result but an `IllegalArgumentException` could be thrown if the buffer was corrupted.

This PR is to avoid calling these methods of `Commands` directly.

### Modifications

- Rename `MessageIdUtils` to `MessageMetadataUtils`, whose name is more accurate.
- Add `peekBaseOffset` and `parseMessageMetadata` methods to replace usage of `Commands`.
- Add `peekOffsetFromEntry`, `peekBaseOffsetFromEntry`, `peekBaseOffset` to get offset or base offset from an entry or buffer.