### PR TITLE
Fix list offsets failure when ledgers are removed by a rollover operation

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -1302,6 +1302,12 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             PersistentTopic perTopic = perTopicOpt.get();
             ManagedLedgerImpl managedLedger = (ManagedLedgerImpl) perTopic.getManagedLedger();
             PositionImpl lac = (PositionImpl) managedLedger.getLastConfirmedEntry();
+            if (lac == null) {
+                log.error("[{}] Unexpected LastConfirmedEntry for topic {}, managed ledger: {}",
+                        ctx, perTopic.getName(), managedLedger.getName());
+                partitionData.complete(Pair.of(Errors.UNKNOWN_SERVER_ERROR, -1L));
+                return;
+            }
             if (timestamp == ListOffsetRequest.LATEST_TIMESTAMP) {
                 PositionImpl position = (PositionImpl) managedLedger.getLastConfirmedEntry();
                 if (log.isDebugEnabled()) {
@@ -1313,14 +1319,25 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
 
             } else if (timestamp == ListOffsetRequest.EARLIEST_TIMESTAMP) {
                 PositionImpl position = OffsetFinder.getFirstValidPosition(managedLedger);
+                if (position == null) {
+                    log.error("[{}] Failed to find first valid position for topic {}", ctx, perTopic.getName());
+                    partitionData.complete(Pair.of(Errors.UNKNOWN_SERVER_ERROR, -1L));
+                    return;
+                }
 
                 if (log.isDebugEnabled()) {
-                    log.debug("Get earliest position for topic {} time {}. result: {}",
-                        perTopic.getName(), timestamp, position);
+                    log.debug("[{}] Get earliest position for topic {}: {}, lac: {}",
+                            ctx, perTopic.getName(), position, lac);
                 }
-                if (position.compareTo(lac) > 0 || MessageMetadataUtils.getCurrentOffset(managedLedger) < 0) {
-                    long offset = Math.max(0, MessageMetadataUtils.getCurrentOffset(managedLedger));
-                    partitionData.complete(Pair.of(Errors.NONE, offset));
+                final long latestOffset = MessageMetadataUtils.getCurrentOffset(managedLedger);
+                if (latestOffset < 0) {
+                    log.warn("[{}] Unexpected latest offset {} (< 0) for topic {}",
+                            ctx, latestOffset, perTopic.getName());
+                    partitionData.complete(Pair.of(Errors.NONE, 0L));
+                    return;
+                }
+                if (position.compareTo(lac) > 0) {
+                    partitionData.complete(Pair.of(Errors.NONE, latestOffset));
                 } else {
                     MessageMetadataUtils.getOffsetOfPosition(managedLedger, position, false, timestamp)
                             .whenComplete((offset, throwable) -> {


### PR DESCRIPTION
Fixes https://github.com/streamnative/kop/issues/876

### Motivation

There is a corner case that `MessageMetadataUtils.getOffsetOfPosition` fails with `NonRecoverableLedgerException`.

If a managed ledger has multiple ledgers that are all expired. After an automatically rollover controlled by max rollover time), a new empty ledger will be created, then the previous ledgers will be removed. However, a rollover doesn't change the `lastConfirmedEntry`, in `ManagedLedgerImpl#getFirstPosition`, if the first ledger's id is greater than the `lastConfirmedEntry`, the returned position's ledger id will be the same with the `lastConfirmedEntry`'s ledger id. In addition, KoP applies `ManagedLedgerImpl#getNextValidPositionInternal` to the first position. In this method, if the position's ledger id is the same with `lastConfirmedEntry`, it's also treated as valid.

Therefore, in this case, KoP will try to read an entry whose ledger id is not in the managed ledger, and a `NonRecoverableLedgerException` will be thrown. See `KafkaRequestHandler#fetchOffset` for details.

### Modifications
- Handle the `NonRecoverableLedgerException` in `readEntriesFailed` callback. In this case, return the LEO as the offset because we can treat the topic as empty.
- Add `testListOffsetForEmptyRolloverLedger` to `MultiLedgerTest` to reproduce the scenario I've described. After the ledgers are all removed by a rollover, use a Kafka consumer to list offsets. Then produce a message and try to consume it.

Besides, this PR also handles the case that `getFirstValidPosition` returns a position whose ledger is doesn't exist but the managed ledger is not empty. Returns the position of first ledger's entry. This case should never happen except there is a bug in Pulsar.