### PR TITLE
[Transaction] Fix transaction coordinator handleEndTransaction behavior and migrate tests

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinatorTest.java
@@ -41,7 +41,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
-
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.curator.shaded.com.google.common.collect.Lists;


### PR DESCRIPTION
### Motivation

Currently, KoP support transaction but don't have units test to cover transaction coordinator `handleEndTransaction ` behavior, for future maintain, we should add units test from Kafka.


### Modification

* Fix `handleEndTransaction ` behavior.
* Add units test to ensure behavior same as Kafka.