### PR TITLE
Add Kafka payload processor 

### DIFF
--- a/kafka-payload-processor/pom.xml
+++ b/kafka-payload-processor/pom.xml
@@ -32,5 +32,10 @@
       <artifactId>pulsar-client-original</artifactId>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/kafka-payload-processor/pom.xml
+++ b/kafka-payload-processor/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
+    <groupId>io.streamnative.pulsar.handlers</groupId>
+    <version>2.9.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>kafka-payload-processor</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>${pulsar.group.id}</groupId>
+      <artifactId>pulsar-client-original</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/kafka-payload-processor/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaPayloadProcessor.java
+++ b/kafka-payload-processor/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaPayloadProcessor.java
@@ -16,7 +16,9 @@ package io.streamnative.pulsar.handlers.kop;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.concurrent.FastThreadLocal;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.function.Consumer;
+import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -105,6 +107,12 @@ public class KafkaPayloadProcessor implements MessagePayloadProcessor {
             valueBuffer = null;
             singleMessageMetadata.setNullValue(true);
             singleMessageMetadata.setPayloadSize(0);
+        }
+
+        for (Header header : record.headers()) {
+            singleMessageMetadata.addProperty()
+                    .setKey(header.key())
+                    .setValue(new String(header.value(), StandardCharsets.UTF_8));
         }
 
         final ByteBuf buf = PulsarByteBufAllocator.DEFAULT.buffer(

--- a/kafka-payload-processor/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaPayloadProcessor.java
+++ b/kafka-payload-processor/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaPayloadProcessor.java
@@ -66,7 +66,7 @@ public class KafkaPayloadProcessor implements MessagePayloadProcessor {
             }
             int index = 0;
             for (RecordBatch batch : records.batches()) {
-                if (batch.isControlBatch() || batch.isTransactional()) {
+                if (batch.isControlBatch()) {
                     continue;
                 }
                 // TODO: Currently KoP doesn't support multi batches in an entry so it works well at this moment. After

--- a/kafka-payload-processor/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaPayloadProcessor.java
+++ b/kafka-payload-processor/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaPayloadProcessor.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import java.util.function.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessagePayload;
+import org.apache.pulsar.client.api.MessagePayloadContext;
+import org.apache.pulsar.client.api.MessagePayloadProcessor;
+import org.apache.pulsar.client.api.Schema;
+
+/**
+ * Process Kafka messages so that Pulsar consumer can recognize.
+ */
+public class KafkaPayloadProcessor implements MessagePayloadProcessor {
+
+    @Override
+    public <T> void process(MessagePayload payload,
+                            MessagePayloadContext context,
+                            Schema<T> schema,
+                            Consumer<Message<T>> messageConsumer) throws Exception {
+        // TODO: convert Kafka messages
+        DEFAULT.process(payload, context, schema, messageConsumer);
+    }
+}

--- a/kafka-payload-processor/src/main/java/io/streamnative/pulsar/handlers/kop/package-info.java
+++ b/kafka-payload-processor/src/main/java/io/streamnative/pulsar/handlers/kop/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
     <module>kafka-impl</module>
     <module>oauth-client</module>
     <module>tests</module>
+    <module>kafka-payload-processor</module>
   </modules>
 
   <!-- dependency definitions -->

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -48,6 +48,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.streamnative.pulsar.handlers</groupId>
+      <artifactId>kafka-payload-processor</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-streams</artifactId>
       <version>${kafka.version}</version>

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
@@ -14,6 +14,7 @@
 package io.streamnative.pulsar.handlers.kop;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -24,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.Cleanup;
@@ -37,6 +39,8 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
@@ -73,6 +77,11 @@ public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
         final KafkaConsumer<String, String> kafkaConsumer = newKafkaConsumer(topic);
         List<String> kafkaReceives = receiveMessages(kafkaConsumer, expectedMessages.size());
         assertEquals(kafkaReceives, expectedMessages);
+
+        @Cleanup
+        final Consumer<byte[]> pulsarConsumer = newPulsarConsumer(topic, SUBSCRIPTION, new KafkaPayloadProcessor());
+        List<String> pulsarReceives = receiveMessages(pulsarConsumer, expectedMessages.size());
+        assertEquals(pulsarReceives, expectedMessages);
     }
 
     @Test(timeOut = 20000)
@@ -288,5 +297,43 @@ public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
         assertEquals(getValuesFromRecords(receivedRecords), values);
         assertEquals(getKeysFromRecords(receivedRecords), keys);
         assertEquals(getFirstHeadersFromRecords(receivedRecords), headers);
+    }
+
+
+    @Test(timeOut = 20000, dataProvider = "enableBatching")
+    public void testKafkaProducePulsarConsume(boolean enableBatching) throws Exception {
+        final String topic = "test-kafka-produce-pulsar-consume";
+        final KafkaProducer<String, String> producer = newKafkaProducer();
+        final int numMessages = 10;
+
+        Future<RecordMetadata> sendFuture = null;
+        for (int i = 0; i < numMessages; i++) {
+            if (i % 2 == 0) {
+                sendFuture = producer.send(new ProducerRecord<>(topic, "msg-" + i));
+            } else {
+                sendFuture = producer.send(new ProducerRecord<>(topic, "key-" + i, "msg-" + i));
+            }
+            if (!enableBatching) {
+                sendFuture.get();
+            }
+        }
+        sendFuture.get();
+        producer.close();
+
+        @Cleanup
+        final Consumer<byte[]> consumer = newPulsarConsumer(
+                topic, "my-sub-" + enableBatching, new KafkaPayloadProcessor());
+        final List<Message<byte[]>> messages = receivePulsarMessages(consumer, numMessages);
+        assertEquals(messages.size(), numMessages);
+        for (int i = 0; i < numMessages; i++) {
+            final Message<byte[]> message = messages.get(i);
+            assertEquals(convertPulsarMessageToString(message), "msg-" + i);
+            if (i % 2 == 0) {
+                assertNull(message.getKey());
+            } else {
+                assertEquals(message.getKey(), "key-" + i);
+                assertEquals(message.getOrderingKey(), ("key-" + i).getBytes(StandardCharsets.UTF_8));
+            }
+        }
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndTestBase.java
@@ -16,7 +16,6 @@ package io.streamnative.pulsar.handlers.kop;
 import static org.junit.Assert.assertEquals;
 
 import io.streamnative.kafka.client.api.Header;
-
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndTestBase.java
@@ -261,8 +261,8 @@ public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
                     log.debug("Pulsar Consumer receive {} from {}",
                             convertPulsarMessageToString(message), message.getMessageId());
                 }
+                numMessages--;
             }
-            numMessages--;
         }
         return messages;
     }


### PR DESCRIPTION
### Motivation

It's recommended to configure `entryFormat=kafka` for better performance among Kafka clients in KoP. However, since it writes the original messages of Kafka format to BK, Pulsar consumer cannot consume these messages.

[PIP-96](https://github.com/apache/pulsar/wiki/PIP-96%3A-Message-payload-processor-for-Pulsar-client), which will be included in Pulsar 2.9.0, introduced a payload processor for Pulsar consumer. Based on PIP-96, this PR intends to add a payload processor for messages of Kafka format.

### Modifications

- Add a `kafka-payload-processor` module that contains the implementation of `KafkaPayloadProcessor`.
- Add tests to cover null values, keys and headers.