### PR TITLE
Avoid listing non-persistent topics and optimize the bundle listener

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -41,7 +41,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -54,12 +53,11 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
-import org.apache.pulsar.broker.namespace.NamespaceBundleOwnershipListener;
+import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.protocol.ProtocolHandler;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
-import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
@@ -98,6 +96,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     @Getter
     private KopEventManager kopEventManager;
     private OrderedScheduler sendResponseScheduler;
+    private NamespaceBundleOwnershipListenerImpl bundleListener;
 
     private final Map<String, GroupCoordinator> groupCoordinatorsByTenant = new ConcurrentHashMap<>();
     private final Map<String, TransactionCoordinator> transactionCoordinatorByTenant = new ConcurrentHashMap<>();
@@ -134,266 +133,6 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                     entryFormatter,
                     producePurgatory);
         });
-    }
-
-    /**
-     * Listener for invalidating the global Broker ownership cache.
-     */
-    @AllArgsConstructor
-    public static class CacheInvalidator implements NamespaceBundleOwnershipListener {
-        final BrokerService service;
-
-        @Override
-        public boolean test(NamespaceBundle namespaceBundle) {
-            // we are interested in every topic,
-            // because we do not know which topics are served by KOP
-            return true;
-        }
-
-        private void invalidateBundleCache(NamespaceBundle bundle) {
-            log.info("invalidateBundleCache for namespaceBundle {}", bundle);
-            service.pulsar().getNamespaceService().getOwnedTopicListForNamespaceBundle(bundle)
-                    .whenComplete((topics, ex) -> {
-                        if (ex == null) {
-                            for (String topic : topics) {
-                                TopicName name = TopicName.get(topic);
-
-                                if (log.isDebugEnabled()) {
-                                    log.debug("invalidateBundleCache for topic {}", topic);
-                                }
-
-                                KafkaTopicManager.deReference(topic);
-
-                                // For non-partitioned topic.
-                                if (!name.isPartitioned()) {
-                                    String partitionedZeroTopicName = name.getPartition(0).toString();
-                                    KafkaTopicManager.deReference(partitionedZeroTopicName);
-                                }
-                            }
-                        } else {
-                            log.error("Failed to get owned topic list for "
-                                            + "CacheInvalidator when triggering bundle ownership change {}.",
-                                    bundle, ex);
-                        }
-                    }
-                    );
-        }
-        @Override
-        public void onLoad(NamespaceBundle bundle) {
-            invalidateBundleCache(bundle);
-        }
-        @Override
-        public void unLoad(NamespaceBundle bundle) {
-            invalidateBundleCache(bundle);
-        }
-    }
-
-    /**
-     * Listener for the changing of topic that stores offsets of consumer group.
-     */
-    public static class OffsetAndTopicListener implements NamespaceBundleOwnershipListener {
-
-        final BrokerService service;
-        final NamespaceName kafkaMetaNs;
-        final NamespaceName kafkaTopicNs;
-        final GroupCoordinator groupCoordinator;
-        final String brokerUrl;
-        final String metadataNamespace;
-
-        public OffsetAndTopicListener(BrokerService service,
-                                      String tenant,
-                                      KafkaServiceConfiguration kafkaConfig,
-                                      GroupCoordinator groupCoordinator) {
-            this.service = service;
-            this.kafkaMetaNs = NamespaceName
-                .get(tenant, kafkaConfig.getKafkaMetadataNamespace());
-            this.groupCoordinator = groupCoordinator;
-            this.kafkaTopicNs = NamespaceName
-                    .get(tenant, kafkaConfig.getKafkaNamespace());
-            this.brokerUrl = service.pulsar().getBrokerServiceUrl();
-            this.metadataNamespace = kafkaConfig.getKafkaMetadataNamespace();
-        }
-
-        @Override
-        public void onLoad(NamespaceBundle bundle) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] onLoad bundle: {}", brokerUrl, bundle);
-            }
-            // 1. get new partitions owned by this pulsar service.
-            // 2. load partitions by GroupCoordinator.handleGroupImmigration.
-            service.pulsar().getNamespaceService().getOwnedTopicListForNamespaceBundle(bundle)
-                .whenComplete((topics, ex) -> {
-                    if (ex == null) {
-                        log.info("get owned topic list when onLoad bundle {}, topic size {} ", bundle, topics.size());
-                        for (String topic : topics) {
-                            TopicName name = TopicName.get(topic);
-
-                            // already filtered namespace, check the local name without partition
-                            if (KopTopic.isGroupMetadataTopicName(topic, metadataNamespace)) {
-                                checkState(name.isPartitioned(),
-                                        "OffsetTopic should be partitioned in onLoad, but get " + name);
-
-                                if (log.isDebugEnabled()) {
-                                    log.debug("New offset partition load:  {}, broker: {}",
-                                            name, service.pulsar().getBrokerServiceUrl());
-                                }
-                                groupCoordinator.handleGroupImmigration(name.getPartitionIndex());
-                            }
-                        }
-                    } else {
-                        log.error("Failed to get owned topic list for "
-                            + "OffsetAndTopicListener when triggering on-loading bundle {}.",
-                            bundle, ex);
-                    }
-                });
-        }
-
-        @Override
-        public void unLoad(NamespaceBundle bundle) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] unLoad bundle: {}", brokerUrl, bundle);
-            }
-            // 1. get partitions owned by this pulsar service.
-            // 2. remove partitions by groupCoordinator.handleGroupEmigration.
-            service.pulsar().getNamespaceService().getOwnedTopicListForNamespaceBundle(bundle)
-                .whenComplete((topics, ex) -> {
-                    if (ex == null) {
-                        log.info("get owned topic list when unLoad bundle {}, topic size {} ", bundle, topics.size());
-                        for (String topic : topics) {
-                            TopicName name = TopicName.get(topic);
-
-                            // already filtered namespace, check the local name without partition
-                            if (KopTopic.isGroupMetadataTopicName(topic, metadataNamespace)) {
-                                checkState(name.isPartitioned(),
-                                        "OffsetTopic should be partitioned in unLoad, but get " + name);
-
-                                if (log.isDebugEnabled()) {
-                                    log.debug("Offset partition unload:  {}, broker: {}",
-                                            name, service.pulsar().getBrokerServiceUrl());
-                                }
-                                groupCoordinator.handleGroupEmigration(name.getPartitionIndex());
-                            }
-                        }
-                    } else {
-                        log.error("Failed to get owned topic list for "
-                            + "OffsetAndTopicListener when triggering un-loading bundle {}.",
-                            bundle, ex);
-                    }
-                });
-        }
-
-        // verify that this bundle is served by this broker,
-        // and namespace is related to kafka metadata namespace
-        @Override
-        public boolean test(NamespaceBundle namespaceBundle) {
-            return namespaceBundle.getNamespaceObject().equals(kafkaMetaNs)
-                    || namespaceBundle.getNamespaceObject().equals(kafkaTopicNs);
-        }
-
-    }
-
-    /**
-     * Listener for the changing of transaction topic when namespace bundle load or unload.
-     */
-    public static class TransactionStateRecover implements NamespaceBundleOwnershipListener {
-        private final BrokerService service;
-        private final NamespaceName kafkaMetaNs;
-        private final NamespaceName kafkaTopicNs;
-        private final String brokerUrl;
-        private final TransactionCoordinator txnCoordinator;
-        private final String metadataNamespace;
-
-        public TransactionStateRecover(
-                BrokerService service,
-                String tenant,
-                KafkaServiceConfiguration kafkaConfig,
-                TransactionCoordinator txnCoordinator) {
-            this.service = service;
-            this.kafkaMetaNs = NamespaceName
-                    .get(tenant, kafkaConfig.getKafkaMetadataNamespace());
-            this.kafkaTopicNs = NamespaceName
-                    .get(tenant, kafkaConfig.getKafkaNamespace());
-            this.brokerUrl = service.pulsar().getBrokerServiceUrl();
-            this.txnCoordinator = txnCoordinator;
-            this.metadataNamespace = kafkaConfig.getKafkaMetadataNamespace();
-        }
-
-        @Override
-        public void onLoad(NamespaceBundle bundle) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] onLoad bundle: {}", brokerUrl, bundle);
-            }
-            // 1. get new partitions owned by this pulsar service.
-            // 2. load partitions by TransactionCoordinator.handleTxnImmigration.
-            service.pulsar().getNamespaceService().getOwnedTopicListForNamespaceBundle(bundle)
-                    .whenComplete((topics, ex) -> {
-                        if (ex == null) {
-                            log.info("get owned topic list when onLoad bundle {}, topic size {} ",
-                                    bundle, topics.size());
-                            for (String topic : topics) {
-                                TopicName name = TopicName.get(topic);
-
-                                if (KopTopic.isTransactionMetadataTopicName(topic, metadataNamespace)) {
-                                    checkState(name.isPartitioned(),
-                                            "TxnTopic should be partitioned in onLoad, but get " + name);
-
-                                    if (log.isDebugEnabled()) {
-                                        log.debug("New transaction partition load:  {}, broker: {}",
-                                                name, service.pulsar().getBrokerServiceUrl());
-                                    }
-                                    txnCoordinator.handleTxnImmigration(name.getPartitionIndex());
-                                }
-                            }
-                        } else {
-                            log.error("Failed to get owned topic list for "
-                                            + "TransactionStateRecover when triggering on-loading bundle {}.",
-                                    bundle, ex);
-                        }
-                    });
-        }
-
-        @Override
-        public void unLoad(NamespaceBundle bundle) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] unLoad bundle: {}", brokerUrl, bundle);
-            }
-            // 1. get partitions owned by this pulsar service.
-            // 2. remove partitions by TransactionCoordinator.handleTxnImmigration.
-            service.pulsar().getNamespaceService().getOwnedTopicListForNamespaceBundle(bundle)
-                    .whenComplete((topics, ex) -> {
-                        if (ex == null) {
-                            log.info("get owned topic list when unLoad bundle {}, topic size {} ",
-                                    bundle, topics.size());
-                            for (String topic : topics) {
-                                TopicName name = TopicName.get(topic);
-
-                                if (KopTopic.isTransactionMetadataTopicName(topic, metadataNamespace)
-                                        && txnCoordinator != null) {
-                                    checkState(name.isPartitioned(),
-                                            "TxnTopic should be partitioned in unLoad, but get " + name);
-
-                                    if (log.isDebugEnabled()) {
-                                        log.debug("Txn partition unload: {}, broker: {}",
-                                                name, service.pulsar().getBrokerServiceUrl());
-                                    }
-                                    txnCoordinator.handleTxnEmigration(name.getPartitionIndex());
-                                }
-                            }
-                        } else {
-                            log.error("Failed to get owned topic list for "
-                                            + "TransactionStateRecover when triggering un-loading bundle {}.",
-                                    bundle, ex);
-                        }
-                    });
-        }
-
-        // Verify that this bundle is served by this broker,
-        // and namespace is related to kafka metadata namespace
-        @Override
-        public boolean test(NamespaceBundle namespaceBundle) {
-            return namespaceBundle.getNamespaceObject().equals(kafkaMetaNs)
-                    || namespaceBundle.getNamespaceObject().equals(kafkaTopicNs);
-        }
     }
 
     @Override
