### PR TITLE
[Docs] Add Monitor KoP link to main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ KoP-2.8.0.13, 2.8.0.14, 2.8.0.15 and 2.8.0.16 minor versions with Pulsar-2.8.0 h
 You can configure and manage KoP based on your requirements. Check the following guides for more details.
 -   [Quick Start](docs/kop.md)
 -   [Configure KoP](docs/configuration.md)
+-   [Monitor KoP](docs/reference-metrics.md)
 -   [Upgrade](docs/upgrade.md)
 -   [Secure KoP](docs/security.md)
 -   [Manage KoP with the Envoy proxy](docs/envoy-proxy.md)

--- a/docs/kop.md
+++ b/docs/kop.md
@@ -133,16 +133,15 @@ After you have installed the KoP protocol handler to Pulsar broker, you can rest
 
 # How to use KoP
 You can configure and manage KoP based on your requirements. Check the following guides for more details.
-- [Configure KoP](https://github.com/streamnative/kop/blob/branch-{{protocol:version}}/docs/configuration.md)
-- [Secure KoP](https://github.com/streamnative/kop/blob/branch-{{protocol:version}}/docs/security.md)
-- [Manage KoP with the Envoy proxy](https://github.com/streamnative/kop/blob/branch-{{protocol:version}}/docs/envoy-proxy.md)
-- [Implementation: How to converse Pulsar and Kafka](https://github.com/streamnative/kop/blob/branch-{{protocol:version}}/docs/implementation.md)
+-   [Configure KoP](https://github.com/streamnative/kop/blob/branch-{{protocol:version}}/docs/configuration.md)
+-   [Monitor KoP](https://github.com/streamnative/kop/blob/branch-{{protocol:version}}/docs/reference-metrics.md)
+-   [Upgrade](https://github.com/streamnative/kop/blob/branch-{{protocol:version}}/docs/upgrade.md)
+-   [Secure KoP](https://github.com/streamnative/kop/blob/branch-{{protocol:version}}/docs/security.md)
+-   [Manage KoP with the Envoy proxy](https://github.com/streamnative/kop/blob/branch-{{protocol:version}}/docs/envoy-proxy.md)
+-   [Implementation: How to converse Pulsar and Kafka](https://github.com/streamnative/kop/blob/branch-{{protocol:version}}/docs/implementation.md)
 
 The followings are important information when you configure and use KoP.
 
 - Set both [retention and time to live (TTL)](http://pulsar.apache.org/docs/en/cookbooks-retention-expiry/) for KoP topics. If you only configure retention without configuring TTL, all messages of KoP topics cannot be deleted because KoP does not update a durable cursor.
 -  If a Pulsar consumer and a Kafka consumer both subscribe the same topic with the same subscription (or group) name, the two consumers consume messages independently and they do not share the same subscription though the subscription name of a Pulsar client is the same with the group name of a Kafka client.
 - KoP supports interaction between Pulsar client and Kafka client by default. If your topic is used only by the Pulsar client or only by the Kafka client, you can set `entryFormat=kafka` for better performance.
-
-## Upgrade
-If you want to upgrade your KoP version, you must first [upgrade your Pulsar version](https://pulsar.apache.org/docs/en/next/administration-upgrade/) accordingly, and then configure offset management.


### PR DESCRIPTION
### Motivation

https://github.com/streamnative/kop/pull/389 exposed the metrics for KoP and added the docs. However, users cannot click into the metrics docs in the main web page.

### Modifications

Add the link of metrics docs to README.md. In addition, sync docs/kop.md with README.md so that upgrade.md and reference-metrics.md can both be navigated from SN hub. Then remove the **Upgrade** section because it's duplicated with upgrade.md.