### PR TITLE
[Transaction] Fix transaction coordinator handleAddPartitionsToTransaction behavior and migrate tests

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -116,6 +116,7 @@ import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.requests.AbstractResponse;
 import org.apache.kafka.common.requests.AddOffsetsToTxnRequest;
+import org.apache.kafka.common.requests.AddOffsetsToTxnResponse;
 import org.apache.kafka.common.requests.AddPartitionsToTxnRequest;
 import org.apache.kafka.common.requests.AddPartitionsToTxnResponse;
 import org.apache.kafka.common.requests.ApiError;
@@ -2063,7 +2064,13 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 } else {
                     TransactionCoordinator transactionCoordinator = getTransactionCoordinator();
                     transactionCoordinator.handleAddPartitionsToTransaction(request.transactionalId(),
-                            request.producerId(), request.producerEpoch(), partitionsToAdd, response);
+                            request.producerId(), request.producerEpoch(), authorizedPartitions, (errors) -> {
+                                // TODO: handle PRODUCER_FENCED errors
+                                Map<TopicPartition, Errors> topicPartitionErrorsMap =
+                                        addPartitionError(partitionsToAdd, errors);
+                                response.complete(
+                                        new AddPartitionsToTxnResponse(0, topicPartitionErrorsMap));
+                            });
                 }
             }
         };
@@ -2100,11 +2107,25 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         int partition = getGroupCoordinator().partitionFor(request.consumerGroupId());
         String offsetTopicName = getGroupCoordinator().getGroupManager().getOffsetConfig().offsetsTopicName();
         TransactionCoordinator transactionCoordinator = getTransactionCoordinator();
+        Set<TopicPartition> topicPartitions = Collections.singleton(new TopicPartition(offsetTopicName, partition));
         transactionCoordinator.handleAddPartitionsToTransaction(
                 request.transactionalId(),
                 request.producerId(),
                 request.producerEpoch(),
-                Collections.singletonList(new TopicPartition(offsetTopicName, partition)), response);
+                topicPartitions,
+                (errors) -> {
+                    // TODO: handle PRODUCER_FENCED errors
+                    response.complete(
+                            new AddOffsetsToTxnResponse(0, errors));
+                });
+    }
+
+    private Map<TopicPartition, Errors> addPartitionError(Collection<TopicPartition> partitions, Errors errors) {
+        Map<TopicPartition, Errors> result = Maps.newHashMap();
+        for (TopicPartition partition : partitions) {
+            result.put(partition, errors);
+        }
+        return result;
     }
 
     @Override

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinatorTest.java
@@ -66,7 +66,7 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
     private ProducerIdManager producerIdManager;
     private TransactionStateManager transactionManager;
     private TransactionCoordinator.InitProducerIdResult result = null;
-    private Errors errors = Errors.NONE;
+    private Errors error = Errors.NONE;
     ArgumentCaptor<TransactionMetadata> capturedTxn = ArgumentCaptor.forClass(TransactionMetadata.class);
     ArgumentCaptor<TransactionStateManager.ResponseCallback> capturedErrorsCallback =
             ArgumentCaptor.forClass(TransactionStateManager.ResponseCallback.class);
@@ -85,7 +85,7 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
     };
 
     private final Consumer<Errors> errorsCallback = (ret) -> {
-        errors = ret;
+        error = ret;
     };
 
     @BeforeClass
@@ -126,7 +126,7 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
     @BeforeMethod
     protected void initializeState() {
         result = null;
-        errors = Errors.NONE;
+        error = Errors.NONE;
         capturedTxn = ArgumentCaptor.forClass(TransactionMetadata.class);
         capturedErrorsCallback = ArgumentCaptor.forClass(TransactionStateManager.ResponseCallback.class);
     }
@@ -335,18 +335,20 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
         assertEquals(new TransactionCoordinator
                 .InitProducerIdResult(-1L, (short) -1, Errors.COORDINATOR_LOAD_IN_PROGRESS), result);
     }