@@ -481,10 +220,34 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
             throw new IllegalStateException(ex);
         }
 
-        brokerService.pulsar()
-                .getNamespaceService()
-                .addNamespaceBundleOwnershipListener(
-                        new CacheInvalidator(brokerService));
+        final NamespaceService namespaceService = brokerService.pulsar().getNamespaceService();
+        bundleListener = new NamespaceBundleOwnershipListenerImpl(namespaceService,
+                brokerService.pulsar().getBrokerServiceUrl());
+        // Listener for invalidating the global Broker ownership cache
+        bundleListener.addTopicOwnershipListener(new TopicOwnershipListener() {
+            @Override
+            public void whenLoad(TopicName topicName) {
+                invalidateBundleCache(topicName);
+            }
+
+            @Override
+            public void whenUnload(TopicName topicName) {
+                invalidateBundleCache(topicName);
+            }
+
+            @Override
+            public String name() {
+                return "CacheInvalidator";
+            }
+
+            private void invalidateBundleCache(TopicName topicName) {
+                KafkaTopicManager.deReference(topicName.toString());
+                if (!topicName.isPartitioned()) {
+                    KafkaTopicManager.deReference(topicName.getPartition(0).toString());
+                }
+            }
+        });
+        namespaceService.addNamespaceBundleOwnershipListener(bundleListener);
 
         // initialize default Group Coordinator
         getGroupCoordinator(kafkaConfig.getKafkaMetadataTenant());
