### PR TITLE
Update tests with the correct way to configure multiple listeners

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -77,6 +77,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     private PrometheusMetricsProvider statsProvider;
     @Getter
     private KopBrokerLookupManager kopBrokerLookupManager;
+    @Getter
     private AdminManager adminManager = null;
     private SystemTopicClient txnTopicClient;
     private DelayedOperationPurgatory<DelayedOperation> producePurgatory;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -77,6 +77,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     private PrometheusMetricsProvider statsProvider;
     @Getter
     private KopBrokerLookupManager kopBrokerLookupManager;
+    @VisibleForTesting
     @Getter
     private AdminManager adminManager = null;
     private SystemTopicClient txnTopicClient;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -35,6 +35,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -81,6 +82,7 @@ import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.MockZooKeeper;
 import org.apache.zookeeper.data.ACL;
 import org.eclipse.jetty.server.Server;
+import org.testng.Assert;
 
 /**
  * Unit test to test KoP handler.
@@ -782,9 +784,20 @@ public abstract class KopProtocolHandlerTestBase {
         return adminProps;
     }
 
+    public KafkaProtocolHandler getProtocolHandler() {
+        return (KafkaProtocolHandler) pulsar.getProtocolHandlers().protocol("kafka");
+    }
+
+    public static <T> T getFirst(Set<T> set) {
+        Assert.assertNotNull(set);
+        final Iterator<T> iterator = set.iterator();
+        Assert.assertTrue(iterator.hasNext());
+        return iterator.next();
+    }
+
     public KafkaChannelInitializer getFirstChannelInitializer() {
-        final KafkaProtocolHandler handler = (KafkaProtocolHandler) pulsar.getProtocolHandlers().protocol("kafka");
-        return (KafkaChannelInitializer) handler.getChannelInitializerMap().entrySet().iterator().next().getValue();
+        return (KafkaChannelInitializer) getFirst(getProtocolHandler().getChannelInitializerMap().entrySet())
+                .getValue();
     }
 
     public KafkaRequestHandler newRequestHandler() throws Exception {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -795,11 +795,6 @@ public abstract class KopProtocolHandlerTestBase {
         return iterator.next();
     }
 
-    public KafkaChannelInitializer getFirstChannelInitializer() {
-        return (KafkaChannelInitializer) getFirst(getProtocolHandler().getChannelInitializerMap().entrySet())
-                .getValue();
-    }
-
     public KafkaRequestHandler newRequestHandler() throws Exception {
         final KafkaProtocolHandler handler = (KafkaProtocolHandler) pulsar.getProtocolHandlers().protocol("kafka");
         final GroupCoordinator groupCoordinator = handler.getGroupCoordinator(conf.getKafkaMetadataTenant());


### PR DESCRIPTION
Fixes https://github.com/streamnative/kop/issues/1142

### Motivation

Currently, `testConnectListenerNotExist` and `testMultipleListenerName` both use the legacy way to configure multiple listeners. Though KoP still supports the legacy way, see [listeners configuration in branch-2.8.2](https://github.com/streamnative/kop/blob/branch-2.8.2/docs/configuration.md#listeners), the advertised listener in METADATA response is not as expected. We should make it clear in tests.

### Modifications
- Use the correct way to configure multiple listeners in `testConnectListenerNotExist` and verify the brokers cache.
- Rename `testMultipleListenerName` to `testLegacyMultipleListenerName` and emphasize the brokers cache doesn't use the host name in `advertisedListeners`.
