### PR TITLE
Fix NPE when managed ledger find entry failed

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManager.java
@@ -237,6 +237,9 @@ public class KafkaTopicConsumerManager implements Closeable {
         }
 
         return MessageMetadataUtils.asyncFindPosition(ledger, offset, skipMessagesWithoutIndex).thenApply(position -> {
+            if (position == null) {
+                return null;
+            }
             final String cursorName = "kop-consumer-cursor-" + topic.getName()
                     + "-" + position.getLedgerId() + "-" + position.getEntryId()
                     + "-" + DigestUtils.sha1Hex(UUID.randomUUID().toString()).substring(0, 10);


### PR DESCRIPTION
Fixes: #1137 

### Motivation

The `ManagedLedgerImpl#asyncFindPosition` method might return future null, when we use it we should check position is null first.


### Modifications
Add NULL check.