@@ -520,11 +283,34 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
             TransactionCoordinator transactionCoordinator =
                     initTransactionCoordinator(tenant, brokerService.getPulsar().getAdminClient(), clusterData);
             // Listening transaction topic load/unload
-            brokerService.pulsar()
-                    .getNamespaceService()
-                    .addNamespaceBundleOwnershipListener(
-                            new TransactionStateRecover(brokerService, tenant, kafkaConfig, transactionCoordinator));
+            final NamespaceName kafkaMetaNs = NamespaceName.get(tenant, kafkaConfig.getKafkaMetadataNamespace());
+            final NamespaceName kafkaTopicNs = NamespaceName.get(tenant, kafkaConfig.getKafkaNamespace());
+            final String metadataNamespace = kafkaConfig.getKafkaMetadataNamespace();
+            bundleListener.addTopicOwnershipListener(new TopicOwnershipListener() {
+                @Override
+                public void whenLoad(TopicName topicName) {
+                    if (KopTopic.isTransactionMetadataTopicName(topicName.toString(), metadataNamespace)) {
+                        transactionCoordinator.handleTxnImmigration(topicName.getPartitionIndex());
+                    }
+                }
 
+                @Override
+                public void whenUnload(TopicName topicName) {
+                    if (KopTopic.isTransactionMetadataTopicName(topicName.toString(), metadataNamespace)) {
+                        transactionCoordinator.handleTxnEmigration(topicName.getPartitionIndex());
+                    }
+                }
+
+                @Override
+                public String name() {
+                    return "TransactionStateRecover";
+                }
+
+                @Override
+                public boolean test(NamespaceName namespaceName) {
+                    return namespaceName.equals(kafkaMetaNs) || namespaceName.equals(kafkaTopicNs);
+                }
+            });
             return transactionCoordinator;
         } catch (Exception e) {
             log.error("Initialized transaction coordinator failed.", e);
@@ -550,10 +336,34 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
             groupCoordinator = startGroupCoordinator(tenant, offsetTopicClient);
 
             // and listener for Offset topics load/unload
-            brokerService.pulsar()
-                    .getNamespaceService()
-                    .addNamespaceBundleOwnershipListener(
-                            new OffsetAndTopicListener(brokerService, tenant, kafkaConfig, groupCoordinator));
+            final NamespaceName kafkaMetaNs = NamespaceName.get(tenant, kafkaConfig.getKafkaMetadataNamespace());
+            final NamespaceName kafkaTopicNs = NamespaceName.get(tenant, kafkaConfig.getKafkaNamespace());
+            final String metadataNamespace = kafkaConfig.getKafkaMetadataNamespace();
+            bundleListener.addTopicOwnershipListener(new TopicOwnershipListener() {
+                @Override
+                public void whenLoad(TopicName topicName) {
+                    if (KopTopic.isGroupMetadataTopicName(topicName.toString(), metadataNamespace)) {
+                        groupCoordinator.handleGroupImmigration(topicName.getPartitionIndex());
+                    }
+                }
+
+                @Override
+                public void whenUnload(TopicName topicName) {
+                    if (KopTopic.isGroupMetadataTopicName(topicName.toString(), metadataNamespace)) {
+                        groupCoordinator.handleGroupEmigration(topicName.getPartitionIndex());
+                    }
+                }
+
+                @Override
+                public String name() {
+                    return "OffsetAndTopicListener";
+                }
+
+                @Override
+                public boolean test(NamespaceName namespaceName) {
+                    return namespaceName.equals(kafkaMetaNs) || namespaceName.equals(kafkaTopicNs);
+                }
+            });
         } catch (Exception e) {
             log.error("Failed to create offset metadata", e);
             throw new IllegalStateException(e);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -303,7 +303,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
 
                 @Override
                 public String name() {
-                    return "TransactionStateRecover";
+                    return "TransactionStateRecover-" + transactionCoordinator.getTopicPartitionName();
                 }
 
                 @Override
@@ -356,7 +356,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
 
                 @Override
                 public String name() {
-                    return "OffsetAndTopicListener";
+                    return "OffsetAndTopicListener-" + groupCoordinator.getGroupManager().getTopicPartitionName();
                 }
 
                 @Override

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -284,7 +284,6 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                     initTransactionCoordinator(tenant, brokerService.getPulsar().getAdminClient(), clusterData);
             // Listening transaction topic load/unload
             final NamespaceName kafkaMetaNs = NamespaceName.get(tenant, kafkaConfig.getKafkaMetadataNamespace());
-            final NamespaceName kafkaTopicNs = NamespaceName.get(tenant, kafkaConfig.getKafkaNamespace());
             final String metadataNamespace = kafkaConfig.getKafkaMetadataNamespace();
             bundleListener.addTopicOwnershipListener(new TopicOwnershipListener() {
                 @Override
@@ -308,7 +307,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
 
                 @Override
                 public boolean test(NamespaceName namespaceName) {
-                    return namespaceName.equals(kafkaMetaNs) || namespaceName.equals(kafkaTopicNs);
+                    return namespaceName.equals(kafkaMetaNs);
                 }
             });
             return transactionCoordinator;
@@ -337,7 +336,6 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
 
             // and listener for Offset topics load/unload
             final NamespaceName kafkaMetaNs = NamespaceName.get(tenant, kafkaConfig.getKafkaMetadataNamespace());
-            final NamespaceName kafkaTopicNs = NamespaceName.get(tenant, kafkaConfig.getKafkaNamespace());
             final String metadataNamespace = kafkaConfig.getKafkaMetadataNamespace();
             bundleListener.addTopicOwnershipListener(new TopicOwnershipListener() {
                 @Override
@@ -361,7 +359,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
 
                 @Override
                 public boolean test(NamespaceName namespaceName) {
-                    return namespaceName.equals(kafkaMetaNs) || namespaceName.equals(kafkaTopicNs);
+                    return namespaceName.equals(kafkaMetaNs);
                 }
             });
         } catch (Exception e) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/NamespaceBundleOwnershipListenerImpl.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/NamespaceBundleOwnershipListenerImpl.java
