### PR TITLE
Internal brokers communication and distribution of topics deleted messages

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
@@ -54,6 +54,7 @@ import org.apache.pulsar.client.admin.PulsarAdminException;
 
 @Slf4j
 class AdminManager {
+    public static final String INTER_ADMIN_CLIENT_ID = "kop-broker-internal-admin-client-id";
 
     private final DelayedOperationPurgatory<DelayedOperation> topicPurgatory =
             DelayedOperationPurgatory.<DelayedOperation>builder()

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
@@ -53,7 +53,7 @@ import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 
 @Slf4j
-class AdminManager {
+public class AdminManager {
     public static final String INTER_ADMIN_CLIENT_ID = "kop-broker-internal-admin-client-id";
 
     private final DelayedOperationPurgatory<DelayedOperation> topicPurgatory =

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/ChildChangeHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/ChildChangeHandler.java
@@ -19,24 +19,6 @@ public interface ChildChangeHandler {
     void handleChildChange();
 }
 
-class DeletionTopicsHandler implements ChildChangeHandler {
-    private final KopEventManager kopEventManager;
-
-    public DeletionTopicsHandler(KopEventManager kopEventManager) {
-        this.kopEventManager = kopEventManager;
-    }
-
-    @Override
-    public String path() {
-        return KopEventManager.getBrokersChangePath();
-    }
-
-    @Override
-    public void handleChildChange() {
-        kopEventManager.put(kopEventManager.getDeleteTopicEvent());
-    }
-}
-
 class BrokersChangeHandler implements ChildChangeHandler {
     private final KopEventManager kopEventManager;
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/EndPoint.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/EndPoint.java
@@ -140,7 +140,7 @@ public class EndPoint {
             } else {
                 if (!endPointMap.containsKey(interBrokerListenerName)) {
                     throw new IllegalStateException("kafkaListeners " + kafkaConfig.getKafkaListeners()
-                            + " has not contained interBrokerListenerName " + interBrokerSecurityProtocol);
+                            + " has not contained interBrokerListenerName " + interBrokerListenerName);
                 } else {
                     kafkaConfig.setInterBrokerSecurityProtocol(
                             endPointMap.get(interBrokerListenerName).getSecurityProtocol().name());
@@ -170,7 +170,7 @@ public class EndPoint {
                 }
                 if (!isMatched) {
                     throw new IllegalStateException("kafkaListeners " + kafkaConfig.getKafkaListeners()
-                            + " has not contained interBrokerSecurityProtocol " + interBrokerListenerName);
+                            + " has not contained interBrokerSecurityProtocol " + interBrokerSecurityProtocol);
                 }
             }
         }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
@@ -59,6 +59,8 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
     private final SslContextFactory.Server sslContextFactory;
     @Getter
     private final StatsLogger statsLogger;
+    @Getter
+    private final KopEventManager kopEventManager;
 
     public KafkaChannelInitializer(PulsarService pulsarService,
                                    KafkaServiceConfiguration kafkaConfig,
@@ -70,7 +72,8 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
                                    boolean enableTLS,
                                    EndPoint advertisedEndPoint,
                                    boolean skipMessagesWithoutIndex,
-                                   StatsLogger statsLogger) {
+                                   StatsLogger statsLogger,
+                                   KopEventManager kopEventManager) {
         super();
         this.pulsarService = pulsarService;
         this.kafkaConfig = kafkaConfig;
@@ -83,6 +86,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
         this.advertisedEndPoint = advertisedEndPoint;
         this.skipMessagesWithoutIndex = skipMessagesWithoutIndex;
         this.statsLogger = statsLogger;
+        this.kopEventManager = kopEventManager;
         if (enableTls) {
             sslContextFactory = SSLUtils.createSslContextFactory(kafkaConfig);
         } else {
@@ -111,8 +115,8 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
     public KafkaRequestHandler newCnx() throws Exception {
         return new KafkaRequestHandler(pulsarService, kafkaConfig,
                 tenantContextManager, kopBrokerLookupManager, adminManager,
-                producePurgatory, fetchPurgatory,
-                enableTls, advertisedEndPoint, skipMessagesWithoutIndex, statsLogger);
+                producePurgatory, fetchPurgatory, enableTls, advertisedEndPoint,
+                skipMessagesWithoutIndex, statsLogger, kopEventManager);
     }
 
     @VisibleForTesting
@@ -120,7 +124,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
                                       final StatsLogger statsLogger) throws Exception {
         return new KafkaRequestHandler(pulsarService, kafkaConfig,
                 tenantContextManager, kopBrokerLookupManager, adminManager,
-                producePurgatory, fetchPurgatory,
-                enableTls, advertisedEndPoint, skipMessagesWithoutIndex, statsLogger);
+                producePurgatory, fetchPurgatory, enableTls, advertisedEndPoint,
+                skipMessagesWithoutIndex, statsLogger, kopEventManager);
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -557,7 +557,8 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 endPoint.isTlsEnabled(),
                 endPoint,
                 kafkaConfig.isSkipMessagesWithoutIndex(),
-                scopeStatsLogger);
+                scopeStatsLogger,
+                kopEventManager);
     }
 
     // this is called after initialize, and with kafkaConfig, brokerService all set.
