### PR TITLE
[BUGFIX] Fix the internal topics should be controlled in the meta namespace

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -198,7 +198,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
         final NamespaceName kafkaTopicNs;
         final GroupCoordinator groupCoordinator;
         final String brokerUrl;
-        final KafkaServiceConfiguration kafkaConfig;
+        final String metadataNamespace;
 
         public OffsetAndTopicListener(BrokerService service,
                                       String tenant,
@@ -211,7 +211,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
             this.kafkaTopicNs = NamespaceName
                     .get(tenant, kafkaConfig.getKafkaNamespace());
             this.brokerUrl = service.pulsar().getBrokerServiceUrl();
-            this.kafkaConfig = kafkaConfig;
+            this.metadataNamespace = kafkaConfig.getKafkaMetadataNamespace();
         }
 
         @Override
@@ -229,7 +229,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                             TopicName name = TopicName.get(topic);
 
                             // already filtered namespace, check the local name without partition
-                            if (KopTopic.isGroupMetadataTopicName(topic, kafkaConfig)) {
+                            if (KopTopic.isGroupMetadataTopicName(topic, metadataNamespace)) {
                                 checkState(name.isPartitioned(),
                                         "OffsetTopic should be partitioned in onLoad, but get " + name);
 
@@ -263,7 +263,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                             TopicName name = TopicName.get(topic);
 
                             // already filtered namespace, check the local name without partition
-                            if (KopTopic.isGroupMetadataTopicName(topic, kafkaConfig)) {
+                            if (KopTopic.isGroupMetadataTopicName(topic, metadataNamespace)) {
                                 checkState(name.isPartitioned(),
                                         "OffsetTopic should be partitioned in unLoad, but get " + name);
 
@@ -301,7 +301,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
         private final NamespaceName kafkaTopicNs;
         private final String brokerUrl;
         private final TransactionCoordinator txnCoordinator;
-        private final KafkaServiceConfiguration kafkaConfig;
+        private final String metadataNamespace;
 
         public TransactionStateRecover(
                 BrokerService service,
@@ -315,7 +315,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                     .get(tenant, kafkaConfig.getKafkaNamespace());
             this.brokerUrl = service.pulsar().getBrokerServiceUrl();
             this.txnCoordinator = txnCoordinator;
-            this.kafkaConfig = kafkaConfig;
+            this.metadataNamespace = kafkaConfig.getKafkaMetadataNamespace();
         }
 
         @Override
@@ -333,7 +333,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                             for (String topic : topics) {
                                 TopicName name = TopicName.get(topic);
 
-                                if (KopTopic.isTransactionMetadataTopicName(topic, kafkaConfig)) {
+                                if (KopTopic.isTransactionMetadataTopicName(topic, metadataNamespace)) {
                                     checkState(name.isPartitioned(),
                                             "TxnTopic should be partitioned in onLoad, but get " + name);
 
@@ -367,7 +367,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                             for (String topic : topics) {
                                 TopicName name = TopicName.get(topic);
 
-                                if (KopTopic.isTransactionMetadataTopicName(topic, kafkaConfig)
+                                if (KopTopic.isTransactionMetadataTopicName(topic, metadataNamespace)
                                         && txnCoordinator != null) {
                                     checkState(name.isPartitioned(),
                                             "TxnTopic should be partitioned in unLoad, but get " + name);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -15,7 +15,6 @@ package io.streamnative.pulsar.handlers.kop;
 
 import static com.google.common.base.Preconditions.checkState;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.SERVER_SCOPE;
-import static io.streamnative.pulsar.handlers.kop.utils.TopicNameUtils.getKafkaTopicNameFromPulsarTopicName;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
@@ -32,6 +31,7 @@ import io.streamnative.pulsar.handlers.kop.stats.PrometheusMetricsProvider;
 import io.streamnative.pulsar.handlers.kop.stats.StatsLogger;
 import io.streamnative.pulsar.handlers.kop.storage.ReplicaManager;
 import io.streamnative.pulsar.handlers.kop.utils.ConfigurationUtils;
+import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
 import io.streamnative.pulsar.handlers.kop.utils.MetadataUtils;
 import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperation;
 import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperationPurgatory;
@@ -198,6 +198,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
         final NamespaceName kafkaTopicNs;
         final GroupCoordinator groupCoordinator;
         final String brokerUrl;
+        final KafkaServiceConfiguration kafkaConfig;
 
         public OffsetAndTopicListener(BrokerService service,
                                       String tenant,
@@ -210,6 +211,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
             this.kafkaTopicNs = NamespaceName
                     .get(tenant, kafkaConfig.getKafkaNamespace());
             this.brokerUrl = service.pulsar().getBrokerServiceUrl();
+            this.kafkaConfig = kafkaConfig;
         }
 
         @Override
@@ -225,16 +227,15 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                         log.info("get owned topic list when onLoad bundle {}, topic size {} ", bundle, topics.size());
                         for (String topic : topics) {
                             TopicName name = TopicName.get(topic);
-                            String kafkaTopicName = getKafkaTopicNameFromPulsarTopicName(name);
 
                             // already filtered namespace, check the local name without partition
-                            if (Topic.GROUP_METADATA_TOPIC_NAME.equals(kafkaTopicName)) {
+                            if (KopTopic.isGroupMetadataTopicName(topic, kafkaConfig)) {
                                 checkState(name.isPartitioned(),
-                                    "OffsetTopic should be partitioned in onLoad, but get " + name);
+                                        "OffsetTopic should be partitioned in onLoad, but get " + name);
 
                                 if (log.isDebugEnabled()) {
                                     log.debug("New offset partition load:  {}, broker: {}",
-                                        name, service.pulsar().getBrokerServiceUrl());
+                                            name, service.pulsar().getBrokerServiceUrl());
                                 }
                                 groupCoordinator.handleGroupImmigration(name.getPartitionIndex());
                             }
@@ -260,16 +261,15 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                         log.info("get owned topic list when unLoad bundle {}, topic size {} ", bundle, topics.size());
                         for (String topic : topics) {
                             TopicName name = TopicName.get(topic);
-                            String kafkaTopicName = getKafkaTopicNameFromPulsarTopicName(name);
 
                             // already filtered namespace, check the local name without partition
-                            if (Topic.GROUP_METADATA_TOPIC_NAME.equals(kafkaTopicName)) {
+                            if (KopTopic.isGroupMetadataTopicName(topic, kafkaConfig)) {
                                 checkState(name.isPartitioned(),
-                                    "OffsetTopic should be partitioned in unLoad, but get " + name);
+                                        "OffsetTopic should be partitioned in unLoad, but get " + name);
 
                                 if (log.isDebugEnabled()) {
                                     log.debug("Offset partition unload:  {}, broker: {}",
-                                        name, service.pulsar().getBrokerServiceUrl());
+                                            name, service.pulsar().getBrokerServiceUrl());
                                 }
                                 groupCoordinator.handleGroupEmigration(name.getPartitionIndex());
                             }
@@ -301,6 +301,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
         private final NamespaceName kafkaTopicNs;
         private final String brokerUrl;
         private final TransactionCoordinator txnCoordinator;
+        private final KafkaServiceConfiguration kafkaConfig;
 
         public TransactionStateRecover(
                 BrokerService service,
@@ -314,6 +315,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                     .get(tenant, kafkaConfig.getKafkaNamespace());
             this.brokerUrl = service.pulsar().getBrokerServiceUrl();
             this.txnCoordinator = txnCoordinator;
+            this.kafkaConfig = kafkaConfig;
         }
 
         @Override
@@ -330,9 +332,8 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                                     bundle, topics.size());
                             for (String topic : topics) {
                                 TopicName name = TopicName.get(topic);
-                                String kafkaTopicName = getKafkaTopicNameFromPulsarTopicName(name);
 
-                                if (Topic.TRANSACTION_STATE_TOPIC_NAME.equals(kafkaTopicName)) {
+                                if (KopTopic.isTransactionMetadataTopicName(topic, kafkaConfig)) {
                                     checkState(name.isPartitioned(),
                                             "TxnTopic should be partitioned in onLoad, but get " + name);
 
@@ -365,9 +366,8 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                                     bundle, topics.size());
                             for (String topic : topics) {
                                 TopicName name = TopicName.get(topic);
-                                String kafkaTopicName = getKafkaTopicNameFromPulsarTopicName(name);
 
-                                if (Topic.TRANSACTION_STATE_TOPIC_NAME.equals(kafkaTopicName)
+                                if (KopTopic.isTransactionMetadataTopicName(topic, kafkaConfig)
                                         && txnCoordinator != null) {
                                     checkState(name.isPartitioned(),
                                             "TxnTopic should be partitioned in unLoad, but get " + name);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -593,7 +593,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                    allTopicMetadata.add(new TopicMetadata(
                                            Errors.TOPIC_AUTHORIZATION_FAILED,
                                            topic,
-                                           KopTopic.isInternalTopic(topicName.toString()),
+                                           KopTopic.isInternalTopic(topicName.toString(), kafkaConfig),
                                            Collections.emptyList()));
                                    return;
                                }
@@ -638,7 +638,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 allTopicMetadata.add(new TopicMetadata(
                         Errors.TOPIC_AUTHORIZATION_FAILED,
                         topic,
-                        KopTopic.isInternalTopic(fullTopicName),
+                        KopTopic.isInternalTopic(fullTopicName, kafkaConfig),
                         Collections.emptyList()));
                 completeOneTopic.run();
             };
@@ -693,7 +693,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                                         new TopicMetadata(
                                                                 Errors.UNKNOWN_TOPIC_OR_PARTITION,
                                                                 topic,
-                                                                KopTopic.isInternalTopic(fullTopicName),
+                                                                KopTopic.isInternalTopic(fullTopicName, kafkaConfig),
                                                                 Collections.emptyList()));
                                                 completeOneTopic.run();
                                             }
@@ -703,7 +703,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                                     new TopicMetadata(
                                                             Errors.UNKNOWN_TOPIC_OR_PARTITION,
                                                             topic,
-                                                            KopTopic.isInternalTopic(fullTopicName),
+                                                            KopTopic.isInternalTopic(fullTopicName, kafkaConfig),
                                                             Collections.emptyList()));
                                             log.warn("[{}] Request {}: Failed to get partitioned pulsar topic {} "
                                                             + "metadata: {}",
@@ -809,7 +809,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                                     // the same with what it sent
                                                     topic,
                                                     KopTopic.isInternalTopic(
-                                                            new KopTopic(topic, namespacePrefix).getFullName()),
+                                                            new KopTopic(topic, namespacePrefix).getFullName(),
+                                                            kafkaConfig),
                                                     partitionMetadatas));
 
                                     // whether completed all the topics requests.
@@ -2231,7 +2232,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
 
                 Set<TopicPartition> successfulOffsetsPartitions = result.keySet()
                         .stream()
-                        .filter(topicPartition -> KopTopic.isGroupMetadataTopicName(topicPartition.topic()))
+                        .filter(topicPartition ->
+                                KopTopic.isGroupMetadataTopicName(topicPartition.topic(), kafkaConfig))
                         .collect(Collectors.toSet());
                 if (!successfulOffsetsPartitions.isEmpty()) {
                     getGroupCoordinator().scheduleHandleTxnCompletion(

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -579,6 +579,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         // e.g. <persistent://public/default/topic1-partition-0, persistent://public/default/topic1>
         final Map<String, TopicName> nonPartitionedTopicMap = Maps.newConcurrentMap();
 
+        final String metadataNamespace = kafkaConfig.getKafkaMetadataNamespace();
+
         if (topics == null || topics.isEmpty()) {
             // clean all cache when get all metadata for librdkafka(<1.0.0).
             KopBrokerLookupManager.clear();
@@ -593,7 +595,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                    allTopicMetadata.add(new TopicMetadata(
                                            Errors.TOPIC_AUTHORIZATION_FAILED,
                                            topic,
-                                           KopTopic.isInternalTopic(topicName.toString(), kafkaConfig),
+                                           KopTopic.isInternalTopic(topicName.toString(), metadataNamespace),
                                            Collections.emptyList()));
                                    return;
                                }
@@ -638,7 +640,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 allTopicMetadata.add(new TopicMetadata(
                         Errors.TOPIC_AUTHORIZATION_FAILED,
                         topic,
-                        KopTopic.isInternalTopic(fullTopicName, kafkaConfig),
+                        KopTopic.isInternalTopic(fullTopicName, metadataNamespace),
                         Collections.emptyList()));
                 completeOneTopic.run();
             };
@@ -693,7 +695,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                                         new TopicMetadata(
                                                                 Errors.UNKNOWN_TOPIC_OR_PARTITION,
                                                                 topic,
-                                                                KopTopic.isInternalTopic(fullTopicName, kafkaConfig),
+                                                                KopTopic.isInternalTopic(fullTopicName,
+                                                                        metadataNamespace),
                                                                 Collections.emptyList()));
                                                 completeOneTopic.run();
                                             }
@@ -703,7 +706,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                                     new TopicMetadata(
                                                             Errors.UNKNOWN_TOPIC_OR_PARTITION,
                                                             topic,
-                                                            KopTopic.isInternalTopic(fullTopicName, kafkaConfig),
+                                                            KopTopic.isInternalTopic(fullTopicName, metadataNamespace),
                                                             Collections.emptyList()));
                                             log.warn("[{}] Request {}: Failed to get partitioned pulsar topic {} "
                                                             + "metadata: {}",
@@ -810,7 +813,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                                     topic,
                                                     KopTopic.isInternalTopic(
                                                             new KopTopic(topic, namespacePrefix).getFullName(),
-                                                            kafkaConfig),
+                                                            metadataNamespace),
                                                     partitionMetadatas));
 
                                     // whether completed all the topics requests.
@@ -2230,10 +2233,11 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 }));
                 updateErrors.accept(producerId, currentErrors);
 