@@ -1,0 +1,113 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.namespace.NamespaceBundleOwnershipListener;
+import org.apache.pulsar.broker.namespace.NamespaceService;
+import org.apache.pulsar.common.naming.NamespaceBundle;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicDomain;
+import org.apache.pulsar.common.naming.TopicName;
+
+@AllArgsConstructor
+@Slf4j
+public class NamespaceBundleOwnershipListenerImpl implements NamespaceBundleOwnershipListener {
+
+    private final List<TopicOwnershipListener> topicOwnershipListeners = new CopyOnWriteArrayList<>();
+    private final NamespaceService namespaceService;
+    private final String brokerUrl;
+
+    public void addTopicOwnershipListener(final TopicOwnershipListener listener) {
+        topicOwnershipListeners.add(listener);
+    }
+
+    @Override
+    public void onLoad(NamespaceBundle bundle) {
+        log.info("[{}] Load bundle: {}", brokerUrl, bundle);
+        getOwnedPersistentTopicList(bundle).whenComplete((topics, e) -> {
+            if (e != null) {
+                log.error("[{}] Failed to get owned topic list of {}", brokerUrl, bundle, e);
+                return;
+            }
+            topicOwnershipListeners.forEach(listener -> {
+                if (!listener.test(bundle.getNamespaceObject())) {
+                    return;
+                }
+                topics.forEach(topic -> {
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}][{}] Trigger load callback for {}", brokerUrl, listener.name(), topic);
+                    }
+                    listener.whenLoad(TopicName.get(topic));
+                });
+            });
+        });
+    }
+
+    @Override
+    public void unLoad(NamespaceBundle bundle) {
+        log.info("[{}] Unload bundle: {}", brokerUrl, bundle);
+        getOwnedPersistentTopicList(bundle).whenComplete((topics, e) -> {
+            if (e != null) {
+                log.error("[{}] Failed to get owned topic list of {}", brokerUrl, bundle, e);
+                return;
+            }
+            topicOwnershipListeners.forEach(listener -> {
+                if (!listener.test(bundle.getNamespaceObject())) {
+                    return;
+                }
+                topics.forEach(topic -> {
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}][{}] Trigger unload callback for {}", brokerUrl, listener.name(), topic);
+                    }
+                    listener.whenUnload(TopicName.get(topic));
+                });
+            });
+        });
+    }
+
+    @Override
+    public boolean test(NamespaceBundle bundle) {
+        return true;
+    }
+
+    // Kafka topics are always persistent so there is no need to get owned non-persistent topics.
+    // However, `NamespaceService#getOwnedTopicListForNamespaceBundle` calls `getFullListTopics`, which always calls
+    // `getListOfNonPersistentTopics`. So this method is a supplement to the existing NamespaceService API.
+    private CompletableFuture<List<String>> getOwnedPersistentTopicList(final NamespaceBundle bundle) {
+        final NamespaceName namespaceName = bundle.getNamespaceObject();
+        final CompletableFuture<List<String>> topicsFuture = namespaceService.getListOfPersistentTopics(namespaceName)
+                .thenApply(topics -> topics.stream()
+                        .filter(topic -> bundle.includes(TopicName.get(topic)))
+                        .collect(Collectors.toList()));
+        final CompletableFuture<List<String>> partitionsFuture =
+                namespaceService.getPartitions(namespaceName, TopicDomain.persistent)
+                        .thenApply(topics -> topics.stream()
+                                .filter(topic -> bundle.includes(TopicName.get(topic)))
+                                .collect(Collectors.toList()));
+        return topicsFuture.thenCombine(partitionsFuture, (topics, partitions) -> {
+            for (String partition : partitions) {
+                if (!topics.contains(partition)) {
+                    topics.add(partition);
+                }
+            }
+            return topics;
+        });
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/NamespaceBundleOwnershipListenerImpl.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/NamespaceBundleOwnershipListenerImpl.java
@@ -34,8 +34,13 @@ public class NamespaceBundleOwnershipListenerImpl implements NamespaceBundleOwne
     private final NamespaceService namespaceService;
     private final String brokerUrl;
 
+    /**
+     * @implNote Like {@link NamespaceService#addNamespaceBundleOwnershipListener}, when a new listener is added, the
+     * `onLoad` method should be called on each owned bundle if `test(bundle)` returns true.
+     */
     public void addTopicOwnershipListener(final TopicOwnershipListener listener) {
         topicOwnershipListeners.add(listener);
+        namespaceService.getOwnedServiceUnits().stream().filter(this).forEach(this::onLoad);
     }
 
     @Override

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/TopicOwnershipListener.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/TopicOwnershipListener.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import java.util.function.Predicate;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicName;
+
+/**
+ * Listener that is triggered when a topic's ownership changed via load or unload.
+ */
+public interface TopicOwnershipListener extends Predicate<NamespaceName> {
+
+    /**
+     * It's triggered when the topic is loaded by a broker.
+     *
+     * @param topicName
+     */
+    void whenLoad(TopicName topicName);
+
+    /**
+     * It's triggered when the topic is unloaded by a broker.
+     *
+     * @param topicName
+     */
+    void whenUnload(TopicName topicName);
+
+    /** Returns the name of the listener. */
+    String name();
+
+    default boolean test(NamespaceName namespaceName) {
+        return true;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/streamnative/kop/issues/1134

### Motivation

In KoP, when namespace bundle ownership changes, there's no need to get the owned non-persistent topics, while `getOwnedTopicListForNamespaceBundle` tries to get all owned topics. There is a bug when getting non-persistent topics at Pulsar side and exceptions might be thrown in the bundle listener's callback, which makes KoP not work well for the bundle load or unload events.

In addition, there are multiple implementations of `NamespaceBundleOwnershipListener` that are registered to the `NamespaceService`. Each listener calls the `getOwnedTopicListForNamespaceBundle` method, this is redundant.

### Modifications

- Only retain a common implementation of `NamespaceBundleOwnershipListener`. Implement a `getOwnedPersistentTopicList` to get only persistent topics of a bundle's owned topics.
- Allow `NamespaceBundleOwnershipListener` to register a `TopicOwnershipListener`, which processes a topic, for example, update the metadata cache, or call the immigration/emigration methods of group/transaction coordinator when the load or unload event happens. It also provides a `test` method to avoid iterating over the topics when the namespace doesn't match.
- Migrate the original implementations of `NamespaceBundleOwnershipListener` to `TopicOwnershipListener`.
- Remove the checks for the default topic namespace (`kafkaTopicNs`) when consumer group/transaction metadata topics are loaded or unloaded.