@@ -579,8 +580,8 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
             ImmutableMap.Builder<InetSocketAddress, ChannelInitializer<SocketChannel>> builder =
                     ImmutableMap.builder();
 
-            EndPoint.parseListeners(kafkaConfig.getListeners(), kafkaConfig.getKafkaProtocolMap()).
-                    forEach((listener, endPoint) ->
+            EndPoint.parseListeners(kafkaConfig)
+                    .forEach((listener, endPoint) ->
                             builder.put(endPoint.getInetAddress(), newKafkaChannelInitializer(endPoint))
                     );
             channelInitializerMap = builder.build();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -31,6 +31,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
 import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.common.configuration.Category;
 import org.apache.pulsar.common.configuration.FieldContext;
@@ -207,6 +208,28 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
                     + "The format is the same as `kafkaListeners`.\n"
     )
     private String kafkaAdvertisedListeners;
+
+    @FieldContext(
+            category = CATEGORY_KOP,
+            doc = "Security protocol used to communicate between kop brokers. Valid values are: \n"
+                    + "[PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL], default: PLAINTEXT"
+                    + ". It is an error to set this and interBrokerListenerNameProp properties at the same time.\n"
+    )
+    private String interBrokerSecurityProtocol = SecurityProtocol.PLAINTEXT.toString();
+
+    @FieldContext(
+            category = CATEGORY_KOP,
+            doc = "Name of listener used for communication between kop brokers. \n"
+                    + "If this is unset, the listener name is defined by interBrokerSecurityProtocol. \n"
+                    + "It is an error to set this and interBrokerSecurityProtocol properties at the same time.\n"
+    )
+    private String interBrokerListenerName;
+
+    @FieldContext(
+            category = CATEGORY_KOP,
+            doc = "SASL mechanism used for inter-broker communication. Default is PLAIN.\n"
+    )
+    private String saslMechanismInterBrokerProtocol = "PLAIN";
 
     @FieldContext(
             category = CATEGORY_KOP,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/AdminClientUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/AdminClientUtils.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.utils;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+import io.streamnative.pulsar.handlers.kop.AdminManager;
+import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
+import java.util.Locale;
+import java.util.Properties;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.KafkaAdminClient;
+import org.apache.kafka.common.config.SaslConfigs;
+
+public class AdminClientUtils {
+
+    public static AdminClient getKafkaAdminClient(final KafkaServiceConfiguration kafkaConfig,
+                                                  final String host,
+                                                  final int port) {
+        final Properties adminProps = new Properties();
+        adminProps.put(AdminClientConfig.CLIENT_ID_CONFIG, AdminManager.INTER_ADMIN_CLIENT_ID);
+        adminProps.put(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, 30000);
+        adminProps.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, host + ":" + port);
+        addSslConfigs(kafkaConfig, adminProps);
+        return KafkaAdminClient.create(adminProps);
+    }
+
+    public static void addSslConfigs(final KafkaServiceConfiguration kafkaConfig,
+                                     final Properties adminProps) {
+        adminProps.put(AdminClientConfig.SECURITY_PROTOCOL_CONFIG, kafkaConfig.getInterBrokerSecurityProtocol());
+        final String mechanismInterBrokerProtocol = kafkaConfig.getSaslMechanismInterBrokerProtocol();
+        adminProps.put(SaslConfigs.SASL_MECHANISM, mechanismInterBrokerProtocol);
+        final String interBrokerSecurityProtocol = kafkaConfig.getInterBrokerSecurityProtocol();
+        final String kafkaUser = kafkaConfig.getKafkaTenant() + "/" + kafkaConfig.getKafkaNamespace();
+        final String brokerClientAuthenticationParameters = kafkaConfig.getBrokerClientAuthenticationParameters();
+        final boolean hasSsl = interBrokerSecurityProtocol.toUpperCase(Locale.ROOT).contains("SSL");
+        final boolean hasSasl = interBrokerSecurityProtocol.toUpperCase(Locale.ROOT).contains("SASL");
+
+        if (hasSsl) {
+            adminProps.put("ssl.truststore.location", kafkaConfig.getKopSslKeystoreLocation());
+            adminProps.put("ssl.truststore.password", kafkaConfig.getKopSslKeystorePassword());
+            adminProps.put("ssl.endpoint.identification.algorithm", "");
+        }
+
+        if ("PLAIN".equals(mechanismInterBrokerProtocol.toUpperCase(Locale.ROOT)) && !hasSsl && hasSasl) {
+            String token = "";
+            try {
+                // brokerClientAuthenticationParameters={"token":"<token-of-super-user-role>"}
+                final JsonObject jsonObject = parseJsonObject(brokerClientAuthenticationParameters);
+                token = "token:" + jsonObject.get("token").getAsString();
+            } catch (JsonSyntaxException | IllegalStateException e) {
+                // brokerClientAuthenticationParameters=token:<token-of-super-user-role>
+                token = brokerClientAuthenticationParameters;
+            }
+            final String plainAuth =
+                    String.format("username=\"%s\" password=\"%s\";", kafkaUser, token);
+            adminProps.put("sasl.jaas.config",
+                    "org.apache.kafka.common.security.plain.PlainLoginModule required " + plainAuth);
+        } else if ("OAUTHBEARER".equals(mechanismInterBrokerProtocol.toUpperCase(Locale.ROOT))) {
+            adminProps.put("sasl.login.callback.handler.class",
+                    "io.streamnative.pulsar.handlers.kop.security.oauth.OauthLoginCallbackHandler");
+            final JsonObject jsonObject = parseJsonObject(brokerClientAuthenticationParameters);
+            final String issuerUrl = jsonObject.get("issuerUrl").getAsString();
+            final String privateKey = jsonObject.get("privateKey").getAsString();
+            final String audience = jsonObject.get("audience").getAsString();
+            final String oauth =
+                    String.format("oauth.issuer.url=\"%s\" oauth.credentials.url=\"%s\" oauth.audience=\"%s\";",
+                            issuerUrl, privateKey, audience);
+            adminProps.put("sasl.jaas.config",
+                    "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required " + oauth);
+        }
+    }
+
+    public static JsonObject parseJsonObject(final String info) {
+        JsonParser parser = new JsonParser();
+        return parser.parse(info).getAsJsonObject();
+    }
+}


### PR DESCRIPTION
Fixes #927 

1.Message forwarding between kop brokers through a given internal communication protocol.
2.Reuse the DeleteTopicsRequest request protocol. If other request protocols are introduced, it will conflict with subsequent Kafka dependent version upgrades.
3.Because the existing protocol is reused, the message is forwarded directly through the KafkaAdminClient management tool, without additional definition of NetWorkClient