### PR TITLE
Speed up group coordinator tests

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinatorTest.java
@@ -49,13 +49,11 @@ import org.apache.kafka.common.requests.OffsetCommitRequest;
 import org.apache.kafka.common.requests.OffsetFetchResponse;
 import org.apache.kafka.common.requests.OffsetFetchResponse.PartitionData;
 import org.apache.kafka.common.requests.TransactionResult;
-import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.ReaderBuilder;
 import org.apache.pulsar.client.api.Schema;
-import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
@@ -81,7 +79,6 @@ public class GroupCoordinatorTest extends KopProtocolHandlerTestBase {
     private MockTimer timer = null;
     private GroupCoordinator groupCoordinator = null;
 
-    private Consumer<ByteBuffer> consumer;
     private OrderedScheduler scheduler;
     private GroupMetadataManager groupMetadataManager;
     private int groupPartitionId = -1;
@@ -127,12 +124,6 @@ public class GroupCoordinatorTest extends KopProtocolHandlerTestBase {
         timer = new MockTimer();
 
         ProducerBuilder<ByteBuffer> producerBuilder = pulsarClient.newProducer(Schema.BYTEBUFFER);
-
-        consumer = pulsarClient.newConsumer(Schema.BYTEBUFFER)
-                .topic(topicName)
-                .subscriptionName("test-sub")
-                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
-                .subscribe();
 
         ReaderBuilder<ByteBuffer> readerBuilder = pulsarClient.newReader(Schema.BYTEBUFFER)
                 .startMessageId(MessageId.earliest);
@@ -191,7 +182,6 @@ public class GroupCoordinatorTest extends KopProtocolHandlerTestBase {
     protected void tearDown() throws PulsarClientException {
         groupCoordinator.shutdown();
         groupMetadataManager.shutdown();
-        consumer.close();
         scheduler.shutdown();
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinatorTest.java
@@ -107,7 +107,7 @@ public class GroupCoordinatorTest extends KopProtocolHandlerTestBase {
     }
 
     @BeforeMethod
-    private void setUp() throws PulsarClientException {
+    protected void setUp() throws PulsarClientException {
         protocols = newProtocols();
 
         scheduler = OrderedScheduler.newSchedulerBuilder()
@@ -188,7 +188,7 @@ public class GroupCoordinatorTest extends KopProtocolHandlerTestBase {
     }
 
     @AfterMethod
-    private void tearDown() throws PulsarClientException {
+    protected void tearDown() throws PulsarClientException {
         groupCoordinator.shutdown();
         groupMetadataManager.shutdown();
         consumer.close();


### PR DESCRIPTION
Master issue: #830

### Motivation

The `GroupCoordinatorTest` spend too much time to start mock pulsar and shutdown mock pulsar in each tests. See: 
https://github.com/streamnative/kop/issues/830#issuecomment-949259927

### Modifications

1. Each time we start new test method, just restart `GroupCoordinator`, instead of restart new mock pulsar.
2. Remove unused consumer

This PR speed up the `GroupCoordinatorTest`, reduce test time from **500s** down to **14s**

**Before** : 
```text
[INFO] Running io.streamnative.pulsar.handlers.kop.coordinator.group.GroupCoordinatorTest
[INFO] Tests run: 63, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 499.022 s - in io.streamnative.pulsar.handlers.kop.coordinator.group.GroupCoordinatorTest
```
**After** : 
```text
[INFO] Running io.streamnative.pulsar.handlers.kop.coordinator.group.GroupCoordinatorTest
[INFO] Tests run: 63, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 14.275 s - in io.streamnative.pulsar.handlers.kop.coordinator.group.GroupCoordinatorTest
```

