### PR TITLE
Return NOT_LEADER_FOR_PARTITION when managed ledger's state is wrong

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
@@ -111,12 +111,8 @@ public class ReplicaManager {
                         .thenAccept(offset -> addPartitionResponse.accept(topicPartition,
                                 new ProduceResponse.PartitionResponse(Errors.NONE, offset, -1L, -1L)))
                         .exceptionally(ex -> {
-                            Errors errors = Errors.forException(ex.getCause());
-                            if (errors == Errors.UNKNOWN_SERVER_ERROR) {
-                                errors = Errors.KAFKA_STORAGE_ERROR;
-                            }
                             addPartitionResponse.accept(topicPartition,
-                                    new ProduceResponse.PartitionResponse(errors));
+                                    new ProduceResponse.PartitionResponse(Errors.forException(ex.getCause())));
                             return null;
                         });
             }


### PR DESCRIPTION
Fixes https://github.com/streamnative/kop/issues/1050

### Motivation

Currently `ReplicaManager#getPartitionLog` transfers exceptions thrown from `PartitionLog#appendRecords` to Kafka's error code by calling `Errors.forException` and treats the unknown error as `KAFKA_STORAGE_ERROR`. However, the exception is thrown from broker side:
- Control records are sent by `ManagedLedger#asyncAddEntry`, the `ManagedLedgerException` will be thrown if failed.
- Normal records are sent by `PersistentTopic#publishMessages`, the `BrokerServiceException` that wraps `ManagedLedgerException` will be thrown if failed.

After a bundle unload event, some entries might still be cached in the managed ledger. In this case, all entries will be failed with `ManagedLedgerAlreadyClosedException`. However, if Kafka producer received an error other than `InvalidMetadataException`, it won't update the metadata and send records to the same broker and failed again. See https://github.com/apache/kafka/blob/7c2d6724130f8251aa255917b74d9c3ef1fe67f7/clients/src/main/java/org/apache/kafka/clients/producer/internals/Sender.java#L636-L647

We should return the error code associated with `InvalidMetadataException` to notify Kafka producer it's time to find the new leader of the partition.

### Modifications

- When the managed ledger's state is wrong, complete the future with `NotLeaderForPartitionException`, which implements `InvalidMetadataException`.
- Add a test `testIllegalManagedLedger` to verify this error code is received when the managed ledger is closed.