### PR TITLE
Bump Pulsar version to 2.10.0.0-rc4

### DIFF
--- a/kafka-payload-processor-shaded-tests/src/test/java/io/streamnative/pulsar/handlers/kop/MockedMessagePayloadContext.java
+++ b/kafka-payload-processor-shaded-tests/src/test/java/io/streamnative/pulsar/handlers/kop/MockedMessagePayloadContext.java
@@ -84,7 +84,8 @@ public class MockedMessagePayloadContext implements MessagePayloadContext {
                     null,
                     schema,
                     0,
-                    false);
+                    false,
+                    Commands.DEFAULT_CONSUMER_EPOCH);
         } finally {
             payloadBuffer.release();
         }

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
     <pulsar.group.id>io.streamnative</pulsar.group.id>
-    <pulsar.version>2.10.0.0-rc2</pulsar.version>
+    <pulsar.version>2.10.0.0-rc4</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testng.version>6.14.3</testng.version>


### PR DESCRIPTION
https://github.com/apache/pulsar/pull/10478 introduced an API change to `MessageImpl#create`, which is included in 2.10.0.0-rc4, we need to fix the conflict.