### PR TITLE
Add docker compose example and docs for KoP standalone

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: "3.4"
+
+services:
+  standalone:
+    container_name: standalone
+    hostname: localhost
+    image: streamnative/sn-pulsar:2.9.1.1
+    command: >
+      bash -c "bin/apply-config-from-env.py conf/standalone.conf &&
+      exec bin/pulsar standalone -nss -nfw" # disable stream storage and functions worker
+    environment:
+      allowAutoTopicCreationType: partitioned
+      brokerDeleteInactiveTopicsEnabled: "false"
+      PULSAR_PREFIX_messagingProtocols: kafka
+      PULSAR_PREFIX_kafkaListeners: PLAINTEXT://0.0.0.0:9092
+      PULSAR_PREFIX_kafkaAdvertisedListeners: PLAINTEXT://127.0.0.1:19092
+      PULSAR_PREFIX_brokerEntryMetadataInterceptors: org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor
+    ports:
+      - 6650:6650
+      - 8080:8080
+      - 19092:9092

--- a/docs/kop.md
+++ b/docs/kop.md
@@ -153,7 +153,7 @@ world
 
 See [docker-compose.yml](../docker-compose.yml) for more details.
 
-It's similar to configure KoP in a cluster started in Docker. You only need to add the environment varialble whose prefix is `PULSAR_PREFIX_` and ensure `bin/apply-config-from-env.py conf/broker.conf` is executed before `bin/pulsar broker`.
+It's similar to configure KoP in a cluster started in Docker. You only need to add the environment varialbles according to your customized configuration and ensure `bin/apply-config-from-env.py conf/broker.conf` is executed before `bin/pulsar broker`. The environment variable should be a property's key if it already exists in the configuration file. Otherwise it should have the prefix `PULSAR_PREFIX_`.
 
 # How to use KoP
 

--- a/docs/kop.md
+++ b/docs/kop.md
@@ -131,8 +131,38 @@ After you have installed the KoP protocol handler to Pulsar broker, you can rest
         This is another message
         ```
 
+### Run KoP in Docker
+
+KoP is a built-in component in StreamNative's `sn-pulsar` image, whose tag matches KoP's version. Take KoP 2.9.1.1 for example, you can run
+
+```bash
+docker compose up
+```
+
+in the KoP project directory to start a Pulsar standalone with KoP enabled. The KoP has one advertised listener `127.0.0.1:19092`. So you can use Kafka's CLI tool to verify it like
+
+```bash
+$ ./bin/kafka-console-producer.sh --bootstrap-server localhost:19092 --topic my-topic                 
+>hello
+>world
+>^C                                                                                                                                                                                                                                                        $ ./bin/kafka-console-consumer.sh --bootstrap-server localhost:19092 --topic my-topic --from-beginning
+hello
+world
+^CProcessed a total of 2 messages
+```
+
+See [docker-compose.yml](../docker-compose.yml) for more details.
+
+It's similar to configure KoP in a cluster started in Docker. You only need to add the environment varialble whose prefix is `PULSAR_PREFIX_` and ensure `bin/apply-config-from-env.py conf/broker.conf` is executed before `bin/pulsar broker`.
+
 # How to use KoP
+
 You can configure and manage KoP based on your requirements. Check the following guides for more details.
+
+> **NOTE**
+>
+> Following links are invalid when you're reading this document in master branch from Github. You can go to the same chapter of [README.md](../README.md) for the correct links.
+
 -   [Configure KoP](https://github.com/streamnative/kop/blob/branch-{{protocol:version}}/docs/configuration.md)
 -   [Monitor KoP](https://github.com/streamnative/kop/blob/branch-{{protocol:version}}/docs/reference-metrics.md)
 -   [Upgrade](https://github.com/streamnative/kop/blob/branch-{{protocol:version}}/docs/upgrade.md)

--- a/docs/kop.md
+++ b/docs/kop.md
@@ -139,7 +139,7 @@ KoP is a built-in component in StreamNative's `sn-pulsar` image, whose tag match
 docker compose up
 ```
 
-in the KoP project directory to start a Pulsar standalone with KoP enabled. The KoP has one advertised listener `127.0.0.1:19092`. So you can use Kafka's CLI tool to verify it like
+in the KoP project directory to start a Pulsar standalone with KoP enabled. The KoP has a single advertised listener `127.0.0.1:19092`, so you should use Kafka's CLI tool to connect KoP like
 
 ```bash
 $ ./bin/kafka-console-producer.sh --bootstrap-server localhost:19092 --topic my-topic                 

--- a/docs/kop.md
+++ b/docs/kop.md
@@ -147,7 +147,7 @@ world
 
 See [docker-compose.yml](../docker-compose.yml) for more details.
 
-It's similar to configure KoP in a cluster started in Docker. You only need to add the environment varialbles according to your customized configuration and ensure `bin/apply-config-from-env.py conf/broker.conf` is executed before `bin/pulsar broker`. The environment variable should be a property's key if it already exists in the configuration file. Otherwise it should have the prefix `PULSAR_PREFIX_`.
+Similar to configuring KoP in a cluster that is started in Docker, you only need to add the environment varialble according to your customized configuration and ensure to execute `bin/apply-config-from-env.py conf/broker.conf` before executing `bin/pulsar broker`. The environment variable should be a property's key if it already exists in the configuration file. Otherwise it should have the prefix `PULSAR_PREFIX_`.
 
 # How to use KoP
 

--- a/docs/kop.md
+++ b/docs/kop.md
@@ -133,13 +133,7 @@ After you have installed the KoP protocol handler to Pulsar broker, you can rest
 
 ### Run KoP in Docker
 
-KoP is a built-in component in StreamNative's `sn-pulsar` image, whose tag matches KoP's version. Take KoP 2.9.1.1 for example, you can run
-
-```bash
-docker compose up
-```
-
-in the KoP project directory to start a Pulsar standalone with KoP enabled. The KoP has a single advertised listener `127.0.0.1:19092`, so you should use Kafka's CLI tool to connect KoP like
+KoP is a built-in component in StreamNative's `sn-pulsar` image, whose tag matches KoP's version. Take KoP 2.9.1.1 for example, you can execute `docker compose up` command in the KoP project directory to start a Pulsar standalone with KoP being enabled. KoP has a single advertised listener `127.0.0.1:19092`, so you should use Kafka's CLI tool to connect KoP, as shown below:
 
 ```bash
 $ ./bin/kafka-console-producer.sh --bootstrap-server localhost:19092 --topic my-topic                 
@@ -161,7 +155,7 @@ You can configure and manage KoP based on your requirements. Check the following
 
 > **NOTE**
 >
-> Following links are invalid when you're reading this document in master branch from Github. You can go to the same chapter of [README.md](../README.md) for the correct links.
+> The following links are invalid when you check this document in the `master` branch from GitHub. You can go to the same chapter of the [README](../README.md) for the correct links.
 
 -   [Configure KoP](https://github.com/streamnative/kop/blob/branch-{{protocol:version}}/docs/configuration.md)
 -   [Monitor KoP](https://github.com/streamnative/kop/blob/branch-{{protocol:version}}/docs/reference-metrics.md)


### PR DESCRIPTION
Master issue: #1043

This PR adds a `docker-compose.yml` in project directory and the related docs for how to start KoP in Docker.