### PR TITLE
[Transaction] Support transactional Id expiration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,9 +118,9 @@ This section lists configurations about the transaction.
 | brokerId                     | The broker ID that is used to create the producer ID.  | 1       |
 | txnLogTopicNumPartitions     | the number of partitions for the transaction log topic. | 50      |
 | txnAbortTimedOutTransactionCleanupIntervalMs | The interval in milliseconds at which to rollback transactions that have timed out. | 10000 |
+| enableTransactionalIdExpiration | Whether to enable transactional ID expiration. | true |
 | transactionalIdExpirationMs | The time (in ms) that the transaction coordinator waits without receiving any transaction status updates for the current transaction before expiring its transactional ID. | 604800 |
 | transactionsRemoveExpiredTransactionalIdCleanupIntervalMs | The interval (in ms) at which to remove expired transactions. | 3600 |
-| enableTransactionalIdExpiration | Whether to enable transactional ID expiration. | true |
 
 ## Authentication
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,9 +118,9 @@ This section lists configurations about the transaction.
 | brokerId                     | The broker ID that is used to create the producer ID.  | 1       |
 | txnLogTopicNumPartitions     | the number of partitions for the transaction log topic. | 50      |
 | txnAbortTimedOutTransactionCleanupIntervalMs | The interval in milliseconds at which to rollback transactions that have timed out. | 10000 |
-| transactionalIdExpirationMs | The time in ms that the transaction coordinator will wait without receiving any transaction status updates for the current transaction before expiring its transactional id. | 604800 |
-| transactionsRemoveExpiredTransactionalIdCleanupIntervalMs | The interval in milliseconds at which to remove transactions that have expired. | 3600 |
-| enableTransactionalIdExpiration | Whether to enable transactional id expiration. | true |
+| transactionalIdExpirationMs | The time (in ms) that the transaction coordinator waits without receiving any transaction status updates for the current transaction before expiring its transactional ID. | 604800 |
+| transactionsRemoveExpiredTransactionalIdCleanupIntervalMs | The interval (in ms) at which to remove expired transactions. | 3600 |
+| enableTransactionalIdExpiration | Whether to enable transactional ID expiration. | true |
 
 ## Authentication
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,7 +118,8 @@ This section lists configurations about the transaction.
 | brokerId                     | The broker ID that is used to create the producer ID.  | 1       |
 | txnLogTopicNumPartitions     | the number of partitions for the transaction log topic. | 50      |
 | txnAbortTimedOutTransactionCleanupIntervalMs | The interval in milliseconds at which to rollback transactions that have timed out. | 10000 |
-
+| transactionalIdExpirationMs | The time in ms that the transaction coordinator will wait without receiving any transaction status updates for the current transaction before expiring its transactional id. | 604800 |
+| transactionsRemoveExpiredTransactionalIdCleanupIntervalMs | The interval in milliseconds at which to remove transactions that have expired. | 3600 |
 ## Authentication
 
 This section lists configurations about the authentication.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,6 +120,8 @@ This section lists configurations about the transaction.
 | txnAbortTimedOutTransactionCleanupIntervalMs | The interval in milliseconds at which to rollback transactions that have timed out. | 10000 |
 | transactionalIdExpirationMs | The time in ms that the transaction coordinator will wait without receiving any transaction status updates for the current transaction before expiring its transactional id. | 604800 |
 | transactionsRemoveExpiredTransactionalIdCleanupIntervalMs | The interval in milliseconds at which to remove transactions that have expired. | 3600 |
+| enableTransactionalIdExpiration | Whether to enable transactional id expiration. | true |
+
 ## Authentication
 
 This section lists configurations about the authentication.

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -664,7 +664,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 OrderedScheduler.newSchedulerBuilder().name("transaction-log-manager").numThreads(1).build(),
                 Time.SYSTEM);
 
-        transactionCoordinator.startup().get();
+        transactionCoordinator.startup(getKafkaConfig().isEnableTransactionalIdExpiration()).get();
 
         return transactionCoordinator;
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -648,6 +648,9 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 .transactionLogNumPartitions(kafkaConfig.getTxnLogTopicNumPartitions())
                 .transactionMetadataTopicName(MetadataUtils.constructTxnLogTopicBaseName(tenant, kafkaConfig))
                 .abortTimedOutTransactionsIntervalMs(kafkaConfig.getTxnAbortTimedOutTransactionCleanupIntervalMs())
+                .transactionalIdExpirationMs(kafkaConfig.getTransactionalIdExpirationMs())
+                .removeExpiredTransactionalIdsIntervalMs(
+                        kafkaConfig.getTransactionsRemoveExpiredTransactionalIdCleanupIntervalMs())
                 .brokerId(kafkaConfig.getBrokerId())
                 .build();
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -664,7 +664,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 OrderedScheduler.newSchedulerBuilder().name("transaction-log-manager").numThreads(1).build(),
                 Time.SYSTEM);
 
-        transactionCoordinator.startup(getKafkaConfig().isEnableTransactionalIdExpiration()).get();
+        transactionCoordinator.startup(kafkaConfig.isEnableTransactionalIdExpiration()).get();
 
         return transactionCoordinator;
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -386,6 +386,12 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
 
     @FieldContext(
             category = CATEGORY_KOP_TRANSACTION,
+            doc = "Whether to enable transactional id expiration."
+    )
+    private boolean enableTransactionalIdExpiration = true;
+
+    @FieldContext(
+            category = CATEGORY_KOP_TRANSACTION,
             doc = "The time in ms that the transaction coordinator will wait without receiving any transaction status"
                     + " updates for the current transaction before expiring its transactional id."
     )

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -59,6 +59,8 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
     public static final int DefaultTxnCoordinatorSchedulerNum = 1;
     public static final int DefaultTxnStateManagerSchedulerNum = 1;
     public static final long DefaultAbortTimedOutTransactionsIntervalMs = TimeUnit.SECONDS.toMillis(10);
+    public static final long DefaultRemoveExpiredTransactionalIdsIntervalMs = TimeUnit.HOURS.toMillis(1);
+    public static final long DefaultTransactionalIdExpirationMs = TimeUnit.DAYS.toMillis(7);
 
     @Category
     private static final String CATEGORY_KOP = "Kafka on Pulsar";
@@ -381,6 +383,20 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
             doc = "The interval in milliseconds at which to rollback transactions that have timed out."
     )
     private long txnAbortTimedOutTransactionCleanupIntervalMs = DefaultAbortTimedOutTransactionsIntervalMs;
