### PR TITLE
Maintain a StatsLogger map to avoid creating new object every time

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
@@ -22,7 +22,6 @@ import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.IdleStateHandler;
-import io.streamnative.pulsar.handlers.kop.stats.StatsLogger;
 import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperation;
 import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperationPurgatory;
 import io.streamnative.pulsar.handlers.kop.utils.ssl.SSLUtils;
@@ -59,7 +58,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
     @Getter
     private final SslContextFactory.Server sslContextFactory;
     @Getter
-    private final StatsLogger statsLogger;
+    private final RequestStats requestStats;
     private final OrderedScheduler sendResponseScheduler;
 
     public KafkaChannelInitializer(PulsarService pulsarService,
@@ -72,7 +71,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
                                    boolean enableTLS,
                                    EndPoint advertisedEndPoint,
                                    boolean skipMessagesWithoutIndex,
-                                   StatsLogger statsLogger,
+                                   RequestStats requestStats,
                                    OrderedScheduler sendResponseScheduler) {
         super();
         this.pulsarService = pulsarService;
@@ -85,7 +84,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
         this.enableTls = enableTLS;
         this.advertisedEndPoint = advertisedEndPoint;
         this.skipMessagesWithoutIndex = skipMessagesWithoutIndex;
-        this.statsLogger = statsLogger;
+        this.requestStats = requestStats;
         if (enableTls) {
             sslContextFactory = SSLUtils.createSslContextFactory(kafkaConfig);
         } else {
@@ -116,15 +115,15 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
         return new KafkaRequestHandler(pulsarService, kafkaConfig,
                 tenantContextManager, kopBrokerLookupManager, adminManager,
                 producePurgatory, fetchPurgatory,
-                enableTls, advertisedEndPoint, skipMessagesWithoutIndex, statsLogger, sendResponseScheduler);
+                enableTls, advertisedEndPoint, skipMessagesWithoutIndex, requestStats, sendResponseScheduler);
     }
 
     @VisibleForTesting
