### PR TITLE
Split the message storage logic into independent classes

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/DelayedProduceAndFetch.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/DelayedProduceAndFetch.java
@@ -20,12 +20,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * A delayed create topic operation that is stored in the topic purgatory.
  */
-class DelayedProduceAndFetch extends DelayedOperation {
+public class DelayedProduceAndFetch extends DelayedOperation {
 
     private final AtomicInteger topicPartitionNum;
     private final Runnable callback;
 
-    DelayedProduceAndFetch(long delayMs, AtomicInteger topicPartitionNum, Runnable callback) {
+    public DelayedProduceAndFetch(long delayMs, AtomicInteger topicPartitionNum, Runnable callback) {
         super(delayMs, Optional.empty());
         this.topicPartitionNum = topicPartitionNum;
         this.callback = callback;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -132,6 +132,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 throw new IllegalStateException(e);
             }
             return new ReplicaManager(
+                    kafkaConfig,
                     Time.SYSTEM,
                     entryFormatter,
                     transactionCoordinatorOptional,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -131,7 +131,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 log.error("Failed to init create enter formatter {}", tenant, e);
                 throw new IllegalStateException(e);
             }
-            return new ReplicaManager(kafkaConfig,
+            return new ReplicaManager(
                     Time.SYSTEM,
                     entryFormatter,
                     transactionCoordinatorOptional,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -126,8 +126,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 return new ReplicaManager(kafkaConfig,
                         Time.SYSTEM,
                         transactionCoordinatorOptional,
-                        producePurgatory,
-                        fetchPurgatory);
+                        producePurgatory);
             } catch (Exception e) {
                 log.error("Failed to init ReplicaManager for tenant {}", tenant, e);
                 throw new IllegalStateException(e);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -928,18 +928,15 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                         requestStats,
                         this::startSendOperationForThrottling,
                         this::completeSendOperationForThrottling,
-                        pendingTopicFuturesMap,
-                        responseCallback
-                );
-                responseCallback.thenAccept(response -> {
-                    Map<TopicPartition, PartitionResponse> mergedResponse = Maps.newHashMap();
-                    mergedResponse.putAll(response);
-                    mergedResponse.putAll(unauthorizedTopicResponsesMap);
-                    resultFuture.complete(new ProduceResponse(mergedResponse));
-                }).exceptionally(ex -> {
-                    resultFuture.completeExceptionally(ex);
-                    return null;
-                });
+                        pendingTopicFuturesMap).thenAccept(response -> {
+                            Map<TopicPartition, PartitionResponse> mergedResponse = Maps.newHashMap();
+                            mergedResponse.putAll(response);
+                            mergedResponse.putAll(unauthorizedTopicResponsesMap);
+                            resultFuture.complete(new ProduceResponse(mergedResponse));
+                        }).exceptionally(ex -> {
+                            resultFuture.completeExceptionally(ex.getCause());
+                            return null;
+                        });
             }
         };
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -930,16 +930,16 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                         namespacePrefix,
                         authorizedRequestInfo,
                         appendRecordsContext
