### PR TITLE
Adjust pom.xml for dependency management

### DIFF
--- a/kafka-0-10/pom.xml
+++ b/kafka-0-10/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>${mavem-shade-plugin.version}</version>
+        <version>${maven-shade-plugin.version}</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/kafka-0-10/src/main/java/io/streamnative/kafka/client/zero/ten/Consumer010Impl.java
+++ b/kafka-0-10/src/main/java/io/streamnative/kafka/client/zero/ten/Consumer010Impl.java
@@ -13,7 +13,6 @@
  */
 package io.streamnative.kafka.client.zero.ten;
 
-import com.google.common.collect.Maps;
 import io.streamnative.kafka.client.api.Consumer;
 import io.streamnative.kafka.client.api.ConsumerConfiguration;
 import io.streamnative.kafka.client.api.ConsumerRecord;
@@ -51,7 +50,7 @@ public class Consumer010Impl<K, V> extends KafkaConsumer<K, V> implements Consum
 
     @Override
     public void commitOffsetSync(List<TopicOffsetAndMetadata> offsets, Duration timeout) {
-        HashMap<TopicPartition, OffsetAndMetadata> offsetsMap = Maps.newHashMap();
+        HashMap<TopicPartition, OffsetAndMetadata> offsetsMap = new HashMap<>();
         offsets.forEach(
                 offsetAndMetadata -> offsetsMap.put(
                         offsetAndMetadata.createTopicPartition(TopicPartition.class),

--- a/kafka-0-9/pom.xml
+++ b/kafka-0-9/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>${mavem-shade-plugin.version}</version>
+        <version>${maven-shade-plugin.version}</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/kafka-0-9/src/main/java/io/streamnative/kafka/client/zero/nine/Consumer009Impl.java
+++ b/kafka-0-9/src/main/java/io/streamnative/kafka/client/zero/nine/Consumer009Impl.java
@@ -13,7 +13,6 @@
  */
 package io.streamnative.kafka.client.zero.nine;
 
-import com.google.common.collect.Maps;
 import io.streamnative.kafka.client.api.Consumer;
 import io.streamnative.kafka.client.api.ConsumerConfiguration;
 import io.streamnative.kafka.client.api.ConsumerRecord;
@@ -57,7 +56,7 @@ public class Consumer009Impl<K, V> extends KafkaConsumer<K, V> implements Consum
 
     @Override
     public void commitOffsetSync(List<TopicOffsetAndMetadata> offsets, Duration timeout) {
-        HashMap<TopicPartition, OffsetAndMetadata> offsetsMap = Maps.newHashMap();
+        HashMap<TopicPartition, OffsetAndMetadata> offsetsMap = new HashMap<>();
         offsets.forEach(
                 offsetAndMetadata -> offsetsMap.put(
                         offsetAndMetadata.createTopicPartition(TopicPartition.class),

--- a/kafka-1-0/pom.xml
+++ b/kafka-1-0/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>${mavem-shade-plugin.version}</version>
+        <version>${maven-shade-plugin.version}</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/kafka-1-0/src/main/java/io/streamnative/kafka/client/one/zero/ConsumerImpl.java
+++ b/kafka-1-0/src/main/java/io/streamnative/kafka/client/one/zero/ConsumerImpl.java
@@ -13,7 +13,6 @@
  */
 package io.streamnative.kafka.client.one.zero;
 
-import com.google.common.collect.Maps;
 import io.streamnative.kafka.client.api.Consumer;
 import io.streamnative.kafka.client.api.ConsumerConfiguration;
 import io.streamnative.kafka.client.api.ConsumerRecord;
@@ -51,7 +50,7 @@ public class ConsumerImpl<K, V> extends KafkaConsumer<K, V> implements Consumer<
 
     @Override
     public void commitOffsetSync(List<TopicOffsetAndMetadata> offsets, Duration timeout) {
-        HashMap<TopicPartition, OffsetAndMetadata> offsetsMap = Maps.newHashMap();
+        HashMap<TopicPartition, OffsetAndMetadata> offsetsMap = new HashMap<>();
         offsets.forEach(
                 offsetAndMetadata -> offsetsMap.put(
                         offsetAndMetadata.createTopicPartition(TopicPartition.class),

--- a/kafka-2-8/pom.xml
+++ b/kafka-2-8/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>${mavem-shade-plugin.version}</version>
+        <version>${maven-shade-plugin.version}</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/kafka-2-8/src/main/java/io/streamnative/kafka/client/two/eight/Consumer280Impl.java
+++ b/kafka-2-8/src/main/java/io/streamnative/kafka/client/two/eight/Consumer280Impl.java
@@ -13,7 +13,6 @@
  */
 package io.streamnative.kafka.client.two.eight;
 
-import com.google.common.collect.Maps;
 import io.streamnative.kafka.client.api.Consumer;
 import io.streamnative.kafka.client.api.ConsumerConfiguration;
 import io.streamnative.kafka.client.api.ConsumerRecord;
@@ -51,7 +50,7 @@ public class Consumer280Impl<K, V> extends KafkaConsumer<K, V> implements Consum
 
     @Override
     public void commitOffsetSync(List<TopicOffsetAndMetadata> offsets, Duration timeout) {
-        HashMap<TopicPartition, OffsetAndMetadata> offsetsMap = Maps.newHashMap();
+        HashMap<TopicPartition, OffsetAndMetadata> offsetsMap = new HashMap<>();
         offsets.forEach(
                 offsetAndMetadata -> offsetsMap.put(
                         offsetAndMetadata.createTopicPartition(TopicPartition.class),

--- a/kafka-3-0/pom.xml
+++ b/kafka-3-0/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>${mavem-shade-plugin.version}</version>
+        <version>${maven-shade-plugin.version}</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/kafka-3-0/src/main/java/io/streamnative/kafka/client/three/zero/Consumer300Impl.java
+++ b/kafka-3-0/src/main/java/io/streamnative/kafka/client/three/zero/Consumer300Impl.java
@@ -13,7 +13,6 @@
  */
 package io.streamnative.kafka.client.three.zero;
 
-import com.google.common.collect.Maps;
 import io.streamnative.kafka.client.api.Consumer;
 import io.streamnative.kafka.client.api.ConsumerConfiguration;
 import io.streamnative.kafka.client.api.ConsumerRecord;
@@ -51,7 +50,7 @@ public class Consumer300Impl<K, V> extends KafkaConsumer<K, V> implements Consum
 
     @Override
     public void commitOffsetSync(List<TopicOffsetAndMetadata> offsets, Duration timeout) {
-        HashMap<TopicPartition, OffsetAndMetadata> offsetsMap = Maps.newHashMap();
+        HashMap<TopicPartition, OffsetAndMetadata> offsetsMap = new HashMap<>();
         offsets.forEach(
                 offsetAndMetadata -> offsetsMap.put(
                         offsetAndMetadata.createTopicPartition(TopicPartition.class),

--- a/kafka-client-api/pom.xml
+++ b/kafka-client-api/pom.xml
@@ -28,4 +28,17 @@
   <name>StreamNative :: Pulsar Protocol Handler :: Kafka Client API</name>
   <description>The Kafka client API without any Kafka dependency</description>
 
+  <dependencies>
+    <!-- TODO: We should remove this dependency in future -->
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
 </project>

--- a/kafka-impl/pom.xml
+++ b/kafka-impl/pom.xml
@@ -32,7 +32,67 @@
 
   <!-- include the dependencies -->
   <dependencies>
-    <!-- runtime dependencies -->
+    <dependency>
+      <groupId>${pulsar.group.id}</groupId>
+      <artifactId>pulsar-broker</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${pulsar.group.id}</groupId>
+      <artifactId>managed-ledger</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kafka-impl/pom.xml
+++ b/kafka-impl/pom.xml
@@ -39,6 +39,12 @@
     </dependency>
 
     <dependency>
+      <groupId>${pulsar.group.id}</groupId>
+      <artifactId>testmocks</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
       <scope>provided</scope>

--- a/oauth-client/pom.xml
+++ b/oauth-client/pom.xml
@@ -31,6 +31,26 @@
 
   <!-- include the dependencies -->
   <dependencies>
-    <!-- runtime dependencies -->
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>${pulsar.group.id}</groupId>
+      <artifactId>pulsar-client-original</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -91,158 +91,161 @@
   <!-- dependency definitions -->
   <dependencyManagement>
     <dependencies>
-      <!-- provided dependencies -->
       <dependency>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-annotations</artifactId>
         <version>${spotbugs-annotations.version}</version>
+        <scope>provided</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-core</artifactId>
+        <version>${log4j2.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>${pulsar.group.id}</groupId>
+        <artifactId>pulsar-broker</artifactId>
+        <version>${pulsar.version}</version>
+        <scope>provided</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>${pulsar.group.id}</groupId>
+        <artifactId>pulsar-broker-common</artifactId>
+        <version>${pulsar.version}</version>
+        <scope>provided</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>${pulsar.group.id}</groupId>
+        <artifactId>pulsar-client-original</artifactId>
+        <version>${pulsar.version}</version>
+        <scope>provided</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>${pulsar.group.id}</groupId>
+        <artifactId>pulsar-client-admin-original</artifactId>
+        <version>${pulsar.version}</version>
+        <scope>provided</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>${pulsar.group.id}</groupId>
+        <artifactId>testmocks</artifactId>
+        <version>${pulsar.version}</version>
+        <scope>provided</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.projectlombok</groupId>
+        <artifactId>lombok</artifactId>
+        <version>${lombok.version}</version>
+        <scope>provided</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-yaml</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.kafka</groupId>
+        <artifactId>kafka-clients</artifactId>
+        <version>${kafka.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.beust</groupId>
+        <artifactId>jcommander</artifactId>
+        <version>${jcommander.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${commons-lang3.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-slf4j-impl</artifactId>
+        <version>${log4j2.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.testng</groupId>
+        <artifactId>testng</artifactId>
+        <version>${testng.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>${pulsar.group.id}</groupId>
+        <artifactId>pulsar-broker</artifactId>
+        <version>${pulsar.version}</version>
+        <type>test-jar</type>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>${pulsar.group.id}</groupId>
+        <artifactId>managed-ledger</artifactId>
+        <version>${pulsar.version}</version>
+        <type>test-jar</type>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro</artifactId>
+        <version>${avro.version}</version>
+        <scope>provided</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.awaitility</groupId>
+        <artifactId>awaitility</artifactId>
+        <version>${awaitility.version}</version>
+        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
-
-  <dependencies>
-    <!-- provided dependencies (available at compilation and test classpths and *NOT* packaged) -->
-    <dependency>
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>${pulsar.group.id}</groupId>
-      <artifactId>pulsar-broker</artifactId>
-      <version>${pulsar.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>${pulsar.group.id}</groupId>
-      <artifactId>pulsar-broker-common</artifactId>
-      <version>${pulsar.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>${pulsar.group.id}</groupId>
-      <artifactId>pulsar-client-original</artifactId>
-      <version>${pulsar.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>${pulsar.group.id}</groupId>
-      <artifactId>pulsar-client-admin-original</artifactId>
-      <version>${pulsar.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>${pulsar.group.id}</groupId>
-      <artifactId>testmocks</artifactId>
-      <version>${pulsar.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
-      <version>${lombok.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>${log4j2.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
-      <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>${jackson.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-clients</artifactId>
-      <version>${kafka.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.beust</groupId>
-      <artifactId>jcommander</artifactId>
-      <version>${jcommander.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>${commons-lang3.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <version>${log4j2.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.testng</groupId>
-      <artifactId>testng</artifactId>
-      <version>${testng.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>${mockito.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>${pulsar.group.id}</groupId>
-      <artifactId>pulsar-broker</artifactId>
-      <version>${pulsar.version}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>${pulsar.group.id}</groupId>
-      <artifactId>managed-ledger</artifactId>
-      <version>${pulsar.version}</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.avro</groupId>
-      <artifactId>avro</artifactId>
-      <version>${avro.version}</version>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <version>${awaitility.version}</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
 
   <build>
     <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -38,33 +38,25 @@
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
 
     <!-- dependencies -->
-    <commons-lang3.version>3.11</commons-lang3.version>
     <jackson.version>2.12.1</jackson.version>
-    <jcommander.version>1.48</jcommander.version>
     <kafka.version>2.0.0</kafka.version>
-    <log4j2.version>2.13.3</log4j2.version>
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
     <pulsar.group.id>io.streamnative</pulsar.group.id>
     <pulsar.version>2.9.0-rc-202110221101</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
-    <testcontainers.version>1.15.1</testcontainers.version>
     <testng.version>6.14.3</testng.version>
-    <avro.version>1.10.2</avro.version>
     <awaitility.version>4.0.3</awaitility.version>
     <!-- plugin dependencies -->
-    <dockerfile-maven.version>1.4.9</dockerfile-maven.version>
     <license-maven-plugin.version>3.0.rc1</license-maven-plugin.version>
     <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-    <mavem-shade-plugin.version>3.2.4</mavem-shade-plugin.version>
+    <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
-    <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
     <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>
     <spotbugs-maven-plugin.version>4.2.2</spotbugs-maven-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
-    <avro.version>1.10.2</avro.version>
   </properties>
 
   <licenses>
@@ -92,64 +84,53 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs-annotations</artifactId>
-        <version>${spotbugs-annotations.version}</version>
-        <scope>provided</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-core</artifactId>
-        <version>${log4j2.version}</version>
+        <groupId>org.apache.kafka</groupId>
+        <artifactId>kafka-clients</artifactId>
+        <version>${kafka.version}</version>
       </dependency>
 
       <dependency>
         <groupId>${pulsar.group.id}</groupId>
         <artifactId>pulsar-broker</artifactId>
         <version>${pulsar.version}</version>
-        <scope>provided</scope>
       </dependency>
 
       <dependency>
         <groupId>${pulsar.group.id}</groupId>
-        <artifactId>pulsar-broker-common</artifactId>
+        <artifactId>pulsar-broker</artifactId>
         <version>${pulsar.version}</version>
-        <scope>provided</scope>
+        <type>test-jar</type>
       </dependency>
 
       <dependency>
         <groupId>${pulsar.group.id}</groupId>
         <artifactId>pulsar-client-original</artifactId>
         <version>${pulsar.version}</version>
-        <scope>provided</scope>
       </dependency>
 
       <dependency>
         <groupId>${pulsar.group.id}</groupId>
         <artifactId>pulsar-client-admin-original</artifactId>
         <version>${pulsar.version}</version>
-        <scope>provided</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>${pulsar.group.id}</groupId>
+        <artifactId>managed-ledger</artifactId>
+        <type>test-jar</type>
+        <version>${pulsar.version}</version>
       </dependency>
 
       <dependency>
         <groupId>${pulsar.group.id}</groupId>
         <artifactId>testmocks</artifactId>
         <version>${pulsar.version}</version>
-        <scope>provided</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>${slf4j.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
         <version>${lombok.version}</version>
-        <scope>provided</scope>
       </dependency>
 
       <dependency>
@@ -177,72 +158,27 @@
       </dependency>
 
       <dependency>
-        <groupId>org.apache.kafka</groupId>
-        <artifactId>kafka-clients</artifactId>
-        <version>${kafka.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.beust</groupId>
-        <artifactId>jcommander</artifactId>
-        <version>${jcommander.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-        <version>${commons-lang3.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-slf4j-impl</artifactId>
-        <version>${log4j2.version}</version>
-        <scope>test</scope>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-annotations</artifactId>
+        <version>${spotbugs-annotations.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.testng</groupId>
         <artifactId>testng</artifactId>
         <version>${testng.version}</version>
-        <scope>test</scope>
       </dependency>
 
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>${mockito.version}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>${pulsar.group.id}</groupId>
-        <artifactId>pulsar-broker</artifactId>
-        <version>${pulsar.version}</version>
-        <type>test-jar</type>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>${pulsar.group.id}</groupId>
-        <artifactId>managed-ledger</artifactId>
-        <version>${pulsar.version}</version>
-        <type>test-jar</type>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.avro</groupId>
-        <artifactId>avro</artifactId>
-        <version>${avro.version}</version>
-        <scope>provided</scope>
       </dependency>
 
       <dependency>
         <groupId>org.awaitility</groupId>
         <artifactId>awaitility</artifactId>
         <version>${awaitility.version}</version>
-        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -408,12 +344,6 @@
   </build>
 
   <repositories>
-    <repository>
-      <id>sonatype-streamnative-maven</id>
-      <name>sonatype</name>
-      <url>https://oss.sonatype.org/content/repositories/iostreamnative-1129</url>
-    </repository>
-
     <repository>
       <id>central</id>
       <layout>default</layout>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -32,6 +32,7 @@
 
   <properties>
     <schema.registry.version>5.0.0</schema.registry.version>
+    <testcontainers.version>1.15.1</testcontainers.version>
   </properties>
 
   <!-- include the dependencies -->

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -39,19 +39,18 @@
     <dependency>
       <groupId>io.streamnative.pulsar.handlers</groupId>
       <artifactId>kafka-client-api</artifactId>
-      <version>2.9.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.streamnative.pulsar.handlers</groupId>
       <artifactId>kafka-client-factory</artifactId>
-      <version>2.9.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-streams</artifactId>
       <version>${kafka.version}</version>
     </dependency>
-    <!-- test dependencies -->
     <dependency>
       <groupId>io.streamnative.pulsar.handlers</groupId>
       <artifactId>pulsar-protocol-handler-kafka</artifactId>
@@ -70,6 +69,61 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
       <version>${testcontainers.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${pulsar.group.id}</groupId>
+      <artifactId>pulsar-broker</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${pulsar.group.id}</groupId>
+      <artifactId>pulsar-broker</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${pulsar.group.id}</groupId>
+      <artifactId>testmocks</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${pulsar.group.id}</groupId>
+      <artifactId>pulsar-client-original</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>${pulsar.group.id}</groupId>
+      <artifactId>pulsar-client-admin-original</artifactId>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Fixes https://github.com/streamnative/kop/issues/924

### Motivation

The current dependency management is bad. We should ensure new added module doesn't depend on some unnecessary dependencies.

### Modifications

The main changes are:
- Move all dependencies from `<dependencies>` under `<dependencyManagement>` block in root `pom.xml`.
- Add required dependencies for each module.

In addition, some minor changes were made:
1. Remove google common dependencies from modules of different Kafka version, like `kafka-0-9`. It's redundant to introduce a dependency just for a `Maps.newHashMap` method.
2. Rename `mavem-shade-plugin.version` to `maven-shade-plugin.version`.

