### PR TITLE
Fix NPE caused by empty polls for a consumer of multiple partitions

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManager.java
@@ -124,8 +124,9 @@ public class KafkaTopicConsumerManager implements Closeable {
 
                 @Override
                 public void deleteCursorFailed(ManagedLedgerException exception, Object ctx) {
-                    log.warn("[{}] Error deleting cursor {} for topic {} for reason: {}.",
-                        requestHandler.ctx.channel(), cursor.getName(), topic.getName(), reason, exception);
+                    log.warn("[{}] Error deleting cursor {} for topic {} for reason: {}. {}",
+                        requestHandler.ctx.channel(), cursor.getName(), topic.getName(), reason,
+                            exception.getMessage());
                 }
             }, null);
             createdCursors.remove(cursor.getName());

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -164,12 +164,9 @@ public final class MessageFetchContext {
 
 
     private void recycle() {
-        if (fetchPurgatory != null) {
-            for (Object key : delayedFetchKeys) {
-                for (DelayedFetch delayedFetch : delayedFetches) {
-                    fetchPurgatory.removeOperation(key, delayedFetch);
-                }
-            }
+        if (delayedFetches != null) {
+            // Prevent DelayedFetch from operating on the recycled MessageFetchContext object
+            delayedFetches.forEach(DelayedFetch::close);
         }
         responseData = null;
         decodeResults = null;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/delayed/DelayedOperationPurgatory.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/delayed/DelayedOperationPurgatory.java
@@ -259,17 +259,6 @@ public class DelayedOperationPurgatory<T extends DelayedOperation> {
             }
         });
     }
-
-    public void removeOperation(Object key, Object operation) {
-        inReadLock(removeWatchersLock, () -> {
-            Watchers watchers = watchersForKey.get(key);
-            if (watchers != null) {
-                watchers.cancelOperation(operation);
-            }
-            return null;
-        });
-    }
-
     /*
      * Return all the current watcher lists,
      * note that the returned watchers may be removed from the list by other threads
@@ -383,13 +372,6 @@ public class DelayedOperationPurgatory<T extends DelayedOperation> {
                 cancelled.add(curr);
             }
             return cancelled;
-        }
-
-        public void cancelOperation(Object operation) {
-            operations.removeIf(e -> e == operation);
-            if (operation instanceof DelayedOperation) {
-                ((DelayedOperation) operation).cancel();
-            }
         }
 
         // traverse the list and purge elements that are already completed by others

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/delayed/DelayedOperationPurgatory.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/delayed/DelayedOperationPurgatory.java
@@ -259,6 +259,17 @@ public class DelayedOperationPurgatory<T extends DelayedOperation> {
             }
         });
     }
+
+    public void removeOperation(Object key, Object operation) {
+        inReadLock(removeWatchersLock, () -> {
+            Watchers watchers = watchersForKey.get(key);
+            if (watchers != null) {
+                watchers.cancelOperation(operation);
+            }
+            return null;
+        });
+    }
+
     /*
      * Return all the current watcher lists,
      * note that the returned watchers may be removed from the list by other threads
@@ -372,6 +383,13 @@ public class DelayedOperationPurgatory<T extends DelayedOperation> {
                 cancelled.add(curr);
             }
             return cancelled;
+        }
+
+        public void cancelOperation(Object operation) {
+            operations.removeIf(e -> e == operation);
+            if (operation instanceof DelayedOperation) {
+                ((DelayedOperation) operation).cancel();
+            }
         }
 
         // traverse the list and purge elements that are already completed by others


### PR DESCRIPTION
Fixes https://github.com/streamnative/kop/issues/1032

### Motivation

When a consumer of multiple partitions polls empty, i.e. there is no available message a `DelayedFetch` instance is created and added to `DelayedOperationPurgatory`. The `DelayedFetch` instance can be triggered when the timeout (`maxWaitMs`) exceeds or triggered by `KafkaRequestHandler#notifyPendingFetches` when some messages are sent successfully.

The latter behavior was introduced from https://github.com/streamnative/kop/pull/973. However, it could cause NPE because the `MessageFetchContext` instance held by `DelayedFetch` might have already be recycled. It's because there is no way to notify the purgatory that there is **a delayed fetch operation whose `messageFetchContext` field is null** now. For a `MessageFetchContext` instance, if one partition has available messages, the `tryComplete` method will be triggered eventually. Then `recycle()` will be called. But the delayed fetch operation won't be removed.

Therefore, `onDataWrittenToSomePartition` will be called on a recycled `MessageFetchContext` in `DelayedFetch#tryComplete`, and NPE will happen because all fields of `MessageFetchContext` are null now.

The KoP release 2.8.2.2+ and 2.9.1.2+ are affected by the bug.

### Modifications

~~We can simply fix this bug by adding null check in `MessageFetchContext#onDataWrittenToSomePartition`. However, instead of that, this PR chooses to save the `DelayedFetch` instances in `MessageFetchContext` and remove them from `DelayedOperationPurgatory` in `recycle()` method.~~

~~Compared with adding null check in `onDataWrittenToSomePartition`, the solution of this PR can remove invalid `DelayFetch` instances from the purgatory and the associated `TimerTask` instances from the task list.~~

This PR adds a test `testEmptyPollWhenProduceAndConsumeConcurrently` to reproduce the empty polls for a consumer of multiple partitions by increasing the `maxWaitMs` to 3 seconds. The test will fail if without the changes in `kafka-impl` module.