### PR TITLE
Fix npe when update producer states

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
@@ -243,23 +243,15 @@ public class KafkaTopicManager {
 
     }
 
-    public void registerProducerInPersistentTopic(String topicName, PersistentTopic persistentTopic) {
+    public Optional<Producer> registerProducerInPersistentTopic(String topicName, PersistentTopic persistentTopic) {
         if (closed.get()) {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Failed to registerProducerInPersistentTopic for topic '{}'",
                         requestHandler.ctx.channel(), topicName);
             }
-            return;
+            return Optional.empty();
         }
-        if (references.containsKey(topicName)) {
-            return;
-        }
-        synchronized (this) {
-            if (references.containsKey(topicName)) {
-                return;
-            }
-            references.put(topicName, registerInPersistentTopic(persistentTopic));
-        }
+        return Optional.of(references.computeIfAbsent(topicName, (__) -> registerInPersistentTopic(persistentTopic)));
     }
 
     // when channel close, release all the topics reference in persistentTopic

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
@@ -280,10 +280,6 @@ public class KafkaTopicManager {
         }
     }
 
-    public static Producer getReferenceProducer(String topicName) {
-        return references.get(topicName);
-    }
-
     private static void removePersistentTopicAndReferenceProducer(final String topicName) {
         // 1. Remove PersistentTopic and Producer from caches, these calls are thread safe
         final CompletableFuture<Optional<PersistentTopic>> topicFuture = topics.remove(topicName);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/EncodeResult.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/EncodeResult.java
@@ -22,10 +22,8 @@ import static io.streamnative.pulsar.handlers.kop.KopServerStats.TOPIC_SCOPE;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.util.Recycler;
-import io.streamnative.pulsar.handlers.kop.KafkaTopicManager;
 import io.streamnative.pulsar.handlers.kop.RequestStats;
 import io.streamnative.pulsar.handlers.kop.stats.StatsLogger;
-import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
 import java.util.concurrent.TimeUnit;
 import lombok.Getter;
 import org.apache.kafka.common.TopicPartition;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/EncodeResult.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/EncodeResult.java
@@ -85,11 +85,9 @@ public class EncodeResult {
 
     public void updateProducerStats(final TopicPartition topicPartition,
                                     final RequestStats requestStats,
-                                    final String namespacePrefix) {
+                                    final Producer producer) {
         final int numBytes = encodedByteBuf.readableBytes();
 
-        final Producer producer = KafkaTopicManager
-                .getReferenceProducer(KopTopic.toString(topicPartition, namespacePrefix));
         producer.updateRates(numMessages, numBytes);
         producer.getTopic().incrementPublishCount(numMessages, numBytes);
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -83,7 +83,6 @@ public class PartitionLog {
     private final KafkaServiceConfiguration kafkaConfig;
     private final Time time;
     private final TopicPartition topicPartition;
-    private final String namespacePrefix;
     private final String fullPartitionName;
     private final EntryFormatter entryFormatter;
     private final ProducerStateManager producerStateManager;
@@ -259,10 +258,13 @@ public class PartitionLog {
             return;
         }
 
-        appendRecordsContext.getTopicManager().registerProducerInPersistentTopic(fullPartitionName, persistentTopic);
-
-        // collect metrics
-        encodeResult.updateProducerStats(topicPartition, requestStats, namespacePrefix);
+        appendRecordsContext
+                .getTopicManager()
+                .registerProducerInPersistentTopic(fullPartitionName, persistentTopic)
+                .ifPresent((producer) -> {
+                    // collect metrics
+                    encodeResult.updateProducerStats(topicPartition, requestStats, producer);
+                });
 
         final int numMessages = encodeResult.getNumMessages();
         final ByteBuf byteBuf = encodeResult.getEncodedByteBuf();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
@@ -46,7 +46,7 @@ public class PartitionLogManager {
         String kopTopic = KopTopic.toString(topicPartition, namespacePrefix);
 
         return logMap.computeIfAbsent(kopTopic, key ->
-                new PartitionLog(kafkaConfig, time, topicPartition, namespacePrefix, kopTopic, formatter,
+                new PartitionLog(kafkaConfig, time, topicPartition, kopTopic, formatter,
                         new ProducerStateManager(kopTopic))
         );
     }

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EncodePerformanceTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EncodePerformanceTest.java
@@ -46,7 +46,6 @@ public class EncodePerformanceTest {
             Time.SYSTEM,
             new TopicPartition("test", 1),
             "test",
-            "test",
             null,
             new ProducerStateManager("test"));
 

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterTest.java
@@ -71,7 +71,6 @@ public class EntryFormatterTest {
             Time.SYSTEM,
             new TopicPartition("test", 1),
             "test",
-            "test",
             null,
             new ProducerStateManager("test"));
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogTest.java
@@ -44,7 +44,6 @@ public class PartitionLogTest {
             Time.SYSTEM,
             new TopicPartition("test", 1),
             "test",
-            "test",
             null,
             new ProducerStateManager("test"));
 


### PR DESCRIPTION
Fixes: #1147

### Motivation

See: #1147

The NPE happened when `KafkaTopicManager#references` removed the producer before `getReferenceProducer`. 


### Modifications

Use `computeIfAbsent` to make sure we can get a producer instance before we use it.


### Documentation

Need to update docs? 

- [x] `no-need-doc` 
  
This is a bug fix no need for docs.
