### PR TITLE
Prevent endless 'Attempted to use a fenced managed ledger' errors loop while fetching from deleted partitions

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
@@ -328,4 +328,9 @@ public class KafkaTopicManager {
             log.error("Failed to close reference for individual topic {}. exception:", topicName, e);
         }
     }
+
+    public void invalidateCacheForFencedManagerLedgerOnTopic(String fullTopicName) {
+        log.info("Invalidating cache for fenced error on topic {} (maybe topic was deleted)", fullTopicName);
+        deReference(fullTopicName);
+    }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -571,8 +571,12 @@ public final class MessageFetchContext {
 
             @Override
             public void readEntriesFailed(ManagedLedgerException exception, Object ctx) {
-                log.error("Error read entry for topic: {}", KopTopic.toString(topicPartition, namespacePrefix));
-                messageReadStats.registerSuccessfulEvent(
+                String fullTopicName = KopTopic.toString(topicPartition, namespacePrefix);
+                log.error("Error read entry for topic: {}", fullTopicName);
+                if (exception instanceof ManagedLedgerException.ManagedLedgerFencedException) {
+                    topicManager.invalidateCacheForFencedManagerLedgerOnTopic(fullTopicName);
+                }
+                messageReadStats.registerFailedEvent(
                         MathUtils.elapsedNanos(startReadingMessagesNanos), TimeUnit.NANOSECONDS);
                 readFuture.completeExceptionally(exception);
             }


### PR DESCRIPTION
**Motivation**

If a partition is deleted, automatically or manually, fetches will result in this kind of errors, in loop:

> 0:17:55.335 [mock-pulsar-bk-OrderedScheduler-0-0:io.streamnative.pulsar.handlers.kop.KafkaTopicConsumerManager@250] DEBUG io.streamnative.pulsar.handlers.kop.KafkaTopicConsumerManager - [[id: 0xf66e59d5, L:/127.0.0.1:15003 - R:/127.0.0.1:59786]] Create cursor kop-consumer-cursor-persistent://public/default/test-delete-partition-partition-1-3-3-584719538a for offset: 3. position: 3:3, previousPosition: 3:2
> 10:17:55.335 [mock-pulsar-bk-OrderedScheduler-0-0:org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl@3501] ERROR org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl - [public/default/persistent/test-delete-partition-partition-1] Attempted to use a fenced managed ledger
> 10:17:55.335 [mock-pulsar-bk-OrderedScheduler-0-0:io.streamnative.pulsar.handlers.kop.KafkaTopicConsumerManager@259] ERROR io.streamnative.pulsar.handlers.kop.KafkaTopicConsumerManager - [[id: 0xf66e59d5, L:/127.0.0.1:15003 - R:/127.0.0.1:59786]] Error new cursor for topic persistent://public/default/test-delete-partition-partition-1 at offset 3 - 3:2. will cause fetch data error.
> org.apache.bookkeeper.mledger.ManagedLedgerException: java.lang.Exception: Attempted to use a fenced managed ledger
> Caused by: java.lang.Exception: Attempted to use a fenced managed ledger
> 	at org.apache.bookkeeper.mledger.ManagedLedgerException.<init>(ManagedLedgerException.java:80) ~[managed-ledger-2.8.3.1.0.1.jar:2.8.3.1.0.1]
> 	at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.checkFenced(ManagedLedgerImpl.java:3502) ~[managed-ledger-2.8.3.1.0.1.jar:2.8.3.1.0.1]
> 	at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.newNonDurableCursor(ManagedLedgerImpl.java:1042) ~[managed-ledger-2.8.3.1.0.1.jar:2.8.3.1.0.1]
> 	at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.newNonDurableCursor(ManagedLedgerImpl.java:1033) ~[managed-ledger-2.8.3.1.0.1.jar:2.8.3.1.0.1]
> 	at io.streamnative.pulsar.handlers.kop.KafkaTopicConsumerManager.lambda(KafkaTopicConsumerManager.java:254) ~[classes/:?]
> 	at java.util.concurrent.CompletableFuture.tryFire(CompletableFuture.java:642) ~[?:?]
> 	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
> 	at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2073) ~[?:?]
> 	at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.findEntryComplete(ManagedLedgerImpl.java:1662) ~[managed-ledger-2.8.3.1.0.1.jar:2.8.3.1.0.1]
> 	at org.apache.bookkeeper.mledger.impl.OpFindNewest.readEntryComplete(OpFindNewest.java:132) ~[managed-ledger-2.8.3.1.0.1.jar:2.8.3.1.0.1]
> 	at org.apache.bookkeeper.mledger.impl.EntryCacheImpl.lambda-zsh(EntryCacheImpl.java:229) ~[managed-ledger-2.8.3.1.0.1.jar:2.8.3.1.0.1]
> 	at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859) [?:?]
> 	at java.util.concurrent.CompletableFuture.tryFire(CompletableFuture.java:837) [?:?]
> 	at java.util.concurrent.CompletableFuture.run(CompletableFuture.java:478) [?:?]
> 	at java.util.concurrent.Executors.call(Executors.java:515) [?:?]
> 	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
> 	at java.util.concurrent.ScheduledThreadPoolExecutor.run(ScheduledThreadPoolExecutor.java:304) [?:?]
> 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
> 	at java.util.concurrent.ThreadPoolExecutor.run(ThreadPoolExecutor.java:628) [?:?]
> 	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-common-4.1.74.Final.jar:4.1.74.Final]
> 	at java.lang.Thread.run(Thread.java:829) [?:?]

	
** Modifications**

- Invalidate cache in case of ManagedLedgerFencedException
- add test case that reproduces the problem (the test case without this fix times out and you can see the errors in the logs)