### PR TITLE
Transactions: implement support for JWT token authentication between brokers

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -567,7 +567,7 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
     protected abstract void
     handleCreatePartitions(KafkaHeaderAndRequest kafkaHeaderAndRequest, CompletableFuture<AbstractResponse> response);
 
-    static class KafkaHeaderAndRequest implements Closeable {
+    public static class KafkaHeaderAndRequest implements Closeable {
 
         private static final String DEFAULT_CLIENT_HOST = "";
 
@@ -576,7 +576,7 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
         private final ByteBuf buffer;
         private final SocketAddress remoteAddress;
 
-        KafkaHeaderAndRequest(RequestHeader header,
+        public KafkaHeaderAndRequest(RequestHeader header,
                               AbstractRequest request,
                               ByteBuf buffer,
                               SocketAddress remoteAddress) {
@@ -630,7 +630,7 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
         return header.apiKey() == API_VERSIONS && !API_VERSIONS.isVersionSupported(header.apiVersion());
     }
 
-    static class KafkaHeaderAndResponse implements Closeable {
+    public static class KafkaHeaderAndResponse implements Closeable {
         private final short apiVersion;
         private final ResponseHeader header;
         private final AbstractResponse response;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -514,13 +514,9 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 .brokerServiceUrl(brokerService.getPulsar().getBrokerServiceUrl())
                 .brokerServiceUrlTls(brokerService.getPulsar().getBrokerServiceUrlTls())
                 .build();
-
-        String namespacePrefixForMetadata = MetadataUtils.constructMetadataNamespace(tenant, kafkaConfig);
-        String namespacePrefixForUserTopics = MetadataUtils.constructUserTopicsNamespace(tenant, kafkaConfig);
         try {
             TransactionCoordinator transactionCoordinator =
-                    initTransactionCoordinator(tenant, brokerService.getPulsar().getAdminClient(), clusterData,
-                            namespacePrefixForMetadata, namespacePrefixForUserTopics);
+                    initTransactionCoordinator(tenant, brokerService.getPulsar().getAdminClient(), clusterData);
             // Listening transaction topic load/unload
             brokerService.pulsar()
                     .getNamespaceService()
@@ -703,9 +699,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     }
 
     public TransactionCoordinator initTransactionCoordinator(String tenant, PulsarAdmin pulsarAdmin,
-                                                             ClusterData clusterData,
-                                                             String namespacePrefixForMetadata,
-                                                             String namespacePrefixForUserTopics) throws Exception {
+                                                             ClusterData clusterData) throws Exception {
         TransactionConfig transactionConfig = TransactionConfig.builder()
                 .transactionLogNumPartitions(kafkaConfig.getTxnLogTopicNumPartitions())
                 .transactionMetadataTopicName(MetadataUtils.constructTxnLogTopicBaseName(tenant, kafkaConfig))
@@ -727,12 +721,10 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 kopBrokerLookupManager,
                 OrderedScheduler
                         .newSchedulerBuilder()
-                        .name("transaction-log-manager-"+tenant)
+                        .name("transaction-log-manager-" + tenant)
                         .numThreads(1)
                         .build(),
-                Time.SYSTEM,
-                namespacePrefixForMetadata,
-                namespacePrefixForUserTopics);
+                Time.SYSTEM);
 
         transactionCoordinator.startup(kafkaConfig.isEnableTransactionalIdExpiration()).get();
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -719,11 +719,17 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
         MetadataUtils.createTxnMetadataIfMissing(tenant, pulsarAdmin, clusterData, kafkaConfig);
 
         TransactionCoordinator transactionCoordinator = TransactionCoordinator.of(
+                tenant,
+                kafkaConfig,
                 transactionConfig,
                 txnTopicClient,
                 brokerService.getPulsar().getLocalMetadataStore(),
                 kopBrokerLookupManager,
-                OrderedScheduler.newSchedulerBuilder().name("transaction-log-manager").numThreads(1).build(),
+                OrderedScheduler
+                        .newSchedulerBuilder()
+                        .name("transaction-log-manager-"+tenant)
+                        .numThreads(1)
+                        .build(),
                 Time.SYSTEM,
                 namespacePrefixForMetadata,
                 namespacePrefixForUserTopics);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -27,6 +27,7 @@ import io.streamnative.pulsar.handlers.kop.KopBrokerLookupManager;
 import io.streamnative.pulsar.handlers.kop.SystemTopicClient;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionMetadata.TxnTransitMetadata;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionStateManager.CoordinatorEpochAndTxnMetadata;
+import io.streamnative.pulsar.handlers.kop.utils.MetadataUtils;
 import io.streamnative.pulsar.handlers.kop.utils.ProducerIdAndEpoch;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -138,9 +139,9 @@ public class TransactionCoordinator {
                                             MetadataStoreExtended metadataStore,
                                             KopBrokerLookupManager kopBrokerLookupManager,
                                             ScheduledExecutorService scheduler,
-                                            Time time,
-                                            String namespacePrefixForMetadata,
-                                            String namespacePrefixForUserTopics) throws Exception {
+                                            Time time) throws Exception {
+        String namespacePrefixForMetadata = MetadataUtils.constructMetadataNamespace(tenant, kafkaConfig);
+        String namespacePrefixForUserTopics = MetadataUtils.constructUserTopicsNamespace(tenant, kafkaConfig);
         TransactionStateManager transactionStateManager =
                 new TransactionStateManager(transactionConfig, txnTopicClient, scheduler, time);
         return new TransactionCoordinator(

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelHandler.java
@@ -217,7 +217,7 @@ public class TransactionMarkerChannelHandler extends ChannelInboundHandlerAdapte
                 .thenApply(cnx::complete)
                 .exceptionally(err -> {
                     cnx.completeExceptionally(err);
-                    return null;
+                    return false;
                 });
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelHandler.java
@@ -45,8 +45,6 @@ import org.apache.kafka.common.requests.SaslAuthenticateResponse;
 import org.apache.kafka.common.requests.SaslHandshakeRequest;
 import org.apache.kafka.common.requests.WriteTxnMarkersRequest;
 import org.apache.kafka.common.requests.WriteTxnMarkersResponse;
-import org.apache.pulsar.client.api.PulsarClientException;
-import org.apache.pulsar.common.util.FutureUtil;
 
 
 /**
@@ -57,8 +55,7 @@ public class TransactionMarkerChannelHandler extends ChannelInboundHandlerAdapte
 
     private final CompletableFuture<ChannelHandlerContext> cnx = new CompletableFuture<>();
     private final ConcurrentLongHashMap<InFlightRequest> inFlightRequestMap = new ConcurrentLongHashMap<>();
-    private final ConcurrentLongHashMap<PendingGenericRequest> genericRequestMap
-            = new ConcurrentLongHashMap<>();
+    private final ConcurrentLongHashMap<PendingGenericRequest> genericRequestMap = new ConcurrentLongHashMap<>();
 
     private final AtomicInteger correlationId = new AtomicInteger(0);
     private final TransactionMarkerChannelManager transactionMarkerChannelManager;
@@ -156,7 +153,7 @@ public class TransactionMarkerChannelHandler extends ChannelInboundHandlerAdapte
             v.onError(exception);
         });
         inFlightRequestMap.clear();
-        genericRequestMap.forEach((k,v)-> {
+        genericRequestMap.forEach((k, v)-> {
             v.response.completeExceptionally(exception);
         });
         genericRequestMap.clear();
@@ -194,7 +191,7 @@ public class TransactionMarkerChannelHandler extends ChannelInboundHandlerAdapte
             v.onError(exception);
         });
         inFlightRequestMap.clear();
-        genericRequestMap.forEach((k,v)-> {
+        genericRequestMap.forEach((k, v)-> {
             v.response.completeExceptionally(exception);
         });
         genericRequestMap.clear();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelHandler.java
@@ -13,28 +13,40 @@
  */
 package io.streamnative.pulsar.handlers.kop.coordinator.transaction;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.kafka.common.protocol.Errors.REQUEST_TIMED_OUT;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.streamnative.pulsar.handlers.kop.KafkaCommandDecoder;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicInteger;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.util.collections.ConcurrentLongHashMap;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.types.Struct;
+import org.apache.kafka.common.requests.AbstractResponse;
 import org.apache.kafka.common.requests.KopRequestUtils;
 import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.requests.ResponseHeader;
+import org.apache.kafka.common.requests.SaslAuthenticateRequest;
+import org.apache.kafka.common.requests.SaslAuthenticateResponse;
+import org.apache.kafka.common.requests.SaslHandshakeRequest;
 import org.apache.kafka.common.requests.WriteTxnMarkersRequest;
 import org.apache.kafka.common.requests.WriteTxnMarkersResponse;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.common.util.FutureUtil;
 
 
 /**
@@ -45,6 +57,8 @@ public class TransactionMarkerChannelHandler extends ChannelInboundHandlerAdapte
 
     private final CompletableFuture<ChannelHandlerContext> cnx = new CompletableFuture<>();
     private final ConcurrentLongHashMap<InFlightRequest> inFlightRequestMap = new ConcurrentLongHashMap<>();
+    private final ConcurrentLongHashMap<PendingGenericRequest> genericRequestMap
+            = new ConcurrentLongHashMap<>();
 
     private final AtomicInteger correlationId = new AtomicInteger(0);
     private final TransactionMarkerChannelManager transactionMarkerChannelManager;
@@ -66,6 +80,13 @@ public class TransactionMarkerChannelHandler extends ChannelInboundHandlerAdapte
             inFlightRequest.onError(err);
             return null;
         });
+    }
+
+    @AllArgsConstructor
+    private static final class PendingGenericRequest {
+        CompletableFuture<AbstractResponse> response;
+        ApiKeys apiKeys;
+        short apiVersion;
     }
 
     private class InFlightRequest {
@@ -122,18 +143,23 @@ public class TransactionMarkerChannelHandler extends ChannelInboundHandlerAdapte
             log.debug("channelActive");
         }
         log.info("[TransactionMarkerChannelHandler] channelActive to {}", channelHandlerContext.channel());
-        this.cnx.complete(channelHandlerContext);
+        handleAuthentication(channelHandlerContext);
         super.channelActive(channelHandlerContext);
     }
 
     @Override
     public void channelInactive(ChannelHandlerContext channelHandlerContext) throws Exception {
-        log.info("[TransactionMarkerChannelHandler] channelInactive, failing {} pending requests",
-                inFlightRequestMap.size());
+        log.info("[TransactionMarkerChannelHandler] channelInactive, failing {} + {} pending requests",
+                inFlightRequestMap.size(), genericRequestMap.size());
+        final Exception exception = new Exception("Connection to remote broker closed");
         inFlightRequestMap.forEach((k, v) -> {
-            v.onError(new Exception("Connection to remote broker closed"));
+            v.onError(exception);
         });
         inFlightRequestMap.clear();
+        genericRequestMap.forEach((k,v)-> {
+            v.response.completeExceptionally(exception);
+        });
+        genericRequestMap.clear();
         transactionMarkerChannelManager.channelFailed((InetSocketAddress) channelHandlerContext
                 .channel()
                 .remoteAddress(), this);
@@ -145,20 +171,33 @@ public class TransactionMarkerChannelHandler extends ChannelInboundHandlerAdapte
         ByteBuffer nio = ((ByteBuf) o).nioBuffer();
         ResponseHeader responseHeader = ResponseHeader.parse(nio);
         InFlightRequest inFlightRequest = inFlightRequestMap.remove(responseHeader.correlationId());
-        if (inFlightRequest == null) {
-            log.error("Miss the inFlightRequest with correlationId {}.", responseHeader.correlationId());
+        if (inFlightRequest != null) {
+            inFlightRequest.onComplete(nio);
             return;
         }
-        inFlightRequest.onComplete(nio);
+        PendingGenericRequest genericRequest = genericRequestMap.remove(responseHeader.correlationId());
+        if (genericRequest != null) {
+            Struct responseBody = genericRequest.apiKeys.parseResponse(genericRequest.apiVersion, nio);
+            AbstractResponse response = AbstractResponse.parseResponse(genericRequest.apiKeys, responseBody);
+            genericRequest.response.complete(response);
+            return;
+        }
+        log.error("Miss the inFlightRequest with correlationId {}.", responseHeader.correlationId());
     }
 
     @Override
     public void exceptionCaught(ChannelHandlerContext channelHandlerContext, Throwable throwable) throws Exception {
         log.error("Transaction marker channel handler caught exception.", throwable);
+        final Exception exception =
+                new Exception("Transaction marker channel handler caught exception: " + throwable, throwable);
         inFlightRequestMap.forEach((k, v) -> {
-            v.onError(new Exception("Transaction marker channel handler caught exception: " + throwable, throwable));
+            v.onError(exception);
         });
         inFlightRequestMap.clear();
+        genericRequestMap.forEach((k,v)-> {
+            v.response.completeExceptionally(exception);
+        });
+        genericRequestMap.clear();
         channelHandlerContext.close();
     }
 
@@ -168,6 +207,127 @@ public class TransactionMarkerChannelHandler extends ChannelInboundHandlerAdapte
             if (ctx != null) {
                 ctx.close();
             }
+        });
+    }
+
+    public void handleAuthentication(ChannelHandlerContext channelHandlerContext) {
+        if (!transactionMarkerChannelManager.getKafkaConfig().isAuthenticationEnabled()) {
+            this.cnx.complete(channelHandlerContext);
+            return;
+        }
+        saslHandshake(channelHandlerContext)
+                .thenCompose(this::authenticate)
+                .thenApply(cnx::complete)
+                .exceptionally(err -> {
+                    cnx.completeExceptionally(err);
+                    return null;
+                });
+    }
+
+    private void sendGenericRequestOnTheWire(ChannelHandlerContext channel,
+                                             KafkaCommandDecoder.KafkaHeaderAndRequest request,
+                                             CompletableFuture<AbstractResponse> result) {
+        long correlationId = request.getHeader().correlationId();
+        genericRequestMap.put(correlationId, new PendingGenericRequest(result,
+                request.getHeader().apiKey(),
+                request.getHeader().apiVersion()));
+        channel.writeAndFlush(request.getBuffer())
+                .addListener(writeFuture -> {
+            if (!writeFuture.isSuccess()) {
+                genericRequestMap.remove(correlationId);
+                // cannot write, so we have to "close()" and trigger failure of every other
+                // pending request and discard the reference to this connection
+                channel.close();
+                result.completeExceptionally(writeFuture.cause());
+            }
+        });
+    }
+
+    private CompletableFuture<ChannelHandlerContext> saslHandshake(ChannelHandlerContext channel) {
+        KafkaCommandDecoder.KafkaHeaderAndRequest fullRequest = buildSASLRequest();
+        CompletableFuture<AbstractResponse> result = new CompletableFuture<>();
+        sendGenericRequestOnTheWire(channel, fullRequest, result);
+        result.exceptionally(error -> {
+            // ensure that we close the channel
+            channel.close();
+            return null;
+        });
+        return result.thenApply(response -> {
+            log.debug("SASL Handshake completed with success");
+            return channel;
+        });
+    }
+
+    private KafkaCommandDecoder.KafkaHeaderAndRequest buildSASLRequest() {
+        RequestHeader header = new RequestHeader(
+                ApiKeys.SASL_HANDSHAKE,
+                ApiKeys.SASL_HANDSHAKE.latestVersion(),
+                "tx", //ignored
+                correlationId.incrementAndGet()
+        );
+        SaslHandshakeRequest request = new SaslHandshakeRequest
+                .Builder("PLAIN")
+                .build();
+        ByteBuffer buffer = request.serialize(header);
+        KafkaCommandDecoder.KafkaHeaderAndRequest fullRequest = new KafkaCommandDecoder.KafkaHeaderAndRequest(
+                header,
+                request,
+                Unpooled.wrappedBuffer(buffer),
+                null
+        );
+        return fullRequest;
+    }
+
+    private CompletableFuture<ChannelHandlerContext> authenticate(final ChannelHandlerContext channel) {
+        CompletableFuture<ChannelHandlerContext> internal = authenticateInternal(channel);
+        // ensure that we close the channel
+        internal.exceptionally(error -> {
+            channel.close();
+            return null;
+        });
+        return internal;
+    }
+
+    private CompletableFuture<ChannelHandlerContext> authenticateInternal(ChannelHandlerContext channel) {
+        RequestHeader header = new RequestHeader(
+                ApiKeys.SASL_AUTHENTICATE,
+                ApiKeys.SASL_AUTHENTICATE.latestVersion(),
+                "tx", // ignored
+                correlationId.incrementAndGet()
+        );
+        String prefix = "TX"; // the prefix TX means nothing, it is ignored by SaslUtils#parseSaslAuthBytes
+        String authUsername = transactionMarkerChannelManager.getAuthenticationUsername();
+        String authPassword = transactionMarkerChannelManager.getAuthenticationPassword();
+        String usernamePassword = prefix
+                + "\u0000" + authUsername
+                + "\u0000" + authPassword;
+        byte[] saslAuthBytes = usernamePassword.getBytes(UTF_8);
+        SaslAuthenticateRequest request = new SaslAuthenticateRequest
+                .Builder(ByteBuffer.wrap(saslAuthBytes))
+                .build();
+
+        ByteBuffer buffer = request.serialize(header);
+
+        KafkaCommandDecoder.KafkaHeaderAndRequest fullRequest = new KafkaCommandDecoder.KafkaHeaderAndRequest(
+                header,
+                request,
+                Unpooled.wrappedBuffer(buffer),
+                null
+        );
+        CompletableFuture<AbstractResponse> result = new CompletableFuture<>();
+        sendGenericRequestOnTheWire(channel, fullRequest, result);
+        return result.thenApply(response -> {
+            SaslAuthenticateResponse saslResponse = (SaslAuthenticateResponse) response;
+            if (saslResponse.error() != Errors.NONE) {
+                log.error("Failed authentication against KOP broker {}{}", saslResponse.error(),
+                        saslResponse.errorMessage());
+                close();
+                throw new CompletionException(saslResponse.error().exception());
+            } else {
+                log.debug("Success step AUTH to KOP broker {} {} {}", saslResponse.error(),
+                        saslResponse.errorMessage(), saslResponse.saslAuthBytes());
+            }
+            return channel;
         });
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelInitializer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelInitializer.java
@@ -30,7 +30,6 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
  */
 public class TransactionMarkerChannelInitializer extends ChannelInitializer<SocketChannel> {
 
-    private final KafkaServiceConfiguration kafkaConfig;
     private final boolean enableTls;
     private final SslContextFactory.Server sslContextFactory;
     private final TransactionMarkerChannelManager transactionMarkerChannelManager;
@@ -38,7 +37,6 @@ public class TransactionMarkerChannelInitializer extends ChannelInitializer<Sock
     public TransactionMarkerChannelInitializer(KafkaServiceConfiguration kafkaConfig,
                                                boolean enableTls,
                                                TransactionMarkerChannelManager transactionMarkerChannelManager) {
-        this.kafkaConfig = kafkaConfig;
         this.enableTls = enableTls;
         this.transactionMarkerChannelManager = transactionMarkerChannelManager;
         if (enableTls) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
@@ -47,8 +47,6 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.TransactionResult;
 import org.apache.kafka.common.requests.WriteTxnMarkersRequest;
 import org.apache.kafka.common.requests.WriteTxnMarkersRequest.TxnMarkerEntry;
-import org.apache.pulsar.client.api.Authentication;
-import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.AuthenticationUtil;
 import org.apache.pulsar.client.impl.auth.AuthenticationToken;
 import org.apache.pulsar.common.util.FutureUtil;
@@ -497,6 +495,6 @@ public class TransactionMarkerChannelManager {
         if (authenticationToken == null) {
             return "";
         }
-        return "token:"+ authenticationToken;
+        return "token:" + authenticationToken;
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
@@ -39,6 +39,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.TopicPartition;
@@ -46,6 +47,10 @@ import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.TransactionResult;
 import org.apache.kafka.common.requests.WriteTxnMarkersRequest;
 import org.apache.kafka.common.requests.WriteTxnMarkersRequest.TxnMarkerEntry;
+import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.impl.AuthenticationUtil;
+import org.apache.pulsar.client.impl.auth.AuthenticationToken;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.netty.ChannelFutures;
 import org.eclipse.jetty.util.BlockingArrayQueue;
@@ -58,7 +63,10 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 @Slf4j
 public class TransactionMarkerChannelManager {
 
+    private final String tenant;
+    @Getter
     private final KafkaServiceConfiguration kafkaConfig;
+    private final String authenticationToken;
     private final EventLoopGroup eventLoopGroup;
     private final boolean enableTls;
     private final SslContextFactory sslContextFactory;
@@ -130,11 +138,13 @@ public class TransactionMarkerChannelManager {
         }
     }
 
-    public TransactionMarkerChannelManager(KafkaServiceConfiguration kafkaConfig,
+    public TransactionMarkerChannelManager(String tenant,
+                                           KafkaServiceConfiguration kafkaConfig,
                                            TransactionStateManager txnStateManager,
                                            KopBrokerLookupManager kopBrokerLookupManager,
                                            boolean enableTls,
-                                           String namespacePrefixForUserTopics) {
+                                           String namespacePrefixForUserTopics) throws Exception {
+        this.tenant = tenant;
         this.kafkaConfig = kafkaConfig;
         this.namespacePrefixForUserTopics = namespacePrefixForUserTopics;
         this.txnStateManager = txnStateManager;
@@ -146,6 +156,17 @@ public class TransactionMarkerChannelManager {
         } else {
             sslContextFactory = null;
             sslEndPoint = null;
+        }
+        if (kafkaConfig.isAuthenticationEnabled()
+                && AuthenticationToken.class.getName().equals(kafkaConfig.getBrokerClientAuthenticationPlugin())) {
+            // this currently works only for JWT authentication
+            String auth = kafkaConfig.getBrokerClientAuthenticationPlugin();
+            String authParams = kafkaConfig.getBrokerClientAuthenticationParameters();
+            authenticationToken = AuthenticationUtil.create(auth, authParams)
+                    .getAuthData()
+                    .getCommandData();
+        } else {
+            authenticationToken = null;
         }
         eventLoopGroup = new NioEventLoopGroup();
         bootstrap = new Bootstrap();
@@ -468,4 +489,14 @@ public class TransactionMarkerChannelManager {
         });
     }
 
+    public String getAuthenticationUsername() {
+        return tenant;
+    }
+
+    public String getAuthenticationPassword() {
+        if (authenticationToken == null) {
+            return "";
+        }
+        return "token:"+ authenticationToken;
+    }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -506,13 +506,17 @@ public abstract class KopProtocolHandlerTestBase {
 
         public KProducer(String topic, Boolean isAsync, String host,
                          int port, String username, String password,
-                         Boolean retry, String keySer, String valueSer) {
+                         Boolean retry, String keySer, String valueSer,
+                         String transactionalId) {
             Properties props = new Properties();
             props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, host + ":" + port);
             props.put(ProducerConfig.CLIENT_ID_CONFIG, "DemoKafkaOnPulsarProducer");
             props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySer);
             props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSer);
             props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 10000);
+            if (transactionalId != null) {
+                props.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId);
+            }
 
             if (retry) {
                 props.put(ProducerConfig.RETRIES_CONFIG, 3);
@@ -531,6 +535,12 @@ public abstract class KopProtocolHandlerTestBase {
             producer = new KafkaProducer<>(props);
             this.topic = topic;
             this.isAsync = isAsync;
+        }
+
+        public KProducer(String topic, Boolean isAsync, String host,
+                         int port, String username, String password,
+                         Boolean retry, String keySer, String valueSer) {
+            this(topic, isAsync, host, port, username, password, retry, keySer, valueSer, null);
         }
 
         public KProducer(String topic, Boolean isAsync, String host,
@@ -614,7 +624,8 @@ public abstract class KopProtocolHandlerTestBase {
         public KConsumer(
             String topic, String host, int port,
             boolean autoCommit, String username, String password,
-            String consumerGroup, String keyDeser, String valueDeser) {
+            String consumerGroup, String keyDeser, String valueDeser,
+            String isolation) {
             Properties props = new Properties();
             props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, host + ":" + port);
             props.put(ConsumerConfig.GROUP_ID_CONFIG, consumerGroup);
@@ -625,6 +636,10 @@ public abstract class KopProtocolHandlerTestBase {
             } else {
                 props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
             }
+            if (isolation != null) {
+                props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, isolation);
+            }
+
 
             if (null != username && null != password) {
                 String jaasTemplate = "org.apache.kafka.common.security.plain.PlainLoginModule "
@@ -644,6 +659,14 @@ public abstract class KopProtocolHandlerTestBase {
             this.consumer = new KafkaConsumer<>(props);
             this.topic = topic;
             this.consumerGroup = consumerGroup;
+        }
+
+        public KConsumer(
+                String topic, String host, int port,
+                boolean autoCommit, String username, String password,
+                String consumerGroup, String keyDeser, String valueDeser) {
+            this(topic, host, port, autoCommit, username, password, consumerGroup,
+                    keyDeser, valueDeser, null);
         }
 
         public KConsumer(String topic, String host, int port, boolean autoCommit,

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslPlainTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslPlainTestBase.java
@@ -52,7 +52,6 @@ import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.impl.auth.AuthenticationToken;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.TenantInfo;
-import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslPlainTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslPlainTestBase.java
@@ -21,22 +21,30 @@ import static org.testng.Assert.fail;
 import com.google.common.collect.Sets;
 import io.jsonwebtoken.SignatureAlgorithm;
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.crypto.SecretKey;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationProviderToken;
@@ -45,6 +53,7 @@ import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.impl.auth.AuthenticationToken;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -215,5 +224,106 @@ public abstract class SaslPlainTestBase extends KopProtocolHandlerTestBase {
             assertTrue(e.getCause() instanceof TimeoutException);
             assertTrue(e.getMessage().contains("Failed to update metadata"));
         }
+    }
+
+    @Test
+    public void transactionsReadCommittedTest() throws Exception {
+        basicProduceAndConsumeTest(TENANT + "/" + NAMESPACE + "/" +  "read-committed-test", "txn-11", "read_committed");
+    }
+
+    @Test(timeOut = 1000 * 10)
+    public void transactionsReadUncommittedTest() throws Exception {
+        basicProduceAndConsumeTest(TENANT + "/" + NAMESPACE + "/" +  "read-uncommitted-test", "txn-12", "read_uncommitted");
+    }
+
+    private void basicProduceAndConsumeTest(String topicName,
+                                           String transactionalId,
+                                           String isolation) throws Exception {
+
+        @Cleanup
+        KProducer kProducer = new KProducer(topicName, false, "localhost", getKafkaBrokerPort(),
+                TENANT + "/" + NAMESPACE, "token:" + userToken, false, IntegerSerializer.class.getName(),
+                StringSerializer.class.getName(), transactionalId);
+
+        KafkaProducer<Integer, String> producer = kProducer.getProducer();
+
+        producer.initTransactions();
+
+        int totalTxnCount = 10;
+        int messageCountPerTxn = 10;
+
+        String lastMessage = "";
+        for (int txnIndex = 0; txnIndex < totalTxnCount; txnIndex++) {
+            producer.beginTransaction();
+
+            String contentBase;
+            if (txnIndex % 2 != 0) {
+                contentBase = "commit msg txnIndex %s messageIndex %s";
+            } else {
+                contentBase = "abort msg txnIndex %s messageIndex %s";
+            }
+
+            for (int messageIndex = 0; messageIndex < messageCountPerTxn; messageIndex++) {
+                String msgContent = String.format(contentBase, txnIndex, messageIndex);
+                log.info("send txn message {}", msgContent);
+                lastMessage = msgContent;
+                producer.send(new ProducerRecord<>(topicName, messageIndex, msgContent)).get();
+            }
+
+            if (txnIndex % 2 != 0) {
+                producer.commitTransaction();
+            } else {
+                producer.abortTransaction();
+            }
+        }
+
+        consumeTxnMessage(topicName, totalTxnCount * messageCountPerTxn, lastMessage, isolation);
+    }
+
+
+    private void consumeTxnMessage(String topicName,
+                                   int totalMessageCount,
+                                   String lastMessage,
+                                   String isolation) throws InterruptedException {
+
+        @Cleanup
+        KConsumer kConsumer = new KConsumer(topicName , "localhost", getKafkaBrokerPort(), false,
+                TENANT + "/" + NAMESPACE, "token:" + userToken, "consumeTxnMessage-" + UUID.randomUUID(),
+                IntegerDeserializer.class.getName(),
+                StringDeserializer.class.getName(), isolation);
+
+        KafkaConsumer<Integer, String> consumer = kConsumer.getConsumer();
+        consumer.subscribe(Collections.singleton(topicName));
+
+        log.info("the last message is: {}", lastMessage);
+        AtomicInteger receiveCount = new AtomicInteger(0);
+        while (true) {
+            ConsumerRecords<Integer, String> consumerRecords =
+                    consumer.poll(Duration.of(100, ChronoUnit.MILLIS));
+
+            boolean readFinish = false;
+            for (ConsumerRecord<Integer, String> record : consumerRecords) {
+                log.info("Fetch for receive record offset: {}, key: {}, value: {}",
+                        record.offset(), record.key(), record.value());
+                receiveCount.incrementAndGet();
+                if (lastMessage.equalsIgnoreCase(record.value())) {
+                    log.info("receive the last message");
+                    readFinish = true;
+                }
+            }
+
+            if (readFinish) {
+                log.info("Fetch for read finish.");
+                break;
+            }
+        }
+        log.info("Fetch for receive message finish. isolation: {}, receive count: {}", isolation, receiveCount.get());
+
+        if (isolation.equals("read_committed")) {
+            Assert.assertEquals(receiveCount.get(), totalMessageCount / 2);
+        } else {
+            Assert.assertEquals(receiveCount.get(), totalMessageCount);
+        }
+        log.info("Fetch for finish consume messages. isolation: {}", isolation);
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslPlainTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslPlainTestBase.java
@@ -99,6 +99,7 @@ public abstract class SaslPlainTestBase extends KopProtocolHandlerTestBase {
         ((KafkaServiceConfiguration) conf).setKafkaMetadataTenant("internal");
         ((KafkaServiceConfiguration) conf).setKafkaMetadataNamespace("__kafka");
 
+        conf.setKafkaTransactionCoordinatorEnabled(true);
         conf.setClusterName(super.configClusterName);
         conf.setAuthorizationEnabled(true);
         conf.setAuthenticationEnabled(true);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslPlainTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslPlainTestBase.java
@@ -33,7 +33,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.crypto.SecretKey;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -228,12 +227,14 @@ public abstract class SaslPlainTestBase extends KopProtocolHandlerTestBase {
 
     @Test
     public void transactionsReadCommittedTest() throws Exception {
-        basicProduceAndConsumeTest(TENANT + "/" + NAMESPACE + "/" +  "read-committed-test", "txn-11", "read_committed");
+        basicProduceAndConsumeTest(TENANT + "/" + NAMESPACE + "/" +  "read-committed-test", "txn-11",
+                "read_committed");
     }
 
     @Test(timeOut = 1000 * 10)
     public void transactionsReadUncommittedTest() throws Exception {
-        basicProduceAndConsumeTest(TENANT + "/" + NAMESPACE + "/" +  "read-uncommitted-test", "txn-12", "read_uncommitted");
+        basicProduceAndConsumeTest(TENANT + "/" + NAMESPACE + "/" +  "read-uncommitted-test", "txn-12",
+                "read_uncommitted");
     }
 
     private void basicProduceAndConsumeTest(String topicName,
@@ -320,9 +321,9 @@ public abstract class SaslPlainTestBase extends KopProtocolHandlerTestBase {
         log.info("Fetch for receive message finish. isolation: {}, receive count: {}", isolation, receiveCount.get());
 
         if (isolation.equals("read_committed")) {
-            Assert.assertEquals(receiveCount.get(), totalMessageCount / 2);
+            assertEquals(receiveCount.get(), totalMessageCount / 2);
         } else {
-            Assert.assertEquals(receiveCount.get(), totalMessageCount);
+            assertEquals(receiveCount.get(), totalMessageCount);
         }
         log.info("Fetch for finish consume messages. isolation: {}", isolation);
     }


### PR DESCRIPTION
**Motivation**
When you enable JWT token authentication transactions do not work because transactions need broker-to-broker communication but there is currently no support for the SASL handshake.

**Changes**
Now when you enable authentication and you configure Token Authentication for Broker-To-Broker communications in Pulsar, we perform SASL PLAIN authentication while preparing the connection to other brokers.

**Tests**
I have extended existing SASL tests in order to use Transactions. I have copy/pasted some parts of the TransactionTest, but there was not enough code to make sense to share the test code.