### PR TITLE
Fix NOT_COORDINATOR error caused by wrong brokers in Metadata response

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -705,6 +705,14 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                         CoreUtils.listToList(listPair.getFailedList(),
                                 metadata -> metadata.toTopicMetadata(getOriginalTopic, metadataNamespace))
                 );
+                topicMetadataList.forEach(topicMetadata ->
+                        topicMetadata.partitionMetadata().forEach(partitionMetadata -> {
+                            final Node leader = partitionMetadata.leader();
+                            if (allNodes.stream().noneMatch(node -> node.equals(leader))) {
+                                allNodes.add(leader);
+                            }
+                        })
+                );
                 resultFuture.complete(
                         KafkaResponseUtils.newMetadata(allNodes, clusterName, controllerId, topicMetadataList));
                 return null;


### PR DESCRIPTION
### Motivation

After https://github.com/streamnative/kop/pull/1107 was cherry-picked into branch-2.8.2, some tests of `KafkaListenerNameTest` are failed. Because that PR forgot to migrate the following code:

https://github.com/streamnative/kop/blob/51563feb582424251c8a8345ed9a7606546cf77e/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java#L792-L796

After that when the advertised listener is different with the listener, the brokers field in `MetadataResponse` doesn't contain the advertised listener, while the leader and ISR in `MetadataResponse.PartitionMetadata` use the advertised listener. Then Kafka client won't be able to find the advertised listener in brokers field.

### Modifications

Add the partition leader's node to the brokers field if the brokers field doesn't contain the node.
