### PR TITLE
kafka cannot support nonroutable meta-address 0.0.0.0

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,7 +18,7 @@ To support multiple listeners, you need to specify different listener names in `
 For example, assuming you need to listen on port 9092 and 19092 with the `PLAINTEXT` protocol, the associated names are `kafka_internal` and `kafka_external`. Then you need to add the following configurations:
 
 ```properties
-kafkaListeners=kafka_internal://0.0.0.0:9092,kafka_external://0.0.0.0:19092
+kafkaListeners=kafka_internal://localhost:9092,kafka_external://localhost:19092
 kafkaProtocolMap=kafka_internal:PLAINTEXT,kafka_external:PLAINTEXT
 kafkaAdvertisedListeners=kafka_internal://localhost:9092,kafka_external://localhost:19092
 ```

--- a/docs/envoy-proxy.md
+++ b/docs/envoy-proxy.md
@@ -27,7 +27,7 @@ This example assumes that you have installed Pulsar 2.8.0, KoP 2.8.0, [Envoy 1.1
       - address:
           socket_address:
             # See KoP config item `kafkaAdvertisedListeners`
-            address: 0.0.0.0
+            address: localhost
             port_value: 19092
         filter_chains:
         - filters:
@@ -76,7 +76,7 @@ This example assumes that you have installed Pulsar 2.8.0, KoP 2.8.0, [Envoy 1.1
     # KoP listens at port 9092 in host "pulsar-broker-0"
     kafkaListeners=PLAINTEXT://pulsar-broker-0:9092
     # Expose the port 19092 as the external port that Kafka client connects to
-    kafkaAdvertisedListeners=PLAINTEXT://0.0.0.0:19092
+    kafkaAdvertisedListeners=PLAINTEXT://localhost:19092
     # Other necessary configs
     messagingProtocols=kafka
     allowAutoTopicCreationType=partitioned
@@ -89,12 +89,12 @@ This example assumes that you have installed Pulsar 2.8.0, KoP 2.8.0, [Envoy 1.1
 
 4. Run KoP.
 
-5. Now the Kafka client can use the exposed address (0.0.0.0:19092) to access KoP. 
+5. Now the Kafka client can use the exposed address (localhost:19092) to access KoP. 
 
     ```java
     final Properties props = new Properties();
     // See KoP config item `kafkaAdvertisedListeners`
-    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "0.0.0.0:19092");
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:19092");
     props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
     props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
     final KafkaProducer<String, String> producer = new KafkaProducer<>(props);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -606,7 +606,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
             ImmutableMap.Builder<InetSocketAddress, ChannelInitializer<SocketChannel>> builder =
                     ImmutableMap.builder();
 
-            EndPoint.parseListeners(kafkaConfig.getListeners(), kafkaConfig.getKafkaProtocolMap()).
+            EndPoint.parseListeners(kafkaConfig.getKafkaAdvertisedListeners(), kafkaConfig.getKafkaProtocolMap()).
                     forEach((listener, endPoint) ->
                             builder.put(endPoint.getInetAddress(), newKafkaChannelInitializer(endPoint))
                     );

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -484,6 +484,9 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
                         .append(hostname)
                         .append(":")
                         .append(matcher.group(3));
