### PR TITLE
Implement dummy ALTER_CONFIGS and DESCRIBE_CONFIGS for Broker - minimal KSQL Server support

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
@@ -202,7 +202,8 @@ class AdminManager {
                                 break;
                             case BROKER:
                                 List<DescribeConfigsResponse.ConfigEntry> dummyConfig = new ArrayList<>();
-                                dummyConfig.add(buildDummyEntryConfig("num.partitions", this.defaultNumPartitions + ""));
+                                dummyConfig.add(buildDummyEntryConfig("num.partitions",
+                                        this.defaultNumPartitions + ""));
                                 // this is useless in KOP, but some tools like KSQL need a value
                                 dummyConfig.add(buildDummyEntryConfig("default.replication.factor", "1"));
                                 dummyConfig.add(buildDummyEntryConfig("delete.topic.enable", "true"));

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -335,6 +335,9 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
                     case DESCRIBE_CONFIGS:
                         handleDescribeConfigs(kafkaHeaderAndRequest, responseFuture);
                         break;
+                    case ALTER_CONFIGS:
+                        handleAlterConfigs(kafkaHeaderAndRequest, responseFuture);
+                        break;
                     case DELETE_TOPICS:
                         handleDeleteTopics(kafkaHeaderAndRequest, responseFuture);
                         break;
@@ -533,6 +536,9 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
 
     protected abstract void
     handleDescribeConfigs(KafkaHeaderAndRequest kafkaHeaderAndRequest, CompletableFuture<AbstractResponse> response);
+
+    protected abstract void
+    handleAlterConfigs(KafkaHeaderAndRequest kafkaHeaderAndRequest, CompletableFuture<AbstractResponse> response);
 
     protected abstract void
     handleInitProducerId(KafkaHeaderAndRequest kafkaHeaderAndRequest, CompletableFuture<AbstractResponse> response);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -2042,6 +2042,9 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                     break;
                 case BROKER:
                     // Current KoP don't support Broker Resource.
+                    // but we are not exposing anything to the client, so it is fine to serve requests.
+                    completeOne.accept(() -> authorizedResources.add(configResource));
+                    break;
                 case UNKNOWN:
                 default:
                     completeOne.accept(() -> log.error("KoP doesn't support resource type: " + configResource.type()));

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -96,7 +96,6 @@ import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.kafka.clients.admin.AlterConfigsOptions;
 import org.apache.kafka.clients.admin.NewPartitions;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
@@ -1958,7 +1957,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         }
 
         Map<ConfigResource, ApiError> results = new HashMap<>();
-        request.configs().forEach( (ConfigResource configResource, AlterConfigsRequest.Config newConfig) -> {
+        request.configs().forEach((ConfigResource configResource, AlterConfigsRequest.Config newConfig) -> {
             newConfig.entries().forEach(entry -> {
                 log.info("Ignoring ALTER_CONFIG for {} {} = {}", configResource, entry.name(), entry.value());
             });

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -595,7 +595,14 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
                 new ConfigResource(ConfigResource.Type.TOPIC, invalidTopic),
                 new Config(Collections.emptyList()))).all().get();
 
+    }
 
+    @Test(timeOut = 10000)
+    public void testDescribeBrokerConfigs() throws Exception {
+        Properties props = new Properties();
+        props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getKafkaBrokerPort());
+        @Cleanup
+        AdminClient kafkaAdmin = AdminClient.create(props);
         Map<ConfigResource, Config> brokerConfigs = kafkaAdmin.describeConfigs(Collections.singletonList(
                 new ConfigResource(ConfigResource.Type.BROKER, ""))).all().get();
         assertEquals(1, brokerConfigs.size());

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -64,6 +64,7 @@ import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConsumerGroupDescription;
 import org.apache.kafka.clients.admin.NewPartitions;
 import org.apache.kafka.clients.admin.NewTopic;
@@ -554,8 +555,8 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
     }
 
     @Test(timeOut = 10000)
-    public void testDescribeConfigs() throws Exception {
-        final String topic = "testDescribeConfigs";
+    public void testDescribeAndAlterConfigs() throws Exception {
+        final String topic = "testDescribeAndAlterConfigs";
         admin.topics().createPartitionedTopic(topic, 1);
 
         Properties props = new Properties();
@@ -588,6 +589,20 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
             assertTrue(e.getCause() instanceof InvalidTopicException);
             assertTrue(e.getMessage().contains("Topic " + invalidTopic + " is non-partitioned"));
         }
+
+        // just call the API, currently we are ignoring any value
+        kafkaAdmin.alterConfigs(Collections.singletonMap(
+                new ConfigResource(ConfigResource.Type.TOPIC, invalidTopic),
+                new Config(Collections.emptyList()))).all().get();
+
+
+        Map<ConfigResource, Config> brokerConfigs = kafkaAdmin.describeConfigs(Collections.singletonList(
+                new ConfigResource(ConfigResource.Type.BROKER, ""))).all().get();
+        assertEquals(1, brokerConfigs.size());
+        Config brokerConfig = brokerConfigs.values().iterator().next();
+        assertEquals(brokerConfig.get("num.partitions").value(), conf.getDefaultNumPartitions() + "");
+        assertEquals(brokerConfig.get("default.replication.factor").value(), "1");
+        assertEquals(brokerConfig.get("delete.topic.enable").value(), "true");
     }
 
     @Test(timeOut = 10000)


### PR DESCRIPTION
**Motivations**
This patch will allow KOP users to use kSQL (https://ksqldb.io/) 

Problems with KOP 2.9.x
- the KSQL Server requires DESCRIBE_CONFIGS to return a couple of configurations
- the KSQL Server tries to override some configurations, that are not under control of KOP, let's ignore such calls

**Modifications**
- Add dummy support for the ALTER_CONFIGS API, ignoring everything
- Add dummy support for DESCRIBE_CONFIGS for the BROKER configuration