### PR TITLE
[Authorization] List topic mapping to pulsar GET_TOPICS permission

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -605,7 +605,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                 topicMap.computeIfAbsent(topic, ignored -> new ArrayList<>()).add(topicName))
                         )
                 );
-                log.info("WK allTopicMap {}", allTopicMap);
                 pulsarTopicsFuture.complete(allTopicMap);
             });
         } else {
@@ -2585,8 +2584,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             case DESCRIBE:
                 if (resource.getResourceType() == ResourceType.TOPIC) {
                     isAuthorizedFuture = authorizer.canLookupAsync(session.getPrincipal(), resource);
-                }
-                if (resource.getResourceType() == ResourceType.NAMESPACE) {
+                } else if (resource.getResourceType() == ResourceType.NAMESPACE) {
                     isAuthorizedFuture = authorizer.canGetTopicList(session.getPrincipal(), resource);
                 }
                 break;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -512,28 +512,44 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         String namespacePrefix = currentNamespacePrefix();
         allowedNamespacesFuture.thenAccept(allowedNamespaces -> {
             final AtomicInteger pendingNamespacesCount = new AtomicInteger(allowedNamespaces.size());
-
+            Runnable completeOne = () -> {
+                if (pendingNamespacesCount.decrementAndGet() == 0) {
+                    topicMapFuture.complete(topicMap);
+                }
+            };
             for (String namespace : allowedNamespaces) {
-                pulsarService.getNamespaceService().getListOfPersistentTopics(NamespaceName.get(namespace))
-                        .whenComplete((topics, e) -> {
-                            if (e != null) {
-                                log.error("Failed to getListOfPersistentTopic of {}", namespace, e);
-                                topicMapFuture.completeExceptionally(e);
+                authorize(AclOperation.DESCRIBE, Resource.of(ResourceType.NAMESPACE, namespace))
+                        .whenComplete((isAuthorized, ex) -> {
+                            if (ex != null) {
+                                log.error("Describe namespace authorize failed, namespace - {}. {}",
+                                        namespace, ex.getMessage());
+                                completeOne.run();
                                 return;
                             }
-                            if (topicMapFuture.isCompletedExceptionally()) {
-                                return;
-                            }
-                            for (String topic : topics) {
-                                final TopicName topicName = TopicName.get(topic);
-                                final String key = topicName.getPartitionedTopicName();
-                                topicMap.computeIfAbsent(
-                                        KopTopic.removeDefaultNamespacePrefix(key, namespacePrefix),
-                                        ignored -> Collections.synchronizedList(new ArrayList<>())
-                                ).add(topicName);
-                            }
-                            if (pendingNamespacesCount.decrementAndGet() == 0) {
-                                topicMapFuture.complete(topicMap);
+                            if (isAuthorized) {
+                                pulsarService.getNamespaceService()
+                                        .getListOfPersistentTopics(NamespaceName.get(namespace))
+                                        .whenComplete((topics, e) -> {
+                                            if (e != null) {
+                                                log.error("Failed to getListOfPersistentTopic of {}", namespace, e);
+                                                topicMapFuture.completeExceptionally(e);
+                                                return;
+                                            }
+                                            if (topicMapFuture.isCompletedExceptionally()) {
+                                                return;
+                                            }
+                                            for (String topic : topics) {
+                                                final TopicName topicName = TopicName.get(topic);
+                                                final String key = topicName.getPartitionedTopicName();
+                                                topicMap.computeIfAbsent(
+                                                        KopTopic.removeDefaultNamespacePrefix(key, namespacePrefix),
+                                                        ignored -> Collections.synchronizedList(new ArrayList<>())
+                                                ).add(topicName);
+                                            }
+                                            completeOne.run();
+                                        });
+                            } else {
+                                completeOne.run();
                             }
                         });
             }
@@ -584,42 +600,13 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             // get all topics, filter by permissions.
             final Map<String, List<TopicName>> topicMap = new ConcurrentHashMap<>();
             getAllTopicsAsync().thenAccept((allTopicMap) -> {
-                if (allTopicMap.isEmpty()) {
-                    pulsarTopicsFuture.complete(allTopicMap);
-                    return;
-                }
-                AtomicInteger allTopicCount =
-                        new AtomicInteger(allTopicMap.values().stream().mapToInt(List::size).sum());
-                if (allTopicCount.get() == 0) {
-                    pulsarTopicsFuture.complete(topicMap);
-                    return;
-                }
-                final Runnable completeOne = () -> {
-                    if (allTopicCount.decrementAndGet() == 0) {
-                        pulsarTopicsFuture.complete(topicMap);
-                    }
-                };
-
-                allTopicMap.forEach((topic, list) -> {
-                   list.forEach((topicName ->
-                           authorize(AclOperation.DESCRIBE, Resource.of(ResourceType.TOPIC, topicName.toString()))
-                           .whenComplete((authorized, ex) -> {
-                               if (ex != null || !authorized) {
-                                   allTopicMetadata.add(new TopicMetadata(
-                                           Errors.TOPIC_AUTHORIZATION_FAILED,
-                                           topic,
-                                           KopTopic.isInternalTopic(topicName.toString(), metadataNamespace),
-                                           Collections.emptyList()));
-                                   completeOne.run();
-                                   return;
-                               }
-                               topicMap.computeIfAbsent(
-                                       topic,
-                                       ignored -> Collections.synchronizedList(new ArrayList<>())
-                               ).add(topicName);
-                               completeOne.run();
-                           })));
-                });
+                allTopicMap.forEach((topic, list) ->
+                        list.forEach((topicName ->
+                                topicMap.computeIfAbsent(topic, ignored -> new ArrayList<>()).add(topicName))
+                        )
+                );
+                log.info("WK allTopicMap {}", allTopicMap);
+                pulsarTopicsFuture.complete(allTopicMap);
             });
         } else {
             // get only the provided topics
@@ -2596,7 +2583,12 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 isAuthorizedFuture = authorizer.canProduceAsync(session.getPrincipal(), resource);
                 break;
             case DESCRIBE:
-                isAuthorizedFuture = authorizer.canLookupAsync(session.getPrincipal(), resource);
+                if (resource.getResourceType() == ResourceType.TOPIC) {
+                    isAuthorizedFuture = authorizer.canLookupAsync(session.getPrincipal(), resource);
+                }
+                if (resource.getResourceType() == ResourceType.NAMESPACE) {
+                    isAuthorizedFuture = authorizer.canGetTopicList(session.getPrincipal(), resource);
+                }
                 break;
             case CREATE:
                 isAuthorizedFuture = authorizer.canCreateTopicAsync(session.getPrincipal(), resource);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/Authorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/Authorizer.java
@@ -33,6 +33,17 @@ public interface Authorizer {
     CompletableFuture<Boolean> canLookupAsync(KafkaPrincipal principal, Resource resource);
 
     /**
+     * Check whether the specified role can list topic.
+     *
+     * For that the caller needs to have producer or consumer permission.
+     *
+     * @param principal login info
+     * @param resource resources to be authorized
+     * @return a boolean to determine whether authorized or not
+     */
+    CompletableFuture<Boolean> canGetTopicList(KafkaPrincipal principal, Resource resource);
+
+    /**
      * Check whether the specified role can access a Pulsar Tenant.
      *
      * @param principal login info

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/ResourceType.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/ResourceType.java
@@ -35,10 +35,16 @@ public enum ResourceType {
      */
     TOPIC((byte) 1),
 
+
+    /**
+     * A Pulsar Namespace.
+     */
+    NAMESPACE((byte) 2),
+
     /**
      * A Pulsar tenant.
      */
-    TENANT((byte) 2),
+    TENANT((byte) 3),
 
     ;
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.authorization.AuthorizationService;
+import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.NamespaceOperation;
 import org.apache.pulsar.common.policies.data.PolicyName;
@@ -142,6 +143,17 @@ public class SimpleAclAuthorizer implements Authorizer {
                 String.format("Expected resource type is TOPIC, but have [%s]", resource.getResourceType()));
         TopicName topicName = TopicName.get(resource.getName());
         return authorizationService.canLookupAsync(topicName, principal.getName(), principal.getAuthenticationData());
+    }
+
+    @Override
+    public CompletableFuture<Boolean> canGetTopicList(KafkaPrincipal principal, Resource resource) {
+        checkArgument(resource.getResourceType() == ResourceType.NAMESPACE,
+                String.format("Expected resource type is NAMESPACE, but have [%s]", resource.getResourceType()));
+        return authorizationService.allowNamespaceOperationAsync(
+                NamespaceName.get(resource.getName()),
+                NamespaceOperation.GET_TOPICS,
+                principal.getName(),
+                principal.getAuthenticationData());
     }
 
     @Override

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationTestBase.java
@@ -333,7 +333,7 @@ public abstract class KafkaAuthorizationTestBase extends KopProtocolHandlerTestB
         try {
             pulsarAdmin.topics().getList(TENANT + "/" + NAMESPACE);
             fail("Should fail with NotAuthorizedException");
-        } catch (Exception ex) {
+        } catch (PulsarAdminException ex) {
             assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
         }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationTestBase.java
@@ -307,7 +307,7 @@ public abstract class KafkaAuthorizationTestBase extends KopProtocolHandlerTestB
         }
     }
 
-    @Test()
+    @Test(timeOut = 20000)
     public void testListTopic() throws Exception {
         String newTopic = "newTestListTopic";
         String fullNewTopicName = "persistent://" + TENANT + "/" + NAMESPACE + "/" + newTopic;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaAuthorizationTestBase.java
@@ -333,8 +333,8 @@ public abstract class KafkaAuthorizationTestBase extends KopProtocolHandlerTestB
         try {
             pulsarAdmin.topics().getList(TENANT + "/" + NAMESPACE);
             fail("Should fail with NotAuthorizedException");
-        } catch (PulsarAdminException ex) {
-            assertTrue(ex instanceof PulsarAdminException.NotAuthorizedException);
+        } catch (PulsarAdminException.NotAuthorizedException ex) {
+            // ignore
         }
 
         // Use consumer to list topic

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
@@ -234,7 +234,7 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
             doReturn(CompletableFuture.completedFuture(true))
                     .when(spyHandler)
                     .authorize(eq(AclOperation.DESCRIBE),
-                            eq(Resource.of(ResourceType.TOPIC, TopicName.get(topic).getPartition(i).toString()))
+                            eq(Resource.of(ResourceType.NAMESPACE, TopicName.get(topic).getNamespace()))
                     );
         }
 


### PR DESCRIPTION
Fixes #1068 

### Motivation

Currently, we are using lookup to authorize the list topic permission, we should follow the pulsar way by using `validateNamespaceOperation(namespaceName, NamespaceOperation.GET_TOPICS);` to check the permission.

### Modifications

List topic use pulsar GET_TOPICS permission
