### PR TITLE
[Transaction] Able to disable transaction coordinator

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -101,6 +101,7 @@ public final class MessageFetchContext {
 
     // recycler and get for this object
     public static MessageFetchContext get(KafkaRequestHandler requestHandler,
+                                          TransactionCoordinator tc,
                                           KafkaHeaderAndRequest kafkaHeaderAndRequest,
                                           CompletableFuture<AbstractResponse> resultFuture,
                                           DelayedOperationPurgatory<DelayedOperation> fetchPurgatory,
@@ -111,7 +112,7 @@ public final class MessageFetchContext {
         context.maxReadEntriesNum = requestHandler.getMaxReadEntriesNum();
         context.topicManager = requestHandler.getTopicManager();
         context.statsLogger = requestHandler.requestStats;
-        context.tc = requestHandler.getTransactionCoordinator();
+        context.tc = tc;
         context.clientHost = kafkaHeaderAndRequest.getClientHost();
         context.fetchRequest = (FetchRequest) kafkaHeaderAndRequest.getRequest();
         context.header = kafkaHeaderAndRequest.getHeader();
@@ -472,7 +473,7 @@ public final class MessageFetchContext {
                     groupName,
                     statsLogger);
             List<FetchResponse.AbortedTransaction> abortedTransactions;
-            if (requestHandler.getKafkaConfig().isKafkaTransactionCoordinatorEnabled() && readCommitted && tc != null) {
+            if (readCommitted) {
                 abortedTransactions = partitionLog.getAbortedIndexList(partitionData.fetchOffset);
             } else {
                 abortedTransactions = null;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
@@ -131,6 +131,7 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
         conf.setKafkaMetadataNamespace("__kafka");
         conf.setKafkaTenant(TENANT);
         conf.setKafkaNamespace(NAMESPACE);
+        conf.setKafkaTransactionCoordinatorEnabled(true);
 
         conf.setClusterName(super.configClusterName);
         conf.setAuthorizationEnabled(true);


### PR DESCRIPTION
Fixes  #1090

### Motivation
Currently, even if we config kafkaTransactionCoordinatorEnabled=false, the Kafka transaction coordinator is still started.
It happened when the broker has a consumer fetch message.


### Modifications
When `kafkaTransactionCoordinatorEnabled = false`, ensure the transaction coordinator don't start.
