### PR TITLE
[Release] Fix javadoc missing bug

### DIFF
--- a/kafka-payload-processor-shaded/pom.xml
+++ b/kafka-payload-processor-shaded/pom.xml
@@ -74,6 +74,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <createSourcesJar>true</createSourcesJar>
               <artifactSet>
                 <includes>
                   <include>${pulsar.group.id}:kafka-payload-processor-original</include>
@@ -87,6 +88,30 @@
               </relocations>
             </configuration>
           </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+            <execution>
+              <id>default-jar</id>
+              <phase>package</phase>
+              <goals>
+                  <goal>jar</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>javadoc-jar</id>
+              <phase>package</phase>
+              <goals>
+                  <goal>jar</goal>
+              </goals>
+              <configuration>
+                  <classifier>javadoc</classifier>
+              </configuration>
+            </execution>
         </executions>
       </plugin>
     </plugins>


### PR DESCRIPTION
# Motivation

Fix upload rule failure during the release process:

```
Error:  Rule failure while trying to close staging repository with ID "iostreamnative-1043".
Error:  
Error:  Nexus Staging Rules Failure Report
Error:  ==================================
Error:  
...
          Missing: no javadoc jar found in folder
...
```