### PR TITLE
[Test] Fix flaky-test: DistributedClusterTest.testMultiBrokerProduceAndConsumeOnePartitionedTopic

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
@@ -577,7 +577,6 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
             if (kConsumer2 != null) {
                 kConsumer2.close();
             }
-            pulsarService1.getAdminClient().topics().deletePartitionedTopic(pulsarTopicName);
         }
 
     }


### PR DESCRIPTION
Fixes: #1056

### Motivation

The `testMultiBrokerProduceAndConsumeOnePartitionedTopic` test method fails sporadically. Because the sometimes delete topic will timeout. link PR: https://github.com/apache/pulsar/pull/14060

### Modifications

* remove the call of `deletePartitionedTopic`