### PR TITLE
[BUGFIX] Fix list topic behavior

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -593,7 +593,12 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                     pulsarTopicsFuture.complete(allTopicMap);
                     return;
                 }
-                AtomicInteger allTopicCount = new AtomicInteger(allTopicMap.size());
+                AtomicInteger allTopicCount =
+                        new AtomicInteger(allTopicMap.values().stream().mapToInt(List::size).sum());
+                if (allTopicCount.get() == 0) {
+                    pulsarTopicsFuture.complete(topicMap);
+                    return;
+                }
                 final Runnable completeOne = () -> {
                     if (allTopicCount.decrementAndGet() == 0) {
                         pulsarTopicsFuture.complete(topicMap);


### PR DESCRIPTION
Fixes #908

### Motivation
In the current implementation, list topic and list offset might get the wrong response, because the authorized future is not finished yet. We need to make sure to authorize future finish correctly. 

The previous fix only checked `allTopicMap` size, but we are traverse allTopicMap's value lists. So the same case might be failed.

### Modifications
* Ensure all future is finished when the response