### PR TITLE
[Transaction] Migrate remains of transaction coordinator handleInitProducerId tests and fix behavior

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerRequestCompletionHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerRequestCompletionHandler.java
@@ -178,8 +178,8 @@ public class TransactionMarkerRequestCompletionHandler {
                             txnMetadata.removePartition(topicPartition);
                             break;
                         default:
-                            throw new IllegalStateException("Unexpected error " + error.exceptionName()
-                                    + " while sending txn marker for $transactionalId");
+                            throw new IllegalStateException(String.format("Unexpected error %s"
+                                    + " while sending txn marker for %s", error.exceptionName(), transactionalId));
                     }
                 }
                 return null;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMetadata.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMetadata.java
@@ -364,15 +364,16 @@ public class TransactionMetadata {
                 epochBumpResult = new ErrorsAndData<>(new BumpEpochResult(producerEpoch, lastProducerEpoch));
             } else {
                 // Otherwise, the producer has a fenced epoch and should receive an PRODUCER_FENCED error
-                log.info("Expected producer epoch $expectedEpoch does not match current "
-                        + "producer epoch $producerEpoch or previous producer epoch $lastProducerEpoch");
+                log.info("Expected producer epoch {} does not match current "
+                        + "producer epoch {} or previous producer epoch {}",
+                        expectedProducerEpoch, producerEpoch, lastProducerEpoch);
                 // TODO the error should be Errors.PRODUCER_FENCED
                 epochBumpResult = new ErrorsAndData<>(Errors.UNKNOWN_SERVER_ERROR);
             }
         }
 
         if (epochBumpResult.hasErrors()) {
-            return new ErrorsAndData<TxnTransitMetadata>(epochBumpResult.getErrors());
+            return new ErrorsAndData<>(epochBumpResult.getErrors());
         } else {
             return new ErrorsAndData<>(
                     prepareTransitionTo(


### PR DESCRIPTION
### Motivation

Currently, KoP support transaction but don't have units test to cover transaction coordinator code behavior, for future maintain, we should add units test from  Kafka.

### Modification
* Add units test to ensure behavior same as Kafka.
* Use get/set method to get or set the `EpochAndTxnTransitMetadata` value.
* Fix some logs content, is should have value.
* Fix `isValidProducerId ` method bad behavior.
* Fix `prepareInitProducerIdTransit` might get null date.