-                ).thenAccept(response -> {
+                ).whenComplete((response, ex) -> {
                     appendRecordsContext.recycle();
+                    if (ex != null) {
+                        resultFuture.completeExceptionally(ex.getCause());
+                        return;
+                    }
                     Map<TopicPartition, PartitionResponse> mergedResponse = new HashMap<>();
                     mergedResponse.putAll(response);
                     mergedResponse.putAll(unauthorizedTopicResponsesMap);
                     resultFuture.complete(new ProduceResponse(mergedResponse));
-                }).exceptionally(ex -> {
-                    appendRecordsContext.recycle();
-                    resultFuture.completeExceptionally(ex.getCause());
-                    return null;
                 });
             }
         };

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/PendingTopicFutures.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/PendingTopicFutures.java
@@ -55,7 +55,7 @@ public class PendingTopicFutures {
 
     public void addListener(CompletableFuture<Optional<PersistentTopic>> topicFuture,
                             @NonNull Consumer<Optional<PersistentTopic>> persistentTopicConsumer,
-                            @NonNull Consumer<Throwable> exceptionConsumer) {
+                            @NonNull CompletableFuture<Long> completableFuture) {
         if (count.compareAndSet(0, 1)) {
             // The first pending future comes
             currentTopicFuture = topicFuture.thenApply(persistentTopic -> {
@@ -65,7 +65,8 @@ public class PendingTopicFutures {
                 return TopicThrowablePair.withTopic(persistentTopic);
             }).exceptionally(e -> {
                 registerQueueLatency(false);
-                exceptionConsumer.accept(e.getCause());
+//                exceptionConsumer.accept(e.getCause());
+                completableFuture.completeExceptionally(e.getCause());
                 count.decrementAndGet();
                 return TopicThrowablePair.withThrowable(e.getCause());
             });
@@ -77,13 +78,15 @@ public class PendingTopicFutures {
                     persistentTopicConsumer.accept(topicThrowablePair.getPersistentTopicOpt());
                 } else {
                     registerQueueLatency(false);
-                    exceptionConsumer.accept(topicThrowablePair.getThrowable());
+                    completableFuture.completeExceptionally(topicThrowablePair.getThrowable());
+//                    exceptionConsumer.accept(topicThrowablePair.getThrowable());
                 }
                 count.decrementAndGet();
                 return topicThrowablePair;
             }).exceptionally(e -> {
                 registerQueueLatency(false);
-                exceptionConsumer.accept(e.getCause());
+//                exceptionConsumer.accept(e.getCause());
+                completableFuture.completeExceptionally(e.getCause());
                 count.decrementAndGet();
                 return TopicThrowablePair.withThrowable(e.getCause());
             });

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/PendingTopicFutures.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/PendingTopicFutures.java
@@ -65,7 +65,6 @@ public class PendingTopicFutures {
                 return TopicThrowablePair.withTopic(persistentTopic);
             }).exceptionally(e -> {
                 registerQueueLatency(false);
-//                exceptionConsumer.accept(e.getCause());
                 completableFuture.completeExceptionally(e.getCause());
                 count.decrementAndGet();
                 return TopicThrowablePair.withThrowable(e.getCause());
@@ -79,13 +78,11 @@ public class PendingTopicFutures {
                 } else {
                     registerQueueLatency(false);
                     completableFuture.completeExceptionally(topicThrowablePair.getThrowable());
-//                    exceptionConsumer.accept(topicThrowablePair.getThrowable());
                 }
                 count.decrementAndGet();
                 return topicThrowablePair;
             }).exceptionally(e -> {
                 registerQueueLatency(false);
-//                exceptionConsumer.accept(e.getCause());
                 completableFuture.completeExceptionally(e.getCause());
                 count.decrementAndGet();
                 return TopicThrowablePair.withThrowable(e.getCause());

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/TenantContextManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/TenantContextManager.java
@@ -15,11 +15,13 @@ package io.streamnative.pulsar.handlers.kop;
 
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupCoordinator;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
+import io.streamnative.pulsar.handlers.kop.storage.ReplicaManager;
 
 /**
  * Access Tenant level coordinators.
  */
 public interface TenantContextManager {
+
     /**
      * Access the GroupCoordinator for the current Tenant.
      * This method bootstraps a new GroupCoordinator if it is not started
@@ -27,6 +29,7 @@ public interface TenantContextManager {
      * @return the GroupCoordinator
      */
     GroupCoordinator getGroupCoordinator(String tenant);
+
     /**
      * Access the TransactionCoordinator for the current Tenant.
      * This method bootstraps a new TransactionCoordinator if it is not started
@@ -34,4 +37,12 @@ public interface TenantContextManager {
      * @return the TransactionCoordinator
      */
     TransactionCoordinator getTransactionCoordinator(String tenant);
+
+    /**
+     * Access the ReplicaManager for the current Tenant.
+     * This method bootstraps a new ReplicaManager if it is not started
+     * @param tenant
+     * @return the ReplicaManager
+     */
+    ReplicaManager getReplicaManager(String tenant);
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/AppendRecordsContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/AppendRecordsContext.java
@@ -17,11 +17,10 @@ import io.netty.util.Recycler;
 import io.streamnative.pulsar.handlers.kop.KafkaTopicManager;
 import io.streamnative.pulsar.handlers.kop.PendingTopicFutures;
 import io.streamnative.pulsar.handlers.kop.RequestStats;
-import lombok.Getter;
-import org.apache.kafka.common.TopicPartition;
-
 import java.util.Map;
 import java.util.function.Consumer;
+import lombok.Getter;
+import org.apache.kafka.common.TopicPartition;
 
 @Getter
 public class AppendRecordsContext {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/AppendRecordsContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/AppendRecordsContext.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.storage;
+
+import io.netty.util.Recycler;
+import io.streamnative.pulsar.handlers.kop.KafkaTopicManager;
+import io.streamnative.pulsar.handlers.kop.PendingTopicFutures;
+import io.streamnative.pulsar.handlers.kop.RequestStats;
+import lombok.Getter;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+@Getter
+public class AppendRecordsContext {
+    private static final Recycler<AppendRecordsContext> RECYCLER = new Recycler<AppendRecordsContext>() {
+        protected AppendRecordsContext newObject(Handle<AppendRecordsContext> handle) {
+            return new AppendRecordsContext(handle);
+        }
+    };
+
+    private final Recycler.Handle<AppendRecordsContext> recyclerHandle;
+    private KafkaTopicManager topicManager;
+    private RequestStats requestStats;
+    private Consumer<Integer> startSendOperationForThrottling;
+    private Consumer<Integer> completeSendOperationForThrottling;
+    private Map<TopicPartition, PendingTopicFutures> pendingTopicFuturesMap;
+
+    private AppendRecordsContext(Recycler.Handle<AppendRecordsContext> recyclerHandle) {
+        this.recyclerHandle = recyclerHandle;
+    }
+
+    // recycler and get for this object
+    public static AppendRecordsContext get(final KafkaTopicManager topicManager,
+                                           final RequestStats requestStats,
+                                           final Consumer<Integer> startSendOperationForThrottling,
+                                           final Consumer<Integer> completeSendOperationForThrottling,
+                                           final Map<TopicPartition, PendingTopicFutures> pendingTopicFuturesMap) {
+        AppendRecordsContext context = RECYCLER.get();
+        context.topicManager = topicManager;
+        context.requestStats = requestStats;
+        context.startSendOperationForThrottling = startSendOperationForThrottling;
+        context.completeSendOperationForThrottling = completeSendOperationForThrottling;
+        context.pendingTopicFuturesMap = pendingTopicFuturesMap;
+
+        return context;
+    }
+
+    public void recycle() {
+        topicManager = null;
+        requestStats = null;
+        startSendOperationForThrottling = null;
+        completeSendOperationForThrottling = null;
+        pendingTopicFuturesMap = null;
+        recyclerHandle.recycle(this);
+    }
+
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/AppendRecordsContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/AppendRecordsContext.java
@@ -22,6 +22,9 @@ import java.util.function.Consumer;
 import lombok.Getter;
 import org.apache.kafka.common.TopicPartition;
 
+/**
+ * AppendRecordsContext is use for pass parameters to ReplicaManager, to avoid long parameter lists.
+ */
 @Getter
 public class AppendRecordsContext {
     private static final Recycler<AppendRecordsContext> RECYCLER = new Recycler<AppendRecordsContext>() {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -52,19 +52,13 @@ import org.apache.pulsar.common.naming.TopicName;
 @Slf4j
 @AllArgsConstructor
 public class PartitionLog {
-    private KafkaServiceConfiguration kafkaConfig;
-    private Time time;
-    private TopicPartition topicPartition;
-    private String namespacePrefix;
-    private String fullPartitionName;
-    private EntryFormatter entryFormatter;
-    private Optional<TransactionCoordinator> transactionCoordinator;
-
-    public CompletableFuture<Long> appendRecords(final MemoryRecords records,
-                                                 final short version,
-                                                 final AppendRecordsContext appendRecordsContext) {
-        return append(records, version, appendRecordsContext);
-    }
+    private final KafkaServiceConfiguration kafkaConfig;
+    private final Time time;
+    private final TopicPartition topicPartition;
+    private final String namespacePrefix;
+    private final String fullPartitionName;
+    private final EntryFormatter entryFormatter;
+    private final Optional<TransactionCoordinator> transactionCoordinator;
 
     /**
      * Append this message to pulsar.
@@ -73,7 +67,7 @@ public class PartitionLog {
      * @param version Inter-broker message protocol version
      * @param appendRecordsContext See {@link AppendRecordsContext}
      */
-    private CompletableFuture<Long> append(final MemoryRecords records,
+    public CompletableFuture<Long> appendRecords(final MemoryRecords records,
                                            final short version,
                                            final AppendRecordsContext appendRecordsContext) {
         CompletableFuture<Long> appendFuture = new CompletableFuture<>();
@@ -123,10 +117,6 @@ public class PartitionLog {
                         time.nanoseconds() - beforeRecordsProcess, TimeUnit.NANOSECONDS);
                 appendRecordsContext.getStartSendOperationForThrottling()
                         .accept(encodeResult.getEncodedByteBuf().readableBytes());
-                if (log.isDebugEnabled()) {
-                    log.debug("Produce messages for topic {} partition {}",
-                            topicPartition.topic(), topicPartition.partition());
-                }
 
                 publishMessages(persistentTopicOpt,
                         appendFuture,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -47,8 +47,11 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.common.naming.TopicName;
 
-@AllArgsConstructor
+/**
+ * An append-only log for storing messages. Mapping to Kafka Log.scala.
+ */
 @Slf4j
+@AllArgsConstructor
 public class PartitionLog {
     private KafkaServiceConfiguration kafkaConfig;
     private Time time;
@@ -89,14 +92,15 @@ public class PartitionLog {
     }
 
     /**
-     * Append this message set to the active segment of the log, rolling over to a fresh segment if necessary.
+     * Append this message to pulsar.
      *
      * This method will generally be responsible for assigning offsets to the messages,
      * however if the assignOffsets=false flag is passed we will only check that the existing offsets are valid.
      *
      * @param records The log records to append
      * @param version Inter-broker message protocol version
-     * @param ignoreRecordSize true to skip validation of record size.
+     * @param ignoreRecordSize true to skip validation of record size
+     * @param appendRecordsContext See {@link AppendRecordsContext}
      */
     private CompletableFuture<Long> append(final MemoryRecords records,
                                            final short version,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -1,0 +1,356 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.storage;
+
+import io.netty.buffer.ByteBuf;
+import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
+import io.streamnative.pulsar.handlers.kop.KafkaTopicManager;
+import io.streamnative.pulsar.handlers.kop.MessagePublishContext;
+import io.streamnative.pulsar.handlers.kop.PendingTopicFutures;
+import io.streamnative.pulsar.handlers.kop.RequestStats;
+import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
+import io.streamnative.pulsar.handlers.kop.format.EncodeRequest;
+import io.streamnative.pulsar.handlers.kop.format.EncodeResult;
+import io.streamnative.pulsar.handlers.kop.format.EntryFormatter;
+import io.streamnative.pulsar.handlers.kop.format.KafkaMixedEntryFormatter;
+import io.streamnative.pulsar.handlers.kop.utils.MessageMetadataUtils;
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.common.util.MathUtils;
+import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.CorruptRecordException;
+import org.apache.kafka.common.errors.RecordTooLargeException;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.InvalidRecordException;
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.MutableRecordBatch;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.common.naming.TopicName;
+
+@AllArgsConstructor
+@Slf4j
+public class PartitionLog {
+    private KafkaServiceConfiguration kafkaConfig;
+    private TopicPartition topicPartition;
+    private String namespacePrefix;
+    private String fullPartitionName;
+    private EntryFormatter entryFormatter;
+
+
+    // A lock that guards all modifications to the log
+    private final Object lock = new Object();
+
+    @Data
+    @AllArgsConstructor
+    public static final class LogAppendInfo {
+        private Optional<Long> firstOffset;
+        private Long lastOffset;
+        private Integer shallowCount;
+        private Boolean offsetsMonotonic;
+        private Long lastOffsetOfFirstBatch;
+        private Integer validBytes;
+
+        public Long numMessages() {
+            return firstOffset.map(firstOffsetVal -> {
+                if (firstOffsetVal >= 0 && lastOffset >= 0) {
+                    return lastOffset - firstOffsetVal + 1;
+                }
+                return 0L;
+            }).orElse(0L);
+        }
+    }
+
+    public void appendRecords(final MemoryRecords records,
+                              final short version,
+                              final KafkaTopicManager topicManager,
+                              final RequestStats requestStats,
+                              final TransactionCoordinator coordinator,
+                              final Consumer<Long> offsetConsumer,
+                              final Consumer<Errors> errorsConsumer,
+                              final Consumer<Throwable> exceptionConsumer,
+                              final Consumer<Integer> startSendOperationForThrottlingConsumer,
+                              final Consumer<Integer> completeSendOperationForThrottlingConsumer,
+                              final Map<TopicPartition, PendingTopicFutures> pendingTopicFuturesMap) {
+        append(records,
+                version,
+                topicManager,
+                requestStats,
+                coordinator,
+                false,
+                offsetConsumer,
+                errorsConsumer,
+                exceptionConsumer,
+                startSendOperationForThrottlingConsumer,
+                completeSendOperationForThrottlingConsumer,
+                pendingTopicFuturesMap);
+    }
+
+    /**
+     * Append this message set to the active segment of the log, rolling over to a fresh segment if necessary.
+     *
+     * This method will generally be responsible for assigning offsets to the messages,
+     * however if the assignOffsets=false flag is passed we will only check that the existing offsets are valid.
+     *
+     * @param records The log records to append
+     * @param version Inter-broker message protocol version
+     * @param ignoreRecordSize true to skip validation of record size.
+     */
+    private void append(final MemoryRecords records,
+                        final short version,
+                        final KafkaTopicManager topicManager,
+                        final RequestStats requestStats,
+                        final TransactionCoordinator coordinator,
+                        final boolean ignoreRecordSize,
+                        final Consumer<Long> offsetConsumer,
+                        final Consumer<Errors> errorsConsumer,
+                        final Consumer<Throwable> exceptionConsumer,
+                        final Consumer<Integer> startSendOperationForThrottlingConsumer,
+                        final Consumer<Integer> completeSendOperationForThrottlingConsumer,
+                        final Map<TopicPartition, PendingTopicFutures> pendingTopicFuturesMap
+                        ) {
+        final long beforeRecordsProcess = MathUtils.nowInNano();
+        final LogAppendInfo appendInfo = analyzeAndValidateRecords(records, version, topicPartition, ignoreRecordSize);
+
+        // return if we have no valid messages or if this is a duplicate of the last appended entry
+        if (appendInfo.getShallowCount() == 0) {
+            return;
+        }
+        // trim any invalid bytes or partial messages before appending it to the on-disk log
+        MemoryRecords validRecords = trimInvalidBytes(records, appendInfo);
+        synchronized (lock) {
+            long offset  = -1;
+            appendInfo.setFirstOffset(Optional.of(offset));
+            // TODO: validateMessagesAndAssignOffsets
+
+            // Append Message into pulsar
+            final CompletableFuture<Optional<PersistentTopic>> topicFuture =
+                    topicManager.getTopic(fullPartitionName);
+            if (topicFuture.isCompletedExceptionally()) {
+                topicFuture.exceptionally(e -> {
+                    exceptionConsumer.accept(e);
+                    return Optional.empty();
+                });
+                return;
+            }
+            if (topicFuture.isDone() && !topicFuture.getNow(Optional.empty()).isPresent()) {
+                errorsConsumer.accept(Errors.NOT_LEADER_FOR_PARTITION);
+                return;
+            }
+            final Consumer<Optional<PersistentTopic>> persistentTopicConsumer = persistentTopicOpt -> {
+                if (!persistentTopicOpt.isPresent()) {
+                    errorsConsumer.accept(Errors.NOT_LEADER_FOR_PARTITION);
+                    return;
+                }
+
+                final EncodeRequest encodeRequest = EncodeRequest.get(validRecords);
+                if (entryFormatter instanceof KafkaMixedEntryFormatter) {
+                    final ManagedLedger managedLedger = persistentTopicOpt.get().getManagedLedger();
+                    final long logEndOffset = MessageMetadataUtils.getLogEndOffset(managedLedger);
+                    encodeRequest.setBaseOffset(logEndOffset);
+                }
+
+                final EncodeResult encodeResult = entryFormatter.encode(encodeRequest);
+                encodeRequest.recycle();
+                requestStats.getProduceEncodeStats().registerSuccessfulEvent(
+                        MathUtils.elapsedNanos(beforeRecordsProcess), TimeUnit.NANOSECONDS);
+//                startSendOperationForThrottling(encodeResult.getEncodedByteBuf().readableBytes());
+                startSendOperationForThrottlingConsumer.accept(encodeResult.getEncodedByteBuf().readableBytes());
+                if (log.isDebugEnabled()) {
+                    log.debug("Produce messages for topic {} partition {}",
+                            topicPartition.topic(), topicPartition.partition());
+                }
+
+                publishMessages(persistentTopicOpt,
+                        topicManager,
+                        coordinator,
+                        requestStats,
+                        encodeResult,
+                        topicPartition,
+                        offsetConsumer,
+                        errorsConsumer,
+                        completeSendOperationForThrottlingConsumer);
+            };
+
+            if (topicFuture.isDone()) {
+                persistentTopicConsumer.accept(topicFuture.getNow(Optional.empty()));
+            } else {
+                // topic is not available now
+                pendingTopicFuturesMap
+                        .computeIfAbsent(topicPartition, ignored ->
+                                new PendingTopicFutures(requestStats))
+                        .addListener(topicFuture, persistentTopicConsumer, exceptionConsumer);
+            }
+        }
+    }
+
+    private void publishMessages(final Optional<PersistentTopic> persistentTopicOpt,
+                                 final KafkaTopicManager topicManager,
+                                 final TransactionCoordinator coordinator,
+                                 final RequestStats requestStats,
+                                 final EncodeResult encodeResult,
+                                 final TopicPartition topicPartition,
+                                 final Consumer<Long> offsetConsumer,
+                                 final Consumer<Errors> errorsConsumer,
+                                 final Consumer<Integer> completeSendOperationForThrottlingConsumer) {
+        final MemoryRecords records = encodeResult.getRecords();
+        final int numMessages = encodeResult.getNumMessages();
+        final ByteBuf byteBuf = encodeResult.getEncodedByteBuf();
+        if (!persistentTopicOpt.isPresent()) {
+            encodeResult.recycle();
+            // It will trigger a retry send of Kafka client
+            errorsConsumer.accept(Errors.NOT_LEADER_FOR_PARTITION);
+            return;
+        }
+        PersistentTopic persistentTopic = persistentTopicOpt.get();
+        if (persistentTopic.isSystemTopic()) {
+            encodeResult.recycle();
+            log.error("Not support producing message to system topic: {}", persistentTopic);
+            errorsConsumer.accept(Errors.INVALID_TOPIC_EXCEPTION);
+            return;
+        }
+
+        topicManager.registerProducerInPersistentTopic(fullPartitionName, persistentTopic);
+
+        // collect metrics
+        encodeResult.updateProducerStats(topicPartition, requestStats, namespacePrefix);
+
+        // publish
+        final CompletableFuture<Long> offsetFuture = new CompletableFuture<>();
+        final long beforePublish = MathUtils.nowInNano();
+        persistentTopic.publishMessage(byteBuf,
+                MessagePublishContext.get(offsetFuture, persistentTopic, numMessages, System.nanoTime()));
+        final RecordBatch batch = records.batchIterator().next();
+        offsetFuture.whenComplete((offset, e) -> {
+//            completeSendOperationForThrottling(byteBuf.readableBytes());
+            completeSendOperationForThrottlingConsumer.accept(byteBuf.readableBytes());
+            encodeResult.recycle();
+            if (e == null) {
+                if (batch.isTransactional()) {
+                    coordinator.addActivePidOffset(TopicName.get(fullPartitionName), batch.producerId(),
+                            offset);
+                }
+                requestStats.getMessagePublishStats().registerSuccessfulEvent(
+                        MathUtils.elapsedNanos(beforePublish), TimeUnit.NANOSECONDS);
+                offsetConsumer.accept(offset);
+            } else {
+                log.error("publishMessages for topic partition: {} failed when write.", fullPartitionName, e);
+                requestStats.getMessagePublishStats().registerFailedEvent(
+                        MathUtils.elapsedNanos(beforePublish), TimeUnit.NANOSECONDS);
+                errorsConsumer.accept(Errors.KAFKA_STORAGE_ERROR);
+            }
+        });
+    }
+
+    private LogAppendInfo analyzeAndValidateRecords(MemoryRecords records,
+                                                    short version,
+                                                    TopicPartition topicPartition,
+                                                    boolean ignoreRecordSize) {
+        int shallowMessageCount = 0;
+        long lastOffset = -1L;
+        Optional<Long> firstOffset = Optional.empty();
+        long lastOffsetOfFirstBatch = -1L;
+        boolean readFirstMessage = false;
+        boolean monotonic = true;
+
+        if (version >= 3) {
+            Iterator<MutableRecordBatch> iterator = records.batches().iterator();
+            if (!iterator.hasNext()) {
+                throw new InvalidRecordException("Produce requests with version " + version + " must have at least "
+                        + "one record batch");
+            }
+
+            MutableRecordBatch entry = iterator.next();
+            if (entry.magic() != RecordBatch.MAGIC_VALUE_V2) {
+                throw new InvalidRecordException("Produce requests with version " + version + " are only allowed to "
+                        + "contain record batches with magic version 2");
+            }
+
+            if (iterator.hasNext()) {
+                throw new InvalidRecordException("Produce requests with version " + version + " are only allowed to "
+                        + "contain exactly one record batch");
+            }
+        }
+
+        int validBytesCount = 0;
+        for (RecordBatch batch : records.batches()) {
+            if (batch.magic() >= RecordBatch.MAGIC_VALUE_V2 && batch.baseOffset() != 0) {
+                throw new InvalidRecordException("The baseOffset of the record batch in the append to "
+                        + topicPartition + " should be 0, but it is " + batch.baseOffset());
+            }
+            if (!readFirstMessage) {
+                if (batch.magic() >= RecordBatch.MAGIC_VALUE_V2) {
+                    firstOffset = Optional.of(batch.baseOffset());
+                }
+                lastOffsetOfFirstBatch = batch.lastOffset();
+                readFirstMessage = true;
+            }
+            // check that offsets are monotonically increasing
+            if (lastOffset >= batch.lastOffset()){
+                monotonic = false;
+            }
+
+            // update the last offset seen
+            lastOffset = batch.lastOffset();
+
+            int batchSize = batch.sizeInBytes();
+            if (!ignoreRecordSize && batchSize > kafkaConfig.getMaxMessageSize()) {
+                throw new RecordTooLargeException(String.format("Message batch size is %s "
+                                + "in append to partition %s which exceeds the maximum configured size of %s .",
+                        batchSize, topicPartition, kafkaConfig.getMaxMessageSize()));
+            }
+
+            batch.ensureValid();
+            shallowMessageCount += 1;
+            validBytesCount += batchSize;
+        }
+
+        if (validBytesCount < 0) {
+            throw new CorruptRecordException("Cannot append record batch with illegal length "
+                    + validBytesCount + " to log for " + topicPartition
+                    + ". A possible cause is corrupted produce request.");
+        }
+
+        return new LogAppendInfo(
+                firstOffset,
+                lastOffset,
+                shallowMessageCount,
+                monotonic,
+                lastOffsetOfFirstBatch,
+                validBytesCount);
+    }
+
+    private MemoryRecords trimInvalidBytes(MemoryRecords records, LogAppendInfo info) {
+        Integer validBytes = info.getValidBytes();
+        if (validBytes < 0){
+            throw new CorruptRecordException(String.format("Cannot append record batch with illegal length %s to "
+                    + "log for %s. A possible cause is a corrupted produce request.", validBytes, topicPartition));
+        } else if (validBytes == records.sizeInBytes()) {
+            return records;
+        } else {
+            ByteBuffer validByteBuffer = records.buffer().duplicate();
+            validByteBuffer.limit(validBytes);
+            return MemoryRecords.readableRecords(validByteBuffer);
+        }
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -31,7 +31,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.kafka.common.TopicPartition;
@@ -57,30 +56,6 @@ public class PartitionLog {
     private String fullPartitionName;
     private EntryFormatter entryFormatter;
     private Optional<TransactionCoordinator> transactionCoordinator;
-
-
-    // A lock that guards all modifications to the log
-    private final Object lock = new Object();
-
-    @Data
-    @AllArgsConstructor
-    public static final class LogAppendInfo {
-        private Optional<Long> firstOffset;
-        private Long lastOffset;
-        private Integer shallowCount;
-        private Boolean offsetsMonotonic;
-        private Long lastOffsetOfFirstBatch;
-        private Integer validBytes;
-
-        public Long numMessages() {
-            return firstOffset.map(firstOffsetVal -> {
-                if (firstOffsetVal >= 0 && lastOffset >= 0) {
-                    return lastOffset - firstOffsetVal + 1;
-                }
-                return 0L;
-            }).orElse(0L);
-        }
-    }
 
     public CompletableFuture<Long> appendRecords(final MemoryRecords records,
                                                  final short version,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
@@ -17,7 +17,6 @@ import com.google.common.collect.Maps;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
 import io.streamnative.pulsar.handlers.kop.format.EntryFormatter;
-import io.streamnative.pulsar.handlers.kop.format.EntryFormatterFactory;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
 import java.util.Map;
 import java.util.Optional;
@@ -38,11 +37,12 @@ public class PartitionLogManager {
     private final Time time;
 
     public PartitionLogManager(KafkaServiceConfiguration config,
+                               EntryFormatter entryFormatter,
                                Optional<TransactionCoordinator> transactionCoordinator,
                                Time time) {
         this.logMap = Maps.newConcurrentMap();
         this.transactionCoordinator = transactionCoordinator;
-        this.formatter = EntryFormatterFactory.create(config);
+        this.formatter = entryFormatter;
         this.config = config;
         this.time = time;
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
@@ -14,7 +14,6 @@
 package io.streamnative.pulsar.handlers.kop.storage;
 
 import com.google.common.collect.Maps;
-import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
 import io.streamnative.pulsar.handlers.kop.format.EntryFormatter;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
@@ -31,26 +30,23 @@ import org.apache.kafka.common.utils.Time;
 public class PartitionLogManager {
 
     private final Map<String, PartitionLog> logMap;
-    private final KafkaServiceConfiguration config;
     private final Optional<TransactionCoordinator> transactionCoordinator;
     private final EntryFormatter formatter;
     private final Time time;
 
-    public PartitionLogManager(KafkaServiceConfiguration config,
-                               EntryFormatter entryFormatter,
+    public PartitionLogManager(EntryFormatter entryFormatter,
                                Optional<TransactionCoordinator> transactionCoordinator,
                                Time time) {
         this.logMap = Maps.newConcurrentMap();
         this.transactionCoordinator = transactionCoordinator;
         this.formatter = entryFormatter;
-        this.config = config;
         this.time = time;
     }
 
     public PartitionLog getLog(TopicPartition topicPartition, String namespacePrefix) {
         String kopTopic = KopTopic.toString(topicPartition, namespacePrefix);
         return logMap.computeIfAbsent(kopTopic, key ->
-                new PartitionLog(config, time, topicPartition, namespacePrefix, kopTopic, formatter,
+                new PartitionLog(time, topicPartition, namespacePrefix, kopTopic, formatter,
                         this.transactionCoordinator)
         );
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.storage;
+
+import com.google.common.collect.Maps;
+import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
+import io.streamnative.pulsar.handlers.kop.format.EntryFormatter;
+import io.streamnative.pulsar.handlers.kop.format.EntryFormatterFactory;
+import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.Time;
+
+@AllArgsConstructor
+public class PartitionLogManager {
+
+    private final Map<String, PartitionLog> logMap;
+    private final KafkaServiceConfiguration config;
+    private final EntryFormatter formatter;
+    private final Time time;
+
+    public PartitionLogManager(KafkaServiceConfiguration config,
+                               Time time) {
+        this.logMap = Maps.newConcurrentMap();
+        this.formatter = EntryFormatterFactory.create(config);
+        this.config = config;
+        this.time = time;
+    }
+
+    public PartitionLog getLog(TopicPartition topicPartition, String namespacePrefix) {
+        String kopTopic = KopTopic.toString(topicPartition, namespacePrefix);
+        return logMap.computeIfAbsent(kopTopic, key ->
+                new PartitionLog(config, topicPartition, namespacePrefix, kopTopic, formatter)
+        );
+    }
+}
+

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
@@ -14,6 +14,7 @@
 package io.streamnative.pulsar.handlers.kop.storage;
 
 import com.google.common.collect.Maps;
+import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
 import io.streamnative.pulsar.handlers.kop.format.EntryFormatter;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
@@ -29,14 +30,17 @@ import org.apache.kafka.common.utils.Time;
 @AllArgsConstructor
 public class PartitionLogManager {
 
+    private KafkaServiceConfiguration kafkaConfig;
     private final Map<String, PartitionLog> logMap;
     private final Optional<TransactionCoordinator> transactionCoordinator;
     private final EntryFormatter formatter;
     private final Time time;
 
-    public PartitionLogManager(EntryFormatter entryFormatter,
+    public PartitionLogManager(KafkaServiceConfiguration kafkaConfig,
+                               EntryFormatter entryFormatter,
                                Optional<TransactionCoordinator> transactionCoordinator,
                                Time time) {
+        this.kafkaConfig = kafkaConfig;
         this.logMap = Maps.newConcurrentMap();
         this.transactionCoordinator = transactionCoordinator;
         this.formatter = entryFormatter;
@@ -46,7 +50,7 @@ public class PartitionLogManager {
     public PartitionLog getLog(TopicPartition topicPartition, String namespacePrefix) {
         String kopTopic = KopTopic.toString(topicPartition, namespacePrefix);
         return logMap.computeIfAbsent(kopTopic, key ->
-                new PartitionLog(time, topicPartition, namespacePrefix, kopTopic, formatter,
+                new PartitionLog(kafkaConfig, time, topicPartition, namespacePrefix, kopTopic, formatter,
                         this.transactionCoordinator)
         );
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
@@ -25,6 +25,9 @@ import lombok.AllArgsConstructor;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Time;
 
+/**
+ * Manage {@link PartitionLog}.
+ */
 @AllArgsConstructor
 public class PartitionLogManager {
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
@@ -36,6 +36,9 @@ import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.requests.ProduceResponse;
 import org.apache.kafka.common.utils.Time;
 
+/**
+ * Used to append records. Mapping to Kafka ReplicaManager.scala.
+ */
 @Slf4j
 public class ReplicaManager {
     private final PartitionLogManager logManager;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
@@ -14,7 +14,6 @@
 package io.streamnative.pulsar.handlers.kop.storage;
 
 import io.streamnative.pulsar.handlers.kop.DelayedProduceAndFetch;
-import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
 import io.streamnative.pulsar.handlers.kop.format.EntryFormatter;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
@@ -45,12 +44,11 @@ public class ReplicaManager {
     private final PartitionLogManager logManager;
     private final DelayedOperationPurgatory<DelayedOperation> producePurgatory;
 
-    public ReplicaManager(KafkaServiceConfiguration config,
-                          Time time,
+    public ReplicaManager(Time time,
                           EntryFormatter entryFormatter,
                           Optional<TransactionCoordinator> transactionCoordinator,
                           DelayedOperationPurgatory<DelayedOperation> producePurgatory) {
-        this.logManager = new PartitionLogManager(config, entryFormatter, transactionCoordinator, time);
+        this.logManager = new PartitionLogManager(entryFormatter, transactionCoordinator, time);
         this.producePurgatory = producePurgatory;
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
@@ -25,6 +25,7 @@ import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperationKey;
 import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperationPurgatory;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -47,9 +48,10 @@ public class ReplicaManager {
 
     public ReplicaManager(KafkaServiceConfiguration config,
                           Time time,
+                          Optional<TransactionCoordinator> transactionCoordinator,
                           DelayedOperationPurgatory<DelayedOperation> producePurgatory,
                           DelayedOperationPurgatory<DelayedOperation> fetchPurgatory) {
-        this.logManager = new PartitionLogManager(config, time);
+        this.logManager = new PartitionLogManager(config, transactionCoordinator, time);
         this.producePurgatory = producePurgatory;
         this.fetchPurgatory = fetchPurgatory;
     }
@@ -66,7 +68,6 @@ public class ReplicaManager {
             final String namespacePrefix,
             final Map<TopicPartition, MemoryRecords> entriesPerPartition,
             final RequestStats requestStats,
-            final TransactionCoordinator coordinator,
             final Consumer<Integer> startSendOperationForThrottlingConsumer,
             final Consumer<Integer> completeSendOperationForThrottlingConsumer,
             final Map<TopicPartition, PendingTopicFutures> pendingTopicFuturesMap,
@@ -126,7 +127,6 @@ public class ReplicaManager {
                         version,
                         topicManager,
                         requestStats,
-                        coordinator,
                         offsetConsumer,
                         errorsConsumer,
                         exceptionConsumer,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
@@ -1,0 +1,152 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.storage;
+
+import io.streamnative.pulsar.handlers.kop.DelayedProduceAndFetch;
+import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
+import io.streamnative.pulsar.handlers.kop.KafkaTopicManager;
+import io.streamnative.pulsar.handlers.kop.PendingTopicFutures;
+import io.streamnative.pulsar.handlers.kop.RequestStats;
+import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
+import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
+import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperation;
+import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperationKey;
+import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperationPurgatory;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.InvalidTopicException;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.requests.ProduceResponse;
+import org.apache.kafka.common.utils.Time;
+
+@Slf4j
+public class ReplicaManager {
+    private final PartitionLogManager logManager;
+    private final DelayedOperationPurgatory<DelayedOperation> producePurgatory;
+    private final DelayedOperationPurgatory<DelayedOperation> fetchPurgatory;
+
+    public ReplicaManager(KafkaServiceConfiguration config,
+                          Time time,
+                          DelayedOperationPurgatory<DelayedOperation> producePurgatory,
+                          DelayedOperationPurgatory<DelayedOperation> fetchPurgatory) {
+        this.logManager = new PartitionLogManager(config, time);
+        this.producePurgatory = producePurgatory;
+        this.fetchPurgatory = fetchPurgatory;
+    }
+
+    public PartitionLog getPartitionLog(TopicPartition topicPartition, String namespacePrefix) {
+        return logManager.getLog(topicPartition, namespacePrefix);
+    }
+
+    public void appendRecords(
+            final long timeout,
+            final boolean internalTopicsAllowed,
+            final short version,
+            final KafkaTopicManager topicManager,
+            final String namespacePrefix,
+            final Map<TopicPartition, MemoryRecords> entriesPerPartition,
+            final RequestStats requestStats,
+            final TransactionCoordinator coordinator,
+            final Consumer<Integer> startSendOperationForThrottlingConsumer,
+            final Consumer<Integer> completeSendOperationForThrottlingConsumer,
+            final Map<TopicPartition, PendingTopicFutures> pendingTopicFuturesMap,
+            final CompletableFuture<Map<TopicPartition, ProduceResponse.PartitionResponse>> responseCallback) {
+
+        final AtomicInteger topicPartitionNum = new AtomicInteger(entriesPerPartition.size());
+        final Map<TopicPartition, ProduceResponse.PartitionResponse> responseMap = new ConcurrentHashMap<>();
+
+        Runnable complete = () -> {
+            topicPartitionNum.set(0);
+            if (responseCallback.isDone()) {
+                // It may be triggered again in DelayedProduceAndFetch
+                return;
+            }
+            // add the topicPartition with timeout error if it's not existed in responseMap
+            entriesPerPartition.keySet().forEach(topicPartition -> {
+                if (!responseMap.containsKey(topicPartition)) {
+                    responseMap.put(topicPartition, new ProduceResponse.PartitionResponse(Errors.REQUEST_TIMED_OUT));
+                }
+            });
+            if (log.isDebugEnabled()) {
+                log.debug("Complete handle appendRecords.");
+            }
+            responseCallback.complete(responseMap);
+        };
+        BiConsumer<TopicPartition, ProduceResponse.PartitionResponse> addPartitionResponse =
+                (topicPartition, response) -> {
+            responseMap.put(topicPartition, response);
+            // reset topicPartitionNum
+            int restTopicPartitionNum = topicPartitionNum.decrementAndGet();
+            if (restTopicPartitionNum < 0) {
+                return;
+            }
+            if (restTopicPartitionNum == 0) {
+                complete.run();
+            }
+        };
+        entriesPerPartition.forEach((topicPartition, memoryRecords) -> {
+            final Consumer<Long> offsetConsumer = offset -> addPartitionResponse.accept(
+                    topicPartition,
+                    new ProduceResponse.PartitionResponse(Errors.NONE, offset, -1L, -1L));
+            final Consumer<Errors> errorsConsumer =
+                    errors -> addPartitionResponse
+                            .accept(topicPartition, new ProduceResponse.PartitionResponse(errors));
+            final Consumer<Throwable> exceptionConsumer =
+                    e -> addPartitionResponse
+                            .accept(topicPartition, new ProduceResponse.PartitionResponse(Errors.forException(e)));
+
+            String fullPartitionName = KopTopic.toString(topicPartition, namespacePrefix);
+            // reject appending to internal topics if it is not allowed
+            if (!internalTopicsAllowed && KopTopic.isInternalTopic(fullPartitionName)) {
+                exceptionConsumer.accept(new InvalidTopicException(
+                        String.format("Cannot append to internal topic %s", topicPartition.topic())));
+            } else {
+                PartitionLog partitionLog = getPartitionLog(topicPartition, namespacePrefix);
+                partitionLog.appendRecords(memoryRecords,
+                        version,
+                        topicManager,
+                        requestStats,
+                        coordinator,
+                        offsetConsumer,
+                        errorsConsumer,
+                        exceptionConsumer,
+                        startSendOperationForThrottlingConsumer,
+                        completeSendOperationForThrottlingConsumer,
+                        pendingTopicFuturesMap);
+            }
+
+        });
+        // delay produce
+        if (timeout <= 0) {
+            complete.run();
+        } else {
+            List<Object> delayedCreateKeys =
+                    entriesPerPartition.keySet().stream()
+                            .map(DelayedOperationKey.TopicPartitionOperationKey::new).collect(Collectors.toList());
+            DelayedProduceAndFetch delayedProduce = new DelayedProduceAndFetch(timeout, topicPartitionNum, complete);
+            producePurgatory.tryCompleteElseWatch(delayedProduce, delayedCreateKeys);
+        }
+
+    }
+
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
@@ -16,6 +16,7 @@ package io.streamnative.pulsar.handlers.kop.storage;
 import io.streamnative.pulsar.handlers.kop.DelayedProduceAndFetch;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
+import io.streamnative.pulsar.handlers.kop.format.EntryFormatter;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
 import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperation;
 import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperationKey;
@@ -46,9 +47,10 @@ public class ReplicaManager {
 
     public ReplicaManager(KafkaServiceConfiguration config,
                           Time time,
+                          EntryFormatter entryFormatter,
                           Optional<TransactionCoordinator> transactionCoordinator,
                           DelayedOperationPurgatory<DelayedOperation> producePurgatory) {
-        this.logManager = new PartitionLogManager(config, transactionCoordinator, time);
+        this.logManager = new PartitionLogManager(config, entryFormatter, transactionCoordinator, time);
         this.producePurgatory = producePurgatory;
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
@@ -14,6 +14,7 @@
 package io.streamnative.pulsar.handlers.kop.storage;
 
 import io.streamnative.pulsar.handlers.kop.DelayedProduceAndFetch;
+import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
 import io.streamnative.pulsar.handlers.kop.format.EntryFormatter;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
@@ -44,11 +45,12 @@ public class ReplicaManager {
     private final PartitionLogManager logManager;
     private final DelayedOperationPurgatory<DelayedOperation> producePurgatory;
 
-    public ReplicaManager(Time time,
+    public ReplicaManager(KafkaServiceConfiguration kafkaConfig,
+                          Time time,
                           EntryFormatter entryFormatter,
                           Optional<TransactionCoordinator> transactionCoordinator,
                           DelayedOperationPurgatory<DelayedOperation> producePurgatory) {
-        this.logManager = new PartitionLogManager(entryFormatter, transactionCoordinator, time);
+        this.logManager = new PartitionLogManager(kafkaConfig, entryFormatter, transactionCoordinator, time);
         this.producePurgatory = producePurgatory;
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
@@ -44,16 +44,13 @@ import org.apache.kafka.common.utils.Time;
 public class ReplicaManager {
     private final PartitionLogManager logManager;
     private final DelayedOperationPurgatory<DelayedOperation> producePurgatory;
-    private final DelayedOperationPurgatory<DelayedOperation> fetchPurgatory;
 
     public ReplicaManager(KafkaServiceConfiguration config,
                           Time time,
                           Optional<TransactionCoordinator> transactionCoordinator,
-                          DelayedOperationPurgatory<DelayedOperation> producePurgatory,
-                          DelayedOperationPurgatory<DelayedOperation> fetchPurgatory) {
+                          DelayedOperationPurgatory<DelayedOperation> producePurgatory) {
         this.logManager = new PartitionLogManager(config, transactionCoordinator, time);
         this.producePurgatory = producePurgatory;
-        this.fetchPurgatory = fetchPurgatory;
     }
 
     public PartitionLog getPartitionLog(TopicPartition topicPartition, String namespacePrefix) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/package-info.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.storage;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KopTopic.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KopTopic.java
@@ -13,11 +13,14 @@
  */
 package io.streamnative.pulsar.handlers.kop.utils;
 
+import static org.apache.kafka.common.internals.Topic.GROUP_METADATA_TOPIC_NAME;
+import static org.apache.kafka.common.internals.Topic.TRANSACTION_STATE_TOPIC_NAME;
 import static org.apache.pulsar.common.naming.TopicName.PARTITIONED_TOPIC_SUFFIX;
 
 import io.streamnative.pulsar.handlers.kop.exceptions.KoPTopicException;
 import lombok.Getter;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.pulsar.common.naming.TopicName;
 
 /**
  * KopTopic maintains two topic name, one is the original topic name, the other is the full topic name used in Pulsar.
@@ -101,6 +104,12 @@ public class KopTopic {
 
     public static String toString(String topic, int partition, String namespacePrefix) {
         return (new KopTopic(topic, namespacePrefix)).getPartitionName(partition);
+    }
+
+    public static boolean isInternalTopic(final String fullTopicName) {
+        String partitionedTopicName = TopicName.get(fullTopicName).getPartitionedTopicName();
+        return partitionedTopicName.endsWith("/" + GROUP_METADATA_TOPIC_NAME)
+                || partitionedTopicName.endsWith("/" + TRANSACTION_STATE_TOPIC_NAME);
     }
 
 }

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/PendingTopicFuturesTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/PendingTopicFuturesTest.java
@@ -64,7 +64,8 @@ public class PendingTopicFuturesTest {
 
         for (int i = 0; i < 10; i++) {
             final int index = i;
-            pendingTopicFutures.addListener(topicFuture, ignored -> completedIndexes.add(index), e -> {});
+            pendingTopicFutures.addListener(
+                    topicFuture, ignored -> completedIndexes.add(index), new CompletableFuture<>());
             changesOfPendingCount.add(pendingTopicFutures.size());
             sleep(234);
         }
@@ -95,7 +96,12 @@ public class PendingTopicFuturesTest {
         final List<Integer> changesOfPendingCount = new ArrayList<>();
 
         for (int i = 0; i < 10; i++) {
-            pendingTopicFutures.addListener(topicFuture, topic -> {}, e -> exceptionMessages.add(e.getMessage()));
+            CompletableFuture<Long> longCompletableFuture = new CompletableFuture<>();
+            longCompletableFuture.exceptionally(ex -> {
+                exceptionMessages.add(ex.getMessage());
+                return null;
+            });
+            pendingTopicFutures.addListener(topicFuture, topic -> {}, longCompletableFuture);
             changesOfPendingCount.add(pendingTopicFutures.size());
             sleep(200);
         }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -26,6 +26,7 @@ import io.netty.channel.EventLoopGroup;
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupCoordinator;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
 import io.streamnative.pulsar.handlers.kop.stats.NullStatsLogger;
+import io.streamnative.pulsar.handlers.kop.storage.ReplicaManager;
 import io.streamnative.pulsar.handlers.kop.utils.MetadataUtils;
 import java.io.Closeable;
 import java.io.IOException;
@@ -768,6 +769,8 @@ public abstract class KopProtocolHandlerTestBase {
         final GroupCoordinator groupCoordinator = handler.getGroupCoordinator(conf.getKafkaMetadataTenant());
         final TransactionCoordinator transactionCoordinator =
                 handler.getTransactionCoordinator(conf.getKafkaMetadataTenant());
+        final ReplicaManager replicaManager =
+                handler.getReplicaManager(conf.getKafkaMetadataTenant());
 
         return ((KafkaChannelInitializer) handler.getChannelInitializerMap().entrySet().iterator().next().getValue())
                 .newCnx(new TenantContextManager() {
@@ -779,6 +782,11 @@ public abstract class KopProtocolHandlerTestBase {
                     @Override
                     public TransactionCoordinator getTransactionCoordinator(String tenant) {
                         return transactionCoordinator;
+                    }
+
+                    @Override
+                    public ReplicaManager getReplicaManager(String tenant) {
+                        return replicaManager;
                     }
                 }, NullStatsLogger.INSTANCE);
     }


### PR DESCRIPTION
### Motivation

Currently, the KoP store message logic is in `KafkaRequestHandler`, to avoid duplicate code and easier to support idempotent produce, we must refactor the message storage logic.

### Modifications
* Refactor message storage logic.
* The `ReplicaManager` is a public interface to store messages, we should always use `ReplicaManager` to store the message in any situation.

* `PartitionLog` mapping to Kafka is `Log`, the reason for using this name is to avoid naming conflict, like: `log.debug()`.

* `PartitionLogManager` hold all `PartitionLog`, key is full partition name, value is `PartitionLog`.

### TODO
* Add fetch operation
