### PR TITLE
Add transaction config prefix

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,13 +116,13 @@ This section lists configurations about the transaction.
 
 | Name                         | Description                                        | Default |
 | ---------------------------- | -------------------------------------------------- | ------- |
-| enableTransactionCoordinator | Whether to enable transaction coordinator.          | false   |
-| brokerId                     | The broker ID that is used to create the producer ID.  | 1       |
-| txnLogTopicNumPartitions     | the number of partitions for the transaction log topic. | 50      |
-| txnAbortTimedOutTransactionCleanupIntervalMs | The interval in milliseconds at which to rollback transactions that have timed out. | 10000 |
-| enableTransactionalIdExpiration | Whether to enable transactional ID expiration. | true |
-| transactionalIdExpirationMs | The time (in ms) that the transaction coordinator waits without receiving any transaction status updates for the current transaction before expiring its transactional ID. | 604800 |
-| transactionsRemoveExpiredTransactionalIdCleanupIntervalMs | The interval (in ms) at which to remove expired transactions. | 3600 |
+| kafkaTransactionCoordinatorEnabled | Whether to enable transaction coordinator.          | false   |
+| kafkaBrokerId                     | The broker ID that is used to create the producer ID.  | 1       |
+| kafkaTxnLogTopicNumPartitions     | the number of partitions for the transaction log topic. | 50      |
+| kafkaTxnAbortTimedOutTransactionCleanupIntervalMs | The interval in milliseconds at which to rollback transactions that have timed out. | 10000 |
+| kafkaTransactionalIdExpirationEnable | Whether to enable transactional ID expiration. | true |
+| kafkaTransactionalIdExpirationMs | The time (in ms) that the transaction coordinator waits without receiving any transaction status updates for the current transaction before expiring its transactional ID. | 604800 |
+| kafkaTransactionsRemoveExpiredTransactionalIdCleanupIntervalMs | The interval (in ms) at which to remove expired transactions. | 3600 |
 
 ## Authentication
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -121,7 +121,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     public ReplicaManager getReplicaManager(String tenant) {
         return replicaManagerByTenant.computeIfAbsent(tenant, s -> {
             Optional<TransactionCoordinator> transactionCoordinatorOptional = Optional.empty();
-            if (kafkaConfig.isEnableTransactionCoordinator()) {
+            if (kafkaConfig.isKafkaTransactionCoordinatorEnabled()) {
                 transactionCoordinatorOptional = Optional.of(getTransactionCoordinator(tenant));
             }
             EntryFormatter entryFormatter;
@@ -495,7 +495,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 groupCoordinatorsByTenant);
         kopEventManager.start();
 
-        if (kafkaConfig.isEnableTransactionCoordinator()) {
+        if (kafkaConfig.isKafkaTransactionCoordinatorEnabled()) {
             getTransactionCoordinator(kafkaConfig.getKafkaMetadataTenant());
         }
 
@@ -705,13 +705,13 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                                                              ClusterData clusterData,
                                                              String namespacePrefix) throws Exception {
         TransactionConfig transactionConfig = TransactionConfig.builder()
-                .transactionLogNumPartitions(kafkaConfig.getTxnLogTopicNumPartitions())
+                .transactionLogNumPartitions(kafkaConfig.getKafkaTxnLogTopicNumPartitions())
                 .transactionMetadataTopicName(MetadataUtils.constructTxnLogTopicBaseName(tenant, kafkaConfig))
-                .abortTimedOutTransactionsIntervalMs(kafkaConfig.getTxnAbortTimedOutTransactionCleanupIntervalMs())
-                .transactionalIdExpirationMs(kafkaConfig.getTransactionalIdExpirationMs())
+                .abortTimedOutTransactionsIntervalMs(kafkaConfig.getKafkaTxnAbortTimedOutTransactionCleanupIntervalMs())
+                .transactionalIdExpirationMs(kafkaConfig.getKafkaTransactionalIdExpirationMs())
                 .removeExpiredTransactionalIdsIntervalMs(
-                        kafkaConfig.getTransactionsRemoveExpiredTransactionalIdCleanupIntervalMs())
-                .brokerId(kafkaConfig.getBrokerId())
+                        kafkaConfig.getKafkaTransactionsRemoveExpiredTransactionalIdCleanupIntervalMs())
+                .brokerId(kafkaConfig.getKafkaBrokerId())
                 .build();
 
         MetadataUtils.createTxnMetadataIfMissing(tenant, pulsarAdmin, clusterData, kafkaConfig);
@@ -725,7 +725,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 Time.SYSTEM,
                 namespacePrefix);
 
-        transactionCoordinator.startup(kafkaConfig.isEnableTransactionalIdExpiration()).get();
+        transactionCoordinator.startup(kafkaConfig.isKafkaTransactionalIdExpirationEnable()).get();
 
         return transactionCoordinator;
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -364,44 +364,44 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
         category = CATEGORY_KOP,
         doc = "The broker id, default is 1"
     )
-    private int brokerId = 1;
+    private int kafkaBrokerId = 1;
 
     @FieldContext(
             category = CATEGORY_KOP_TRANSACTION,
             doc = "Flag to enable transaction coordinator"
     )
-    private boolean enableTransactionCoordinator = false;
+    private boolean kafkaTransactionCoordinatorEnabled = false;
 
     @FieldContext(
             category = CATEGORY_KOP_TRANSACTION,
             doc = "Number of partitions for the transaction log topic"
     )
-    private int txnLogTopicNumPartitions = DefaultTxnLogTopicNumPartitions;
+    private int kafkaTxnLogTopicNumPartitions = DefaultTxnLogTopicNumPartitions;
 
     @FieldContext(
             category = CATEGORY_KOP_TRANSACTION,
             doc = "The interval in milliseconds at which to rollback transactions that have timed out."
     )
-    private long txnAbortTimedOutTransactionCleanupIntervalMs = DefaultAbortTimedOutTransactionsIntervalMs;
+    private long kafkaTxnAbortTimedOutTransactionCleanupIntervalMs = DefaultAbortTimedOutTransactionsIntervalMs;
 
     @FieldContext(
             category = CATEGORY_KOP_TRANSACTION,
             doc = "Whether to enable transactional ID expiration."
     )
-    private boolean enableTransactionalIdExpiration = true;
+    private boolean kafkaTransactionalIdExpirationEnable = true;
 
     @FieldContext(
             category = CATEGORY_KOP_TRANSACTION,
             doc = "The time (in ms) that the transaction coordinator waits without receiving any transaction status"
                     + " updates for the current transaction before expiring its transactional ID."
     )
-    private long transactionalIdExpirationMs = DefaultTransactionalIdExpirationMs;
+    private long kafkaTransactionalIdExpirationMs = DefaultTransactionalIdExpirationMs;
 
     @FieldContext(
             category = CATEGORY_KOP_TRANSACTION,
             doc = "The interval (in ms) at which to remove expired transactions."
     )
-    private long transactionsRemoveExpiredTransactionalIdCleanupIntervalMs =
+    private long kafkaTransactionsRemoveExpiredTransactionalIdCleanupIntervalMs =
             DefaultRemoveExpiredTransactionalIdsIntervalMs;
 
     @FieldContext(

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
@@ -70,7 +70,7 @@ public class MetadataUtils {
         KopTopic kopTopic = new KopTopic(constructTxnLogTopicBaseName(tenant, conf),
                 constructMetadataNamespace(tenant, conf));
         createKafkaMetadataIfMissing(tenant, pulsarAdmin, clusterData, conf, kopTopic,
-                conf.getTxnLogTopicNumPartitions());
+                conf.getKafkaTxnLogTopicNumPartitions());
     }
 
     /**

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtilsTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtilsTest.java
@@ -110,7 +110,7 @@ public class MetadataUtilsTest {
         verify(mockTopics, times(1)).createPartitionedTopic(
                 eq(offsetsTopic.getFullName()), eq(conf.getOffsetsTopicNumPartitions()));
         verify(mockTopics, times(1)).createPartitionedTopic(
-                eq(txnTopic.getFullName()), eq(conf.getTxnLogTopicNumPartitions()));
+                eq(txnTopic.getFullName()), eq(conf.getKafkaTxnLogTopicNumPartitions()));
 
         // Test that cluster is added to existing Tenant if missing
         // Test that the cluster is added to the namespace replication cluster list if it is missing
@@ -135,7 +135,7 @@ public class MetadataUtilsTest {
         for (int i = 0; i < conf.getOffsetsTopicNumPartitions() - 2; i++) {
             incompletePartitionList.add(offsetsTopic.getPartitionName(i));
         }
-        for (int i = 0; i < conf.getTxnLogTopicNumPartitions() - 2; i++) {
+        for (int i = 0; i < conf.getKafkaTxnLogTopicNumPartitions() - 2; i++) {
             incompletePartitionList.add(txnTopic.getPartitionName(i));
         }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CacheInvalidatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CacheInvalidatorTest.java
@@ -95,7 +95,7 @@ public class CacheInvalidatorTest extends KopProtocolHandlerTestBase {
     @BeforeClass
     @Override
     protected void setup() throws Exception {
-        conf.setEnableTransactionCoordinator(true);
+        conf.setKafkaTransactionCoordinatorEnabled(true);
         super.internalSetup();
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaIntegrationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaIntegrationTest.java
@@ -149,7 +149,7 @@ public class KafkaIntegrationTest extends KopProtocolHandlerTestBase {
     @Override
     protected void setup() throws Exception {
         super.resetConfig();
-        this.conf.setEnableTransactionCoordinator(true);
+        this.conf.setKafkaTransactionCoordinatorEnabled(true);
         // in order to access PulsarBroker when using Docker for Mac, we need to adjust things:
         // - set pulsar advertized address to host IP
         // - use the `host.testcontainers.internal` address exposed by testcontainers

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaNonPartitionedTopicTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaNonPartitionedTopicTest.java
@@ -49,7 +49,7 @@ public class KafkaNonPartitionedTopicTest extends KopProtocolHandlerTestBase {
         conf.setKafkaNamespace(NAMESPACE);
         conf.setKafkaMetadataTenant("internal");
         conf.setKafkaMetadataNamespace("__kafka");
-        conf.setEnableTransactionCoordinator(true);
+        conf.setKafkaTransactionCoordinatorEnabled(true);
 
         conf.setClusterName(super.configClusterName);
         super.internalSetup();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -179,8 +179,8 @@ public abstract class KopProtocolHandlerTestBase {
         // kafka related settings.
         kafkaConfig.setOffsetsTopicNumPartitions(1);
 
-        kafkaConfig.setEnableTransactionCoordinator(false);
-        kafkaConfig.setTxnLogTopicNumPartitions(1);
+        kafkaConfig.setKafkaTransactionCoordinatorEnabled(false);
+        kafkaConfig.setKafkaTxnLogTopicNumPartitions(1);
 
         kafkaConfig.setKafkaListeners(
                 PLAINTEXT_PREFIX + "localhost:" + kafkaBrokerPort + ","
@@ -287,7 +287,7 @@ public abstract class KopProtocolHandlerTestBase {
         createClient();
 
         MetadataUtils.createOffsetMetadataIfMissing(conf.getKafkaMetadataTenant(), admin, clusterData, this.conf);
-        if (conf.isEnableTransactionCoordinator()) {
+        if (conf.isKafkaTransactionCoordinatorEnabled()) {
             MetadataUtils.createTxnMetadataIfMissing(conf.getKafkaMetadataTenant(), admin, clusterData, this.conf);
         }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
@@ -53,7 +53,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
     @BeforeClass
     @Override
     protected void setup() throws Exception {
-        this.conf.setEnableTransactionCoordinator(true);
+        this.conf.setKafkaTransactionCoordinatorEnabled(true);
         super.internalSetup();
         log.info("success internal setup");
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinatorTest.java
@@ -97,7 +97,7 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
     @BeforeClass
     @Override
     protected void setup() throws Exception {
-        conf.setEnableTransactionCoordinator(false);
+        conf.setKafkaTransactionCoordinatorEnabled(false);
         super.internalSetup();
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManagerTest.java
@@ -106,7 +106,7 @@ public class TransactionStateManagerTest extends KopProtocolHandlerTestBase {
     @BeforeClass
     @Override
     protected void setup() throws Exception {
-        this.conf.setTxnLogTopicNumPartitions(numPartitions);
+        this.conf.setKafkaTxnLogTopicNumPartitions(numPartitions);
         internalSetup();
         MetadataUtils.createTxnMetadataIfMissing(conf.getKafkaMetadataTenant(), admin, clusterData, this.conf);
     }


### PR DESCRIPTION
### Motivation

In KoP the transaction config might confuse users, and some config in the future might duplicate with Pulsar, we should add a prefix to distinguish it. 

### Modifications

Add prefix for transaction config.