### PR TITLE
Handle duplicate topic names requests in MetadataRequest

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -663,7 +663,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         // This map is used to find the original topic name. Both key and value don't have the "-partition-" suffix.
         final Map<String, String> fullTopicNameToOriginal = (request.topics() == null)
                 ? Collections.emptyMap()
-                : request.topics().stream().collect(
+                : request.topics().stream().distinct().collect(
                         Collectors.toMap(
                                 topic -> new KopTopic(topic, namespacePrefix).getFullName(),
                                 topic -> topic


### PR DESCRIPTION
This is fix for a regression introduced by fbd91a8880a10af0996aeac15d8de0b38712ad07

This is the error I am seeing in a system test that uses KSQLDB.
It refers to this line https://github.com/datastax/starlight-for-kafka/blob/a23423388ed5b476e3f30870370a066814cbd484/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java#L678 


> java.lang.IllegalStateException: Duplicate key persistent://public/default/_confluent-ksql-ktool_ksqldb__command_topic (attempted merging values _confluent-ksql-ktool_ksqldb__command_topic and _  (logs truncated.....)
> at java.util.stream.Collectors.duplicateKeyException(Collectors.java:133) ~[?:?]                                                                                                               > at java.util.stream.Collectors.lambda$uniqKeysMapAccumulator$1(Collectors.java:180) ~[?:?]                                                                                                     > at java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169) ~[?:?]                                                                                                                  > at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655) ~[?:?]                                                                                                       > at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) ~[?:?]                                                                                                                 > at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[?:?]      
> at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913) ~[?:?]                                                                                                           > at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]                                                                                                                > at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578) ~[?:?]                                                                                                               > at io.streamnative.pulsar.handlers.kop.KafkaRequestHandler.handleTopicMetadataRequest(KafkaRequestHandler.java:678) ~[4lTuHlI-OvogQpI9ZCLkuF8BmTtSg-BTfi4Po5ohsac/:?]                          │
> io.streamnative.pulsar.handlers.kop.KafkaCommandDecoder.channelRead(KafkaCommandDecoder.java:270) [4lTuHlI-OvogQpI9ZCLkuF8BmTtSg-BTfi4Po5ohsac/:?]                                          │
> io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [io.netty-netty-transport-4.1.74.Final.jar:4.1.74.Final]      
> 