### PR TITLE
Bump Pulsar version to 2.10.0.0-rc2

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/InternalProducer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/InternalProducer.java
@@ -34,7 +34,7 @@ public class InternalProducer extends Producer {
                             long producerId, String producerName) {
         super(topic, cnx, producerId, producerName, null,
                 false, null, null, 0, false,
-                ProducerAccessMode.Shared, Optional.empty());
+                ProducerAccessMode.Shared, Optional.empty(), false);
         this.serverCnx = cnx;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
     <pulsar.group.id>io.streamnative</pulsar.group.id>
-    <pulsar.version>2.10.0.0-rc-1</pulsar.version>
+    <pulsar.version>2.10.0.0-rc2</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testng.version>6.14.3</testng.version>

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/OffsetResetTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/OffsetResetTest.java
@@ -251,7 +251,7 @@ public class OffsetResetTest extends KopProtocolHandlerTestBase {
         }
 
         managedLedger.rollCurrentLedgerIfFull();
-        managedLedger.trimConsumedLedgersInBackground(Futures.nullPromise_);
+        managedLedger.trimConsumedLedgersInBackground(Futures.NULL_PROMISE);
         Thread.sleep(1000);
         log.info("current ledger ids: {}", managedLedger.getLedgersInfo().keySet());
         log.info("finish deleting some ledgers");


### PR DESCRIPTION
Bump Pulsar version to 2.10.0.0-rc2 and fix the incompatibility issues introduced from https://github.com/apache/pulsar/pull/14004 and https://github.com/apache/pulsar/pull/12401.