### PR TITLE
Bump log4j to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <jackson.version>2.12.1</jackson.version>
     <jcommander.version>1.48</jcommander.version>
     <kafka.version>2.0.0</kafka.version>
-    <log4j2.version>2.13.3</log4j2.version>
+    <log4j2.version>2.16.0</log4j2.version>
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
     <pulsar.group.id>io.streamnative</pulsar.group.id>


### PR DESCRIPTION
### Motivation
Bump log4j to 2.16.0 for branch-2.8.0

### Modifications
Update log4j version from 2.13.3 to 2.16.0.

We need to prepare new patch releases for the affected kop version.