### PR TITLE
Bump KoP version to 2.10.0-SNAPSHOT (#1037)

### DIFF
--- a/kafka-0-10/pom.xml
+++ b/kafka-0-10/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
     <groupId>io.streamnative.pulsar.handlers</groupId>
-    <version>2.9.0-SNAPSHOT</version>
+    <version>2.10.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kafka-0-9/pom.xml
+++ b/kafka-0-9/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
     <groupId>io.streamnative.pulsar.handlers</groupId>
-    <version>2.9.0-SNAPSHOT</version>
+    <version>2.10.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kafka-1-0/pom.xml
+++ b/kafka-1-0/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
     <groupId>io.streamnative.pulsar.handlers</groupId>
-    <version>2.9.0-SNAPSHOT</version>
+    <version>2.10.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kafka-2-8/pom.xml
+++ b/kafka-2-8/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
     <groupId>io.streamnative.pulsar.handlers</groupId>
-    <version>2.9.0-SNAPSHOT</version>
+    <version>2.10.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kafka-3-0/pom.xml
+++ b/kafka-3-0/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
     <groupId>io.streamnative.pulsar.handlers</groupId>
-    <version>2.9.0-SNAPSHOT</version>
+    <version>2.10.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kafka-client-api/pom.xml
+++ b/kafka-client-api/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
     <groupId>io.streamnative.pulsar.handlers</groupId>
-    <version>2.9.0-SNAPSHOT</version>
+    <version>2.10.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kafka-client-factory/pom.xml
+++ b/kafka-client-factory/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
     <groupId>io.streamnative.pulsar.handlers</groupId>
-    <version>2.9.0-SNAPSHOT</version>
+    <version>2.10.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kafka-impl/pom.xml
+++ b/kafka-impl/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.streamnative.pulsar.handlers</groupId>
     <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
-    <version>2.9.0-SNAPSHOT</version>
+    <version>2.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>io.streamnative.pulsar.handlers</groupId>

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
@@ -272,7 +272,7 @@ class AdminManager {
             errorConsumer.accept("Cannot find position");
             return;
         }
-        if (position.equals(PositionImpl.latest)) {
+        if (position.equals(PositionImpl.LATEST)) {
             admin.topics()
                 .truncateAsync(topicToDelete)
                 .thenRun(() -> {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManager.java
@@ -300,7 +300,7 @@ public class KafkaTopicConsumerManager implements Closeable {
                     && Objects.equals(lastConfirmedEntry.getNext(), position)) {
                 log.debug("Found position {} for offset {}, LAC {} -> RETURN LATEST",
                         position, offset, lastConfirmedEntry);
-                return PositionImpl.latest;
+                return PositionImpl.LATEST;
             } else {
                 return position;
             }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -570,7 +570,7 @@ public final class MessageFetchContext {
                         MathUtils.elapsedNanos(startReadingMessagesNanos), TimeUnit.NANOSECONDS);
                 readFuture.completeExceptionally(exception);
             }
-        }, null, PositionImpl.latest);
+        }, null, PositionImpl.LATEST);
 
         return readFuture;
     }

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
@@ -152,7 +152,7 @@ public class KafkaServiceConfigurationTest {
             ConfigurationUtils.create(stream, KafkaServiceConfiguration.class);
 
         assertNotNull(kafkaServiceConfig);
-        assertEquals(kafkaServiceConfig.getZookeeperServers(), zkServer);
+        assertEquals(kafkaServiceConfig.getMetadataStoreUrl(), zkServer);
         assertEquals(kafkaServiceConfig.isBrokerDeleteInactiveTopicsEnabled(), true);
         assertEquals(kafkaServiceConfig.getBacklogQuotaDefaultLimitGB(), 18.0);
         assertEquals(kafkaServiceConfig.getClusterName(), "usc");

--- a/kafka-payload-processor-shaded-tests/pom.xml
+++ b/kafka-payload-processor-shaded-tests/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
     <groupId>io.streamnative.pulsar.handlers</groupId>
-    <version>2.9.0-SNAPSHOT</version>
+    <version>2.10.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kafka-payload-processor-shaded/pom.xml
+++ b/kafka-payload-processor-shaded/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
     <groupId>io.streamnative.pulsar.handlers</groupId>
-    <version>2.9.0-SNAPSHOT</version>
+    <version>2.10.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kafka-payload-processor/pom.xml
+++ b/kafka-payload-processor/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
     <groupId>io.streamnative.pulsar.handlers</groupId>
-    <version>2.9.0-SNAPSHOT</version>
+    <version>2.10.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/oauth-client/pom.xml
+++ b/oauth-client/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
     <groupId>io.streamnative.pulsar.handlers</groupId>
-    <version>2.9.0-SNAPSHOT</version>
+    <version>2.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>oauth-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
   <groupId>io.streamnative.pulsar.handlers</groupId>
   <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
-  <version>2.9.0-SNAPSHOT</version>
+  <version>2.10.0-SNAPSHOT</version>
   <name>StreamNative :: Pulsar Protocol Handler :: KoP Parent</name>
   <description>Parent for Kafka on Pulsar implemented using Pulsar Protocol Handler.</description>
 
@@ -43,7 +43,7 @@
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
     <pulsar.group.id>io.streamnative</pulsar.group.id>
-    <pulsar.version>2.9.0-rc-202110221101</pulsar.version>
+    <pulsar.version>2.10.0.0-rc-1</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testng.version>6.14.3</testng.version>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.streamnative.pulsar.handlers</groupId>
     <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
-    <version>2.9.0-SNAPSHOT</version>
+    <version>2.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>io.streamnative.pulsar.handlers</groupId>

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
@@ -255,7 +255,7 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
         PersistentTopic persistentTopic = (PersistentTopic)
                 pulsar.getBrokerService().getTopicReference(pulsarPartitionName).get();
 
-        long backlogSize = persistentTopic.getStats(true, true).backlogSize;
+        long backlogSize = persistentTopic.getStats(true, true, true).backlogSize;
         verifyBacklogAndNumCursor(persistentTopic, backlogSize, 3);
 
         // simulate a read complete;
@@ -287,14 +287,14 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
         AtomicInteger cursorCount = new AtomicInteger(0);
         retryStrategically(
             ((test) -> {
-                backlog.set(persistentTopic.getStats(true, true).backlogSize);
+                backlog.set(persistentTopic.getStats(true, true, true).backlogSize);
                 return backlog.get() == expectedBacklog;
             }),
             5,
             200);
 
         if (log.isDebugEnabled()) {
-            TopicStats topicStats = persistentTopic.getStats(true, true);
+            TopicStats topicStats = persistentTopic.getStats(true, true, true);
             log.info(" dump topicStats for topic : {}, storageSize: {}, backlogSize: {}, expected: {}",
                 persistentTopic.getName(),
                 topicStats.getStorageSize(), topicStats.getBacklogSize(), expectedBacklog);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/OffsetResetTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/OffsetResetTest.java
@@ -251,7 +251,7 @@ public class OffsetResetTest extends KopProtocolHandlerTestBase {
         }
 
         managedLedger.rollCurrentLedgerIfFull();
-        managedLedger.trimConsumedLedgersInBackground(Futures.NULL_PROMISE);
+        managedLedger.trimConsumedLedgersInBackground(Futures.nullPromise_);
         Thread.sleep(1000);
         log.info("current ledger ids: {}", managedLedger.getLedgersInfo().keySet());
         log.info("finish deleting some ledgers");


### PR DESCRIPTION
This PR cherry-picks 9820289 to master since Pulsar 2.10.0 is closed. After Pulsar 2.10.0 is released, we should bump project version to 2.11.0-SNAPSHOT and pulsar version to 2.10.0.x.