### PR TITLE
Implement placeholder 'advertisedAddress' in kafkaAdvertisedListeners

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -446,7 +446,9 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     // This method is called after initialize
     @Override
     public String getProtocolDataToAdvertise() {
-        return kafkaConfig.getKafkaAdvertisedListeners();
+        String result =  kafkaConfig.getKafkaAdvertisedListeners();
+        log.info("Advertised addresses for the 'kafka' endpoint: {}", result);
+        return result;
     }
 
     @Override

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -477,7 +477,7 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
                 } catch (UnknownHostException e) {
                     throw new IllegalStateException("hostname is empty and localhost is unknown: " + e.getMessage());
                 }
-            } else if (hostname.equalsIgnoreCase("advertisedAddress")) {
+            } else if (hostname.equals("advertisedAddress")) {
                 hostname = getAdvertisedAddress();
                 listenersReBuilder.append(matcher.group(1))
                         .append("://")

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -477,6 +477,13 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
                 } catch (UnknownHostException e) {
                     throw new IllegalStateException("hostname is empty and localhost is unknown: " + e.getMessage());
                 }
+            } else if (hostname.equalsIgnoreCase("advertisedAddress")) {
+                hostname = getAdvertisedAddress();
+                listenersReBuilder.append(matcher.group(1))
+                        .append("://")
+                        .append(hostname)
+                        .append(":")
+                        .append(matcher.group(3));
             } else {
                 listenersReBuilder.append(listener);
             }

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
@@ -88,6 +88,28 @@ public class KafkaServiceConfigurationTest {
     }
 
     @Test
+    public void testKafkaListenersWithAdvertisedListener() throws UnknownHostException {
+        KafkaServiceConfiguration configuration = new KafkaServiceConfiguration();
+        configuration.setAdvertisedAddress("advertise-me");
+        configuration.setKafkaListeners("PLAINTEXT://0.0.0.0:9092");
+        configuration.setKafkaAdvertisedListeners("PLAINTEXT://advertisedAddress:9092");
+        assertEquals(configuration.getListeners(), "PLAINTEXT://0.0.0.0:9092");
+        String expectAdvertisedListeners = "PLAINTEXT://advertise-me:9092";
+        assertEquals(configuration.getKafkaAdvertisedListeners(), expectAdvertisedListeners);
+    }
+
+    @Test
+    public void testKafkaListenersWithAdvertisedListenerSASL() throws UnknownHostException {
+        KafkaServiceConfiguration configuration = new KafkaServiceConfiguration();
+        configuration.setAdvertisedAddress("advertise-me");
+        configuration.setKafkaListeners("SASL_PLAINTEXT://0.0.0.0:9092");
+        configuration.setKafkaAdvertisedListeners("SASL_PLAINTEXT://advertisedAddress:9092");
+        assertEquals(configuration.getListeners(), "SASL_PLAINTEXT://0.0.0.0:9092");
+        String expectAdvertisedListeners = "SASL_PLAINTEXT://advertise-me:9092";
+        assertEquals(configuration.getKafkaAdvertisedListeners(), expectAdvertisedListeners);
+    }
+
+    @Test
     public void testGroupIdZooKeeperPath() {
         String zkPathForKop = "/consumer_group_test";
         KafkaServiceConfiguration configuration = new KafkaServiceConfiguration();


### PR DESCRIPTION
With this patch when you configure kafkaAdvertisedListeners you can use the special placeholder `advertisedAddress` that picks up the value configured for `advertisedAddress` in broker.conf.

Something like:
`kafkaAdvertisedListeners=PLAINTEXT://advertisedAddress:9092`

Without this placeholder you have to inject the value using other external means, like adding stuff to the Helm Chart (status.podIP) and it is not trivial.

