### PR TITLE
Transactions: don't create a thread per-tenant

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -131,7 +131,8 @@ public class TransactionCoordinator {
         return new TransactionCoordinator(
                 transactionConfig,
                 new TransactionMarkerChannelManager(tenant, kafkaConfig, transactionStateManager,
-                        kopBrokerLookupManager, false, namespacePrefixForUserTopics),
+                        kopBrokerLookupManager, false, namespacePrefixForUserTopics,
+                        scheduler),
                 scheduler,
                 new ProducerIdManagerImpl(transactionConfig.getBrokerId(), metadataStore),
                 transactionStateManager,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
@@ -220,6 +220,7 @@ public class TransactionMarkerChannelManager {
                                     TransactionMetadata txnMetadata,
                                     TransactionMetadata.TxnTransitMetadata newMetadata,
                                     String namespacePrefix) {
+        ensureDrainQueuedTransactionMarkersActivity();
         String transactionalId = txnMetadata.getTransactionalId();
         PendingCompleteTxn pendingCompleteTxn = new PendingCompleteTxn(
                 transactionalId,
@@ -244,6 +245,7 @@ public class TransactionMarkerChannelManager {
     }
 
     public void maybeWriteTxnCompletion(String transactionalId) {
+        ensureDrainQueuedTransactionMarkersActivity();
         PendingCompleteTxn pendingCompleteTxn = transactionsWithPendingMarkers.get(transactionalId);
         if (!hasPendingMarkersToWrite(pendingCompleteTxn.txnMetadata)
                 && transactionsWithPendingMarkers.remove(transactionalId, pendingCompleteTxn)) {
@@ -258,6 +260,7 @@ public class TransactionMarkerChannelManager {
                                            Integer coordinatorEpoch,
                                            Set<TopicPartition> topicPartitions,
                                            String namespacePrefixForUserTopics) {
+        ensureDrainQueuedTransactionMarkersActivity();
         Integer txnTopicPartition = txnStateManager.partitionFor(transactionalId);
 
         Map<InetSocketAddress, List<TopicPartition>> addressAndPartitionMap = new ConcurrentHashMap<>();
@@ -399,6 +402,7 @@ public class TransactionMarkerChannelManager {
     }
 
     public void removeMarkersForTxnTopicPartition(Integer txnTopicPartitionId) {
+        ensureDrainQueuedTransactionMarkersActivity();
         BlockingQueue<TxnIdAndMarkerEntry> unknownBrokerMarkerEntries =
                 markersQueueForUnknownBroker.removeMarkersForTxnTopicPartition(txnTopicPartitionId);
         if (unknownBrokerMarkerEntries != null) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
@@ -35,6 +35,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import lombok.AllArgsConstructor;
@@ -82,6 +85,8 @@ public class TransactionMarkerChannelManager {
     private BlockingQueue<PendingCompleteTxn> txnLogAppendRetryQueue = new LinkedBlockingQueue<>();
     private volatile boolean closed;
     private final String namespacePrefixForUserTopics;
+    private final ScheduledExecutorService scheduler;
+    private ScheduledFuture<?> drainQueuedTransactionMarkersHandle;
 
     @AllArgsConstructor
     @ToString
@@ -141,13 +146,15 @@ public class TransactionMarkerChannelManager {
                                            TransactionStateManager txnStateManager,
                                            KopBrokerLookupManager kopBrokerLookupManager,
                                            boolean enableTls,
-                                           String namespacePrefixForUserTopics) throws Exception {
+                                           String namespacePrefixForUserTopics,
+                                           ScheduledExecutorService scheduler) throws Exception {
         this.tenant = tenant;
         this.kafkaConfig = kafkaConfig;
         this.namespacePrefixForUserTopics = namespacePrefixForUserTopics;
         this.txnStateManager = txnStateManager;
         this.kopBrokerLookupManager = kopBrokerLookupManager;
         this.enableTls = enableTls;
+        this.scheduler = scheduler;
         if (this.enableTls) {
             sslContextFactory = SSLUtils.createSslContextFactory(kafkaConfig);
             sslEndPoint = EndPoint.getSslEndPoint(kafkaConfig.getKafkaListeners());
@@ -171,25 +178,13 @@ public class TransactionMarkerChannelManager {
         bootstrap.group(eventLoopGroup);
         bootstrap.channel(NioSocketChannel.class);
         bootstrap.handler(new TransactionMarkerChannelInitializer(kafkaConfig, enableTls, this));
-
-        Thread thread = new Thread(() -> {
-            while (!closed) {
-                drainQueuedTransactionMarkers();
-                try {
-                    Thread.sleep(1);
-                } catch (InterruptedException e) {
-                    log.info("ignore {}", e);
-                }
-            }
-        }, "kop-transaction-channel-manager-" + namespacePrefixForUserTopics);
-        thread.setDaemon(true);
-        thread.start();
     }
 
     public CompletableFuture<TransactionMarkerChannelHandler> getChannel(InetSocketAddress socketAddress) {
         if (closed) {
             return FutureUtil.failedFuture(new Exception("This TransactionMarkerChannelManager is closed"));
         }
+        ensureDrainQueuedTransactionMarkersActivity();
         return handlerMap.computeIfAbsent(socketAddress, address -> {
             CompletableFuture<TransactionMarkerChannelHandler> handlerFuture = new CompletableFuture<>();
             ChannelFutures.toCompletableFuture(bootstrap.connect(socketAddress))
@@ -475,8 +470,24 @@ public class TransactionMarkerChannelManager {
         }
     }
 
+    private synchronized void ensureDrainQueuedTransactionMarkersActivity() {
+        if (drainQueuedTransactionMarkersHandle != null || closed) {
+            return;
+        }
+        drainQueuedTransactionMarkersHandle = scheduler.scheduleWithFixedDelay(() -> {
+            drainQueuedTransactionMarkers();
+        }, 100, 100, TimeUnit.MILLISECONDS);
+    }
+
+    private synchronized void stopDrainQueuedTransactionMarkersHandleActivity() {
+        if (drainQueuedTransactionMarkersHandle != null) {
+            drainQueuedTransactionMarkersHandle.cancel(false);
+        }
+    }
+
     public void close() {
         this.closed = true;
+        stopDrainQueuedTransactionMarkersHandleActivity();
         handlerMap.forEach((address, handler) -> {
             try {
                 final TransactionMarkerChannelHandler transactionMarkerChannelHandler = handler.get();


### PR DESCRIPTION
**Modifications**
- use a shared threadpool
- lazily start the drainQueuedTransactionMarkers activity only when needed
- set period to 100ms (instead of 1ms)

**Result**
If a tenant never uses transactions, then you never start the background activity, also we are able to scale the number for active tenants.

A future improvement may be to shutdown the activity when a tenant is idle for a while