### PR TITLE
Avoid waiting a future when channel is closed

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
@@ -312,6 +312,9 @@ public class KafkaTopicManager {
                             topicName, (producer.getTopic() == null) ? "null" : producer.getTopic().getName());
                 }
             }
+        }).exceptionally(e -> {
+            log.error("Failed to get topic '{}' in removeTopicAndReferenceProducer", topicName, e);
+            return null;
         });
     }
 


### PR DESCRIPTION
### Motivation

`KafkaRequestChannel#close` calls `KafkaTopicManager#removePersistentTopicAndReferenceProducer` for each topic in cache. But `CompletableFuture#get` is called in `removePersistentTopicAndReferenceProducer`, which is called in an I/O thread. It will lead to a deadlock issue.

![image](https://user-images.githubusercontent.com/18204803/143367299-1644a871-2911-4863-9806-cf3a558cf8a1.png)

### Modifications

Instead of calling `get` for a `PersistentTopic` object, call `thenAccept` and `exceptionally` method on the future to do the cleanup work for `PersistentTopic`.