-    public KafkaRequestHandler newCnx(final TenantContextManager tenantContextManager,
-                                      final StatsLogger statsLogger) throws Exception {
+    public KafkaRequestHandler newCnxWithoutStats(final TenantContextManager tenantContextManager) throws Exception {
         return new KafkaRequestHandler(pulsarService, kafkaConfig,
                 tenantContextManager, kopBrokerLookupManager, adminManager,
                 producePurgatory, fetchPurgatory,
-                enableTls, advertisedEndPoint, skipMessagesWithoutIndex, statsLogger, sendResponseScheduler);
+                enableTls, advertisedEndPoint, skipMessagesWithoutIndex, RequestStats.NULL_INSTANCE,
+                sendResponseScheduler);
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -72,10 +72,10 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
 
     private final OrderedScheduler sendResponseScheduler;
 
-    public KafkaCommandDecoder(StatsLogger statsLogger,
+    public KafkaCommandDecoder(RequestStats requestStats,
                                KafkaServiceConfiguration kafkaConfig,
                                OrderedScheduler sendResponseScheduler) {
-        this.requestStats = new RequestStats(statsLogger);
+        this.requestStats = requestStats;
         this.kafkaConfig = kafkaConfig;
         this.requestQueue = new LinkedBlockingQueue<>(kafkaConfig.getMaxQueuedRequests());
         this.sendResponseScheduler = sendResponseScheduler;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -86,7 +86,7 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
                                           final String operationName,
                                           final boolean success) {
         final OpStatsLogger opStatsLogger = apiKeysToStatsLogger.computeIfAbsent(apiKey, __ ->
-                requestStats.getStatsLogger().scopeLabel(KopServerStats.REQUEST_SCOPE, apiKey.name())
+                requestStats.getStatsLogger().scopeLabel(KopServerStats.REQUEST_SCOPE, apiKey.name)
         ).getOpStatsLogger(operationName);
         if (success) {
             opStatsLogger.registerSuccessfulEvent(MathUtils.elapsedNanos(startProcessTimeNs), TimeUnit.NANOSECONDS);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -74,8 +74,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     public static final String TLS_HANDLER = "tls";
     private static final Map<PulsarService, LookupClient> LOOKUP_CLIENT_MAP = new ConcurrentHashMap<>();
 
-    private StatsLogger rootStatsLogger;
-    private StatsLogger scopeStatsLogger;
+    private RequestStats requestStats;
     private PrometheusMetricsProvider statsProvider;
     @Getter
     private KopBrokerLookupManager kopBrokerLookupManager;
@@ -435,8 +434,8 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
         }
 
         statsProvider = new PrometheusMetricsProvider();
-        rootStatsLogger = statsProvider.getStatsLogger("");
-        scopeStatsLogger = rootStatsLogger.scope(SERVER_SCOPE);
+        StatsLogger rootStatsLogger = statsProvider.getStatsLogger("");
+        requestStats = new RequestStats(rootStatsLogger.scope(SERVER_SCOPE));
         sendResponseScheduler = OrderedScheduler.newSchedulerBuilder()
                 .name("send-response")
                 .numThreads(kafkaConfig.getNumSendKafkaResponseThreads())
@@ -492,7 +491,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
         // init KopEventManager
         kopEventManager = new KopEventManager(adminManager,
                 brokerService.getPulsar().getLocalMetadataStore(),
-                scopeStatsLogger,
+                requestStats.getStatsLogger(),
                 kafkaConfig,
                 groupCoordinatorsByTenant);
         kopEventManager.start();
@@ -583,7 +582,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 endPoint.isTlsEnabled(),
                 endPoint,
                 kafkaConfig.isSkipMessagesWithoutIndex(),
-                scopeStatsLogger,
+                requestStats,
                 sendResponseScheduler);
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -74,6 +74,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     public static final String TLS_HANDLER = "tls";
     private static final Map<PulsarService, LookupClient> LOOKUP_CLIENT_MAP = new ConcurrentHashMap<>();
 
+    @Getter
     private RequestStats requestStats;
     private PrometheusMetricsProvider statsProvider;
     @Getter

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -42,7 +42,6 @@ import io.streamnative.pulsar.handlers.kop.security.auth.Authorizer;
 import io.streamnative.pulsar.handlers.kop.security.auth.Resource;
 import io.streamnative.pulsar.handlers.kop.security.auth.ResourceType;
 import io.streamnative.pulsar.handlers.kop.security.auth.SimpleAclAuthorizer;
-import io.streamnative.pulsar.handlers.kop.stats.StatsLogger;
 import io.streamnative.pulsar.handlers.kop.storage.AppendRecordsContext;
 import io.streamnative.pulsar.handlers.kop.storage.PartitionLog;
 import io.streamnative.pulsar.handlers.kop.storage.ReplicaManager;
@@ -289,9 +288,9 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                Boolean tlsEnabled,
                                EndPoint advertisedEndPoint,
                                boolean skipMessagesWithoutIndex,
-                               StatsLogger statsLogger,
+                               RequestStats requestStats,
                                OrderedScheduler sendResponseScheduler) throws Exception {
-        super(statsLogger, kafkaConfig, sendResponseScheduler);
+        super(requestStats, kafkaConfig, sendResponseScheduler);
         this.pulsarService = pulsarService;
         this.tenantContextManager = tenantContextManager;
         this.kopBrokerLookupManager = kopBrokerLookupManager;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -376,7 +376,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     protected void channelPrepare(ChannelHandlerContext ctx,
                                   ByteBuf requestBuf,
                                   BiConsumer<Long, Throwable> registerRequestParseLatency,
-                                  BiConsumer<String, Long> registerRequestLatency)
+                                  BiConsumer<ApiKeys, Long> registerRequestLatency)
             throws AuthenticationException {
         if (authenticator != null) {
             authenticator.authenticate(ctx, requestBuf, registerRequestParseLatency, registerRequestLatency,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/RequestStats.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/RequestStats.java
@@ -30,9 +30,12 @@ import static io.streamnative.pulsar.handlers.kop.KopServerStats.RESPONSE_BLOCKE
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.SERVER_SCOPE;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.WAITING_FETCHES_TRIGGERED;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.streamnative.pulsar.handlers.kop.stats.NullStatsLogger;
 import io.streamnative.pulsar.handlers.kop.stats.StatsLogger;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Getter;
@@ -204,5 +207,10 @@ public class RequestStats {
         return apiKeysToStatsLogger.computeIfAbsent(apiKey,
                 __ -> statsLogger.scopeLabel(KopServerStats.REQUEST_SCOPE, apiKey.name)
         ).getOpStatsLogger(statsName);
+    }
+
+    @VisibleForTesting
+    public Set<ApiKeys> getApiKeysSet() {
+        return new TreeSet<>(apiKeysToStatsLogger.keySet());
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/RequestStats.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/RequestStats.java
@@ -30,6 +30,7 @@ import static io.streamnative.pulsar.handlers.kop.KopServerStats.RESPONSE_BLOCKE
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.SERVER_SCOPE;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.WAITING_FETCHES_TRIGGERED;
 
+import io.streamnative.pulsar.handlers.kop.stats.NullStatsLogger;
 import io.streamnative.pulsar.handlers.kop.stats.StatsLogger;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Getter;
@@ -56,6 +57,8 @@ public class RequestStats {
     public static final AtomicInteger BATCH_COUNT_PER_MEMORY_RECORDS_INSTANCE = new AtomicInteger(0);
     public static final AtomicInteger ALIVE_CHANNEL_COUNT_INSTANCE = new AtomicInteger(0);
     public static final AtomicInteger ACTIVE_CHANNEL_COUNT_INSTANCE = new AtomicInteger(0);
+
+    public static final RequestStats NULL_INSTANCE = new RequestStats(NullStatsLogger.INSTANCE);
 
     private final StatsLogger statsLogger;
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -25,7 +25,6 @@ import io.confluent.kafka.schemaregistry.rest.SchemaRegistryRestApplication;
 import io.netty.channel.EventLoopGroup;
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupCoordinator;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
-import io.streamnative.pulsar.handlers.kop.stats.NullStatsLogger;
 import io.streamnative.pulsar.handlers.kop.storage.ReplicaManager;
 import io.streamnative.pulsar.handlers.kop.utils.MetadataUtils;
 import java.io.Closeable;
@@ -796,7 +795,7 @@ public abstract class KopProtocolHandlerTestBase {
                 handler.getReplicaManager(conf.getKafkaMetadataTenant());
 
         return ((KafkaChannelInitializer) handler.getChannelInitializerMap().entrySet().iterator().next().getValue())
-                .newCnx(new TenantContextManager() {
+                .newCnxWithoutStats(new TenantContextManager() {
                     @Override
                     public GroupCoordinator getGroupCoordinator(String tenant) {
                         return groupCoordinator;
@@ -811,6 +810,6 @@ public abstract class KopProtocolHandlerTestBase {
                     public ReplicaManager getReplicaManager(String tenant) {
                         return replicaManager;
                     }
-                }, NullStatsLogger.INSTANCE);
+                });
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
@@ -18,9 +18,12 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -37,6 +40,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.protocol.ApiKeys;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -61,6 +65,10 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase{
         super.internalCleanup();
     }
 
+    private Set<ApiKeys> getApiKeysSet() {
+        return ((KafkaProtocolHandler) pulsar.getProtocolHandlers().protocol("kafka"))
+                .getRequestStats().getApiKeysSet();
+    }
 
     @Test(timeOut = 30000)
     public void testMetricsProvider() throws Exception {
@@ -92,6 +100,9 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase{
             }
         }
 
+        Assert.assertEquals(getApiKeysSet(), new TreeSet<>(
+                Arrays.asList(ApiKeys.API_VERSIONS, ApiKeys.METADATA, ApiKeys.PRODUCE)));
+
         // 2. consume messages with Kafka consumer
         @Cleanup
         KConsumer kConsumer = new KConsumer(kafkaTopicName, getKafkaBrokerPort());
@@ -115,8 +126,17 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase{
         }
         Assert.assertEquals(msgs, totalMsgs);
 
+        Assert.assertEquals(getApiKeysSet(), new TreeSet<>(Arrays.asList(
+                ApiKeys.API_VERSIONS, ApiKeys.METADATA, ApiKeys.PRODUCE, ApiKeys.FIND_COORDINATOR, ApiKeys.LIST_OFFSETS,
+                ApiKeys.OFFSET_FETCH, ApiKeys.FETCH
+        )));
+
         // commit offsets
         kConsumer.getConsumer().commitSync(Duration.ofSeconds(5));
+        Assert.assertEquals(getApiKeysSet(), new TreeSet<>(Arrays.asList(
+                ApiKeys.API_VERSIONS, ApiKeys.METADATA, ApiKeys.PRODUCE, ApiKeys.FIND_COORDINATOR, ApiKeys.LIST_OFFSETS,
+                ApiKeys.OFFSET_FETCH, ApiKeys.FETCH, ApiKeys.OFFSET_COMMIT
+        )));
 
         try {
             Thread.sleep(1000);


### PR DESCRIPTION
### Motivation

Currently when the metrics related to Kafka requests are updated, a `PrometheusStatsLogger` will be created each time a request arrived.

```java
            requestStats.getStatsLogger()
                    .scopeLabel(KopServerStats.REQUEST_SCOPE, apiName)
```

The `StatsLogger#scopeLabel` method calls `scope` method:

```java
    public StatsLogger scope(String name) {
        return new PrometheusStatsLogger(provider, completeName(name), labels);
    }
```

The newly created `PrometheusStatsLogger` object is nearly the same with the caller itself except the name. The shared `provider` field is responsible to maintain the cache of Prometheus stats.

Therefore, there is no need to create another object if the name keeps the same. This PR is to avoid the redundant small object creations of `PrometheusStatsLogger`.

### Modifications

Maintain a `ConcurrentHashMap` for each channel. The key is the `ApiVersions` object that represents a Kafka request's type, the value is the associated `StatsLogger` object.

In addition, since a `RequestStats` instance is associated with only one `StatsLogger` instance, this PR creates the `RequestStats` instance at the beginning and avoid creating the instance for each connection.