### PR TITLE
Improve TransactionMarkerChannelManager

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
@@ -167,5 +167,4 @@ public class KopBrokerLookupManager {
             log.error("Close metadataStoreCacheLoader failed.", e);
         }
     }
-
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinator.java
@@ -787,14 +787,13 @@ public class GroupCoordinator {
 
     public CompletableFuture<Void> scheduleHandleTxnCompletion(
         long producerId,
-        Stream<TopicPartition> offsetsPartitions,
+        Set<Integer> offsetsPartitions,
         TransactionResult transactionResult
     ) {
         boolean isCommit = TransactionResult.COMMIT == transactionResult;
         return groupManager.scheduleHandleTxnCompletion(
             producerId,
-            offsetsPartitions.map(TopicPartition::partition)
-                .collect(Collectors.toSet()),
+            offsetsPartitions,
             isCommit
         );
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinator.java
@@ -50,7 +50,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.kafka.common.TopicPartition;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -78,7 +79,7 @@ public class TransactionCoordinator {
     // map from topic to the map from initial offset to producerId
     private final Map<TopicName, NavigableMap<Long, Long>> activeOffsetPidMap = new HashMap<>();
     private final Map<TopicName, ConcurrentHashMap<Long, Long>> activePidOffsetMap = new HashMap<>();
-    private final List<AbortedIndexEntry> abortedIndexList = new ArrayList<>();
+    private final List<AbortedIndexEntry> abortedIndexList = new CopyOnWriteArrayList<>();
 
     private final ScheduledExecutorService scheduler;
 
@@ -152,7 +153,7 @@ public class TransactionCoordinator {
      * @param partition The partition that we are now leading
      */
     public CompletableFuture<Void> handleTxnImmigration(int partition) {
-        log.info("Elected as the txn coordinator for partition {}.", partition);
+        log.info("Elected as the txn coordinator for partition {} for {}.", partition, namespacePrefix);
         // The operations performed during immigration must be resilient to any previous errors we saw or partial state
         // we left off during the unloading phase. Ensure we remove all associated state for this partition before we
         // continue loading it.
@@ -172,7 +173,7 @@ public class TransactionCoordinator {
      * @param partition The partition that we are no longer leading
      */
     public void handleTxnEmigration(int partition) {
-        log.info("Resigned as the txn coordinator for partition {}.", partition);
+        log.info("Resigned as the txn coordinator for partition {} for {}.", partition, namespacePrefix);
         txnManager.removeTransactionsForTxnTopicPartition(partition);
         transactionMarkerChannelManager.removeMarkersForTxnTopicPartition(partition);
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelHandler.java
@@ -165,7 +165,7 @@ public class TransactionMarkerChannelHandler extends ChannelInboundHandlerAdapte
 
     public void close() {
         log.info("[TransactionMarkerChannelHandler] closing");
-        this.cnx.whenComplete( (ctx, err) -> {
+        this.cnx.whenComplete((ctx, err) -> {
             if (ctx != null) {
                 ctx.close();
             }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelHandler.java
@@ -14,6 +14,7 @@
 package io.streamnative.pulsar.handlers.kop.coordinator.transaction;
 
 import static org.apache.kafka.common.protocol.Errors.REQUEST_TIMED_OUT;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -119,7 +120,7 @@ public class TransactionMarkerChannelHandler extends ChannelInboundHandlerAdapte
     public void channelInactive(ChannelHandlerContext channelHandlerContext) throws Exception {
         log.info("[TransactionMarkerChannelHandler] channelInactive, failing {} pending requests",
                 inFlightRequestMap.size());
-        inFlightRequestMap.forEach((k,v) -> {
+        inFlightRequestMap.forEach((k, v) -> {
             v.onError(new Exception("Connection to remote broker closed"));
         });
         inFlightRequestMap.clear();
@@ -144,7 +145,7 @@ public class TransactionMarkerChannelHandler extends ChannelInboundHandlerAdapte
     @Override
     public void exceptionCaught(ChannelHandlerContext channelHandlerContext, Throwable throwable) throws Exception {
         log.error("Transaction marker channel handler caught exception.", throwable);
-        inFlightRequestMap.forEach((k,v) -> {
+        inFlightRequestMap.forEach((k, v) -> {
             v.onError(new Exception("Transaction marker channel handler caught exception: " + throwable, throwable));
         });
         inFlightRequestMap.clear();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelHandler.java
@@ -103,7 +103,7 @@ public class TransactionMarkerChannelHandler extends ChannelInboundHandlerAdapte
                 for (TopicPartition partition : entry.partitions()) {
                     errorsPerPartition.put(partition, REQUEST_TIMED_OUT);
                     log.error("Handle error " + error
-                            + " as  REQUEST_TIMED_OUT for " + partition + " producer " + entry.producerId());
+                            + " as REQUEST_TIMED_OUT for " + partition + " producer " + entry.producerId());
                 }
                 errors.put(entry.producerId(), errorsPerPartition);
             }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelHandler.java
@@ -91,7 +91,11 @@ public class TransactionMarkerChannelHandler extends ChannelInboundHandlerAdapte
             WriteTxnMarkersResponse response = WriteTxnMarkersResponse
                     .parse(nio, ApiKeys.WRITE_TXN_MARKERS.latestVersion());
             log.info("[TransactionMarkerChannelHandler] onComplete {}", response);
-            requestCompletionHandler.onComplete(response);
+            try {
+                requestCompletionHandler.onComplete(response);
+            } catch (RuntimeException unhandledError) {
+                onError(unhandledError);
+            }
         }
 
         public void onError(Throwable error) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelInitializer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelInitializer.java
@@ -33,11 +33,14 @@ public class TransactionMarkerChannelInitializer extends ChannelInitializer<Sock
     private final KafkaServiceConfiguration kafkaConfig;
     private final boolean enableTls;
     private final SslContextFactory.Server sslContextFactory;
+    private final TransactionMarkerChannelManager transactionMarkerChannelManager;
 
     public TransactionMarkerChannelInitializer(KafkaServiceConfiguration kafkaConfig,
-                                               boolean enableTls) {
+                                               boolean enableTls,
+                                               TransactionMarkerChannelManager transactionMarkerChannelManager) {
         this.kafkaConfig = kafkaConfig;
         this.enableTls = enableTls;
+        this.transactionMarkerChannelManager = transactionMarkerChannelManager;
         if (enableTls) {
             sslContextFactory = SSLUtils.createSslContextFactory(kafkaConfig);
         } else {
@@ -53,6 +56,6 @@ public class TransactionMarkerChannelInitializer extends ChannelInitializer<Sock
         ch.pipeline().addLast(new LengthFieldPrepender(4));
         ch.pipeline().addLast("frameDecoder",
                 new LengthFieldBasedFrameDecoder(MAX_FRAME_LENGTH, 0, 4, 0, 4));
-        ch.pipeline().addLast("txnHandler", new TransactionMarkerChannelHandler());
+        ch.pipeline().addLast("txnHandler", new TransactionMarkerChannelHandler(transactionMarkerChannelManager));
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
@@ -162,7 +162,7 @@ public class TransactionMarkerChannelManager {
                     log.info("ignore {}", e);
                 }
             }
-        }, "kop-transaction-channel-manager-"+namespacePrefix);
+        }, "kop-transaction-channel-manager-" + namespacePrefix);
         thread.setDaemon(true);
         thread.start();
     }
@@ -249,7 +249,7 @@ public class TransactionMarkerChannelManager {
         Map<InetSocketAddress, List<TopicPartition>> addressAndPartitionMap = new ConcurrentHashMap<>();
         List<TopicPartition> unknownBrokerTopicList = new ArrayList<>();
 
-        List<CompletableFuture<Void>> addressFutureList = new ArrayList<>();
+        List<CompletableFuture<Void>> addressFutureList = new ArrayList<>();TransactionMarkerChannelManager
         for (TopicPartition topicPartition : topicPartitions) {
             String pulsarTopic = new KopTopic(topicPartition.topic(), namespacePrefix)
                     .getPartitionName(topicPartition.partition());

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
@@ -258,7 +258,7 @@ public class TransactionMarkerChannelManager {
             CompletableFuture<Void> addFuture = new CompletableFuture<>();
             addressFutureList.add(addFuture);
             addressFuture.whenComplete((address, throwable) -> {
-                if (throwable != null)  {
+                if (throwable != null) {
                     log.warn("Failed to find broker for topic partition {}", topicPartition, throwable);
                     unknownBrokerTopicList.add(topicPartition);
                     addFuture.completeExceptionally(throwable);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
@@ -249,7 +249,7 @@ public class TransactionMarkerChannelManager {
         Map<InetSocketAddress, List<TopicPartition>> addressAndPartitionMap = new ConcurrentHashMap<>();
         List<TopicPartition> unknownBrokerTopicList = new ArrayList<>();
 
-        List<CompletableFuture<Void>> addressFutureList = new ArrayList<>();TransactionMarkerChannelManager
+        List<CompletableFuture<Void>> addressFutureList = new ArrayList<>();
         for (TopicPartition topicPartition : topicPartitions) {
             String pulsarTopic = new KopTopic(topicPartition.topic(), namespacePrefix)
                     .getPartitionName(topicPartition.partition());

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerRequestCompletionHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerRequestCompletionHandler.java
@@ -168,7 +168,8 @@ public class TransactionMarkerRequestCompletionHandler {
                                             + "retrying with current coordinator epoch {} and invalidating cache",
                                     transactionalId, topicPartition,
                                     error.exceptionName(), epochAndMetadata.getCoordinatorEpoch());
-                            KopBrokerLookupManager.removeTopicManagerCache(KopTopic.toString(topicPartition, namespacePrefix));
+                            KopBrokerLookupManager.removeTopicManagerCache(
+                                    KopTopic.toString(topicPartition, namespacePrefix));
                             abortSendingAndRetryPartitions.retryPartitions.add(topicPartition);
                             break;
                         case INVALID_PRODUCER_EPOCH:

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerRequestCompletionHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerRequestCompletionHandler.java
@@ -154,6 +154,8 @@ public class TransactionMarkerRequestCompletionHandler {
                         case NOT_ENOUGH_REPLICAS:
                         case NOT_ENOUGH_REPLICAS_AFTER_APPEND:
                         case REQUEST_TIMED_OUT:
+                        case LEADER_NOT_AVAILABLE:
+                        case NOT_LEADER_FOR_PARTITION:
                         case KAFKA_STORAGE_ERROR: // these are retriable errors
                             log.info("Sending {}'s transaction marker for partition {} has failed with error {}, "
                                     + "retrying with current coordinator epoch {}", transactionalId, topicPartition,

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinatorTest.java
@@ -1202,7 +1202,7 @@ public class GroupCoordinatorTest extends KopProtocolHandlerTestBase {
         // send commit marker
         groupCoordinator.scheduleHandleTxnCompletion(
             producerId,
-            Lists.newArrayList(offsetsTopic).stream(),
+            Collections.singleton(offsetsTopic.partition()),
             TransactionResult.COMMIT
         ).get();
 
@@ -1245,7 +1245,7 @@ public class GroupCoordinatorTest extends KopProtocolHandlerTestBase {
         // send commit marker
         groupCoordinator.scheduleHandleTxnCompletion(
             producerId,
-            Lists.newArrayList(offsetsTopic).stream(),
+            Collections.singleton(offsetsTopic.partition()),
             TransactionResult.ABORT
         ).get();
 
@@ -1287,7 +1287,7 @@ public class GroupCoordinatorTest extends KopProtocolHandlerTestBase {
         // send commit marker
         groupCoordinator.scheduleHandleTxnCompletion(
             producerId,
-            Lists.newArrayList(offsetsTopic).stream(),
+            Collections.singleton(offsetsTopic.partition()),
             TransactionResult.ABORT
         ).get();
 
@@ -1300,7 +1300,7 @@ public class GroupCoordinatorTest extends KopProtocolHandlerTestBase {
         // ignore spurious commit
         groupCoordinator.scheduleHandleTxnCompletion(
             producerId,
-            Lists.newArrayList(offsetsTopic).stream(),
+            Collections.singleton(offsetsTopic.partition()),
             TransactionResult.COMMIT
         ).get();
 
@@ -1358,7 +1358,7 @@ public class GroupCoordinatorTest extends KopProtocolHandlerTestBase {
         // We got a commit for only one __consumer_offsets partition. We should only materialize it's group offsets.
         groupCoordinator.scheduleHandleTxnCompletion(
             producerId,
-            Lists.newArrayList(offsetTopicPartitions.get(0)).stream(),
+            Collections.singleton(offsetTopicPartitions.get(0).partition()),
             TransactionResult.COMMIT
         ).get();
 
@@ -1392,7 +1392,7 @@ public class GroupCoordinatorTest extends KopProtocolHandlerTestBase {
         // Now we receive the other marker
         groupCoordinator.scheduleHandleTxnCompletion(
             producerId,
-            Lists.newArrayList(offsetTopicPartitions.get(1)).stream(),
+            Collections.singleton(offsetTopicPartitions.get(1).partition()),
             TransactionResult.COMMIT
         ).get();
         errors.clear();
@@ -1468,7 +1468,7 @@ public class GroupCoordinatorTest extends KopProtocolHandlerTestBase {
         // producer0 commits its transaction.
         groupCoordinator.scheduleHandleTxnCompletion(
             producerIds.get(0),
-            Lists.newArrayList(offsetTopicPartition).stream(),
+            Collections.singleton(offsetTopicPartition.partition()),
             TransactionResult.COMMIT
         ).get();
 
@@ -1489,7 +1489,7 @@ public class GroupCoordinatorTest extends KopProtocolHandlerTestBase {
         // producer 1 now commits its transaction
         groupCoordinator.scheduleHandleTxnCompletion(
             producerIds.get(1),
-            Lists.newArrayList(offsetTopicPartition).stream(),
+            Collections.singleton(offsetTopicPartition.partition()),
             TransactionResult.COMMIT
         ).get();
 


### PR DESCRIPTION
This patch adds failure handling on TransactionMarkerChannelHandler.
In case of failure on the socket we must fail every pending request, otherwise the system will be stuck 