### PR TITLE
Bump Pulsar version to 2.8.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
     <pulsar.group.id>io.streamnative</pulsar.group.id>
-    <pulsar.version>2.8.1.0</pulsar.version>
+    <pulsar.version>2.8.2.0</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testng.version>6.14.3</testng.version>


### PR DESCRIPTION
The https://github.com/apache/pulsar/pull/12600 changed behavior. 
Before this change, only tenant admin allow to list topics, after https://github.com/apache/pulsar/pull/12600, it allows consume permission list topics. 