+
+    @FieldContext(
+            category = CATEGORY_KOP_TRANSACTION,
+            doc = "The time in ms that the transaction coordinator will wait without receiving any transaction status"
+                    + " updates for the current transaction before expiring its transactional id."
+    )
+    private long transactionalIdExpirationMs = DefaultTransactionalIdExpirationMs;
+
+    @FieldContext(
+            category = CATEGORY_KOP_TRANSACTION,
+            doc = "The interval in milliseconds at which to remove transactions that have expired."
+    )
+    private long transactionsRemoveExpiredTransactionalIdCleanupIntervalMs =
+            DefaultRemoveExpiredTransactionalIdsIntervalMs;
 
     @FieldContext(
             category = CATEGORY_KOP,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -392,8 +392,8 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
 
     @FieldContext(
             category = CATEGORY_KOP_TRANSACTION,
-            doc = "The time (in ms) that the transaction coordinator waits without receiving any transaction status " +
-                    "updates for the current transaction before expiring its transactional ID."
+            doc = "The time (in ms) that the transaction coordinator waits without receiving any transaction status"
+                    + " updates for the current transaction before expiring its transactional ID."
     )
     private long transactionalIdExpirationMs = DefaultTransactionalIdExpirationMs;
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -386,20 +386,20 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
 
     @FieldContext(
             category = CATEGORY_KOP_TRANSACTION,
-            doc = "Whether to enable transactional id expiration."
+            doc = "Whether to enable transactional ID expiration."
     )
     private boolean enableTransactionalIdExpiration = true;
 
     @FieldContext(
             category = CATEGORY_KOP_TRANSACTION,
-            doc = "The time in ms that the transaction coordinator will wait without receiving any transaction status"
-                    + " updates for the current transaction before expiring its transactional id."
+            doc = "The time (in ms) that the transaction coordinator waits without receiving any transaction status " +
+                    "updates for the current transaction before expiring its transactional ID."
     )
     private long transactionalIdExpirationMs = DefaultTransactionalIdExpirationMs;
 
     @FieldContext(
             category = CATEGORY_KOP_TRANSACTION,
-            doc = "The interval in milliseconds at which to remove transactions that have expired."
+            doc = "The interval (in ms) at which to remove expired transactions."
     )
     private long transactionsRemoveExpiredTransactionalIdCleanupIntervalMs =
             DefaultRemoveExpiredTransactionalIdsIntervalMs;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionConfig.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionConfig.java
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 import lombok.Builder;
 import lombok.Builder.Default;
 import lombok.Data;
+import org.apache.kafka.common.record.CompressionType;
 
 /**
  * Transaction config.
@@ -33,6 +34,7 @@ public class TransactionConfig {
     public static final int DefaultTransactionCoordinatorSchedulerNum = 1;
     public static final int DefaultTransactionStateManagerSchedulerNum = 1;
     public static final int DefaultTransactionLogNumPartitions = 8;
+    public static final int DefaultMaxMessageSize = 5 * 1024 * 1024;
 
     @Default
     private int brokerId = 1;
@@ -54,5 +56,9 @@ public class TransactionConfig {
     private int transactionCoordinatorSchedulerNum = DefaultTransactionCoordinatorSchedulerNum;
     @Default
     private int transactionStateManagerSchedulerNum = DefaultTransactionStateManagerSchedulerNum;
+    @Default
+    private int maxMessageSize = DefaultMaxMessageSize;
+    @Default
+    private CompressionType transactionMetadataTopicCompressionType = CompressionType.NONE;
 
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionConfig.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionConfig.java
@@ -17,7 +17,6 @@ import java.util.concurrent.TimeUnit;
 import lombok.Builder;
 import lombok.Builder.Default;
 import lombok.Data;
-import org.apache.kafka.common.record.CompressionType;
 
 /**
  * Transaction config.
@@ -34,7 +33,6 @@ public class TransactionConfig {
     public static final int DefaultTransactionCoordinatorSchedulerNum = 1;
     public static final int DefaultTransactionStateManagerSchedulerNum = 1;
     public static final int DefaultTransactionLogNumPartitions = 8;
-    public static final int DefaultMaxMessageSize = 5 * 1024 * 1024;
 
     @Default
     private int brokerId = 1;
@@ -56,9 +54,5 @@ public class TransactionConfig {
     private int transactionCoordinatorSchedulerNum = DefaultTransactionCoordinatorSchedulerNum;
     @Default
     private int transactionStateManagerSchedulerNum = DefaultTransactionStateManagerSchedulerNum;
-    @Default
-    private int maxMessageSize = DefaultMaxMessageSize;
-    @Default
-    private CompressionType transactionMetadataTopicCompressionType = CompressionType.NONE;
 
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -955,7 +955,7 @@ public class TransactionCoordinator {
                 transactionConfig.getAbortTimedOutTransactionsIntervalMs(),
                 TimeUnit.MILLISECONDS);
 
-        // TODO transaction id expiration
+        txnManager.startup(true);
 
         return this.producerIdManager.initialize().thenCompose(ignored -> {
             log.info("Startup transaction coordinator complete.");

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -944,7 +944,7 @@ public class TransactionCoordinator {
     /**
      * Startup logic executed at the same time when the server starts up.
      */
-    public CompletableFuture<Void> startup() {
+    public CompletableFuture<Void> startup(boolean enableTransactionalIdExpiration) {
         log.info("Starting up transaction coordinator ...");
 
         // Abort timeout transactions
@@ -955,7 +955,7 @@ public class TransactionCoordinator {
                 transactionConfig.getAbortTimedOutTransactionsIntervalMs(),
                 TimeUnit.MILLISECONDS);
 
-        txnManager.startup(true);
+        txnManager.startup(enableTransactionalIdExpiration);
 
         return this.producerIdManager.initialize().thenCompose(ignored -> {
             log.info("Startup transaction coordinator complete.");

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMetadata.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMetadata.java
@@ -465,6 +465,11 @@ public class TransactionMetadata {
                 txnTimeoutMs, Collections.emptySet(), txnStartTimestamp, updateTimestamp);
     }
 
+    public TxnTransitMetadata prepareDead() {
+        return prepareTransitionTo(TransactionState.DEAD, producerId, producerEpoch, lastProducerEpoch, txnTimeoutMs,
+                Collections.emptySet(), txnStartTimestamp, txnLastUpdateTimestamp);
+    }
+
     private void throwStateTransitionFailure(TxnTransitMetadata txnTransitMetadata) throws IllegalStateException {
         log.error("{} transition to {} failed: this should not happen.", this, txnTransitMetadata);
         throw new IllegalStateException("TransactionalId " + transactionalId + " failed transition to state "

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMetadata.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMetadata.java
@@ -206,7 +206,7 @@ public class TransactionMetadata {
 
         if (!pendingState.isPresent()) {
             throw new IllegalStateException("TransactionalId " + transactionalId
-                    + "completing transaction state transition while it does not have a pending state");
+                    + " completing transaction state transition while it does not have a pending state");
         }
         TransactionState toState = pendingState.get();
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionState.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionState.java
@@ -102,5 +102,19 @@ public enum TransactionState {
         }
     }
 
-
+    public boolean isExpirationAllowed() {
+        switch (this) {
+            case EMPTY:
+            case COMPLETE_COMMIT:
+            case COMPLETE_ABORT:
+                return true;
+            case DEAD:
+            case ONGOING:
+            case PREPARE_ABORT:
+            case PREPARE_COMMIT:
+            case PREPARE_EPOCH_FENCE:
+            default:
+                return false;
+        }
+    }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManager.java
@@ -633,7 +633,7 @@ public class TransactionStateManager {
         long startTimeMs = SystemTime.SYSTEM.milliseconds();
         return getProducer(topicPartition.partition())
                 .thenCompose(producer ->
-                        producer.newMessage().value(ByteBuffer.wrap(new byte[0])).sendAsync())
+                        producer.newMessage().value(null).sendAsync())
                 .thenCompose(lastMsgId -> {
                     if (log.isDebugEnabled()) {
                         log.debug("Successfully write a placeholder record into {} @ {}",
@@ -687,7 +687,7 @@ public class TransactionStateManager {
             }
 
             // skip place holder
-            if (message.getKeyBytes() == null || message.getValue().limit() == 0) {
+            if (!message.hasKey()) {
                 loadNextTransaction(partition, reader, lastMessageId, loadFuture, transactionMetadataMap);
                 return;
             }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManager.java
@@ -839,7 +839,7 @@ public class TransactionStateManager {
         });
     }
 
-    private CompletableFuture<MessageId> storeTxnLog(String transactionalId,
+    protected CompletableFuture<MessageId> storeTxnLog(String transactionalId,
                                                      TransactionMetadata.TxnTransitMetadata txnTransitMetadata) {
         byte[] keyBytes = new TransactionLogKey(transactionalId).toBytes();
         ByteBuffer valueByteBuffer = new TransactionLogValue(txnTransitMetadata).toByteBuffer();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManager.java
@@ -699,7 +699,7 @@ public class TransactionStateManager {
                 TransactionMetadata transactionMetadata =
                         TransactionLogValue.readTxnRecordValue(transactionId, message.getValue());
                 if (transactionMetadata == null) {
-                    // tom
+                    // Should remove from transactionMetadataMap when it's tombstone message
                     transactionMetadataMap.remove(transactionId);
                 } else {
                     transactionMetadataMap.put(logKey.getTransactionId(), transactionMetadata);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -93,7 +93,7 @@ public abstract class KopProtocolHandlerTestBase {
     protected URL brokerUrl;
     protected URL brokerUrlTls;
     protected PulsarClient pulsarClient;
-
+    protected ClusterData clusterData;
     protected int brokerWebservicePort = PortManager.nextFreePort();
     protected int brokerWebservicePortTls = PortManager.nextFreePort();
     @Getter
@@ -266,7 +266,7 @@ public abstract class KopProtocolHandlerTestBase {
         String brokerServiceUrl = "pulsar://" + getAdvertisedAddress() + ":" + brokerPort;
         String brokerServiceUrlTls = null; // TLS not supported at this time
 
-        final ClusterData clusterData = ClusterData.builder()
+        clusterData = ClusterData.builder()
                 .serviceUrl(serviceUrl)
                 .serviceUrlTls(serviceUrlTls)
                 .brokerServiceUrl(brokerServiceUrl)

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManagerTest.java
@@ -13,13 +13,18 @@
  */
 package io.streamnative.pulsar.handlers.kop.coordinator.transaction;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertNull;
+import static org.testng.AssertJUnit.assertTrue;
+import static org.testng.AssertJUnit.fail;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import io.streamnative.pulsar.handlers.kop.KafkaProtocolHandler;
 import io.streamnative.pulsar.handlers.kop.KopProtocolHandlerTestBase;
 import java.time.Duration;
@@ -27,21 +32,33 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+
+import io.streamnative.pulsar.handlers.kop.SystemTopicClient;
+import io.streamnative.pulsar.handlers.kop.utils.timer.MockTime;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.common.util.OrderedScheduler;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.record.SimpleRecord;
 import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.common.policies.data.BundlesData;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.awaitility.Awaitility;
+import org.mockito.ArgumentCaptor;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.testng.collections.Maps;
 
@@ -53,40 +70,72 @@ public class TransactionStateManagerTest extends KopProtocolHandlerTestBase {
 
     private static final Short producerEpoch = 0;
     private static final Integer transactionTimeoutMs = 1000;
+    private static final int partitionId = 0;
+    private static final int numPartitions = 2;
+    private static final String transactionalId1 = "one";
+    private static final String transactionalId2 = "two";
+    private static final MockTime time = new MockTime();
+    private static final TransactionConfig txnConfig = TransactionConfig
+            .builder()
+            .transactionLogNumPartitions(numPartitions)
+            .build();
+    private static final Map<String, Long> producerIds = new HashMap<String, Long>(){{
+        put(transactionalId1, 1L);
+        put(transactionalId2, 2L);
+    }};
+    private static final TransactionMetadata txnMetadata1 =
+            transactionMetadata(transactionalId1, producerIds.get(transactionalId1), TransactionState.EMPTY,
+                    transactionTimeoutMs);
 
-    private int txnLogTopicNumPartitions;
-    private TransactionCoordinator transactionCoordinator;
+    private static final TransactionMetadata txnMetadata2 =
+            transactionMetadata(transactionalId2, producerIds.get(transactionalId2), TransactionState.EMPTY,
+                    transactionTimeoutMs);
+
+    private TransactionStateManager transactionManager;
+
+    private OrderedScheduler scheduler;
+    private SystemTopicClient systemTopicClient;
+
+    private static TransactionMetadata transactionMetadata(String transactionalId,
+                                                    Long producerId,
+                                                    TransactionState state,
+                                                    int txnTimeout) {
+        return TransactionMetadata.builder()
+                .transactionalId(transactionalId)
+                .producerId(producerId)
+                .producerEpoch((short) 0)
+                .txnTimeoutMs(txnTimeout)
+                .state(state)
+                .build();
+    }
 
     @BeforeClass
     @Override
     protected void setup() throws Exception {
-        this.conf.setEnableTransactionCoordinator(true);
-        this.txnLogTopicNumPartitions = this.conf.getTxnLogTopicNumPartitions();
-
+        this.conf.setTxnLogTopicNumPartitions(numPartitions);
         internalSetup();
-        transactionCoordinator = getTxnCoordinator();
-
-        TenantInfoImpl tenantInfo =
-                new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test"));
-        if (!admin.tenants().getTenants().contains("public")) {
-            admin.tenants().createTenant("public", tenantInfo);
-        } else {
-            admin.tenants().updateTenant("public", tenantInfo);
-        }
-        if (!admin.namespaces().getNamespaces("public").contains("public/default")) {
-            admin.namespaces().createNamespace("public/default");
-            admin.namespaces().setNamespaceReplicationClusters("public/default", Sets.newHashSet("test"));
-            admin.namespaces().setRetention("public/default",
-                    new RetentionPolicies(60, 1000));
-        }
-        if (!admin.namespaces().getNamespaces("public").contains("public/__kafka")) {
-            admin.namespaces().createNamespace("public/__kafka");
-            admin.namespaces().setNamespaceReplicationClusters("public/__kafka", Sets.newHashSet("test"));
-            admin.namespaces().setRetention("public/__kafka",
-                    new RetentionPolicies(20, 100));
-        }
-        log.info("txn topic partition {}", admin.topics().getPartitionedTopicMetadata(
-                TransactionConfig.DefaultTransactionMetadataTopicName).partitions);
+//
+//        TenantInfoImpl tenantInfo =
+//                new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test"));
+//        if (!admin.tenants().getTenants().contains("public")) {
+//            admin.tenants().createTenant("public", tenantInfo);
+//        } else {
+//            admin.tenants().updateTenant("public", tenantInfo);
+//        }
+//        if (!admin.namespaces().getNamespaces("public").contains("public/default")) {
+//            admin.namespaces().createNamespace("public/default");
+//            admin.namespaces().setNamespaceReplicationClusters("public/default", Sets.newHashSet("test"));
+//            admin.namespaces().setRetention("public/default",
+//                    new RetentionPolicies(60, 1000));
+//        }
+//        if (!admin.namespaces().getNamespaces("public").contains("public/__kafka")) {
+//            admin.namespaces().createNamespace("public/__kafka");
+//            admin.namespaces().setNamespaceReplicationClusters("public/__kafka", Sets.newHashSet("test"));
+//            admin.namespaces().setRetention("public/__kafka",
+//                    new RetentionPolicies(20, 100));
+//        }
+//        log.info("txn topic partition {}", admin.topics().getPartitionedTopicMetadata(
+//                TransactionConfig.DefaultTransactionMetadataTopicName).partitions);
     }
 
     @AfterClass
@@ -95,86 +144,203 @@ public class TransactionStateManagerTest extends KopProtocolHandlerTestBase {
         internalCleanup();
     }
 
+    @BeforeMethod
+    protected void setUp() {
+        systemTopicClient = new SystemTopicClient(pulsar, conf);
+        scheduler = OrderedScheduler.newSchedulerBuilder()
+                .name("test-txn-coordinator-scheduler")
+                .numThreads(1)
+                .build();
+        transactionManager =
+                spy(new TransactionStateManager(txnConfig, systemTopicClient, scheduler, time));
+        transactionManager.startup(false);
+        // make sure the transactional id hashes to the assigning partition id
+        assertEquals(partitionId, transactionManager.partitionFor(transactionalId1));
+        assertEquals(partitionId, transactionManager.partitionFor(transactionalId2));
+    }
+
+    @AfterMethod
+    protected void tearDown() {
+        transactionManager.shutdown();
+        systemTopicClient.close();
+        scheduler.shutdown();
+    }
+
+
+//    @Test(timeOut = 1000 * 10)
+//    public void txnLogStoreAndTCImmigrationTest() throws Exception {
+//        Map<String, Long> pidMappings = Maps.newHashMap();
+//        pidMappings.put("zero", 0L);
+//        pidMappings.put("one", 1L);
+//        pidMappings.put("two", 2L);
+//        pidMappings.put("three", 3L);
+//        pidMappings.put("four", 4L);
+//        pidMappings.put("five", 5L);
+//
+//        Map<Long, TransactionState> transactionStates = Maps.newHashMap();
+//        transactionStates.put(0L, TransactionState.EMPTY);
+//        transactionStates.put(1L, TransactionState.ONGOING);
+//        transactionStates.put(2L, TransactionState.PREPARE_COMMIT);
+//        transactionStates.put(3L, TransactionState.COMPLETE_COMMIT);
+//        transactionStates.put(4L, TransactionState.PREPARE_ABORT);
+//        transactionStates.put(5L, TransactionState.COMPLETE_ABORT);
+//
+//        // Make sure transaction state log already loaded.
+//        this.loadTxnImmigration();
+//        TransactionStateManager transactionStateManager = getTxnManager();
+//
+//        CountDownLatch countDownLatch = new CountDownLatch(pidMappings.size());
+//        pidMappings.forEach((transactionalId, producerId) -> {
+//            TransactionMetadata.TransactionMetadataBuilder txnMetadataBuilder = TransactionMetadata.builder()
+//                    .transactionalId(transactionalId)
+//                    .producerId(producerId)
+//                    .lastProducerId(RecordBatch.NO_PRODUCER_ID)
+//                    .producerEpoch(producerEpoch)
+//                    .lastProducerEpoch(RecordBatch.NO_PRODUCER_EPOCH)
+//                    .txnTimeoutMs(transactionTimeoutMs)
+//                    .state(transactionStates.get(producerId))
+//                    .pendingState(Optional.of(transactionStates.get(producerId)))
+//                    .topicPartitions(Sets.newHashSet())
+//                    .txnStartTimestamp(transactionStates.get(producerId) == TransactionState.EMPTY
+//                            ? -1 : System.currentTimeMillis());
+//
+//            if (transactionStates.get(producerId).equals(TransactionState.COMPLETE_ABORT)
+//                    || transactionStates.get(producerId).equals(TransactionState.COMPLETE_COMMIT)) {
+//                txnMetadataBuilder.txnStartTimestamp(0);
+//            }
+//            TransactionMetadata txnMetadata = txnMetadataBuilder.build();
+//
+//            transactionStateManager.putTransactionStateIfNotExists(txnMetadata);
+//            transactionStateManager.appendTransactionToLog(transactionalId, -1, txnMetadata.prepareNoTransit(),
+//                    new TransactionStateManager.ResponseCallback() {
+//                        @Override
+//                        public void complete() {
+//                            log.info("Success append transaction log.");
+//                            countDownLatch.countDown();
+//                        }
+//
+//                        @Override
+//                        public void fail(Errors errors) {
+//                            log.error("Failed append transaction log.", errors.exception());
+//                            countDownLatch.countDown();
+//                            Assert.fail("Failed append transaction log.");
+//                        }
+//                    }, errors -> false);
+//        });
+//        countDownLatch.await();
+//
+//        Map<Integer, Map<String, TransactionMetadata>> txnMetadataCache =
+//                transactionStateManager.transactionMetadataCache;
+//        // retain the transaction metadata cache
+//        Map<Integer, Map<String, TransactionMetadata>> beforeTxnMetadataCache = new HashMap<>(txnMetadataCache);
+//
+//        BundlesData bundles = pulsar.getAdminClient().namespaces().getBundles(
+//                conf.getKafkaTenant() + "/" + conf.getKafkaNamespace());
+//        List<String> boundaries = bundles.getBoundaries();
+//        for (int i = 0; i < boundaries.size() - 1; i++) {
+//            String bundle = String.format("%s_%s", boundaries.get(i), boundaries.get(i + 1));
+//            pulsar.getAdminClient().namespaces()
+//                    .unloadNamespaceBundle(conf.getKafkaTenant() + "/" + conf.getKafkaNamespace(), bundle);
+//        }
+//
+//        waitTCImmigrationComplete();
+//
+//        // verify the loaded transaction metadata
+//        verifyImmigration(transactionStateManager, beforeTxnMetadataCache);
+//    }
+
     @Test(timeOut = 1000 * 10)
-    public void txnLogStoreAndTCImmigrationTest() throws Exception {
-        Map<String, Long> pidMappings = Maps.newHashMap();
-        pidMappings.put("zero", 0L);
-        pidMappings.put("one", 1L);
-        pidMappings.put("two", 2L);
-        pidMappings.put("three", 3L);
-        pidMappings.put("four", 4L);
-        pidMappings.put("five", 5L);
+    public void shouldRemoveCompleteCommitExpiredTransactionalIds() {
+        setupAndRunTransactionalIdExpiration(Errors.NONE, TransactionState.COMPLETE_COMMIT);
+        verifyMetadataDoesntExist(transactionalId1);
+        verifyMetadataDoesExistAndIsUsable(transactionalId2);
+    }
 
-        Map<Long, TransactionState> transactionStates = Maps.newHashMap();
-        transactionStates.put(0L, TransactionState.EMPTY);
-        transactionStates.put(1L, TransactionState.ONGOING);
-        transactionStates.put(2L, TransactionState.PREPARE_COMMIT);
-        transactionStates.put(3L, TransactionState.COMPLETE_COMMIT);
-        transactionStates.put(4L, TransactionState.PREPARE_ABORT);
-        transactionStates.put(5L, TransactionState.COMPLETE_ABORT);
-
-        // Make sure transaction state log already loaded.
-        this.loadTxnImmigration();
-        TransactionStateManager transactionStateManager = getTxnManager();
-
-        CountDownLatch countDownLatch = new CountDownLatch(pidMappings.size());
-        pidMappings.forEach((transactionalId, producerId) -> {
-            TransactionMetadata.TransactionMetadataBuilder txnMetadataBuilder = TransactionMetadata.builder()
-                    .transactionalId(transactionalId)
-                    .producerId(producerId)
-                    .lastProducerId(RecordBatch.NO_PRODUCER_ID)
-                    .producerEpoch(producerEpoch)
-                    .lastProducerEpoch(RecordBatch.NO_PRODUCER_EPOCH)
-                    .txnTimeoutMs(transactionTimeoutMs)
-                    .state(transactionStates.get(producerId))
-                    .pendingState(Optional.of(transactionStates.get(producerId)))
-                    .topicPartitions(Sets.newHashSet())
-                    .txnStartTimestamp(transactionStates.get(producerId) == TransactionState.EMPTY
-                            ? -1 : System.currentTimeMillis());
-
-            if (transactionStates.get(producerId).equals(TransactionState.COMPLETE_ABORT)
-                    || transactionStates.get(producerId).equals(TransactionState.COMPLETE_COMMIT)) {
-                txnMetadataBuilder.txnStartTimestamp(0);
-            }
-            TransactionMetadata txnMetadata = txnMetadataBuilder.build();
-
-            transactionStateManager.putTransactionStateIfNotExists(txnMetadata);
-            transactionStateManager.appendTransactionToLog(transactionalId, -1, txnMetadata.prepareNoTransit(),
-                    new TransactionStateManager.ResponseCallback() {
-                        @Override
-                        public void complete() {
-                            log.info("Success append transaction log.");
-                            countDownLatch.countDown();
-                        }
-
-                        @Override
-                        public void fail(Errors errors) {
-                            log.error("Failed append transaction log.", errors.exception());
-                            countDownLatch.countDown();
-                            Assert.fail("Failed append transaction log.");
-                        }
-                    }, errors -> false);
-        });
-        countDownLatch.await();
-
-        Map<Integer, Map<String, TransactionMetadata>> txnMetadataCache =
-                transactionStateManager.transactionMetadataCache;
-        // retain the transaction metadata cache
-        Map<Integer, Map<String, TransactionMetadata>> beforeTxnMetadataCache = new HashMap<>(txnMetadataCache);
-
-        BundlesData bundles = pulsar.getAdminClient().namespaces().getBundles(
-                conf.getKafkaTenant() + "/" + conf.getKafkaNamespace());
-        List<String> boundaries = bundles.getBoundaries();
-        for (int i = 0; i < boundaries.size() - 1; i++) {
-            String bundle = String.format("%s_%s", boundaries.get(i), boundaries.get(i + 1));
-            pulsar.getAdminClient().namespaces()
-                    .unloadNamespaceBundle(conf.getKafkaTenant() + "/" + conf.getKafkaNamespace(), bundle);
+    private void verifyMetadataDoesntExist(String transactionalId) {
+        ErrorsAndData<Optional<TransactionStateManager.CoordinatorEpochAndTxnMetadata>> transactionState =
+                transactionManager.getTransactionState(transactionalId);
+        if (transactionState.hasErrors()) {
+            fail("shouldn't have been any errors");
+            return;
         }
+        if (transactionState.getData().isPresent()) {
+            fail("metadata should have been removed");
+        }
+    }
 
-        waitTCImmigrationComplete();
+    private void verifyMetadataDoesExistAndIsUsable(String transactionalId) {
+        ErrorsAndData<Optional<TransactionStateManager.CoordinatorEpochAndTxnMetadata>> transactionState =
+                transactionManager.getTransactionState(transactionalId);
+        if (transactionState.hasErrors()) {
+            fail("shouldn't have been any errors");
+            return;
+        }
+        if (!transactionState.getData().isPresent()) {
+            fail("metadata should have been removed");
+            return;
+        }
+        TransactionStateManager.CoordinatorEpochAndTxnMetadata metadata = transactionState.getData().get();
 
-        // verify the loaded transaction metadata
-        verifyImmigration(transactionStateManager, beforeTxnMetadataCache);
+        assertFalse("metadata shouldn't be in a pending state", metadata.getTransactionMetadata().getPendingState().isPresent());
+    }
+
+    private void setupAndRunTransactionalIdExpiration(Errors error, TransactionState txnState) {
+        loadTransactionsForPartitions(0, numPartitions);
+        txnMetadata1.setTxnLastUpdateTimestamp(time.milliseconds() - txnConfig.getTransactionalIdExpirationMs());
+        txnMetadata1.setState(txnState);
+        transactionManager.putTransactionStateIfNotExists(txnMetadata1);
+
+        txnMetadata2.setTxnLastUpdateTimestamp(time.milliseconds());
+        transactionManager.putTransactionStateIfNotExists(txnMetadata2);
+
+        Map<Integer, List<MemoryRecords>> appendedRecords = Maps.newHashMap();
+        expectTransactionalIdExpiration(error, appendedRecords);
+
+        transactionManager.removeExpiredTransactionalIds();
+
+        boolean stateAllowsExpiration = txnState.isExpirationAllowed();
+        if (stateAllowsExpiration) {
+            int partitionId = transactionManager.partitionFor(transactionalId1);
+            SimpleRecord expectedTombstone =
+                    new SimpleRecord(time.milliseconds(),
+                            new TransactionLogKey(transactionalId1).toBytes(), null);
+            MemoryRecords expectedRecords =
+                    MemoryRecords.withRecords(txnConfig.getTransactionMetadataTopicCompressionType(),
+                            expectedTombstone);
+            assertTrue(appendedRecords.containsKey(partitionId));
+            assertEquals(Lists.newArrayList(expectedRecords), appendedRecords.get(partitionId));
+
+        } else {
+            assertTrue(appendedRecords.isEmpty());
+        }
+    }
+
+    private void expectTransactionalIdExpiration(Errors appendError,
+                                                 Map<Integer, List<MemoryRecords>> capturedAppends){
+        ArgumentCaptor<Integer> partitionCapture = ArgumentCaptor.forClass(Integer.class);
+
+        ArgumentCaptor<MemoryRecords> recordsCapture = ArgumentCaptor.forClass(MemoryRecords.class);
+
+        doAnswer(__ -> {
+            Integer partition = partitionCapture.getValue();
+            MemoryRecords memoryRecords = recordsCapture.getValue();
+            List<MemoryRecords> batches = capturedAppends.getOrDefault(partition, Lists.newArrayList());
+            batches.add(memoryRecords);
+            capturedAppends.put(partition, batches);
+            if (appendError == Errors.NONE) {
+                return CompletableFuture.completedFuture(null);
+            }
+            CompletableFuture<MessageId> completableFuture = new CompletableFuture<>();
+            completableFuture.completeExceptionally(appendError.exception());
+            return completableFuture;
+        }).when(transactionManager)
+                .appendTombstoneRecords(partitionCapture.capture(), recordsCapture.capture());
+    }
+
+    private void loadTransactionsForPartitions(int startPartitionNum, int endPartitionNum) {
+        for (int partitionId = startPartitionNum; partitionId < endPartitionNum; partitionId++) {
+            transactionManager.addLoadedTransactionsToCache(partitionId, Maps.newConcurrentMap());
+        }
     }
 
     private void verifyImmigration(TransactionStateManager transactionStateManager,
@@ -244,15 +410,15 @@ public class TransactionStateManagerTest extends KopProtocolHandlerTestBase {
         return getTxnCoordinator().getTxnManager();
     }
 
-    private void loadTxnImmigration() {
-        List<CompletableFuture<Void>> allFuture = Lists.newArrayList();
-        for (int i = 0; i < txnLogTopicNumPartitions; i++) {
-            allFuture.add(transactionCoordinator.handleTxnImmigration(i));
-        }
-        try {
-            FutureUtil.waitForAll(allFuture).get();
-        } catch (InterruptedException | ExecutionException e) {
-            log.error("Load txn immigration failed.", e);
-        }
-    }
+//    private void loadTxnImmigration() {
+//        List<CompletableFuture<Void>> allFuture = Lists.newArrayList();
+//        for (int i = 0; i < txnLogTopicNumPartitions; i++) {
+//            allFuture.add(transactionCoordinator.handleTxnImmigration(i));
+//        }
+//        try {
+//            FutureUtil.waitForAll(allFuture).get();
+//        } catch (InterruptedException | ExecutionException e) {
+//            log.error("Load txn immigration failed.", e);
+//        }
+//    }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManagerTest.java
@@ -13,48 +13,30 @@
  */
 package io.streamnative.pulsar.handlers.kop.coordinator.transaction;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
-import static org.testng.AssertJUnit.assertNull;
 import static org.testng.AssertJUnit.assertTrue;
 import static org.testng.AssertJUnit.fail;
 
 import com.google.common.collect.Lists;
-import io.streamnative.pulsar.handlers.kop.KafkaProtocolHandler;
 import io.streamnative.pulsar.handlers.kop.KopProtocolHandlerTestBase;
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-
 import io.streamnative.pulsar.handlers.kop.SystemTopicClient;
 import io.streamnative.pulsar.handlers.kop.utils.timer.MockTime;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.MemoryRecords;
-import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.SimpleRecord;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.MessageId;
-import org.apache.pulsar.common.policies.data.BundlesData;
-import org.apache.pulsar.common.policies.data.RetentionPolicies;
-import org.apache.pulsar.common.policies.data.TenantInfoImpl;
-import org.apache.pulsar.common.util.FutureUtil;
-import org.awaitility.Awaitility;
 import org.mockito.ArgumentCaptor;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
@@ -63,7 +45,7 @@ import org.testng.annotations.Test;
 import org.testng.collections.Maps;
 
 /**
- * Transaction state manager test.
+ * Unit test {@link TransactionStateManager}.
  */
 @Slf4j
 public class TransactionStateManagerTest extends KopProtocolHandlerTestBase {
@@ -83,6 +65,7 @@ public class TransactionStateManagerTest extends KopProtocolHandlerTestBase {
         put(transactionalId1, 1L);
         put(transactionalId2, 2L);
     }};
+    protected final long defaultTestTimeout = 20000;
     private static final TransactionMetadata txnMetadata1 =
             transactionMetadata(transactionalId1, producerIds.get(transactionalId1), TransactionState.EMPTY,
                     transactionTimeoutMs);
@@ -103,7 +86,7 @@ public class TransactionStateManagerTest extends KopProtocolHandlerTestBase {
         return TransactionMetadata.builder()
                 .transactionalId(transactionalId)
                 .producerId(producerId)
-                .producerEpoch((short) 0)
+                .producerEpoch(producerEpoch)
                 .txnTimeoutMs(txnTimeout)
                 .state(state)
                 .build();
@@ -114,28 +97,6 @@ public class TransactionStateManagerTest extends KopProtocolHandlerTestBase {
     protected void setup() throws Exception {
         this.conf.setTxnLogTopicNumPartitions(numPartitions);
         internalSetup();
-//
-//        TenantInfoImpl tenantInfo =
-//                new TenantInfoImpl(Sets.newHashSet("appid1", "appid2"), Sets.newHashSet("test"));
-//        if (!admin.tenants().getTenants().contains("public")) {
-//            admin.tenants().createTenant("public", tenantInfo);
-//        } else {
-//            admin.tenants().updateTenant("public", tenantInfo);
-//        }
-//        if (!admin.namespaces().getNamespaces("public").contains("public/default")) {
-//            admin.namespaces().createNamespace("public/default");
-//            admin.namespaces().setNamespaceReplicationClusters("public/default", Sets.newHashSet("test"));
-//            admin.namespaces().setRetention("public/default",
-//                    new RetentionPolicies(60, 1000));
-//        }
-//        if (!admin.namespaces().getNamespaces("public").contains("public/__kafka")) {
-//            admin.namespaces().createNamespace("public/__kafka");
-//            admin.namespaces().setNamespaceReplicationClusters("public/__kafka", Sets.newHashSet("test"));
-//            admin.namespaces().setRetention("public/__kafka",
-//                    new RetentionPolicies(20, 100));
-//        }
-//        log.info("txn topic partition {}", admin.topics().getPartitionedTopicMetadata(
-//                TransactionConfig.DefaultTransactionMetadataTopicName).partitions);
     }
 
     @AfterClass
@@ -160,101 +121,61 @@ public class TransactionStateManagerTest extends KopProtocolHandlerTestBase {
     }
 
     @AfterMethod
-    protected void tearDown() {
+    protected void tearDown() throws PulsarAdminException {
         transactionManager.shutdown();
         systemTopicClient.close();
         scheduler.shutdown();
     }
 
-
-//    @Test(timeOut = 1000 * 10)
-//    public void txnLogStoreAndTCImmigrationTest() throws Exception {
-//        Map<String, Long> pidMappings = Maps.newHashMap();
-//        pidMappings.put("zero", 0L);
-//        pidMappings.put("one", 1L);
-//        pidMappings.put("two", 2L);
-//        pidMappings.put("three", 3L);
-//        pidMappings.put("four", 4L);
-//        pidMappings.put("five", 5L);
-//
-//        Map<Long, TransactionState> transactionStates = Maps.newHashMap();
-//        transactionStates.put(0L, TransactionState.EMPTY);
-//        transactionStates.put(1L, TransactionState.ONGOING);
-//        transactionStates.put(2L, TransactionState.PREPARE_COMMIT);
-//        transactionStates.put(3L, TransactionState.COMPLETE_COMMIT);
-//        transactionStates.put(4L, TransactionState.PREPARE_ABORT);
-//        transactionStates.put(5L, TransactionState.COMPLETE_ABORT);
-//
-//        // Make sure transaction state log already loaded.
-//        this.loadTxnImmigration();
-//        TransactionStateManager transactionStateManager = getTxnManager();
-//
-//        CountDownLatch countDownLatch = new CountDownLatch(pidMappings.size());
-//        pidMappings.forEach((transactionalId, producerId) -> {
-//            TransactionMetadata.TransactionMetadataBuilder txnMetadataBuilder = TransactionMetadata.builder()
-//                    .transactionalId(transactionalId)
-//                    .producerId(producerId)
-//                    .lastProducerId(RecordBatch.NO_PRODUCER_ID)
-//                    .producerEpoch(producerEpoch)
-//                    .lastProducerEpoch(RecordBatch.NO_PRODUCER_EPOCH)
-//                    .txnTimeoutMs(transactionTimeoutMs)
-//                    .state(transactionStates.get(producerId))
-//                    .pendingState(Optional.of(transactionStates.get(producerId)))
-//                    .topicPartitions(Sets.newHashSet())
-//                    .txnStartTimestamp(transactionStates.get(producerId) == TransactionState.EMPTY
-//                            ? -1 : System.currentTimeMillis());
-//
-//            if (transactionStates.get(producerId).equals(TransactionState.COMPLETE_ABORT)
-//                    || transactionStates.get(producerId).equals(TransactionState.COMPLETE_COMMIT)) {
-//                txnMetadataBuilder.txnStartTimestamp(0);
-//            }
-//            TransactionMetadata txnMetadata = txnMetadataBuilder.build();
-//
-//            transactionStateManager.putTransactionStateIfNotExists(txnMetadata);
-//            transactionStateManager.appendTransactionToLog(transactionalId, -1, txnMetadata.prepareNoTransit(),
-//                    new TransactionStateManager.ResponseCallback() {
-//                        @Override
-//                        public void complete() {
-//                            log.info("Success append transaction log.");
-//                            countDownLatch.countDown();
-//                        }
-//
-//                        @Override
-//                        public void fail(Errors errors) {
-//                            log.error("Failed append transaction log.", errors.exception());
-//                            countDownLatch.countDown();
-//                            Assert.fail("Failed append transaction log.");
-//                        }
-//                    }, errors -> false);
-//        });
-//        countDownLatch.await();
-//
-//        Map<Integer, Map<String, TransactionMetadata>> txnMetadataCache =
-//                transactionStateManager.transactionMetadataCache;
-//        // retain the transaction metadata cache
-//        Map<Integer, Map<String, TransactionMetadata>> beforeTxnMetadataCache = new HashMap<>(txnMetadataCache);
-//
-//        BundlesData bundles = pulsar.getAdminClient().namespaces().getBundles(
-//                conf.getKafkaTenant() + "/" + conf.getKafkaNamespace());
-//        List<String> boundaries = bundles.getBoundaries();
-//        for (int i = 0; i < boundaries.size() - 1; i++) {
-//            String bundle = String.format("%s_%s", boundaries.get(i), boundaries.get(i + 1));
-//            pulsar.getAdminClient().namespaces()
-//                    .unloadNamespaceBundle(conf.getKafkaTenant() + "/" + conf.getKafkaNamespace(), bundle);
-//        }
-//
-//        waitTCImmigrationComplete();
-//
-//        // verify the loaded transaction metadata
-//        verifyImmigration(transactionStateManager, beforeTxnMetadataCache);
-//    }
-
-    @Test(timeOut = 1000 * 10)
+    @Test(timeOut = defaultTestTimeout)
     public void shouldRemoveCompleteCommitExpiredTransactionalIds() {
         setupAndRunTransactionalIdExpiration(Errors.NONE, TransactionState.COMPLETE_COMMIT);
         verifyMetadataDoesntExist(transactionalId1);
         verifyMetadataDoesExistAndIsUsable(transactionalId2);
     }
+
+    @Test(timeOut = defaultTestTimeout)
+    public void shouldRemoveCompleteAbortExpiredTransactionalIds() {
+        setupAndRunTransactionalIdExpiration(Errors.NONE, TransactionState.COMPLETE_ABORT);
+        verifyMetadataDoesntExist(transactionalId1);
+        verifyMetadataDoesExistAndIsUsable(transactionalId2);
+    }
+
+    @Test(timeOut = defaultTestTimeout)
+    public void shouldRemoveEmptyExpiredTransactionalIds() {
+        setupAndRunTransactionalIdExpiration(Errors.NONE, TransactionState.EMPTY);
+        verifyMetadataDoesntExist(transactionalId1);
+        verifyMetadataDoesExistAndIsUsable(transactionalId2);
+    }
+
+    @Test(timeOut = defaultTestTimeout)
+    public void shouldNotRemoveExpiredTransactionalIdsIfLogAppendFails() {
+        setupAndRunTransactionalIdExpiration(Errors.NOT_ENOUGH_REPLICAS, TransactionState.COMPLETE_ABORT);
+        verifyMetadataDoesExistAndIsUsable(transactionalId1);
+        verifyMetadataDoesExistAndIsUsable(transactionalId2);
+    }
+
+    @Test(timeOut = defaultTestTimeout)
+    public void shouldNotRemoveOngoingTransactionalIds() {
+        setupAndRunTransactionalIdExpiration(Errors.NONE, TransactionState.ONGOING);
+        verifyMetadataDoesExistAndIsUsable(transactionalId1);
+        verifyMetadataDoesExistAndIsUsable(transactionalId2);
+    }
+
+    @Test(timeOut = defaultTestTimeout)
+    public void shouldNotRemovePrepareAbortTransactionalIds() {
+        setupAndRunTransactionalIdExpiration(Errors.NONE, TransactionState.PREPARE_ABORT);
+        verifyMetadataDoesExistAndIsUsable(transactionalId1);
+        verifyMetadataDoesExistAndIsUsable(transactionalId2);
+    }
+
+    @Test(timeOut = defaultTestTimeout)
+    public void shouldNotRemovePrepareCommitTransactionalIds() {
+        setupAndRunTransactionalIdExpiration(Errors.NONE, TransactionState.PREPARE_COMMIT);
+        verifyMetadataDoesExistAndIsUsable(transactionalId1);
+        verifyMetadataDoesExistAndIsUsable(transactionalId2);
+    }
+
 
     private void verifyMetadataDoesntExist(String transactionalId) {
         ErrorsAndData<Optional<TransactionStateManager.CoordinatorEpochAndTxnMetadata>> transactionState =
@@ -281,7 +202,8 @@ public class TransactionStateManagerTest extends KopProtocolHandlerTestBase {
         }
         TransactionStateManager.CoordinatorEpochAndTxnMetadata metadata = transactionState.getData().get();
 
-        assertFalse("metadata shouldn't be in a pending state", metadata.getTransactionMetadata().getPendingState().isPresent());
+        assertFalse("metadata shouldn't be in a pending state",
+                metadata.getTransactionMetadata().getPendingState().isPresent());
     }
 
     private void setupAndRunTransactionalIdExpiration(Errors error, TransactionState txnState) {
@@ -342,83 +264,4 @@ public class TransactionStateManagerTest extends KopProtocolHandlerTestBase {
             transactionManager.addLoadedTransactionsToCache(partitionId, Maps.newConcurrentMap());
         }
     }
-
-    private void verifyImmigration(TransactionStateManager transactionStateManager,
-                                   Map<Integer, Map<String, TransactionMetadata>> beforeTxnMetadataCache) {
-        Map<Integer, Map<String, TransactionMetadata>> loadedTxnMetadataCache =
-                transactionStateManager.transactionMetadataCache;
-
-        for (int i = 0; i < conf.getTxnLogTopicNumPartitions(); i++) {
-            Map<String, TransactionMetadata> txnMetadataMap = beforeTxnMetadataCache.get(i);
-            Map<String, TransactionMetadata> loadedTxnMetadataMap = loadedTxnMetadataCache.get(i);
-            if (txnMetadataMap == null) {
-                assertNull(loadedTxnMetadataMap);
-                continue;
-            }
-            assertEquals(txnMetadataMap.size(), loadedTxnMetadataMap.size());
-            txnMetadataMap.forEach((txnId, txnMetadata) -> {
-                TransactionMetadata loadedTxnMetadata = loadedTxnMetadataMap.get(txnId);
-                assertEquals(txnMetadata.getTransactionalId(), loadedTxnMetadata.getTransactionalId());
-                assertEquals(txnMetadata.getProducerId(), loadedTxnMetadata.getProducerId());
-                assertEquals(txnMetadata.getLastProducerId(), loadedTxnMetadata.getLastProducerId());
-                assertEquals(txnMetadata.getProducerEpoch(), loadedTxnMetadata.getProducerEpoch());
-                assertEquals(txnMetadata.getLastProducerEpoch(), loadedTxnMetadata.getLastProducerEpoch());
-                assertEquals(txnMetadata.getTxnTimeoutMs(), loadedTxnMetadata.getTxnTimeoutMs());
-                assertEquals(txnMetadata.getTopicPartitions(), loadedTxnMetadata.getTopicPartitions());
-                assertEquals(txnMetadata.getTxnStartTimestamp(), loadedTxnMetadata.getTxnStartTimestamp());
-                if (txnMetadata.getState().equals(TransactionState.PREPARE_ABORT)) {
-                    // to prepare state will complete
-                    waitTxnComplete(loadedTxnMetadata, TransactionState.COMPLETE_ABORT);
-                } else if (txnMetadata.getState().equals(TransactionState.PREPARE_COMMIT)) {
-                    // to prepare state will complete
-                    waitTxnComplete(loadedTxnMetadata, TransactionState.COMPLETE_COMMIT);
-                } else {
-                    assertEquals(txnMetadata.getState(), loadedTxnMetadata.getState());
-                    assertEquals(txnMetadata.getTxnLastUpdateTimestamp(),
-                            loadedTxnMetadata.getTxnLastUpdateTimestamp());
-                }
-            });
-        }
-    }
-
-    private void waitTxnComplete(TransactionMetadata loadedTxnMetadata, TransactionState expectedState) {
-        Awaitility.await()
-                .pollDelay(Duration.ofMillis(500))
-                .untilAsserted(() -> assertEquals(loadedTxnMetadata.getState(), expectedState));
-        assertEquals(expectedState, loadedTxnMetadata.getState());
-        assertTrue(loadedTxnMetadata.getTxnLastUpdateTimestamp() > 0);
-    }
-
-    private void waitTCImmigrationComplete() throws PulsarAdminException {
-        admin.lookups().lookupTopic("public/default/__transaction_state-partition-0");
-        TransactionStateManager txnStateManager = getTxnManager();
-        // The lookup request will trigger topic on-load operation,
-        // the TC partition log will recover when the namespace on-load, it's asynchronously,
-        // so wait the TC partition log load complete.
-        assertTrue(txnStateManager.isLoading());
-        Awaitility.await()
-                .pollDelay(Duration.ofMillis(500))
-                .untilAsserted(() -> assertFalse(txnStateManager.isLoading()));
-    }
-
-    private TransactionCoordinator getTxnCoordinator() {
-        return ((KafkaProtocolHandler) this.pulsar.getProtocolHandlers().protocol("kafka"))
-                .getTransactionCoordinator("public");
-    }
-
-    private TransactionStateManager getTxnManager() {
-        return getTxnCoordinator().getTxnManager();
-    }
-
-//    private void loadTxnImmigration() {
-//        List<CompletableFuture<Void>> allFuture = Lists.newArrayList();
-//        for (int i = 0; i < txnLogTopicNumPartitions; i++) {
-//            allFuture.add(transactionCoordinator.handleTxnImmigration(i));
-//        }
-//        try {
-//            FutureUtil.waitForAll(allFuture).get();
-//        } catch (InterruptedException | ExecutionException e) {
-//            log.error("Load txn immigration failed.", e);
-//        }
-//    }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManagerTest.java
@@ -338,7 +338,7 @@ public class TransactionStateManagerTest extends KopProtocolHandlerTestBase {
 
     private TransactionMetadata generateTransactionMetadata(String transactionalId,
                                                             long startTime,
-                                                            long LastUpdateTime) {
+                                                            long lastUpdateTime) {
         return TransactionMetadata.builder()
                 .transactionalId(transactionalId)
                 .producerId(producerId)
@@ -350,7 +350,7 @@ public class TransactionStateManagerTest extends KopProtocolHandlerTestBase {
                 .pendingState(Optional.of(TransactionState.COMPLETE_COMMIT))
                 .topicPartitions(Collections.emptySet())
                 .txnStartTimestamp(startTime)
-                .txnLastUpdateTimestamp(LastUpdateTime)
+                .txnLastUpdateTimestamp(lastUpdateTime)
                 .build();
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManagerTest.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Lists;
 import io.streamnative.pulsar.handlers.kop.KopProtocolHandlerTestBase;
 import io.streamnative.pulsar.handlers.kop.SystemTopicClient;
 import io.streamnative.pulsar.handlers.kop.utils.timer.MockTime;
-
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.List;


### PR DESCRIPTION
### Motivation
#896

### Modifications
1. Support transactional Id expiration
2. Refactor `TransactionStateManagerTest`
3. Remove `txnLogStoreAndTCImmigrationTest`, it will add back in other PR.
4. Use TransactionConfig `TransactionMetadataTopicName` instead of `Topic.TRANSACTION_STATE_TOPIC_NAME`.
