### PR TITLE
Add skipMessagesWithoutIndex option to enable skipping old messages

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
@@ -54,6 +54,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
     private final boolean enableTls;
     @Getter
     private final EndPoint advertisedEndPoint;
+    private final boolean skipMessagesWithoutIndex;
     @Getter
     private final SslContextFactory.Server sslContextFactory;
     @Getter
@@ -68,6 +69,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
                                    DelayedOperationPurgatory<DelayedOperation> fetchPurgatory,
                                    boolean enableTLS,
                                    EndPoint advertisedEndPoint,
+                                   boolean skipMessagesWithoutIndex,
                                    StatsLogger statsLogger) {
         super();
         this.pulsarService = pulsarService;
@@ -79,6 +81,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
         this.fetchPurgatory = fetchPurgatory;
         this.enableTls = enableTLS;
         this.advertisedEndPoint = advertisedEndPoint;
+        this.skipMessagesWithoutIndex = skipMessagesWithoutIndex;
         this.statsLogger = statsLogger;
         if (enableTls) {
             sslContextFactory = SSLUtils.createSslContextFactory(kafkaConfig);
@@ -109,7 +112,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
         return new KafkaRequestHandler(pulsarService, kafkaConfig,
                 tenantContextManager, kopBrokerLookupManager, adminManager,
                 producePurgatory, fetchPurgatory,
-                enableTls, advertisedEndPoint, statsLogger);
+                enableTls, advertisedEndPoint, skipMessagesWithoutIndex, statsLogger);
     }
 
     @VisibleForTesting
@@ -118,6 +121,6 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
         return new KafkaRequestHandler(pulsarService, kafkaConfig,
                 tenantContextManager, kopBrokerLookupManager, adminManager,
                 producePurgatory, fetchPurgatory,
-                enableTls, advertisedEndPoint, statsLogger);
+                enableTls, advertisedEndPoint, skipMessagesWithoutIndex, statsLogger);
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -555,6 +555,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 fetchPurgatory,
                 endPoint.isTlsEnabled(),
                 endPoint,
+                kafkaConfig.isSkipMessagesWithoutIndex(),
                 scopeStatsLogger);
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -441,6 +441,14 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
     )
     private String kafkaCompressionType = "none";
 
+    @FieldContext(
+            category = CATEGORY_KOP,
+            doc = "Whether to skip messages without the index (Kafka offset).\n"
+                    + "It should be enabled if KoP is upgraded from version lower than 2.8.0 to 2.8.0 or higher\n"
+                    + "After that, the old messages without index will be skipped."
+    )
+    private boolean skipMessagesWithoutIndex = false;
+
     private String checkAdvertisedListeners(String advertisedListeners) {
         StringBuilder listenersReBuilder = new StringBuilder();
         for (String listener : advertisedListeners.split(EndPoint.END_POINT_SEPARATOR)) {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/UpgradeTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/UpgradeTest.java
@@ -58,6 +58,7 @@ public class UpgradeTest extends KopProtocolHandlerTestBase {
     @BeforeClass(timeOut = 30000L)
     @Override
     protected void setup() throws Exception {
+        conf.setSkipMessagesWithoutIndex(true);
         conf.setBrokerEntryMetadataInterceptors(null);
         enableBrokerEntryMetadata = false;
         internalSetup();


### PR DESCRIPTION
### Motivation

https://github.com/streamnative/kop/pull/907 support skipping old messages without BrokerEntryMetadata (message index).  Even if the client gets the wrong offset from old `__consumer_offsets` topic, when KoP handles FETCH request, it will still skip these messages and fetch messages from offset 0. This behavior should be disabled by default because the KoP upgrade might not be aware by client so that users might find some messages are lost after a long time.

### Modifications
- Add a `skipMessagesWithoutIndex` to configuration. Keep the original behavior in `asyncFindPosition` and `getOffsetOfPosition` if it's false (by default).
- Enable the `skipMessagesWithoutIndex` in `UpgradeTest` to make tests pass.