+                final String metadataNamespace = kafkaConfig.getKafkaMetadataNamespace();
                 Set<TopicPartition> successfulOffsetsPartitions = result.keySet()
                         .stream()
                         .filter(topicPartition ->
-                                KopTopic.isGroupMetadataTopicName(topicPartition.topic(), kafkaConfig))
+                                KopTopic.isGroupMetadataTopicName(topicPartition.topic(), metadataNamespace))
                         .collect(Collectors.toSet());
                 if (!successfulOffsetsPartitions.isEmpty()) {
                     getGroupCoordinator().scheduleHandleTxnCompletion(

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/OffsetConfig.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/OffsetConfig.java
@@ -31,7 +31,7 @@ public class OffsetConfig {
     public static final int DefaultMaxMetadataSize = 4096;
     public static final long DefaultOffsetsRetentionMs = 24 * 60 * 60 * 1000L;
     public static final long DefaultOffsetsRetentionCheckIntervalMs = 600000L;
-    public static final String DefaultOffsetsTopicName = "public/default/__consumer_offsets";
+    public static final String DefaultOffsetsTopicName = "public/__kafka/__consumer_offsets";
     public static final int DefaultOffsetsNumPartitions = KafkaServiceConfiguration.DefaultOffsetsTopicNumPartitions;
 
     @Default

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
@@ -19,6 +19,7 @@ import io.streamnative.pulsar.handlers.kop.format.EntryFormatter;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
 import java.util.Map;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Time;
 
@@ -28,6 +29,7 @@ import org.apache.kafka.common.utils.Time;
 @AllArgsConstructor
 public class PartitionLogManager {
 
+    @Getter
     private final KafkaServiceConfiguration kafkaConfig;
     private final Map<String, PartitionLog> logMap;
     private final EntryFormatter formatter;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
@@ -19,7 +19,6 @@ import io.streamnative.pulsar.handlers.kop.format.EntryFormatter;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
 import java.util.Map;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Time;
 
@@ -29,7 +28,6 @@ import org.apache.kafka.common.utils.Time;
 @AllArgsConstructor
 public class PartitionLogManager {
 
-    @Getter
     private final KafkaServiceConfiguration kafkaConfig;
     private final Map<String, PartitionLog> logMap;
     private final EntryFormatter formatter;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
@@ -42,6 +42,7 @@ import org.apache.kafka.common.utils.Time;
 public class ReplicaManager {
     private final PartitionLogManager logManager;
     private final DelayedOperationPurgatory<DelayedOperation> producePurgatory;
+    private final String metadataNamespace;
 
     public ReplicaManager(KafkaServiceConfiguration kafkaConfig,
                           Time time,
@@ -49,6 +50,7 @@ public class ReplicaManager {
                           DelayedOperationPurgatory<DelayedOperation> producePurgatory) {
         this.logManager = new PartitionLogManager(kafkaConfig, entryFormatter, time);
         this.producePurgatory = producePurgatory;
+        this.metadataNamespace = kafkaConfig.getKafkaMetadataNamespace();
     }
 
     public PartitionLog getPartitionLog(TopicPartition topicPartition, String namespacePrefix) {
@@ -99,7 +101,7 @@ public class ReplicaManager {
         entriesPerPartition.forEach((topicPartition, memoryRecords) -> {
             String fullPartitionName = KopTopic.toString(topicPartition, namespacePrefix);
             // reject appending to internal topics if it is not allowed
-            if (!internalTopicsAllowed && KopTopic.isInternalTopic(fullPartitionName, logManager.getKafkaConfig())) {
+            if (!internalTopicsAllowed && KopTopic.isInternalTopic(fullPartitionName, metadataNamespace)) {
                 addPartitionResponse.accept(topicPartition, new ProduceResponse.PartitionResponse(
                         Errors.forException(new InvalidTopicException(
                                 String.format("Cannot append to internal topic %s", topicPartition.topic())))));

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
@@ -99,7 +99,7 @@ public class ReplicaManager {
         entriesPerPartition.forEach((topicPartition, memoryRecords) -> {
             String fullPartitionName = KopTopic.toString(topicPartition, namespacePrefix);
             // reject appending to internal topics if it is not allowed
-            if (!internalTopicsAllowed && KopTopic.isInternalTopic(fullPartitionName)) {
+            if (!internalTopicsAllowed && KopTopic.isInternalTopic(fullPartitionName, logManager.getKafkaConfig())) {
                 addPartitionResponse.accept(topicPartition, new ProduceResponse.PartitionResponse(
                         Errors.forException(new InvalidTopicException(
                                 String.format("Cannot append to internal topic %s", topicPartition.topic())))));

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KopTopic.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KopTopic.java
@@ -17,6 +17,7 @@ import static org.apache.kafka.common.internals.Topic.GROUP_METADATA_TOPIC_NAME;
 import static org.apache.kafka.common.internals.Topic.TRANSACTION_STATE_TOPIC_NAME;
 import static org.apache.pulsar.common.naming.TopicName.PARTITIONED_TOPIC_SUFFIX;
 
+import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import io.streamnative.pulsar.handlers.kop.exceptions.KoPTopicException;
 import lombok.Getter;
 import org.apache.kafka.common.TopicPartition;
@@ -106,15 +107,20 @@ public class KopTopic {
         return (new KopTopic(topic, namespacePrefix)).getPartitionName(partition);
     }
 
-    public static boolean isInternalTopic(final String fullTopicName) {
+    public static boolean isInternalTopic(final String fullTopicName, KafkaServiceConfiguration conf) {
         String partitionedTopicName = TopicName.get(fullTopicName).getPartitionedTopicName();
-        return partitionedTopicName.endsWith("/" + GROUP_METADATA_TOPIC_NAME)
-                || partitionedTopicName.endsWith("/" + TRANSACTION_STATE_TOPIC_NAME);
+        return partitionedTopicName.endsWith(conf.getKafkaMetadataNamespace() + "/" + GROUP_METADATA_TOPIC_NAME)
+                || partitionedTopicName.endsWith(conf.getKafkaMetadataNamespace() + "/" + TRANSACTION_STATE_TOPIC_NAME);
     }
 
-    public static boolean isGroupMetadataTopicName(final String fullTopicName) {
+    public static boolean isGroupMetadataTopicName(final String fullTopicName, KafkaServiceConfiguration conf) {
         String partitionedTopicName = TopicName.get(fullTopicName).getPartitionedTopicName();
-        return partitionedTopicName.endsWith("/" + GROUP_METADATA_TOPIC_NAME);
+        return partitionedTopicName.endsWith(conf.getKafkaMetadataNamespace() + "/" + GROUP_METADATA_TOPIC_NAME);
+    }
+
+    public static boolean isTransactionMetadataTopicName(final String fullTopicName, KafkaServiceConfiguration conf) {
+        String partitionedTopicName = TopicName.get(fullTopicName).getPartitionedTopicName();
+        return partitionedTopicName.endsWith(conf.getKafkaMetadataNamespace() + "/" + TRANSACTION_STATE_TOPIC_NAME);
     }
 
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KopTopic.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KopTopic.java
@@ -110,7 +110,7 @@ public class KopTopic {
 
         final String localName = topicName.getLocalName();
         return topicValidation.apply(topicName.isPartitioned()
-                ? localName.substring(0, localName.lastIndexOf(TopicName.PARTITIONED_TOPIC_SUFFIX))
+                ? localName.substring(0, localName.lastIndexOf(PARTITIONED_TOPIC_SUFFIX))
                 : localName);
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KopTopic.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KopTopic.java
@@ -104,7 +104,7 @@ public class KopTopic {
                                          final String namespace,
                                          final Function<String, Boolean> topicValidation) {
         final TopicName topicName = TopicName.get(fullTopicName);
-        if (!topicName.getNamespace().equals(namespace)) {
+        if (!topicName.getNamespacePortion().equals(namespace)) {
             return false;
         }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/TopicNameUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/TopicNameUtils.java
@@ -72,14 +72,6 @@ public class TopicNameUtils {
         }
     }
 
-    // get local name without partition part
-    public static String getKafkaTopicNameFromPulsarTopicName(TopicName topicName) {
-        // remove partition part
-        String localName = topicName.getPartitionedTopicName();
-        // remove persistent://tenant/ns
-        return TopicName.get(localName).getLocalName();
-    }
-
     /**
      * Get an url encoded topic name.
      */

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -14,7 +14,6 @@
 package io.streamnative.pulsar.handlers.kop;
 
 
-import static io.streamnative.pulsar.handlers.kop.utils.TopicNameUtils.getKafkaTopicNameFromPulsarTopicName;
 import static io.streamnative.pulsar.handlers.kop.utils.TopicNameUtils.getPartitionedTopicNameWithoutPartitions;
 import static org.apache.pulsar.common.naming.TopicName.PARTITIONED_TOPIC_SUFFIX;
 import static org.mockito.Mockito.doReturn;
@@ -278,20 +277,6 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
 
         assertEquals(topicString, getPartitionedTopicNameWithoutPartitions(topicName));
         assertEquals(topicString, getPartitionedTopicNameWithoutPartitions(topicNamePartition));
-    }
-
-    @Test
-    public void testGetKafkaTopicNameFromPulsarTopicName() {
-        String localName = "localTopicName2";
-        String topicString = "persistent://test-tenants/test-ns/" + localName;
-        int partitionIndex = 77;
-
-        TopicName topicName = TopicName.get(topicString);
-        TopicName topicNamePartition =
-            TopicName.get(topicString + PARTITIONED_TOPIC_SUFFIX + partitionIndex);
-
-        assertEquals(localName, getKafkaTopicNameFromPulsarTopicName(topicName));
-        assertEquals(localName, getKafkaTopicNameFromPulsarTopicName(topicNamePartition));
     }
 
     private void createTopicsByKafkaAdmin(AdminClient admin, Map<String, Integer> topicToNumPartitions)


### PR DESCRIPTION
`public/default/__consumer_offsets` is incorrectly considered as an internal metadata topic
![image](https://user-images.githubusercontent.com/35599757/145700452-ddbe8f39-3e05-4d2f-9df0-d442ddc1bc1d.png)


1. Based on #793 , we can control whether users are allowed to access the `metadata` namespace

2. I am still not sure whether we should allow users to access the kafka topics which under other namespaces (such as `default` ) have the same name with the internal topics. The current implementation of the kafka topics under the `default` namespace have the same name with the internal topics will be used as the internal topics and returned to the kafka client.

3. However, we should bind to the `metadata` namespace when judging the `internal` topics.

This PR solves problem 3. When problem 3 is solved, we can treat the kafka topics which under other namespaces have the same name with the internal topics  as user topics.
