### PR TITLE
Optimize the way to get the controllerId

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
@@ -430,6 +430,7 @@ class AdminManager {
     }
 
     public Collection<? extends Node> getBrokers(String listenerName) {
+
         if (brokersCache.containsKey(listenerName)) {
             return brokersCache.get(listenerName);
         }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -77,7 +77,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.Getter;
@@ -752,9 +751,10 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
 
         // 2. After get all topics, for each topic, get the service Broker for it, and add to response
         AtomicInteger topicsCompleted = new AtomicInteger(0);
-        // Each Pulsar broker can manage metadata like controller in Kafka, Kafka's AdminClient needs to find a
-        // controller node for metadata management. So here we return the broker itself as a controller.
-        final int controllerId = newSelfNode().id();
+        // Each Pulsar broker can manage metadata like controller in Kafka,
+        // Kafka's AdminClient needs to find a controller node for metadata management.
+        // So here we return an random broker as a controller for the given listenerName.
+        final int controllerId = adminManager.getControllerId(advertisedEndPoint.getListenerName());
         pulsarTopicsFuture.whenComplete((pulsarTopics, e) -> {
             if (e != null) {
                 log.warn("[{}] Request {}: Exception fetching metadata, will return null Response",
@@ -2531,17 +2531,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             Murmur3_32Hash.getInstance().makeHash((address.getHostString() + address.getPort()).getBytes(UTF_8)),
             address.getHostString(),
             address.getPort());
-    }
-
-    Node newSelfNode() {
-        String advertisedListeners = kafkaConfig.getKafkaAdvertisedListeners();
-        String listener = EndPoint.findListener(advertisedListeners, advertisedEndPoint.getListenerName());
-        if (listener == null) {
-            return newNode(advertisedEndPoint.getInetAddress());
-        }
-        final Matcher matcher = EndPoint.matcherListener(listener,
-                listener + " cannot be split into 3 parts");
-        return newNode(new InetSocketAddress(matcher.group(2), Integer.parseInt(matcher.group(3))));
     }
 
     static PartitionMetadata newPartitionMetadata(TopicName topicName, Node node) {


### PR DESCRIPTION
Related to this #1092 

1. The current brokers metadata is maintained in the AdminManager, and obtaining the controllerId from here can ensure data consistency.
2. Avoid extra complex parsing listeners and handling exceptions.
3. The node ID is calculated from the hostname and port hash. If kop is not configured with ip or hostname, the program will automatically obtain the hostname. One of the problems is: when kop is running, if a new hostname address is added to the local domain name self-resolution, and as for the first position, it may cause the program to return a different host alias, the controller node id will inconsistent with the Broker cache in metadataStore. You can see the PR #648 I submitted a long time ago.
4. Reuse `testMetadataRequestForMultiListeners` test validation controller.
5. A random node from the broker cache is used as the controller. There is no controller concept in kop. It is the same whether it returns to the node itself or randomly selects a node.