### PR TITLE
Fetch: do not decode data in critical BookKeeper OrderedExecutor thread

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -71,6 +71,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -2650,4 +2651,14 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             throw new AuthenticationException("Internal error while verifying tenant access:" + err, err);
         }
     }
+
+    /**
+     * Return the threadpool that executes the conversion of data during Fetches.
+     * We don't want to decode data inside the critical threads like the ManagedLedger Ordered Executor threads.
+     * @return a executor.
+     */
+    public Executor getDecodeExecutor() {
+        return this.executor;
+    }
+
 }


### PR DESCRIPTION
**Motivation**
During OMB testing @dave2wave noticed that the BookKeeperClientScheduler-OrderedScheduler-X-Y thread pool is busy in doing decoding work (from Pulsar -> Kafka) and this is something that may limit the efficiency of the system because that threadpool handles all the BookKeeper activities.

**Modifications**
With this patch we are performing the "decoding" from Pulsar -> Kafka (con the consumer code path) in a threadpool that is not the BookKeeper Ordered Executor pool (BookKeeperClientScheduler-OrderedScheduler-X-Y).

**Results**
With this patch @dave2wave reported far better performances using OMB:
> the test results show the BookKeeperClientWorker-OrderedExecutor is working much less than before. It is about 40-45% cpu in our OMB tests now. The equivalent Pulsar workload is about 20% cpu. Before this fix the process blocked at 95-100%

with this patch we are able to push OMB to 1 million messages/second even with `entryFormat:pulsar`, before this patch this was possible in that env only with `entryFormat:kafka`