-//
-//    @Test(timeOut = defaultTestTimeout)
-//    public void shouldRespondWithInvalidPidMappingOnAddPartitionsToTransactionWhenTransactionalIdNotPresent() {
-//        doReturn(new ErrorsAndData<>(Errors.NONE, Optional.empty()))
-//                .when(transactionManager).getTransactionState(eq(transactionalId));
-//        transactionCoordinator.handleAddPartitionsToTransaction(
-//                0L,
-//                1,
-//                partitions,
-//                errorsCallback
-//        );
-//    }
+
+    @Test(timeOut = defaultTestTimeout)
+    public void shouldRespondWithInvalidPidMappingOnAddPartitionsToTransactionWhenTransactionalIdNotPresent() {
+        doReturn(new ErrorsAndData<>(Errors.NONE, Optional.empty()))
+                .when(transactionManager).getTransactionState(eq(transactionalId));
+        transactionCoordinator.handleAddPartitionsToTransaction(
+                transactionalId,
+                0L,
+                (short) 1,
+                partitions,
+                errorsCallback
+        );
+        assertEquals(Errors.INVALID_PRODUCER_ID_MAPPING, error);
+    }
 
     @Test(timeOut = defaultTestTimeout)
     public void shouldAbortExpiredTransactionsInOngoingStateAndBumpEpoch() {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinatorTest.java
@@ -66,6 +66,7 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
     private ProducerIdManager producerIdManager;
     private TransactionStateManager transactionManager;
     private TransactionCoordinator.InitProducerIdResult result = null;
+    private Errors errors = Errors.NONE;
     ArgumentCaptor<TransactionMetadata> capturedTxn = ArgumentCaptor.forClass(TransactionMetadata.class);
     ArgumentCaptor<TransactionStateManager.ResponseCallback> capturedErrorsCallback =
             ArgumentCaptor.forClass(TransactionStateManager.ResponseCallback.class);
@@ -81,6 +82,10 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
 
     private final Consumer<TransactionCoordinator.InitProducerIdResult> initProducerIdMockCallback = (ret) -> {
         result = ret;
+    };
+
+    private final Consumer<Errors> errorsCallback = (ret) -> {
+        errors = ret;
     };
 
     @BeforeClass
@@ -121,6 +126,7 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
     @BeforeMethod
     protected void initializeState() {
         result = null;
+        errors = Errors.NONE;
         capturedTxn = ArgumentCaptor.forClass(TransactionMetadata.class);
         capturedErrorsCallback = ArgumentCaptor.forClass(TransactionStateManager.ResponseCallback.class);
     }
@@ -329,6 +335,18 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
         assertEquals(new TransactionCoordinator
                 .InitProducerIdResult(-1L, (short) -1, Errors.COORDINATOR_LOAD_IN_PROGRESS), result);
     }
+//
+//    @Test(timeOut = defaultTestTimeout)
+//    public void shouldRespondWithInvalidPidMappingOnAddPartitionsToTransactionWhenTransactionalIdNotPresent() {
+//        doReturn(new ErrorsAndData<>(Errors.NONE, Optional.empty()))
+//                .when(transactionManager).getTransactionState(eq(transactionalId));
+//        transactionCoordinator.handleAddPartitionsToTransaction(
+//                0L,
+//                1,
+//                partitions,
+//                errorsCallback
+//        );
+//    }
 
     @Test(timeOut = defaultTestTimeout)
     public void shouldAbortExpiredTransactionsInOngoingStateAndBumpEpoch() {


### PR DESCRIPTION
### Motivation

Currently, KoP support transaction but don't have units test to cover transaction coordinator `handleAddPartitionsToTransaction` behavior, for future maintain, we should add units test from Kafka.

**In addition**: `handleAddOffsetsToTxn ` should response  `AddOffsetsToTxnResponse`, previous implementation use `AddPartitionsToTxnResponse` to response.

### Modification

* Fix `handleAddPartitionsToTransaction` behavior.
* Fix `handleAddOffsetsToTxn ` wrong response.
* Add units test to ensure behavior same as Kafka.