### PR TITLE
Fix NPE during lookup during bundle unload

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
@@ -68,6 +68,11 @@ public class KopBrokerLookupManager {
                     try {
                         final String listener = getAdvertisedListener(
                                 internalListenerAddress, topic, advertisedEndPoint);
+                        if (listener == null) {
+                            log.error("Failed to find the advertised listener for {} ", topic);
+                            removeTopicManagerCache(topic);
+                            return Optional.empty();
+                        }
                         if (log.isDebugEnabled()) {
                             log.debug("Found listener {} for topic {}", listener, topic);
                         }


### PR DESCRIPTION
This patches fixes a NPE that happens during bundle unload

> 17:25:52.106 [AsyncHttpClient-62-1] ERROR io.streamnative.pulsar.handlers.kop.KopBrokerLookupManager - No node for broker 10.8.3.4:6650 under loadBalance
> 17:25:16.881 [pulsar-client-io-47-1] WARN  io.streamnative.pulsar.handlers.kop.KafkaRequestHandler - [[id: 0x3ed2997b, L:/10.8.5.5:9092 - R:/10.8.4.131:58416]] Request RequestHeader(apiKey=METADATA, apiVersion=7, clientId=consumer-sub-000-pcryMaM-4, correlationId=7703): Exception while find Broker metadata
> java.util.concurrent.CompletionException: java.lang.NullPointerException
>         at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:314) ~[?:?]
>         at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:319) ~[?:?]
>         at java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:645) ~[?:?]
>         at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
>         at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2073) ~[?:?]
>         at org.apache.pulsar.client.impl.BinaryProtoLookupService.lambda$findBroker$1(BinaryProtoLookupService.java:159) ~[com.datastax.oss-pulsar-client-original-2.8.0.1.1.21.jar:2.8.0.1.1.21]
>         at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859) [?:?]
>         at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:837) [?:?]
>         at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) [?:?]
>         at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2073) [?:?]
>         at org.apache.pulsar.client.impl.ClientCnx.handleLookupResponse(ClientCnx.java:560) [com.datastax.oss-pulsar-client-original-2.8.0.1.1.21.jar:2.8.0.1.1.21]
>         at org.apache.pulsar.common.protocol.PulsarDecoder.channelRead(PulsarDecoder.java:139) [com.datastax.oss-pulsar-common-2.8.0.1.1.21.jar:2.8.0.1.1.21]
>         at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [io.netty-netty-transport-4.1.73.Final.jar:4.1.73.Final]
>         at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [io.netty-netty-transport-4.1.73.Final.jar:4.1.73.Final]
>         at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) [io.netty-netty-transport-4.1.73.Final.jar:4.1.73.Final]
>         at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:327) [io.netty-netty-codec-4.1.73.Final.jar:4.1.73.Final]
>         at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:299) [io.netty-netty-codec-4.1.73.Final.jar:4.1.73.Final]
>         at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [io.netty-netty-transport-4.1.73.Final.jar:4.1.73.Final]
>         at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [io.netty-netty-transport-4.1.73.Final.jar:4.1.73.Final]
>         at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) [io.netty-netty-transport-4.1.73.Final.jar:4.1.73.Final]
>         at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) [io.netty-netty-transport-4.1.73.Final.jar:4.1.73.Final]
>         at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [io.netty-netty-transport-4.1.73.Final.jar:4.1.73.Final]
>         at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [io.netty-netty-transport-4.1.73.Final.jar:4.1.73.Final]
>         at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) [io.netty-netty-transport-4.1.73.Final.jar:4.1.73.Final]
>         at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:795) [io.netty-netty-transport-classes-epoll-4.1.73.Final.jar:4.1.73.Final]
>         at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:480) [io.netty-netty-transport-classes-epoll-4.1.73.Final.jar:4.1.73.Final]
>         at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:378) [io.netty-netty-transport-classes-epoll-4.1.73.Final.jar:4.1.73.Final]
>         at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986) [io.netty-netty-common-4.1.73.Final.jar:4.1.73.Final]
>         at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [io.netty-netty-common-4.1.73.Final.jar:4.1.73.Final]
>         at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [io.netty-netty-common-4.1.73.Final.jar:4.1.73.Final]
>         at java.lang.Thread.run(Thread.java:829) [?:?]
> Caused by: java.lang.NullPointerException
>         at java.util.regex.Matcher.getTextLength(Matcher.java:1770) ~[?:?]
>         at java.util.regex.Matcher.reset(Matcher.java:416) ~[?:?]
>         at java.util.regex.Matcher.<init>(Matcher.java:253) ~[?:?]
>         at java.util.regex.Pattern.matcher(Pattern.java:1133) ~[?:?]
>         at io.streamnative.pulsar.handlers.kop.EndPoint.matcherListener(EndPoint.java:189) ~[?:?]
>         at io.streamnative.pulsar.handlers.kop.KopBrokerLookupManager.lambda$findBroker$0(KopBrokerLookupManager.java:74) ~[?:?]
>         at java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:642) ~[?:?]
>         ... 28 more