+            } else if (hostname.equals("0.0.0.0")) {
+                throw new IllegalStateException(advertisedListeners
+                        + " cannot use the nonroutable meta-address 0.0.0.0. Use a routable IP address.");
             } else {
                 listenersReBuilder.append(listener);
             }

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
@@ -91,9 +91,9 @@ public class KafkaServiceConfigurationTest {
     public void testKafkaListenersWithAdvertisedListener() throws UnknownHostException {
         KafkaServiceConfiguration configuration = new KafkaServiceConfiguration();
         configuration.setAdvertisedAddress("advertise-me");
-        configuration.setKafkaListeners("PLAINTEXT://0.0.0.0:9092");
+        configuration.setKafkaListeners("PLAINTEXT://localhost:9092");
         configuration.setKafkaAdvertisedListeners("PLAINTEXT://advertisedAddress:9092");
-        assertEquals(configuration.getListeners(), "PLAINTEXT://0.0.0.0:9092");
+        assertEquals(configuration.getListeners(), "PLAINTEXT://localhost:9092");
         String expectAdvertisedListeners = "PLAINTEXT://advertise-me:9092";
         assertEquals(configuration.getKafkaAdvertisedListeners(), expectAdvertisedListeners);
     }
@@ -102,9 +102,9 @@ public class KafkaServiceConfigurationTest {
     public void testKafkaListenersWithAdvertisedListenerSASL() throws UnknownHostException {
         KafkaServiceConfiguration configuration = new KafkaServiceConfiguration();
         configuration.setAdvertisedAddress("advertise-me");
-        configuration.setKafkaListeners("SASL_PLAINTEXT://0.0.0.0:9092");
+        configuration.setKafkaListeners("SASL_PLAINTEXT://localhost:9092");
         configuration.setKafkaAdvertisedListeners("SASL_PLAINTEXT://advertisedAddress:9092");
-        assertEquals(configuration.getListeners(), "SASL_PLAINTEXT://0.0.0.0:9092");
+        assertEquals(configuration.getListeners(), "SASL_PLAINTEXT://localhost:9092");
         String expectAdvertisedListeners = "SASL_PLAINTEXT://advertise-me:9092";
         assertEquals(configuration.getKafkaAdvertisedListeners(), expectAdvertisedListeners);
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaListenerNameTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaListenerNameTest.java
@@ -73,7 +73,7 @@ public class KafkaListenerNameTest extends KopProtocolHandlerTestBase {
                 InetSocketAddress.createUnresolved("192.168.0.2", PortManager.nextFreePort()));
 
         super.resetConfig();
-        conf.setKafkaListeners("PLAINTEXT://0.0.0.0:" + kafkaBrokerPort + ",GW://0.0.0.0:" + anotherKafkaPort);
+        conf.setKafkaListeners("PLAINTEXT://localhost:" + kafkaBrokerPort + ",GW://localhost:" + anotherKafkaPort);
         conf.setKafkaProtocolMap("PLAINTEXT:PLAINTEXT,GW:PLAINTEXT");
 
         conf.setKafkaAdvertisedListeners(String.format("PLAINTEXT://%s,GW://%s",
@@ -156,8 +156,8 @@ public class KafkaListenerNameTest extends KopProtocolHandlerTestBase {
         final String kafkaProtocolMap = "kafka:PLAINTEXT,kafka_external:PLAINTEXT";
         conf.setKafkaProtocolMap(kafkaProtocolMap);
         int externalPort = PortManager.nextFreePort();
-        final String kafkaListeners = "kafka://0.0.0.0:" + kafkaBrokerPort
-                + ",kafka_external://0.0.0.0:" + externalPort;
+        final String kafkaListeners = "kafka://localhost:" + kafkaBrokerPort
+                + ",kafka_external://localhost:" + externalPort;
         conf.setKafkaListeners(kafkaListeners);
         final String advertisedListeners =
                 "pulsar:pulsar://" + localAddress + ":" + brokerPort
@@ -178,7 +178,7 @@ public class KafkaListenerNameTest extends KopProtocolHandlerTestBase {
         final int externalPort = PortManager.nextFreePort();
         super.resetConfig();
         conf.setAdvertisedAddress(null);
-        conf.setKafkaListeners("kafka://0.0.0.0:" + kafkaBrokerPort + ",kafka_external://0.0.0.0:" + externalPort);
+        conf.setKafkaListeners("kafka://localhost:" + kafkaBrokerPort + ",kafka_external://localhost:" + externalPort);
         conf.setKafkaProtocolMap("kafka:PLAINTEXT,kafka_external:PLAINTEXT");
         conf.setAdvertisedListeners("pulsar:pulsar://localhost:" + brokerPort
                 + ",kafka:pulsar://localhost:" + kafkaBrokerPort


### PR DESCRIPTION
Fixes #1038 

`kafkaListeners` and `kafkaAdvertisedListeners` will expose metadata addresses to kafka clients, if configured as `0.0.0.0 ` address that cannot be routed, clients will not be able to access the service address.