### PR TITLE
Implement ability to not handle namespaces automatically: kafkaManageSystemNamespaces

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -81,6 +81,12 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
     private int numSendKafkaResponseThreads = 4;
 
     @FieldContext(
+            required = true,
+            doc = "Manage automatically system namespaces and topic"
+    )
+    private boolean kafkaManageSystemNamespaces = true;
+
+    @FieldContext(
         category = CATEGORY_KOP,
         required = true,
         doc = "Kafka on Pulsar Broker tenant"

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
@@ -98,6 +98,10 @@ public class MetadataUtils {
                                                      KopTopic kopTopic,
                                                      int partitionNum)
         throws PulsarAdminException {
+        if (!conf.isKafkaManageSystemNamespaces()) {
+            log.info("Skipping initialization of topic {} for tenant {}", kopTopic.getFullName(), tenant);
+            return;
+        }
         String cluster = conf.getClusterName();
         String kafkaMetadataNamespace = tenant + "/" + conf.getKafkaMetadataNamespace();
 

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtilsTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtilsTest.java
@@ -160,7 +160,6 @@ public class MetadataUtilsTest {
 
     @Test(timeOut = 30000)
     public void testDisableCreateKafkaMetadata() throws Exception {
-        String namespacePrefix = "public/default";
         KafkaServiceConfiguration conf = new KafkaServiceConfiguration();
         conf.setKafkaManageSystemNamespaces(false);
         Clusters mockClusters = mock(Clusters.class);

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtilsTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtilsTest.java
@@ -172,7 +172,8 @@ public class MetadataUtilsTest {
         doReturn(mockTenants).when(mockPulsarAdmin).tenants();
         doReturn(mockNamespaces).when(mockPulsarAdmin).namespaces();
         doReturn(mockTopics).when(mockPulsarAdmin).topics();
-        MetadataUtils.createOffsetMetadataIfMissing(conf.getKafkaMetadataTenant(), mockPulsarAdmin, ClusterData.builder().build(), conf);
+        MetadataUtils.createOffsetMetadataIfMissing(conf.getKafkaMetadataTenant(), mockPulsarAdmin,
+                                                                     ClusterData.builder().build(), conf);
 
         verify(mockTenants, times(0)).createTenant(any(), any());
         verify(mockNamespaces, times(0)).createNamespace(any(), any(Set.class));


### PR DESCRIPTION
**Motivation**

When you have a system with many independent tenants having a global configuration that is the same for every tenant is problematic.
Therefore there are cases in which you don't want that the PH creates namespaces or overrides the configuration, because there is some other component (like a separate control plane) that is in charge of managing all the system configurations for each tenant.

**Changes**
Add a new configuration option `kafkaManageSystemNamespaces` to disable any operation about creating namespaces or setting any configuration.
This option will allow to move the management of such things to an external entity.