### PR TITLE
Multi Tenant Aware: Apply current tenant when using short topic name

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
@@ -76,7 +76,9 @@ class AdminManager {
         topicPurgatory.shutdown();
     }
 
-    CompletableFuture<Map<String, ApiError>> createTopicsAsync(Map<String, TopicDetails> createInfo, int timeoutMs) {
+    CompletableFuture<Map<String, ApiError>> createTopicsAsync(Map<String, TopicDetails> createInfo,
+                                                               int timeoutMs,
+                                                               String namespacePrefix) {
         final Map<String, CompletableFuture<ApiError>> futureMap = new ConcurrentHashMap<>();
         final AtomicInteger numTopics = new AtomicInteger(createInfo.size());
         final CompletableFuture<Map<String, ApiError>> resultFuture = new CompletableFuture<>();
@@ -102,7 +104,7 @@ class AdminManager {
 
             KopTopic kopTopic;
             try {
-                kopTopic = new KopTopic(topic);
+                kopTopic = new KopTopic(topic, namespacePrefix);
             } catch (KoPTopicException e) {
                 errorFuture.complete(ApiError.fromThrowable(e));
                 if (numTopics.decrementAndGet() == 0) {
@@ -158,7 +160,7 @@ class AdminManager {
     }
 
     CompletableFuture<Map<ConfigResource, DescribeConfigsResponse.Config>> describeConfigsAsync(
-            Map<ConfigResource, Optional<Set<String>>> resourceToConfigNames) {
+            Map<ConfigResource, Optional<Set<String>>> resourceToConfigNames, String namespacePrefix) {
         // Since Kafka's storage and policies are much different from Pulsar, here we just return a default config to
         // avoid some Kafka based systems need to send DescribeConfigs request, like confluent schema registry.
         final DescribeConfigsResponse.Config defaultTopicConfig = new DescribeConfigsResponse.Config(ApiError.NONE,
@@ -175,7 +177,7 @@ class AdminManager {
                         CompletableFuture<DescribeConfigsResponse.Config> future = new CompletableFuture<>();
                         switch (resource.type()) {
                             case TOPIC:
-                                KopTopic kopTopic = new KopTopic(resource.name());
+                                KopTopic kopTopic = new KopTopic(resource.name(), namespacePrefix);
                                 admin.topics().getPartitionedTopicMetadataAsync(kopTopic.getFullName())
                                         .whenComplete((metadata, e) -> {
                                             if (e != null) {
@@ -279,7 +281,8 @@ class AdminManager {
 
 
     CompletableFuture<Map<String, ApiError>> createPartitionsAsync(Map<String, NewPartitions> createInfo,
-                                                                   int timeoutMs) {
+                                                                   int timeoutMs,
+                                                                   String namespacePrefix) {
         final Map<String, CompletableFuture<ApiError>> futureMap = new ConcurrentHashMap<>();
         final AtomicInteger numTopics = new AtomicInteger(createInfo.size());
         final CompletableFuture<Map<String, ApiError>> resultFuture = new CompletableFuture<>();
@@ -304,7 +307,7 @@ class AdminManager {
             futureMap.put(topic, errorFuture);
 
             try {
-                KopTopic kopTopic = new KopTopic(topic);
+                KopTopic kopTopic = new KopTopic(topic, namespacePrefix);
 
                 int numPartitions = newPartitions.totalCount();
                 if (numPartitions < 0) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -257,6 +257,7 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
             if (!isActive.get()) {
                 handleInactive(kafkaHeaderAndRequest, responseFuture);
             } else {
+                log.info("process {}", kafkaHeaderAndRequest.getHeader().apiKey());
                 switch (kafkaHeaderAndRequest.getHeader().apiKey()) {
                     case API_VERSIONS:
                         handleApiVersionsRequest(kafkaHeaderAndRequest, responseFuture);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -257,7 +257,6 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
             if (!isActive.get()) {
                 handleInactive(kafkaHeaderAndRequest, responseFuture);
             } else {
-                log.info("process {}", kafkaHeaderAndRequest.getHeader().apiKey());
                 switch (kafkaHeaderAndRequest.getHeader().apiKey()) {
                     case API_VERSIONS:
                         handleApiVersionsRequest(kafkaHeaderAndRequest, responseFuture);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -29,7 +29,6 @@ import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCo
 import io.streamnative.pulsar.handlers.kop.stats.PrometheusMetricsProvider;
 import io.streamnative.pulsar.handlers.kop.stats.StatsLogger;
 import io.streamnative.pulsar.handlers.kop.utils.ConfigurationUtils;
-import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
 import io.streamnative.pulsar.handlers.kop.utils.MetadataUtils;
 import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperation;
 import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperationPurgatory;
@@ -386,6 +385,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
 
     @Override
     public void initialize(ServiceConfiguration conf) throws Exception {
+        log.info("init {}", conf, new Exception("init").fillInStackTrace());
         // init config
         if (conf instanceof KafkaServiceConfiguration) {
             // in unit test, passed in conf will be KafkaServiceConfiguration
@@ -399,7 +399,6 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
             kafkaConfig.setAdvertisedAddress(conf.getAdvertisedAddress());
             kafkaConfig.setBindAddress(conf.getBindAddress());
         }
-        KopTopic.initialize(kafkaConfig.getKafkaTenant() + "/" + kafkaConfig.getKafkaNamespace());
 
         // Validate the namespaces
         for (String fullNamespace : kafkaConfig.getKopAllowedNamespaces()) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -250,7 +250,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         return defaultTenant;
     }
 
-    private String currentNamespacePrefix() {
+    public String currentNamespacePrefix() {
         String currentTenant = getCurrentTenant(kafkaConfig.getKafkaTenant());
         return currentTenant + "/" + kafkaConfig.getKafkaNamespace();
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -250,6 +250,11 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         return defaultTenant;
     }
 
+    private String currentNamespacePrefix() {
+        String currentTenant = getCurrentTenant(kafkaConfig.getKafkaTenant());
+        return currentTenant + "/" + kafkaConfig.getKafkaNamespace();
+    }
+
     private static String extractTenantFromTenantSpec(String tenantSpec) {
         if (tenantSpec != null && !tenantSpec.isEmpty()) {
             String tenant = tenantSpec;
@@ -514,7 +519,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         final Map<String, List<TopicName>> topicMap = new ConcurrentHashMap<>();
         final CompletableFuture<Set<String>> allowedNamespacesFuture =
                 expandAllowedNamespaces(kafkaConfig.getKopAllowedNamespaces());
-
+        String namespacePrefix = currentNamespacePrefix();
         allowedNamespacesFuture.thenAccept(allowedNamespaces -> {
             final AtomicInteger pendingNamespacesCount = new AtomicInteger(allowedNamespaces.size());
 
@@ -533,7 +538,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                 final TopicName topicName = TopicName.get(topic);
                                 final String key = topicName.getPartitionedTopicName();
                                 topicMap.computeIfAbsent(
-                                        KopTopic.removeDefaultNamespacePrefix(key),
+                                        KopTopic.removeDefaultNamespacePrefix(key, namespacePrefix),
                                         ignored -> Collections.synchronizedList(new ArrayList<>())
                                 ).add(topicName);
                             }
@@ -625,9 +630,9 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                     pulsarTopicsFuture.complete(pulsarTopics);
                 }
             };
-
+            final String namespacePrefix = currentNamespacePrefix();
             final BiConsumer<String, Integer> addTopicPartition = (topic, partition) -> {
-                final KopTopic kopTopic = new KopTopic(topic);
+                final KopTopic kopTopic = new KopTopic(topic, namespacePrefix);
                 pulsarTopics.putIfAbsent(topic,
                         IntStream.range(0, partition)
                                 .mapToObj(i -> TopicName.get(kopTopic.getPartitionName(i)))
@@ -645,7 +650,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             };
 
             requestTopics.forEach(topic -> {
-                final String fullTopicName = new KopTopic(topic).getFullName();
+                final String fullTopicName = new KopTopic(topic, namespacePrefix).getFullName();
 
                 authorize(AclOperation.DESCRIBE, Resource.of(ResourceType.TOPIC, fullTopicName))
                     .whenComplete((authorized, ex) -> {
@@ -768,7 +773,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 resultFuture.complete(finalResponse);
                 return;
             }
-
+            final String namespacePrefix = currentNamespacePrefix();
             pulsarTopics.forEach((topic, list) -> {
                 final int partitionsNumber = list.size();
                 AtomicInteger partitionsCompleted = new AtomicInteger(0);
@@ -809,7 +814,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                                     // The topic returned to Kafka clients should be
                                                     // the same with what it sent
                                                     topic,
-                                                    isInternalTopic(new KopTopic(topic).getFullName()),
+                                                    isInternalTopic(new KopTopic(topic, namespacePrefix).getFullName()),
                                                     partitionMetadatas));
 
                                     // whether completed all the topics requests.
@@ -910,11 +915,12 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             errorsConsumer.accept(Errors.INVALID_TOPIC_EXCEPTION);
             return;
         }
-        final String partitionName = KopTopic.toString(topicPartition);
+        String namespacePrefix = currentNamespacePrefix();
+        final String partitionName = KopTopic.toString(topicPartition, namespacePrefix);
 
         topicManager.registerProducerInPersistentTopic(partitionName, persistentTopic);
         // collect metrics
-        encodeResult.updateProducerStats(topicPartition, requestStats);
+        encodeResult.updateProducerStats(topicPartition, requestStats, namespacePrefix);
 
         // publish
         final CompletableFuture<Long> offsetFuture = new CompletableFuture<>();
@@ -983,6 +989,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             }
         };
 
+        String namespacePrefix = currentNamespacePrefix();
         produceRequest.partitionRecordsOrFail().forEach((topicPartition, records) -> {
             final Consumer<Long> offsetConsumer = offset -> addPartitionResponse.accept(
                     topicPartition, new PartitionResponse(Errors.NONE, offset, -1L, -1L));
@@ -990,7 +997,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                     errors -> addPartitionResponse.accept(topicPartition, new PartitionResponse(errors));
             final Consumer<Throwable> exceptionConsumer =
                     e -> addPartitionResponse.accept(topicPartition, new PartitionResponse(Errors.forException(e)));
-            final String fullPartitionName = KopTopic.toString(topicPartition);
+            final String fullPartitionName = KopTopic.toString(topicPartition, namespacePrefix);
 
             authorize(AclOperation.WRITE, Resource.of(ResourceType.TOPIC, fullPartitionName))
                     .whenComplete((isAuthorized, ex) -> {
@@ -1180,6 +1187,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     @VisibleForTesting
     public <T> void replaceTopicPartition(Map<TopicPartition, T> replacedMap,
                                           Map<TopicPartition, TopicPartition> replacingIndex) {
+        String namespacePrefix = currentNamespacePrefix();
         Map<TopicPartition, T> newMap = new HashMap<>();
         replacedMap.entrySet().removeIf(entry -> {
             if (replacingIndex.containsKey(entry.getKey())) {
@@ -1187,7 +1195,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 return true;
             } else if (KopTopic.isFullTopicName(entry.getKey().topic())) {
                 newMap.put(new TopicPartition(
-                                KopTopic.removeDefaultNamespacePrefix(entry.getKey().topic()),
+                                KopTopic.removeDefaultNamespacePrefix(entry.getKey().topic(),
+                                        namespacePrefix),
                                 entry.getKey().partition()),
                         entry.getValue());
                 return true;
@@ -1226,9 +1235,10 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                     authorizeFuture.complete(authorizedPartitions);
                 }
             };
+            final String namespacePrefix = currentNamespacePrefix();
             request.partitions().forEach(tp -> {
                 try {
-                    String fullName =  new KopTopic(tp.topic()).getFullName();
+                    String fullName =  new KopTopic(tp.topic(), namespacePrefix).getFullName();
                     authorize(AclOperation.DESCRIBE, Resource.of(ResourceType.TOPIC, fullName))
                             .whenComplete((isAuthorized, ex) -> {
                                 if (ex != null) {
@@ -1433,9 +1443,9 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         ListOffsetRequest request = (ListOffsetRequest) listOffset.getRequest();
         Map<TopicPartition, CompletableFuture<Pair<Errors, Long>>> responseData =
                 Maps.newConcurrentMap();
-
+        String namespacePrefix = currentNamespacePrefix();
         KafkaRequestUtils.forEachListOffsetRequest(request, (topic, times) -> {
-            String fullPartitionName = KopTopic.toString(topic);
+            String fullPartitionName = KopTopic.toString(topic, namespacePrefix);
             authorize(AclOperation.DESCRIBE, Resource.of(ResourceType.TOPIC, fullPartitionName))
                     .whenComplete((isAuthorized, ex) -> {
                                 if (ex != null) {
@@ -1474,8 +1484,9 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         if (log.isDebugEnabled()) {
             log.debug("received a v0 listOffset: {}", request.toString(true));
         }
+        String namespacePrefix = currentNamespacePrefix();
         KafkaRequestUtils.LegacyUtils.forEachListOffsetRequest(request, topic -> times -> maxNumOffsets -> {
-            String fullPartitionName = KopTopic.toString(topic);
+            String fullPartitionName = KopTopic.toString(topic, namespacePrefix);
 
             authorize(AclOperation.DESCRIBE, Resource.of(ResourceType.TOPIC, fullPartitionName))
                     .whenComplete((isAuthorized, ex) -> {
@@ -1672,10 +1683,11 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 }
             }
         };
+        final String namespacePrefix = currentNamespacePrefix();
         request.offsetData().forEach((tp, partitionData) -> {
             KopTopic kopTopic;
             try {
-                kopTopic = new KopTopic(tp.topic());
+                kopTopic = new KopTopic(tp.topic(), namespacePrefix);
             } catch (KoPTopicException e) {
                 log.warn("Invalid topic name: {}", tp.topic(), e);
                 completeOne.accept(() -> nonExistingTopicErrors.put(tp, Errors.UNKNOWN_TOPIC_OR_PARTITION));
@@ -1698,7 +1710,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                         }
                         completeOne.accept(() -> {
                             TopicPartition newTopicPartition = new TopicPartition(
-                                    new KopTopic(tp.topic()).getFullName(), tp.partition());
+                                    new KopTopic(tp.topic(), namespacePrefix).getFullName(), tp.partition());
 
                             convertedOffsetData.put(newTopicPartition, partitionData);
                             replacingIndex.put(newTopicPartition, tp);
@@ -1722,8 +1734,9 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                     topic, data.toString());
             });
         }
-
-        MessageFetchContext.get(this, fetch, resultFuture, fetchPurgatory).handleFetch();
+        String namespacePrefix = currentNamespacePrefix();
+        MessageFetchContext.get(this, fetch, resultFuture,
+                fetchPurgatory, namespacePrefix).handleFetch();
     }
 
     @Override
@@ -1903,6 +1916,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             return;
         }
 
+        String namespacePrefix = currentNamespacePrefix();
         final AtomicInteger validTopicsCount = new AtomicInteger(validTopics.size());
         final Map<String, TopicDetails> authorizedTopics = Maps.newConcurrentMap();
         Runnable createTopicsAsync = () -> {
@@ -1911,7 +1925,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 return;
             }
             // TODO: handle request.validateOnly()
-            adminManager.createTopicsAsync(authorizedTopics, request.timeout()).thenApply(validResult -> {
+            adminManager.createTopicsAsync(authorizedTopics, request.timeout(), namespacePrefix)
+                    .thenApply(validResult -> {
                 result.putAll(validResult);
                 resultFuture.complete(KafkaResponseUtils.newCreateTopics(result));
                 return null;
@@ -1933,7 +1948,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         validTopics.forEach((topic, details) -> {
             KopTopic kopTopic;
             try {
-                kopTopic = new KopTopic(topic);
+                kopTopic = new KopTopic(topic, namespacePrefix);
             } catch (KoPTopicException e) {
                 completeOneErrorTopic.accept(topic, ApiError.fromThrowable(e));
                 return;
@@ -1949,6 +1964,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                            return;
                        }
                        if (!isAuthorized) {
+                           log.error("CreateTopics authorize failed, topic - {}.", fullTopicName);
                            completeOneErrorTopic
                                    .accept(topic, new ApiError(Errors.TOPIC_AUTHORIZATION_FAILED, null));
                            return;
@@ -1997,7 +2013,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 Maps.newConcurrentMap();
         AtomicInteger unfinishedAuthorizationCount = new AtomicInteger(request.resources().size());
 
-
+        String namespacePrefix = currentNamespacePrefix();
         Consumer<Runnable> completeOne = (action) -> {
             // When complete one authorization or failed, will do the action first.
             action.run();
@@ -2006,7 +2022,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                         .collect(Collectors.toMap(
                                 resource -> resource,
                                 resource -> Optional.ofNullable(request.configNames(resource)).map(HashSet::new)
-                        ))
+                        )), namespacePrefix
                 ).thenApply(configResourceConfigMap -> {
                     configResourceConfigMap.putAll(failedConfigResourceMap);
                     resultFuture.complete(new DescribeConfigsResponse(0, configResourceConfigMap));
@@ -2021,7 +2037,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 case TOPIC:
                     KopTopic kopTopic;
                     try {
-                        kopTopic = new KopTopic(configResource.name());
+                        kopTopic = new KopTopic(configResource.name(), namespacePrefix);
                     } catch (KoPTopicException e) {
                         completeOne.accept(() -> {
                             final ApiError error = new ApiError(
@@ -2115,10 +2131,11 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 }
             }
         };
+        String namespacePrefix = currentNamespacePrefix();
         partitionsToAdd.forEach(tp -> {
             String fullPartitionName;
             try {
-                fullPartitionName = KopTopic.toString(tp);
+                fullPartitionName = KopTopic.toString(tp, namespacePrefix);
             } catch (KoPTopicException e) {
                 log.warn("Invalid topic name: {}", tp.topic(), e);
                 completeOne.accept(() -> nonExistingTopicErrors.put(tp, Errors.UNKNOWN_TOPIC_OR_PARTITION));
@@ -2214,10 +2231,11 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 });
             }
         };
+        final String namespacePrefix = currentNamespacePrefix();
         request.offsets().forEach((tp, commitOffset) -> {
             KopTopic kopTopic;
             try {
-                kopTopic = new KopTopic(tp.topic());
+                kopTopic = new KopTopic(tp.topic(), namespacePrefix);
             } catch (KoPTopicException e) {
                 log.warn("Invalid topic name: {}", tp.topic(), e);
                 completeOne.accept(() -> nonExistingTopicErrors.put(tp, Errors.UNKNOWN_TOPIC_OR_PARTITION));
@@ -2281,6 +2299,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         Map<Long, Map<TopicPartition, Errors>> resultMap = new HashMap<>();
         List<CompletableFuture<Void>> resultFutureList = new ArrayList<>();
         TransactionCoordinator transactionCoordinator = getTransactionCoordinator();
+        String namespacePrefix = currentNamespacePrefix();
         for (WriteTxnMarkersRequest.TxnMarkerEntry txnMarkerEntry : request.markers()) {
             Map<TopicPartition, Errors> partitionErrorsMap =
                     resultMap.computeIfAbsent(txnMarkerEntry.producerId(), pid -> new HashMap<>());
@@ -2321,7 +2340,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                             resultFuture.completeExceptionally(handleGroupThrowable);
                             return;
                         }
-                        String fullPartitionName = KopTopic.toString(topicPartition);
+                        String fullPartitionName = KopTopic.toString(topicPartition, namespacePrefix);
                         TopicName topicName = TopicName.get(fullPartitionName);
 
                         long firstOffset = transactionCoordinator.removeActivePidOffset(
@@ -2380,10 +2399,11 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 resultFuture.complete(KafkaResponseUtils.newDeleteTopics(deleteTopicsResponse));
             }
         };
+        final String namespacePrefix = currentNamespacePrefix();
         topicsToDelete.forEach(topic -> {
             KopTopic kopTopic;
             try {
-                kopTopic = new KopTopic(topic);
+                kopTopic = new KopTopic(topic, namespacePrefix);
             } catch (KoPTopicException e) {
                 completeOne.accept(topic, Errors.UNKNOWN_TOPIC_OR_PARTITION);
                 return;
@@ -2428,10 +2448,11 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 resultFuture.complete(KafkaResponseUtils.newDeleteRecords(deleteRecordsResponse));
             }
         };
+        final String namespacePrefix = currentNamespacePrefix();
         partitionOffsets.forEach((topicPartition, offset) -> {
             KopTopic kopTopic;
             try {
-                kopTopic = new KopTopic(topicPartition.topic());
+                kopTopic = new KopTopic(topicPartition.topic(), namespacePrefix);
             } catch (KoPTopicException e) {
                 completeOne.accept(topicPartition, Errors.UNKNOWN_TOPIC_OR_PARTITION);
                 return;
@@ -2491,6 +2512,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             return;
         }
 
+        String namespacePrefix = currentNamespacePrefix();
         final AtomicInteger validTopicsCount = new AtomicInteger(validTopics.size());
         final Map<String, NewPartitions> authorizedTopics = Maps.newConcurrentMap();
         Runnable createPartitionsAsync = () -> {
@@ -2498,7 +2520,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 resultFuture.complete(KafkaResponseUtils.newCreatePartitions(result));
                 return;
             }
-            adminManager.createPartitionsAsync(authorizedTopics, request.timeout()).thenApply(validResult -> {
+            adminManager.createPartitionsAsync(authorizedTopics, request.timeout(), namespacePrefix)
+                    .thenApply(validResult -> {
                 result.putAll(validResult);
                 resultFuture.complete(KafkaResponseUtils.newCreatePartitions(result));
                 return null;
@@ -2519,7 +2542,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         };
         validTopics.forEach((topic, newPartitions) -> {
             try {
-                KopTopic kopTopic = new KopTopic(topic);
+                KopTopic kopTopic = new KopTopic(topic, namespacePrefix);
                 String fullTopicName = kopTopic.getFullName();
                 authorize(AclOperation.ALTER, Resource.of(ResourceType.TOPIC, fullTopicName))
                         .whenComplete((isAuthorized, ex) -> {
@@ -2553,7 +2576,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                 long producerId,
                                 short producerEpoch) {
         CompletableFuture<Long> offsetFuture = new CompletableFuture<>();
-        String fullPartitionName = KopTopic.toString(topicPartition);
+        String namespacePrefix = currentNamespacePrefix();
+        String fullPartitionName = KopTopic.toString(topicPartition, namespacePrefix);
         TopicName topicName = TopicName.get(fullPartitionName);
         topicManager.getTopic(topicName.toString())
                 .whenComplete((persistentTopicOpt, throwable) -> {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManager.java
@@ -301,7 +301,7 @@ public class KopEventManager {
                         HashSet<String> topicsFullNameDeletionsSets = Sets.newHashSet();
                         HashSet<KopTopic> kopTopicsSet = Sets.newHashSet();
                         topicsDeletions.forEach(topic -> {
-                            KopTopic kopTopic = new KopTopic(TopicNameUtils.getTopicNameWithUrlDecoded(topic));
+                            KopTopic kopTopic = new KopTopic(TopicNameUtils.getTopicNameWithUrlDecoded(topic), null);
                             kopTopicsSet.add(kopTopic);
                             topicsFullNameDeletionsSets.add(kopTopic.getFullName());
                         });

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManager.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -306,7 +305,8 @@ public class KopEventManager {
                         HashSet<KopTopic> kopTopicsSet = Sets.newHashSet();
                         String namespacePrefix = MetadataUtils.constructMetadataNamespace(tenant, kafkaConfig);
                         topicsDeletions.forEach(topic -> {
-                            KopTopic kopTopic = new KopTopic(TopicNameUtils.getTopicNameWithUrlDecoded(topic), namespacePrefix);
+                            KopTopic kopTopic = new KopTopic(TopicNameUtils.getTopicNameWithUrlDecoded(topic),
+                                    namespacePrefix);
                             kopTopicsSet.add(kopTopic);
                             topicsFullNameDeletionsSets.add(kopTopic.getFullName());
                         });

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManager.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -346,7 +347,7 @@ public class KopEventManager {
                         });
                     }
                 });
-            } catch (Throwable e) {
+            } catch (ExecutionException | InterruptedException e) {
                 log.error("DeleteTopicsEvent process have an error", e);
             } finally {
                 registerEventLatency.accept(name(), startProcessTime);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManager.java
@@ -23,6 +23,7 @@ import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupCoordinator;
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupMetadata;
 import io.streamnative.pulsar.handlers.kop.stats.StatsLogger;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
+import io.streamnative.pulsar.handlers.kop.utils.MetadataUtils;
 import io.streamnative.pulsar.handlers.kop.utils.ShutdownableThread;
 import io.streamnative.pulsar.handlers.kop.utils.TopicNameUtils;
 import java.nio.charset.StandardCharsets;
@@ -59,6 +60,7 @@ public class KopEventManager {
             new KopEventThread(kopEventThreadName);
     private final Map<String, GroupCoordinator> groupCoordinatorsByTenant;
     private final AdminManager adminManager;
+    private final KafkaServiceConfiguration kafkaConfig;
     private final DeletionTopicsHandler deletionTopicsHandler;
     private final BrokersChangeHandler brokersChangeHandler;
     private final MetadataStore metadataStore;
@@ -74,11 +76,13 @@ public class KopEventManager {
     public KopEventManager(AdminManager adminManager,
                            MetadataStore metadataStore,
                            StatsLogger statsLogger,
+                           KafkaServiceConfiguration kafkaConfig,
                            Map<String, GroupCoordinator> groupCoordinatorsByTenant) {
         this.adminManager = adminManager;
         this.deletionTopicsHandler = new DeletionTopicsHandler(this);
         this.brokersChangeHandler = new BrokersChangeHandler(this);
         this.metadataStore = metadataStore;
+        this.kafkaConfig = kafkaConfig;
         this.eventManagerStats = new KopEventManagerStats(statsLogger, queue);
         this.groupCoordinatorsByTenant = groupCoordinatorsByTenant;
     }
@@ -300,8 +304,9 @@ public class KopEventManager {
                     if (groupCoordinator.isActive()) {
                         HashSet<String> topicsFullNameDeletionsSets = Sets.newHashSet();
                         HashSet<KopTopic> kopTopicsSet = Sets.newHashSet();
+                        String namespacePrefix = MetadataUtils.constructMetadataNamespace(tenant, kafkaConfig);
                         topicsDeletions.forEach(topic -> {
-                            KopTopic kopTopic = new KopTopic(TopicNameUtils.getTopicNameWithUrlDecoded(topic), null);
+                            KopTopic kopTopic = new KopTopic(TopicNameUtils.getTopicNameWithUrlDecoded(topic), namespacePrefix);
                             kopTopicsSet.add(kopTopic);
                             topicsFullNameDeletionsSets.add(kopTopic.getFullName());
                         });
@@ -341,7 +346,7 @@ public class KopEventManager {
                         });
                     }
                 });
-            } catch (ExecutionException | InterruptedException e) {
+            } catch (Throwable e) {
                 log.error("DeleteTopicsEvent process have an error", e);
             } finally {
                 registerEventLatency.accept(name(), startProcessTime);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -165,6 +165,7 @@ public final class MessageFetchContext {
         hasComplete = null;
         bytesReadable = null;
         fetchPurgatory = null;
+        namespacePrefix = null;
         recyclerHandle.recycle(this);
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinator.java
@@ -73,9 +73,11 @@ import org.apache.pulsar.common.util.FutureUtil;
 public class GroupCoordinator {
 
     public static GroupCoordinator of(
+        String tenant,
         SystemTopicClient client,
         GroupConfig groupConfig,
         OffsetConfig offsetConfig,
+        String namespacePrefix,
         Timer timer,
         Time time
     ) {
@@ -85,10 +87,12 @@ public class GroupCoordinator {
                 .build();
 
         GroupMetadataManager metadataManager = new GroupMetadataManager(
+            tenant,
             offsetConfig,
             client.newProducerBuilder(),
             client.newReaderBuilder(),
             coordinatorExecutor,
+            namespacePrefix,
             time
         );
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinator.java
@@ -87,7 +87,6 @@ public class GroupCoordinator {
                 .build();
 
         GroupMetadataManager metadataManager = new GroupMetadataManager(
-            tenant,
             offsetConfig,
             client.newProducerBuilder(),
             client.newReaderBuilder(),

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadata.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadata.java
@@ -662,7 +662,7 @@ public class GroupMetadata {
                             // has chances to be converted when it is missing
                             try {
                                 return offsets.get(new TopicPartition(
-                                        new KopTopic(tp.topic()).getFullName(), tp.partition()));
+                                        new KopTopic(tp.topic(), null).getFullName(), tp.partition()));
                             } catch (KoPTopicException e) {
                                 // In theory, this place will not be executed
                                 log.warn("Invalid topic name: {}", tp.topic(), e);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadata.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadata.java
@@ -652,7 +652,7 @@ public class GroupMetadata {
         ));
     }
 
-    public Optional<OffsetAndMetadata> offset(TopicPartition topicPartition) {
+    public Optional<OffsetAndMetadata> offset(TopicPartition topicPartition, String namespacePrefix) {
         return Optional
                 .ofNullable(offsets.computeIfAbsent(
                         topicPartition,
@@ -662,7 +662,7 @@ public class GroupMetadata {
                             // has chances to be converted when it is missing
                             try {
                                 return offsets.get(new TopicPartition(
-                                        new KopTopic(tp.topic(), null).getFullName(), tp.partition()));
+                                        new KopTopic(tp.topic(), namespacePrefix).getFullName(), tp.partition()));
                             } catch (KoPTopicException e) {
                                 // In theory, this place will not be executed
                                 log.warn("Invalid topic name: {}", tp.topic(), e);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataConstants.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataConstants.java
@@ -228,7 +228,8 @@ public final class GroupMetadataConstants {
         if (topicPartition.partition() >= 0 && !KopTopic.isFullTopicName(topicPartition.topic())) {
             try {
                 topicPartition = new TopicPartition(
-                        new KopTopic(topicPartition.topic(), namespacePrefix).getFullName(), topicPartition.partition());
+                        new KopTopic(topicPartition.topic(), namespacePrefix).getFullName(),
+                        topicPartition.partition());
             } catch (KoPTopicException e) {
                 // In theory, this place will not be executed
                 log.warn("Invalid topic name: {}", topicPartition.topic(), e);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataConstants.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataConstants.java
@@ -213,12 +213,14 @@ public final class GroupMetadataConstants {
      * @return key for offset commit message
      */
     static byte[] offsetCommitKey(String group,
-                                  TopicPartition topicPartition) {
-        return offsetCommitKey(group, topicPartition, (short) 0);
+                                  TopicPartition topicPartition,
+                                  String namespacePrefix) {
+        return offsetCommitKey(group, topicPartition, namespacePrefix, (short) 0);
     }
 
     static byte[] offsetCommitKey(String group,
                                   TopicPartition topicPartition,
+                                  String namespacePrefix,
                                   short versionId) {
         // Some test cases may use the original topic name to commit the offset
         // directly from this method, so we need to ensure that all the topics
@@ -226,7 +228,7 @@ public final class GroupMetadataConstants {
         if (topicPartition.partition() >= 0 && !KopTopic.isFullTopicName(topicPartition.topic())) {
             try {
                 topicPartition = new TopicPartition(
-                        new KopTopic(topicPartition.topic(), null).getFullName(), topicPartition.partition());
+                        new KopTopic(topicPartition.topic(), namespacePrefix).getFullName(), topicPartition.partition());
             } catch (KoPTopicException e) {
                 // In theory, this place will not be executed
                 log.warn("Invalid topic name: {}", topicPartition.topic(), e);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataConstants.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataConstants.java
@@ -226,7 +226,7 @@ public final class GroupMetadataConstants {
         if (topicPartition.partition() >= 0 && !KopTopic.isFullTopicName(topicPartition.topic())) {
             try {
                 topicPartition = new TopicPartition(
-                        new KopTopic(topicPartition.topic()).getFullName(), topicPartition.partition());
+                        new KopTopic(topicPartition.topic(), null).getFullName(), topicPartition.partition());
             } catch (KoPTopicException e) {
                 // In theory, this place will not be executed
                 log.warn("Invalid topic name: {}", topicPartition.topic(), e);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
@@ -167,7 +167,6 @@ public class GroupMetadataManager {
     @Getter
     private final OffsetConfig offsetConfig;
 
-    private final String tenant;
     private final String namespacePrefix;
 
     private final ConcurrentMap<String, GroupMetadata> groupMetadataCache;
@@ -205,15 +204,13 @@ public class GroupMetadataManager {
     private final Time time;
     private final Function<String, Integer> partitioner;
 
-    public GroupMetadataManager(String tenant,
-                                OffsetConfig offsetConfig,
+    public GroupMetadataManager(OffsetConfig offsetConfig,
                                 ProducerBuilder<ByteBuffer> metadataTopicProducerBuilder,
                                 ReaderBuilder<ByteBuffer> metadataTopicReaderBuilder,
                                 ScheduledExecutorService scheduler,
                                 String namespacePrefix,
                                 Time time) {
-        this(tenant,
-            offsetConfig,
+        this(offsetConfig,
             metadataTopicProducerBuilder,
             metadataTopicReaderBuilder,
             scheduler,
@@ -229,15 +226,13 @@ public class GroupMetadataManager {
         return MathUtils.signSafeMod(groupId.hashCode(), offsetsTopicNumPartitions);
     }
 
-    GroupMetadataManager(String tenant,
-                         OffsetConfig offsetConfig,
+    GroupMetadataManager(OffsetConfig offsetConfig,
                          ProducerBuilder<ByteBuffer> metadataTopicProducerBuilder,
                          ReaderBuilder<ByteBuffer> metadataTopicConsumerBuilder,
                          ScheduledExecutorService scheduler,
                          Time time,
                          Function<String, Integer> partitioner,
                          String namespacePrefix) {
-        this.tenant = tenant;
         this.namespacePrefix = namespacePrefix;
         this.offsetConfig = offsetConfig;
         this.compressionType = offsetConfig.offsetsTopicCompressionType();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
@@ -93,6 +93,46 @@ import org.apache.pulsar.common.util.FutureUtil;
 @Slf4j
 public class GroupMetadataManager {
 
+    private final byte magicValue = RecordBatch.CURRENT_MAGIC_VALUE;
+    private final CompressionType compressionType;
+    @Getter
+    private final OffsetConfig offsetConfig;
+    private final String namespacePrefix;
+    private final ConcurrentMap<String, GroupMetadata> groupMetadataCache;
+    /* lock protecting access to loading and owned partition sets */
+    private final ReentrantLock partitionLock = new ReentrantLock();
+    /**
+     * partitions of consumer groups that are being loaded, its lock should
+     * be always called BEFORE the group lock if needed.
+     */
+    private final Set<Integer> loadingPartitions = new HashSet<>();
+    /* partitions of consumer groups that are assigned, using the same loading partition lock */
+    private final Set<Integer> ownedPartitions = new HashSet<>();
+    /* shutting down flag */
+    private final AtomicBoolean shuttingDown = new AtomicBoolean(false);
+    private final int groupMetadataTopicPartitionCount;
+
+    // Map of <PartitionId, Producer>
+    private final ConcurrentMap<Integer, CompletableFuture<Producer<ByteBuffer>>> offsetsProducers =
+            new ConcurrentHashMap<>();
+    private final ConcurrentMap<Integer, CompletableFuture<Reader<ByteBuffer>>> offsetsReaders =
+            new ConcurrentHashMap<>();
+
+    /* single-thread scheduler to handle offset/group metadata cache loading and unloading */
+    private final ScheduledExecutorService scheduler;
+    /**
+     * The groups with open transactional offsets commits per producer. We need this because when the commit or abort
+     * marker comes in for a transaction, it is for a particular partition on the offsets topic and a particular
+     * producerId. We use this structure to quickly find the groups which need to be updated by the commit/abort
+     * marker.
+     */
+    private final Map<Long, Set<String>> openGroupsForProducer = new HashMap<>();
+
+    private final ProducerBuilder<ByteBuffer> metadataTopicProducerBuilder;
+    private final ReaderBuilder<ByteBuffer> metadataTopicReaderBuilder;
+    private final Time time;
+    private final Function<String, Integer> partitioner;
+
     /**
      * The key interface.
      */
@@ -161,48 +201,6 @@ public class GroupMetadataManager {
         }
 
     }
-
-    private final byte magicValue = RecordBatch.CURRENT_MAGIC_VALUE;
-    private final CompressionType compressionType;
-    @Getter
-    private final OffsetConfig offsetConfig;
-
-    private final String namespacePrefix;
-
-    private final ConcurrentMap<String, GroupMetadata> groupMetadataCache;
-    /* lock protecting access to loading and owned partition sets */
-    private final ReentrantLock partitionLock = new ReentrantLock();
-    /**
-     * partitions of consumer groups that are being loaded, its lock should
-     * be always called BEFORE the group lock if needed.
-     */
-    private final Set<Integer> loadingPartitions = new HashSet<>();
-    /* partitions of consumer groups that are assigned, using the same loading partition lock */
-    private final Set<Integer> ownedPartitions = new HashSet<>();
-    /* shutting down flag */
-    private final AtomicBoolean shuttingDown = new AtomicBoolean(false);
-    private final int groupMetadataTopicPartitionCount;
-
-    // Map of <PartitionId, Producer>
-    private final ConcurrentMap<Integer, CompletableFuture<Producer<ByteBuffer>>> offsetsProducers =
-        new ConcurrentHashMap<>();
-    private final ConcurrentMap<Integer, CompletableFuture<Reader<ByteBuffer>>> offsetsReaders =
-        new ConcurrentHashMap<>();
-
-    /* single-thread scheduler to handle offset/group metadata cache loading and unloading */
-    private final ScheduledExecutorService scheduler;
-    /**
-     * The groups with open transactional offsets commits per producer. We need this because when the commit or abort
-     * marker comes in for a transaction, it is for a particular partition on the offsets topic and a particular
-     * producerId. We use this structure to quickly find the groups which need to be updated by the commit/abort
-     * marker.
-     */
-    private final Map<Long, Set<String>> openGroupsForProducer = new HashMap<>();
-
-    private final ProducerBuilder<ByteBuffer> metadataTopicProducerBuilder;
-    private final ReaderBuilder<ByteBuffer> metadataTopicReaderBuilder;
-    private final Time time;
-    private final Function<String, Integer> partitioner;
 
     public GroupMetadataManager(OffsetConfig offsetConfig,
                                 ProducerBuilder<ByteBuffer> metadataTopicProducerBuilder,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
@@ -222,7 +222,8 @@ public class TransactionMarkerChannelManager {
 
         List<CompletableFuture<Void>> addressFutureList = new ArrayList<>();
         for (TopicPartition topicPartition : topicPartitions) {
-            String pulsarTopic = new KopTopic(topicPartition.topic()).getPartitionName(topicPartition.partition());
+            String pulsarTopic = new KopTopic(topicPartition.topic(), null)
+                    .getPartitionName(topicPartition.partition());
             CompletableFuture<Optional<InetSocketAddress>> addressFuture =
                     kopBrokerLookupManager.findBroker(pulsarTopic, sslEndPoint);
             CompletableFuture<Void> addFuture = new CompletableFuture<>();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerRequestCompletionHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerRequestCompletionHandler.java
@@ -37,6 +37,7 @@ public class TransactionMarkerRequestCompletionHandler {
     private TransactionStateManager txnStateManager;
     private TransactionMarkerChannelManager txnMarkerChannelManager;
     private List<TransactionMarkerChannelManager.TxnIdAndMarkerEntry> txnIdAndMarkerEntries;
+    private final String namespacePrefix;
 
     private static class AbortSendingRetryPartitions {
         private AtomicBoolean abortSending = new AtomicBoolean(false);
@@ -108,7 +109,8 @@ public class TransactionMarkerRequestCompletionHandler {
                     txnMarker.producerEpoch(),
                     txnMarker.transactionResult(),
                     txnMarker.coordinatorEpoch(),
-                    abortSendOrRetryPartitions.retryPartitions);
+                    abortSendOrRetryPartitions.retryPartitions,
+                    namespacePrefix);
         }
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/EncodeResult.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/EncodeResult.java
@@ -78,10 +78,12 @@ public class EncodeResult {
     }
 
     public void updateProducerStats(final TopicPartition topicPartition,
-                                    final RequestStats requestStats) {
+                                    final RequestStats requestStats,
+                                    final String namespacePrefix) {
         final int numBytes = encodedByteBuf.readableBytes();
 
-        final Producer producer = KafkaTopicManager.getReferenceProducer(KopTopic.toString(topicPartition));
+        final Producer producer = KafkaTopicManager
+                .getReferenceProducer(KopTopic.toString(topicPartition, namespacePrefix));
         producer.updateRates(numMessages, numBytes);
         producer.getTopic().incrementPublishCount(numMessages, numBytes);
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KopTopic.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KopTopic.java
@@ -58,9 +58,6 @@ public class KopTopic {
     }
 
     public KopTopic(String topic, String namespacePrefix) {
-        if (namespacePrefix == null) {
-            throw new KoPTopicNotInitializedException("KopTopic is not initialized");
-        }
         originalName = topic;
         fullName = expandToFullName(topic, namespacePrefix);
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KopTopic.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KopTopic.java
@@ -28,22 +28,14 @@ import org.apache.kafka.common.TopicPartition;
 public class KopTopic {
 
     private static final String persistentDomain = "persistent://";
-    private static volatile String namespacePrefix;  // the full namespace prefix, e.g. "public/default"
 
-    public static String removeDefaultNamespacePrefix(String fullTopicName) {
+    public static String removeDefaultNamespacePrefix(String fullTopicName, String namespacePrefix) {
         final String topicPrefix = persistentDomain + namespacePrefix + "/";
         if (fullTopicName.startsWith(topicPrefix)) {
             return fullTopicName.substring(topicPrefix.length());
         } else {
             return fullTopicName;
         }
-    }
-
-    public static void initialize(String namespace) {
-        if (namespace.split("/").length != 2) {
-            throw new KoPTopicIllegalArgumentException("Invalid namespace: " + namespace);
-        }
-        KopTopic.namespacePrefix = namespace;
     }
 
     @Getter
@@ -65,15 +57,15 @@ public class KopTopic {
         }
     }
 
-    public KopTopic(String topic) {
+    public KopTopic(String topic, String namespacePrefix) {
         if (namespacePrefix == null) {
             throw new KoPTopicNotInitializedException("KopTopic is not initialized");
         }
         originalName = topic;
-        fullName = expandToFullName(topic);
+        fullName = expandToFullName(topic, namespacePrefix);
     }
 
-    private String expandToFullName(String topic) {
+    private String expandToFullName(String topic, String namespacePrefix) {
         if (topic.startsWith(persistentDomain)) {
             if (topic.substring(persistentDomain.length()).split("/").length != 3) {
                 throw new KoPTopicIllegalArgumentException("Invalid topic name '" + topic + "', it should be "
@@ -85,7 +77,7 @@ public class KopTopic {
         String[] parts = topic.split("/");
         if (parts.length == 3) {
             return persistentDomain + topic;
-        } else if (parts.length == 1) {
+        } else if (parts.length == 1 && namespacePrefix != null) {
             return persistentDomain + namespacePrefix + "/" + topic;
         } else {
             throw new KoPTopicIllegalArgumentException(
@@ -106,7 +98,12 @@ public class KopTopic {
         return topic.startsWith(persistentDomain);
     }
 
-    public static String toString(TopicPartition topicPartition) {
-        return (new KopTopic(topicPartition.topic())).getPartitionName(topicPartition.partition());
+    public static String toString(TopicPartition topicPartition, String namespacePrefix) {
+        return (new KopTopic(topicPartition.topic(), namespacePrefix)).getPartitionName(topicPartition.partition());
     }
+
+    public static String toString(String topic, int partition, String namespacePrefix) {
+        return (new KopTopic(topic, namespacePrefix)).getPartitionName(partition);
+    }
+
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
@@ -48,11 +48,16 @@ public class MetadataUtils {
                 + "/" + Topic.TRANSACTION_STATE_TOPIC_NAME;
     }
 
+    public static String constructMetadataNamespace(String tenant, KafkaServiceConfiguration conf) {
+        return tenant + "/" + conf.getKafkaMetadataNamespace();
+    }
+
     public static void createOffsetMetadataIfMissing(String tenant, PulsarAdmin pulsarAdmin,
                                                      ClusterData clusterData,
                                                      KafkaServiceConfiguration conf)
             throws PulsarAdminException {
-        KopTopic kopTopic = new KopTopic(constructOffsetsTopicBaseName(tenant, conf));
+        KopTopic kopTopic = new KopTopic(constructOffsetsTopicBaseName(tenant, conf),
+                constructMetadataNamespace(tenant, conf));
         createKafkaMetadataIfMissing(tenant, pulsarAdmin, clusterData, conf, kopTopic,
                 conf.getOffsetsTopicNumPartitions());
     }
@@ -62,7 +67,8 @@ public class MetadataUtils {
                                                   ClusterData clusterData,
                                                   KafkaServiceConfiguration conf)
             throws PulsarAdminException {
-        KopTopic kopTopic = new KopTopic(constructTxnLogTopicBaseName(tenant, conf));
+        KopTopic kopTopic = new KopTopic(constructTxnLogTopicBaseName(tenant, conf),
+                constructMetadataNamespace(tenant, conf));
         createKafkaMetadataIfMissing(tenant, pulsarAdmin, clusterData, conf, kopTopic,
                 conf.getTxnLogTopicNumPartitions());
     }

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/MessageFetchContextTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/MessageFetchContextTest.java
@@ -50,7 +50,7 @@ public class MessageFetchContextTest {
         fetchData.put(tp1, null);
         fetchData.put(tp2, null);
         resultFuture = new CompletableFuture<>();
-        messageFetchContext = MessageFetchContext.getForTest(fetchRequest, resultFuture);
+        messageFetchContext = MessageFetchContext.getForTest(fetchRequest, "public/default", resultFuture);
     }
 
     private void startThreads() throws Exception {

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/KopTopicTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/KopTopicTest.java
@@ -30,8 +30,9 @@ public class KopTopicTest {
         try {
             topic = new KopTopic("my-topic", null);
             fail();
-        } catch (KopTopic.KoPTopicNotInitializedException e) {
-            assertEquals(e.getMessage(), "KopTopic is not initialized");
+        } catch (KopTopic.KoPTopicIllegalArgumentException e) {
+            assertEquals(e.getMessage(), "Invalid short topic name 'my-topic', "
+                    + "it should be in the format of <tenant>/<namespace>/<topic> or <topic>");
         }
 
         String namespacePrefix = "my-tenant/my-ns";

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/KopTopicTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/KopTopicTest.java
@@ -56,12 +56,6 @@ public class KopTopicTest {
         }
 
         try {
-            topic = new KopTopic("my-topic", null);
-            fail();
-        } catch (KopTopic.KoPTopicIllegalArgumentException e) {
-            assertTrue(e.getMessage().contains("Invalid short topic name"));
-        }
-        try {
             topic = new KopTopic("persistent://my-topic", namespacePrefix);
         } catch (KopTopic.KoPTopicIllegalArgumentException e) {
             assertTrue(e.getMessage().contains("Invalid topic name"));

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/KopTopicTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/KopTopicTest.java
@@ -28,34 +28,41 @@ public class KopTopicTest {
     public void testConstructor() {
         KopTopic topic;
         try {
-            topic = new KopTopic("my-topic");
+            topic = new KopTopic("my-topic", null);
             fail();
         } catch (KopTopic.KoPTopicNotInitializedException e) {
             assertEquals(e.getMessage(), "KopTopic is not initialized");
         }
 
-        KopTopic.initialize("my-tenant/my-ns");
+        String namespacePrefix = "my-tenant/my-ns";
 
-        topic = new KopTopic("my-topic");
+        topic = new KopTopic("my-topic", namespacePrefix);
         assertEquals(topic.getOriginalName(), "my-topic");
         assertEquals(topic.getFullName(), "persistent://my-tenant/my-ns/my-topic");
 
-        topic = new KopTopic("my-tenant-2/my-ns-2/my-topic");
+        topic = new KopTopic("my-tenant-2/my-ns-2/my-topic", namespacePrefix);
         assertEquals(topic.getOriginalName(), "my-tenant-2/my-ns-2/my-topic");
         assertEquals(topic.getFullName(), "persistent://my-tenant-2/my-ns-2/my-topic");
 
-        topic = new KopTopic("persistent://my-tenant-3/my-ns-3/my-topic");
+        topic = new KopTopic("persistent://my-tenant-3/my-ns-3/my-topic", namespacePrefix);
         assertEquals(topic.getOriginalName(), "persistent://my-tenant-3/my-ns-3/my-topic");
         assertEquals(topic.getFullName(), topic.getOriginalName());
 
         try {
-            topic = new KopTopic("my-ns/my-topic");
+            topic = new KopTopic("my-ns/my-topic", namespacePrefix);
+            fail();
+        } catch (KopTopic.KoPTopicIllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("Invalid short topic name"));
+        }
+
+        try {
+            topic = new KopTopic("my-topic", null);
             fail();
         } catch (KopTopic.KoPTopicIllegalArgumentException e) {
             assertTrue(e.getMessage().contains("Invalid short topic name"));
         }
         try {
-            topic = new KopTopic("persistent://my-topic");
+            topic = new KopTopic("persistent://my-topic", namespacePrefix);
         } catch (KopTopic.KoPTopicIllegalArgumentException e) {
             assertTrue(e.getMessage().contains("Invalid topic name"));
         }
@@ -63,8 +70,9 @@ public class KopTopicTest {
 
     @Test
     public void testGetPartitionName() {
-        KopTopic.initialize("my-tenant/my-ns");
-        KopTopic topic = new KopTopic("my-topic");
+        String namespacePrefix = "my-tenant/my-ns";
+
+        KopTopic topic = new KopTopic("my-topic", namespacePrefix);
         assertEquals(topic.getPartitionName(0), "persistent://my-tenant/my-ns/my-topic-partition-0");
         assertEquals(topic.getPartitionName(12), "persistent://my-tenant/my-ns/my-topic-partition-12");
         try {
@@ -77,11 +85,11 @@ public class KopTopicTest {
 
     @Test
     public void testRemoveDefaultNamespacePrefix() {
-        KopTopic.initialize("my-tenant/my-ns");
+        String namespacePrefix = "my-tenant/my-ns";
 
         final String topic1 = "persistent://my-tenant/my-ns/my-topic";
         final String topic2 = "persistent://my-tenant/another-ns/my-topic";
-        assertEquals(KopTopic.removeDefaultNamespacePrefix(topic1), "my-topic");
-        assertEquals(KopTopic.removeDefaultNamespacePrefix(topic2), topic2);
+        assertEquals(KopTopic.removeDefaultNamespacePrefix(topic1, namespacePrefix), "my-topic");
+        assertEquals(KopTopic.removeDefaultNamespacePrefix(topic2, namespacePrefix), topic2);
     }
 }

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtilsTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtilsTest.java
@@ -46,7 +46,7 @@ public class MetadataUtilsTest {
 
     @Test(timeOut = 30000)
     public void testCreateKafkaMetadataIfMissing() throws Exception {
-        KopTopic.initialize("public/default");
+        String namespacePrefix = "public/default";
         KafkaServiceConfiguration conf = new KafkaServiceConfiguration();
         ClusterData clusterData = ClusterData.builder().build();
         conf.setClusterName("test");
@@ -56,9 +56,9 @@ public class MetadataUtilsTest {
         conf.setOffsetsTopicNumPartitions(8);
 
         final KopTopic offsetsTopic = new KopTopic(MetadataUtils
-                .constructOffsetsTopicBaseName(conf.getKafkaMetadataTenant(), conf));
+                .constructOffsetsTopicBaseName(conf.getKafkaMetadataTenant(), conf), namespacePrefix);
         final KopTopic txnTopic = new KopTopic(MetadataUtils
-                .constructTxnLogTopicBaseName(conf.getKafkaMetadataTenant(), conf));
+                .constructTxnLogTopicBaseName(conf.getKafkaMetadataTenant(), conf), namespacePrefix);
 
         List<String> emptyList = Lists.newArrayList();
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -717,7 +717,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
         // verify
         GroupMetadataManager groupMetadataManager = handler.getGroupCoordinator().getGroupManager();
         GroupMetadata metadata = groupMetadataManager.getGroup(group).get();
-        OffsetAndMetadata offsetAndMetadata = metadata.offset(topicPartition).get();
+        OffsetAndMetadata offsetAndMetadata = metadata.offset(topicPartition, handler.currentNamespacePrefix()).get();
 
         // offset in cache
         Assert.assertNotNull(offsetAndMetadata);
@@ -731,7 +731,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
                 "expect no expired offset. but " + removeExpiredOffsets + " expired.");
 
         metadata = groupMetadataManager.getGroup(group).get();
-        offsetAndMetadata = metadata.offset(topicPartition).get();
+        offsetAndMetadata = metadata.offset(topicPartition, handler.currentNamespacePrefix()).get();
 
         // not cleanup
         Assert.assertNotNull(offsetAndMetadata);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
@@ -368,11 +368,11 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
 
         // create partitioned topic.
         admin.topics().createPartitionedTopic(topicName, 1);
-        TopicPartition tp = new TopicPartition(new KopTopic(topicName, null).getFullName(), 0);
+        TopicPartition tp = new TopicPartition(new KopTopic(topicName, handler.currentNamespacePrefix()).getFullName(), 0);
         doReturn(CompletableFuture.completedFuture(true))
                 .when(spyHandler)
                 .authorize(eq(AclOperation.DESCRIBE),
-                        eq(Resource.of(ResourceType.TOPIC, new KopTopic(tp.topic(), null).getFullName()))
+                        eq(Resource.of(ResourceType.TOPIC, new KopTopic(tp.topic(), handler.currentNamespacePrefix()).getFullName()))
                 );
         OffsetFetchRequest.Builder builder =
                 new OffsetFetchRequest.Builder(groupId, Collections.singletonList(tp));
@@ -403,7 +403,7 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
 
         // create partitioned topic.
         admin.topics().createPartitionedTopic(topicName, 1);
-        TopicPartition tp = new TopicPartition(new KopTopic(topicName, null).getFullName(), 0);
+        TopicPartition tp = new TopicPartition(new KopTopic(topicName, handler.currentNamespacePrefix()).getFullName(), 0);
         OffsetFetchRequest.Builder builder =
                 new OffsetFetchRequest.Builder(groupId, Collections.singletonList(tp));
 
@@ -476,7 +476,7 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
         doReturn(CompletableFuture.completedFuture(true))
                 .when(spyHandler)
                 .authorize(eq(AclOperation.READ),
-                        eq(Resource.of(ResourceType.TOPIC, new KopTopic(topicPartition1.topic(), null).getFullName()))
+                        eq(Resource.of(ResourceType.TOPIC, new KopTopic(topicPartition1.topic(), handler.currentNamespacePrefix()).getFullName()))
                 );
 
         // Handle request
@@ -542,7 +542,7 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
         doReturn(CompletableFuture.completedFuture(true))
                 .when(spyHandler)
                 .authorize(eq(AclOperation.READ),
-                        eq(Resource.of(ResourceType.TOPIC, new KopTopic(topicPartition1.topic(), null).getFullName()))
+                        eq(Resource.of(ResourceType.TOPIC, new KopTopic(topicPartition1.topic(), handler.currentNamespacePrefix()).getFullName()))
                 );
 
         // Handle request
@@ -575,7 +575,7 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
         doReturn(CompletableFuture.completedFuture(true))
                 .when(spyHandler)
                 .authorize(eq(AclOperation.WRITE),
-                        eq(Resource.of(ResourceType.TOPIC, KopTopic.toString(topicPartition1, null)))
+                        eq(Resource.of(ResourceType.TOPIC, KopTopic.toString(topicPartition1, handler.currentNamespacePrefix())))
                 );
         // Handle request
         CompletableFuture<AbstractResponse> responseFuture = new CompletableFuture<>();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
@@ -368,11 +368,13 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
 
         // create partitioned topic.
         admin.topics().createPartitionedTopic(topicName, 1);
-        TopicPartition tp = new TopicPartition(new KopTopic(topicName, handler.currentNamespacePrefix()).getFullName(), 0);
+        TopicPartition tp = new TopicPartition(new KopTopic(topicName,
+                handler.currentNamespacePrefix()).getFullName(), 0);
         doReturn(CompletableFuture.completedFuture(true))
                 .when(spyHandler)
                 .authorize(eq(AclOperation.DESCRIBE),
-                        eq(Resource.of(ResourceType.TOPIC, new KopTopic(tp.topic(), handler.currentNamespacePrefix()).getFullName()))
+                        eq(Resource.of(ResourceType.TOPIC, new KopTopic(tp.topic(),
+                                handler.currentNamespacePrefix()).getFullName()))
                 );
         OffsetFetchRequest.Builder builder =
                 new OffsetFetchRequest.Builder(groupId, Collections.singletonList(tp));
@@ -403,7 +405,8 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
 
         // create partitioned topic.
         admin.topics().createPartitionedTopic(topicName, 1);
-        TopicPartition tp = new TopicPartition(new KopTopic(topicName, handler.currentNamespacePrefix()).getFullName(), 0);
+        TopicPartition tp = new TopicPartition(new KopTopic(topicName,
+                handler.currentNamespacePrefix()).getFullName(), 0);
         OffsetFetchRequest.Builder builder =
                 new OffsetFetchRequest.Builder(groupId, Collections.singletonList(tp));
 
@@ -476,7 +479,8 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
         doReturn(CompletableFuture.completedFuture(true))
                 .when(spyHandler)
                 .authorize(eq(AclOperation.READ),
-                        eq(Resource.of(ResourceType.TOPIC, new KopTopic(topicPartition1.topic(), handler.currentNamespacePrefix()).getFullName()))
+                        eq(Resource.of(ResourceType.TOPIC, new KopTopic(topicPartition1.topic(),
+                                handler.currentNamespacePrefix()).getFullName()))
                 );
 
         // Handle request
@@ -542,7 +546,8 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
         doReturn(CompletableFuture.completedFuture(true))
                 .when(spyHandler)
                 .authorize(eq(AclOperation.READ),
-                        eq(Resource.of(ResourceType.TOPIC, new KopTopic(topicPartition1.topic(), handler.currentNamespacePrefix()).getFullName()))
+                        eq(Resource.of(ResourceType.TOPIC, new KopTopic(topicPartition1.topic(),
+                                handler.currentNamespacePrefix()).getFullName()))
                 );
 
         // Handle request
@@ -575,7 +580,8 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
         doReturn(CompletableFuture.completedFuture(true))
                 .when(spyHandler)
                 .authorize(eq(AclOperation.WRITE),
-                        eq(Resource.of(ResourceType.TOPIC, KopTopic.toString(topicPartition1, handler.currentNamespacePrefix())))
+                        eq(Resource.of(ResourceType.TOPIC, KopTopic.toString(topicPartition1,
+                                handler.currentNamespacePrefix())))
                 );
         // Handle request
         CompletableFuture<AbstractResponse> responseFuture = new CompletableFuture<>();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
@@ -368,11 +368,11 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
 
         // create partitioned topic.
         admin.topics().createPartitionedTopic(topicName, 1);
-        TopicPartition tp = new TopicPartition(new KopTopic(topicName).getFullName(), 0);
+        TopicPartition tp = new TopicPartition(new KopTopic(topicName, null).getFullName(), 0);
         doReturn(CompletableFuture.completedFuture(true))
                 .when(spyHandler)
                 .authorize(eq(AclOperation.DESCRIBE),
-                        eq(Resource.of(ResourceType.TOPIC, new KopTopic(tp.topic()).getFullName()))
+                        eq(Resource.of(ResourceType.TOPIC, new KopTopic(tp.topic(), null).getFullName()))
                 );
         OffsetFetchRequest.Builder builder =
                 new OffsetFetchRequest.Builder(groupId, Collections.singletonList(tp));
@@ -403,7 +403,7 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
 
         // create partitioned topic.
         admin.topics().createPartitionedTopic(topicName, 1);
-        TopicPartition tp = new TopicPartition(new KopTopic(topicName).getFullName(), 0);
+        TopicPartition tp = new TopicPartition(new KopTopic(topicName, null).getFullName(), 0);
         OffsetFetchRequest.Builder builder =
                 new OffsetFetchRequest.Builder(groupId, Collections.singletonList(tp));
 
@@ -476,7 +476,7 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
         doReturn(CompletableFuture.completedFuture(true))
                 .when(spyHandler)
                 .authorize(eq(AclOperation.READ),
-                        eq(Resource.of(ResourceType.TOPIC, new KopTopic(topicPartition1.topic()).getFullName()))
+                        eq(Resource.of(ResourceType.TOPIC, new KopTopic(topicPartition1.topic(), null).getFullName()))
                 );
 
         // Handle request
@@ -542,7 +542,7 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
         doReturn(CompletableFuture.completedFuture(true))
                 .when(spyHandler)
                 .authorize(eq(AclOperation.READ),
-                        eq(Resource.of(ResourceType.TOPIC, new KopTopic(topicPartition1.topic()).getFullName()))
+                        eq(Resource.of(ResourceType.TOPIC, new KopTopic(topicPartition1.topic(), null).getFullName()))
                 );
 
         // Handle request
@@ -575,7 +575,7 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
         doReturn(CompletableFuture.completedFuture(true))
                 .when(spyHandler)
                 .authorize(eq(AclOperation.WRITE),
-                        eq(Resource.of(ResourceType.TOPIC, KopTopic.toString(topicPartition1)))
+                        eq(Resource.of(ResourceType.TOPIC, KopTopic.toString(topicPartition1, null)))
                 );
         // Handle request
         CompletableFuture<AbstractResponse> responseFuture = new CompletableFuture<>();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
@@ -326,7 +326,7 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
     @Test(timeOut = 20000)
     public void testOnlyOneCursorCreated() throws Exception {
         final String topic = "testOnlyOneCursorCreated";
-        final String partitionName = new KopTopic(topic).getPartitionName(0);
+        final String partitionName = new KopTopic(topic, "public/default").getPartitionName(0);
         admin.topics().createPartitionedTopic(topic, 1);
 
         final int numMessages = 100;
@@ -358,7 +358,7 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
     @Test(timeOut = 20000)
     public void testCursorCountForMultiGroups() throws Exception {
         final String topic = "test-cursor-count-for-multi-groups";
-        final String partitionName = new KopTopic(topic).getPartitionName(0);
+        final String partitionName = new KopTopic(topic, "public/default").getPartitionName(0);
         final int numMessages = 100;
         final int numConsumers = 5;
 
@@ -438,7 +438,7 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
         }
 
         final Function<Integer, KafkaTopicConsumerManager> getTcmForPartition = partition -> {
-            final String fullTopicName = new KopTopic(topic).getPartitionName(partition);
+            final String fullTopicName = new KopTopic(topic, "public/default").getPartitionName(partition);
             final List<KafkaTopicConsumerManager> tcmList =
                     KafkaTopicConsumerManagerCache.getInstance().getTopicConsumerManagers(fullTopicName);
             return tcmList.isEmpty() ? null : tcmList.get(0);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinatorTest.java
@@ -133,6 +133,7 @@ public class GroupCoordinatorTest extends KopProtocolHandlerTestBase {
         otherGroupId = "otherGroupId";
         offsetConfig.offsetsTopicNumPartitions(4);
         groupMetadataManager = spy(new GroupMetadataManager(
+                tenant,
                 offsetConfig,
                 producerBuilder,
                 readerBuilder,
@@ -144,7 +145,8 @@ public class GroupCoordinatorTest extends KopProtocolHandlerTestBase {
                     } else {
                         return otherGroupPartitionId;
                     }
-                }
+                },
+            "public/default"
         ));
 
         assertNotEquals(groupPartitionId, otherGroupPartitionId);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinatorTest.java
@@ -133,7 +133,6 @@ public class GroupCoordinatorTest extends KopProtocolHandlerTestBase {
         otherGroupId = "otherGroupId";
         offsetConfig.offsetsTopicNumPartitions(4);
         groupMetadataManager = spy(new GroupMetadataManager(
-                tenant,
                 offsetConfig,
                 producerBuilder,
                 readerBuilder,

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
@@ -153,7 +153,6 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
                 .numThreads(1)
                 .build();
         groupMetadataManager = new GroupMetadataManager(
-                tenant,
                 offsetConfig,
                 producerBuilder,
                 readerBuilder,
@@ -883,7 +882,6 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
     @Test
     public void testGroupNotExits() {
         groupMetadataManager = new GroupMetadataManager(
-            tenant,
             offsetConfig,
             producerBuilder,
             readerBuilder,
@@ -1229,7 +1227,6 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
     @Test
     public void testAddGroup() {
         groupMetadataManager = new GroupMetadataManager(
-            tenant,
             offsetConfig,
             producerBuilder,
             readerBuilder,

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
@@ -1446,7 +1446,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
                 GroupTopicPartition gtp = ok.key();
                 assertEquals(groupId, gtp.group());
                 assertEquals(new TopicPartition(
-                        new KopTopic(topicPartition.topic()).getFullName(), topicPartition.partition()),
+                        new KopTopic(topicPartition.topic(), null).getFullName(), topicPartition.partition()),
                         gtp.topicPartition());
 
                 OffsetAndMetadata gm = GroupMetadataConstants.readOffsetMessageValue(
@@ -1798,7 +1798,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
                 assertTrue(bk instanceof OffsetKey);
                 OffsetKey ok = (OffsetKey) bk;
                 assertEquals(groupId, ok.key().group());
-                assertEquals(new KopTopic("foo").getFullName(), ok.key().topicPartition().topic());
+                assertEquals(new KopTopic("foo", null).getFullName(), ok.key().topicPartition().topic());
             }
         });
         assertEquals(0, verified.get());

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
@@ -920,7 +920,8 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         committedOffsets.put(
             new TopicPartition("bar", 0), 8992L);
 
-        List<SimpleRecord> offsetCommitRecords = createCommittedOffsetRecords(committedOffsets, groupId, NAMESPACE_PREFIX);
+        List<SimpleRecord> offsetCommitRecords = createCommittedOffsetRecords(committedOffsets, groupId,
+                NAMESPACE_PREFIX);
         SimpleRecord tombstone = new SimpleRecord(
             offsetCommitKey(groupId, tombstonePartition, NAMESPACE_PREFIX),
             null
@@ -979,7 +980,8 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         committedOffsets.put(
             new TopicPartition("bar", 0), 8992L);
 
-        List<SimpleRecord> offsetCommitRecords = createCommittedOffsetRecords(committedOffsets, groupId, NAMESPACE_PREFIX);
+        List<SimpleRecord> offsetCommitRecords = createCommittedOffsetRecords(committedOffsets, groupId,
+                NAMESPACE_PREFIX);
         String memberId = "98098230493";
         SimpleRecord groupMetadataRecord = buildStableGroupRecordWithMember(
             generation,
@@ -1468,7 +1470,8 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
                 GroupTopicPartition gtp = ok.key();
                 assertEquals(groupId, gtp.group());
                 assertEquals(new TopicPartition(
-                        new KopTopic(topicPartition.topic(), NAMESPACE_PREFIX).getFullName(), topicPartition.partition()),
+                        new KopTopic(topicPartition.topic(), NAMESPACE_PREFIX).getFullName(),
+                                topicPartition.partition()),
                         gtp.topicPartition());
 
                 OffsetAndMetadata gm = GroupMetadataConstants.readOffsetMessageValue(
@@ -1675,7 +1678,8 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
 
         assertEquals(Optional.of(group), groupMetadataManager.getGroup(groupId));
         assertEquals(Optional.empty(), group.offset(topicPartition1, NAMESPACE_PREFIX));
-        assertEquals(Optional.of(offset), group.offset(topicPartition2, NAMESPACE_PREFIX).map(OffsetAndMetadata::offset));
+        assertEquals(Optional.of(offset), group.offset(topicPartition2, NAMESPACE_PREFIX)
+                .map(OffsetAndMetadata::offset));
 
         Map<TopicPartition, PartitionData> cachedOffsets = groupMetadataManager.getOffsets(
             groupId,

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
@@ -98,6 +98,7 @@ import org.testng.annotations.Test;
 @Slf4j
 public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
 
+    private static final String NAMESPACE_PREFIX = "public/default";
     private static final String groupId = "foo";
     private static final int groupPartitionId = 0;
 
@@ -152,10 +153,12 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
                 .numThreads(1)
                 .build();
         groupMetadataManager = new GroupMetadataManager(
+                tenant,
                 offsetConfig,
                 producerBuilder,
                 readerBuilder,
                 scheduler,
+                "public/default",
                 Time.SYSTEM
         );
         groupMetadataManager.startup(false);
@@ -173,10 +176,10 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
     }
 
     private List<SimpleRecord> createCommittedOffsetRecords(Map<TopicPartition, Long> committedOffsets,
-                                                            String groupId) {
+                                                            String groupId, String namespacePrefix) {
         return committedOffsets.entrySet().stream().map(e -> {
             OffsetAndMetadata offsetAndMetadata = OffsetAndMetadata.apply(e.getValue());
-            byte[] offsetCommitKey = offsetCommitKey(groupId, e.getKey());
+            byte[] offsetCommitKey = offsetCommitKey(groupId, e.getKey(), namespacePrefix);
             byte[] offsetCommitValue = offsetCommitValue(offsetAndMetadata);
             return new SimpleRecord(offsetCommitKey, offsetCommitValue);
         }).collect(Collectors.toList());
@@ -285,7 +288,8 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
                                            Map<TopicPartition, Long> offsets) {
         MemoryRecordsBuilder builder =
             MemoryRecords.builder(buffer, CompressionType.NONE, TimestampType.LOG_APPEND_TIME, baseOffset);
-        List<SimpleRecord> commitRecords = createCommittedOffsetRecords(offsets, groupId);
+        List<SimpleRecord> commitRecords = createCommittedOffsetRecords(offsets, groupId,
+                NAMESPACE_PREFIX);
         commitRecords.forEach(builder::append);
         builder.build();
         return offsets.size();
@@ -295,10 +299,11 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
                                                  long producerId,
                                                  short producerEpoch,
                                                  long baseOffset,
-                                                 Map<TopicPartition, Long> offsets) {
+                                                 Map<TopicPartition, Long> offsets,
+                                                 String namespacePrefix) {
         MemoryRecordsBuilder builder =
             MemoryRecords.builder(buffer, CompressionType.NONE, baseOffset, producerId, producerEpoch, 0, true);
-        List<SimpleRecord> commitRecords = createCommittedOffsetRecords(offsets, groupId);
+        List<SimpleRecord> commitRecords = createCommittedOffsetRecords(offsets, groupId, namespacePrefix);
         commitRecords.forEach(builder::append);
         builder.build();
         return offsets.size();
@@ -354,7 +359,8 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
 
         List<SimpleRecord> offsetCommitRecords = createCommittedOffsetRecords(
             committedOffsets,
-            groupId
+            groupId,
+            NAMESPACE_PREFIX
         );
         ByteBuffer buffer = newMemoryRecordsBuffer(offsetCommitRecords);
         byte[] key = groupMetadataKey(groupId);
@@ -381,7 +387,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         assertEquals(Empty, group.currentState());
         assertEquals(committedOffsets.size(), group.allOffsets().size());
         committedOffsets.forEach((tp, offset) ->
-            assertEquals(Optional.of(offset), group.offset(tp).map(OffsetAndMetadata::offset)));
+            assertEquals(Optional.of(offset), group.offset(tp, NAMESPACE_PREFIX).map(OffsetAndMetadata::offset)));
 
 
     }
@@ -401,7 +407,8 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
 
         List<SimpleRecord> offsetCommitRecords = createCommittedOffsetRecords(
             committedOffsets,
-            groupId
+            groupId,
+            NAMESPACE_PREFIX
         );
         offsetCommitRecords.add(
             buildEmptyGroupRecord(generation, protocolType));
@@ -436,7 +443,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         assertNull(group.leaderOrNull());
         assertNull(group.protocolOrNull());
         committedOffsets.forEach((tp, offset) ->
-            assertEquals(Optional.of(offset), group.offset(tp).map(OffsetAndMetadata::offset)));
+            assertEquals(Optional.of(offset), group.offset(tp, NAMESPACE_PREFIX).map(OffsetAndMetadata::offset)));
     }
 
     @Test
@@ -455,7 +462,8 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         ByteBuffer buffer = ByteBuffer.allocate(1024);
         int nextOffset = 0;
         nextOffset += appendTransactionalOffsetCommits(
-            buffer, producerId, producerEpoch, nextOffset, committedOffsets
+            buffer, producerId, producerEpoch, nextOffset, committedOffsets,
+                NAMESPACE_PREFIX
         );
         completeTransactionalOffsetCommit(
             buffer, producerId, producerEpoch, nextOffset, true
@@ -486,7 +494,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         assertEquals(Empty, group.currentState());
         assertEquals(committedOffsets.size(), group.allOffsets().size());
         committedOffsets.forEach((tp, offset) ->
-            assertEquals(Optional.of(offset), group.offset(tp).map(OffsetAndMetadata::offset)));
+            assertEquals(Optional.of(offset), group.offset(tp, NAMESPACE_PREFIX).map(OffsetAndMetadata::offset)));
     }
 
     @Test
@@ -504,7 +512,8 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
 
         ByteBuffer buffer = ByteBuffer.allocate(1024);
         int nextOffset = 0;
-        nextOffset += appendTransactionalOffsetCommits(buffer, producerId, producerEpoch, nextOffset, abortedOffsets);
+        nextOffset += appendTransactionalOffsetCommits(buffer, producerId, producerEpoch, nextOffset, abortedOffsets,
+                NAMESPACE_PREFIX);
         completeTransactionalOffsetCommit(buffer, producerId, producerEpoch, nextOffset, false);
         buffer.flip();
 
@@ -540,7 +549,8 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
 
         ByteBuffer buffer = ByteBuffer.allocate(1024);
         int nextOffset = 0;
-        appendTransactionalOffsetCommits(buffer, producerId, producerEpoch, nextOffset, pendingOffsets);
+        appendTransactionalOffsetCommits(buffer, producerId, producerEpoch, nextOffset, pendingOffsets,
+                NAMESPACE_PREFIX);
         buffer.flip();
 
         byte[] key = groupMetadataKey(groupId);
@@ -595,9 +605,11 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
 
         ByteBuffer buffer = ByteBuffer.allocate(1024);
         int nextOffset = 0;
-        nextOffset += appendTransactionalOffsetCommits(buffer, producerId, producerEpoch, nextOffset, abortedOffsets);
+        nextOffset += appendTransactionalOffsetCommits(buffer, producerId, producerEpoch, nextOffset, abortedOffsets,
+                NAMESPACE_PREFIX);
         nextOffset += completeTransactionalOffsetCommit(buffer, producerId, producerEpoch, nextOffset, false);
-        nextOffset += appendTransactionalOffsetCommits(buffer, producerId, producerEpoch, nextOffset, committedOffsets);
+        nextOffset += appendTransactionalOffsetCommits(buffer, producerId, producerEpoch, nextOffset, committedOffsets,
+                NAMESPACE_PREFIX);
         completeTransactionalOffsetCommit(buffer, producerId, producerEpoch, nextOffset, true);
         buffer.flip();
 
@@ -630,7 +642,8 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         // are truly discarded.
         assertEquals(committedOffsets.size(), group.allOffsets().size());
         committedOffsets.forEach((tp, offset) ->
-            assertEquals(Optional.of(offset), group.offset(tp).map(OffsetAndMetadata::offset)));
+            assertEquals(Optional.of(offset), group.offset(tp, NAMESPACE_PREFIX)
+                    .map(OffsetAndMetadata::offset)));
         assertFalse(group.hasPendingOffsetCommitsFromProducer(producerId));
     }
 
@@ -665,11 +678,14 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
 
         ByteBuffer buffer = ByteBuffer.allocate(2048);
         int nextOffset = 0;
-        nextOffset += appendTransactionalOffsetCommits(buffer, producerId, producerEpoch, nextOffset, committedOffsets);
+        nextOffset += appendTransactionalOffsetCommits(buffer, producerId, producerEpoch, nextOffset, committedOffsets,
+                NAMESPACE_PREFIX);
         nextOffset += completeTransactionalOffsetCommit(buffer, producerId, producerEpoch, nextOffset, true);
-        nextOffset += appendTransactionalOffsetCommits(buffer, producerId, producerEpoch, nextOffset, abortedOffsets);
+        nextOffset += appendTransactionalOffsetCommits(buffer, producerId, producerEpoch, nextOffset, abortedOffsets,
+                NAMESPACE_PREFIX);
         nextOffset += completeTransactionalOffsetCommit(buffer, producerId, producerEpoch, nextOffset, false);
-        nextOffset += appendTransactionalOffsetCommits(buffer, producerId, producerEpoch, nextOffset, pendingOffsets);
+        nextOffset += appendTransactionalOffsetCommits(buffer, producerId, producerEpoch, nextOffset, pendingOffsets,
+                NAMESPACE_PREFIX);
         buffer.flip();
 
         byte[] key = groupMetadataKey(groupId);
@@ -700,7 +716,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         // for the producer. This allows us to be certain that the aborted offset commits are truly discarded.
         assertEquals(committedOffsets.size(), group.allOffsets().size());
         committedOffsets.forEach((tp, offset) ->
-            assertEquals(Optional.of(offset), group.offset(tp).map(OffsetAndMetadata::offset)));
+            assertEquals(Optional.of(offset), group.offset(tp, NAMESPACE_PREFIX).map(OffsetAndMetadata::offset)));
 
         // We should have pending commits.
         assertTrue(group.hasPendingOffsetCommitsFromProducer(producerId));
@@ -712,7 +728,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
             true, new CompletableFuture<>());
         assertFalse(group.hasPendingOffsetCommitsFromProducer(producerId));
         pendingOffsets.forEach((tp, offset) ->
-            assertEquals(Optional.of(offset), group.offset(tp).map(OffsetAndMetadata::offset)));
+            assertEquals(Optional.of(offset), group.offset(tp, NAMESPACE_PREFIX).map(OffsetAndMetadata::offset)));
 
     }
 
@@ -743,14 +759,16 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         int nextOffset = 0;
         int firstProduceRecordOffset = nextOffset;
         nextOffset += appendTransactionalOffsetCommits(
-            buffer, firstProducerId, firstProducerEpoch, nextOffset, committedOffsetsFirstProducer
+            buffer, firstProducerId, firstProducerEpoch, nextOffset, committedOffsetsFirstProducer,
+                NAMESPACE_PREFIX
         );
         nextOffset += completeTransactionalOffsetCommit(
             buffer, firstProducerId, firstProducerEpoch, nextOffset, true
         );
         int secondProduceRecordOffset = nextOffset;
         nextOffset += appendTransactionalOffsetCommits(
-            buffer, secondProducerId, secondProducerEpoch, nextOffset, committedOffsetsSecondProducer
+            buffer, secondProducerId, secondProducerEpoch, nextOffset, committedOffsetsSecondProducer,
+                NAMESPACE_PREFIX
         );
         nextOffset += completeTransactionalOffsetCommit(
             buffer, secondProducerId, secondProducerEpoch, nextOffset, true
@@ -786,13 +804,13 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         assertEquals(committedOffsetsFirstProducer.size() + committedOffsetsSecondProducer.size(),
             group.allOffsets().size());
         committedOffsetsFirstProducer.forEach((tp, offset) -> {
-            assertEquals(Optional.of(offset), group.offset(tp).map(OffsetAndMetadata::offset));
+            assertEquals(Optional.of(offset), group.offset(tp, NAMESPACE_PREFIX).map(OffsetAndMetadata::offset));
             assertEquals(
                 Optional.of((long) firstProduceRecordOffset),
                 group.offsetWithRecordMetadata(tp).flatMap(CommitRecordMetadataAndOffset::appendedBatchOffset));
         });
         committedOffsetsSecondProducer.forEach((tp, offset) -> {
-            assertEquals(Optional.of(offset), group.offset(tp).map(OffsetAndMetadata::offset));
+            assertEquals(Optional.of(offset), group.offset(tp, NAMESPACE_PREFIX).map(OffsetAndMetadata::offset));
             assertEquals(
                 Optional.of((long) secondProduceRecordOffset),
                 group.offsetWithRecordMetadata(tp).flatMap(CommitRecordMetadataAndOffset::appendedBatchOffset));
@@ -819,7 +837,8 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
             buffer, nextOffset, consumerOffsetCommits
         );
         nextOffset += appendTransactionalOffsetCommits(
-            buffer, producerId, producerEpoch, nextOffset, transactionalOffsetCommits
+            buffer, producerId, producerEpoch, nextOffset, transactionalOffsetCommits,
+            NAMESPACE_PREFIX
         );
         nextOffset += completeTransactionalOffsetCommit(
             buffer, producerId, producerEpoch, nextOffset, true
@@ -856,7 +875,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         assertFalse(group.hasPendingOffsetCommitsFromProducer(producerId));
         assertEquals(consumerOffsetCommits.size(), group.allOffsets().size());
         transactionalOffsetCommits.forEach((tp, offset) -> {
-            assertEquals(Optional.of(offset), group.offset(tp).map(OffsetAndMetadata::offset));
+            assertEquals(Optional.of(offset), group.offset(tp, NAMESPACE_PREFIX).map(OffsetAndMetadata::offset));
         });
 
     }
@@ -864,10 +883,12 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
     @Test
     public void testGroupNotExits() {
         groupMetadataManager = new GroupMetadataManager(
+            tenant,
             offsetConfig,
-                producerBuilder,
-                readerBuilder,
+            producerBuilder,
+            readerBuilder,
             scheduler,
+            NAMESPACE_PREFIX,
             new MockTime()
         );
         // group is not owned
@@ -901,9 +922,9 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         committedOffsets.put(
             new TopicPartition("bar", 0), 8992L);
 
-        List<SimpleRecord> offsetCommitRecords = createCommittedOffsetRecords(committedOffsets, groupId);
+        List<SimpleRecord> offsetCommitRecords = createCommittedOffsetRecords(committedOffsets, groupId, NAMESPACE_PREFIX);
         SimpleRecord tombstone = new SimpleRecord(
-            offsetCommitKey(groupId, tombstonePartition),
+            offsetCommitKey(groupId, tombstonePartition, NAMESPACE_PREFIX),
             null
         );
         offsetCommitRecords.add(tombstone);
@@ -938,9 +959,9 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         assertEquals(committedOffsets.size() - 1, group.allOffsets().size());
         committedOffsets.forEach((tp, offset) -> {
             if (tp == tombstonePartition) {
-                assertEquals(Optional.empty(), group.offset(tp));
+                assertEquals(Optional.empty(), group.offset(tp, NAMESPACE_PREFIX));
             } else {
-                assertEquals(Optional.of(offset), group.offset(tp).map(OffsetAndMetadata::offset));
+                assertEquals(Optional.of(offset), group.offset(tp, NAMESPACE_PREFIX).map(OffsetAndMetadata::offset));
             }
         });
 
@@ -960,7 +981,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         committedOffsets.put(
             new TopicPartition("bar", 0), 8992L);
 
-        List<SimpleRecord> offsetCommitRecords = createCommittedOffsetRecords(committedOffsets, groupId);
+        List<SimpleRecord> offsetCommitRecords = createCommittedOffsetRecords(committedOffsets, groupId, NAMESPACE_PREFIX);
         String memberId = "98098230493";
         SimpleRecord groupMetadataRecord = buildStableGroupRecordWithMember(
             generation,
@@ -1006,7 +1027,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
             group.allOffsets().size()
         );
         committedOffsets.forEach((tp, offset) -> {
-            assertEquals(Optional.of(offset), group.offset(tp).map(OffsetAndMetadata::offset));
+            assertEquals(Optional.of(offset), group.offset(tp, NAMESPACE_PREFIX).map(OffsetAndMetadata::offset));
         });
 
     }
@@ -1068,7 +1089,8 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         committedOffsets.put(
             new TopicPartition("bar", 0), 8992L);
 
-        List<SimpleRecord> offsetCommitRecords = createCommittedOffsetRecords(committedOffsets, groupId);
+        List<SimpleRecord> offsetCommitRecords = createCommittedOffsetRecords(committedOffsets, groupId,
+                                                    NAMESPACE_PREFIX);
         SimpleRecord groupMetadataRecord = buildStableGroupRecordWithMember(
             generation,
             protocolType,
@@ -1112,7 +1134,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         assertEquals(Empty, group.currentState());
         assertEquals(committedOffsets.size(), group.allOffsets().size());
         committedOffsets.forEach((tp, offset) -> {
-            assertEquals(Optional.of(offset), group.offset(tp).map(OffsetAndMetadata::offset));
+            assertEquals(Optional.of(offset), group.offset(tp, NAMESPACE_PREFIX).map(OffsetAndMetadata::offset));
         });
     }
 
@@ -1131,7 +1153,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         segment1Offsets.put(tp0, 23L);
         segment1Offsets.put(tp1, 455L);
         segment1Offsets.put(tp3, 42L);
-        List<SimpleRecord> segment1Records = createCommittedOffsetRecords(segment1Offsets, groupId);
+        List<SimpleRecord> segment1Records = createCommittedOffsetRecords(segment1Offsets, groupId, NAMESPACE_PREFIX);
         SimpleRecord segment1Group = buildStableGroupRecordWithMember(
             generation,
             protocolType,
@@ -1146,7 +1168,8 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         segment2Offsets.put(tp0, 33L);
         segment2Offsets.put(tp2, 8992L);
         segment2Offsets.put(tp3, 10L);
-        List<SimpleRecord> segment2Records = createCommittedOffsetRecords(segment2Offsets, groupId);
+        List<SimpleRecord> segment2Records = createCommittedOffsetRecords(segment2Offsets, groupId,
+                NAMESPACE_PREFIX);
         SimpleRecord segment2Group = buildStableGroupRecordWithMember(
             generation,
             protocolType,
@@ -1198,7 +1221,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         committedOffsets.putAll(segment2Offsets);
         assertEquals(committedOffsets.size(), group.allOffsets().size());
         committedOffsets.forEach((tp, offset) -> {
-            assertEquals(Optional.of(offset), group.offset(tp).map(OffsetAndMetadata::offset));
+            assertEquals(Optional.of(offset), group.offset(tp, NAMESPACE_PREFIX).map(OffsetAndMetadata::offset));
         });
 
     }
@@ -1206,10 +1229,12 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
     @Test
     public void testAddGroup() {
         groupMetadataManager = new GroupMetadataManager(
+            tenant,
             offsetConfig,
-                producerBuilder,
-                readerBuilder,
+            producerBuilder,
+            readerBuilder,
             scheduler,
+            NAMESPACE_PREFIX,
             new MockTime()
         );
         GroupMetadata group = new GroupMetadata("foo", Empty);
@@ -1446,7 +1471,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
                 GroupTopicPartition gtp = ok.key();
                 assertEquals(groupId, gtp.group());
                 assertEquals(new TopicPartition(
-                        new KopTopic(topicPartition.topic(), null).getFullName(), topicPartition.partition()),
+                        new KopTopic(topicPartition.topic(), NAMESPACE_PREFIX).getFullName(), topicPartition.partition()),
                         gtp.topicPartition());
 
                 OffsetAndMetadata gm = GroupMetadataConstants.readOffsetMessageValue(
@@ -1511,7 +1536,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
 
         assertEquals(
             Optional.of(OffsetAndMetadata.apply(offset)),
-            group.offset(topicPartition)
+            group.offset(topicPartition, NAMESPACE_PREFIX)
         );
 
     }
@@ -1652,8 +1677,8 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         groupMetadataManager.cleanupGroupMetadata();
 
         assertEquals(Optional.of(group), groupMetadataManager.getGroup(groupId));
-        assertEquals(Optional.empty(), group.offset(topicPartition1));
-        assertEquals(Optional.of(offset), group.offset(topicPartition2).map(OffsetAndMetadata::offset));
+        assertEquals(Optional.empty(), group.offset(topicPartition1, NAMESPACE_PREFIX));
+        assertEquals(Optional.of(offset), group.offset(topicPartition2, NAMESPACE_PREFIX).map(OffsetAndMetadata::offset));
 
         Map<TopicPartition, PartitionData> cachedOffsets = groupMetadataManager.getOffsets(
             groupId,
@@ -1798,7 +1823,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
                 assertTrue(bk instanceof OffsetKey);
                 OffsetKey ok = (OffsetKey) bk;
                 assertEquals(groupId, ok.key().group());
-                assertEquals(new KopTopic("foo", null).getFullName(), ok.key().topicPartition().topic());
+                assertEquals(new KopTopic("foo", NAMESPACE_PREFIX).getFullName(), ok.key().topicPartition().topic());
             }
         });
         assertEquals(0, verified.get());
@@ -1872,11 +1897,11 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         );
         assertEquals(
             Optional.empty(),
-            group.offset(topicPartition1)
+            group.offset(topicPartition1, NAMESPACE_PREFIX)
         );
         assertEquals(
             Optional.empty(),
-            group.offset(topicPartition2)
+            group.offset(topicPartition2, NAMESPACE_PREFIX)
         );
 
         Map<TopicPartition, PartitionData> cachedOffsets = groupMetadataManager.getOffsets(

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinatorTest.java
@@ -64,7 +64,7 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
 
     protected final long defaultTestTimeout = 20000;
     public static final long DefaultAbortTimedOutTransactionsIntervalMs = TimeUnit.SECONDS.toMillis(1);
-    private final static String NAMESPACE_PREFIX = "public/default";
+    private static final String NAMESPACE_PREFIX = "public/default";
     private TransactionCoordinator transactionCoordinator;
     private ProducerIdManager producerIdManager;
     private TransactionStateManager transactionManager;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinatorTest.java
@@ -64,7 +64,7 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
 
     protected final long defaultTestTimeout = 20000;
     public static final long DefaultAbortTimedOutTransactionsIntervalMs = TimeUnit.SECONDS.toMillis(1);
-
+    private final static String NAMESPACE_PREFIX = "public/default";
     private TransactionCoordinator transactionCoordinator;
     private ProducerIdManager producerIdManager;
     private TransactionStateManager transactionManager;
@@ -130,7 +130,8 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
                 scheduler,
                 producerIdManager,
                 transactionManager,
-                time);
+                time,
+                NAMESPACE_PREFIX);
         result = null;
         error = Errors.NONE;
         capturedTxn = ArgumentCaptor.forClass(TransactionMetadata.class);


### PR DESCRIPTION
**Problem**
When you enable multi-tenancy aware mode (enabled by default) the user that is not on the "default" tenant must use fully qualified topic names.

**Changes**
In this change we remove the static 'namespacePrefix' variable from KopTopic and we explicitly pass the 'namespacePrefix' every time we construct a KopTopic instance.
