### PR TITLE
AdminManager: handle properly async deletePartitionedTopic

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
@@ -51,7 +51,6 @@ import org.apache.kafka.common.requests.CreateTopicsRequest;
 import org.apache.kafka.common.requests.DescribeConfigsResponse;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
-import org.apache.pulsar.common.util.FutureUtil;
 
 @Slf4j
 class AdminManager {
@@ -214,8 +213,11 @@ class AdminManager {
                                 future.complete(new DescribeConfigsResponse.Config(ApiError.NONE, dummyConfig));
                                 break;
                             default:
-                                return FutureUtil.failedFuture(
-                                        new InvalidRequestException("Unsupported resource type: " + resource.type()));
+                                return CompletableFuture.completedFuture(new DescribeConfigsResponse.Config(
+                                        ApiError.fromThrowable(
+                                            new InvalidRequestException("Unsupported resource type: "
+                                                    + resource.type())),
+                                            Collections.emptyList()));
                         }
                         return future;
                     } catch (Exception e) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
@@ -214,7 +214,8 @@ class AdminManager {
                                 future.complete(new DescribeConfigsResponse.Config(ApiError.NONE, dummyConfig));
                                 break;
                             default:
-                                return FutureUtil.failedFuture(new InvalidRequestException("Unsupported resource type: " + resource.type()));
+                                return FutureUtil.failedFuture(
+                                        new InvalidRequestException("Unsupported resource type: " + resource.type()));
                         }
                         return future;
                     } catch (Exception e) {


### PR DESCRIPTION
In AdminManager there are some points in which we are not using correctly CompletableFuture.
This patch fixes deletePartitionedTopic and a couple of other parts.

This patch is trivial rework, no need to add tests