### PR TITLE
[Transaction] Migrate transaction coordinator test and fix behavior

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManager.java
@@ -344,6 +344,11 @@ public class TransactionStateManager {
                         log.debug("Appending new metadata {} for transaction id {} to the local transaction log with "
                                 + "messageId {}", newMetadata, transactionalId, messageId);
                     }
+                }).exceptionally(ex -> {
+                    log.error("Store transactional log failed, transactionalId : {}, metadata: [{}].",
+                            transactionalId, newMetadata, ex);
+                    responseCallback.fail(Errors.forException(ex));
+                    return null;
                 });
                 return null;
             });


### PR DESCRIPTION
Master issue: #897

### Motivation

Currently, KoP support transaction but don't have units test to cover transaction coordinator code behavior, for future maintain, we should add units test from  Kafka.

### Modification
* Fix `endTransaction` behavior.
* Add units test to ensure behavior same as Kafka.