### PR TITLE
KafkaMessageOrderKafkaTest: prevent spammy logs due to wrong entry in Kafka format received by the Pulsar consumer

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaMessageOrderTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaMessageOrderTestBase.java
@@ -102,7 +102,7 @@ public abstract class KafkaMessageOrderTestBase extends KopProtocolHandlerTestBa
             }
 
             final Properties props = new Properties();
-            props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getClientPort());
+            props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getKafkaBrokerPort());
             props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
             props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
             props.put(ProducerConfig.BATCH_SIZE_CONFIG, batchSize); // avoid all messages are in a single batch
@@ -160,7 +160,7 @@ public abstract class KafkaMessageOrderTestBase extends KopProtocolHandlerTestBa
 
             // 3. Consume messages use Kafka consumer.
             @Cleanup
-            KConsumer kConsumer = new KConsumer(topicName, getClientPort(), "testKafkaProduce-KafkaConsume");
+            KConsumer kConsumer = new KConsumer(topicName, getKafkaBrokerPort(), "testKafkaProduce-KafkaConsume");
             kConsumer.getConsumer().subscribe(Collections.singleton(topicName));
             for (int i = 0; i < totalMsgs; ) {
                 ConsumerRecords<Integer, String> records = kConsumer.getConsumer().poll(Duration.ofSeconds(1));

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaMessageOrderTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaMessageOrderTestBase.java
@@ -89,83 +89,94 @@ public abstract class KafkaMessageOrderTestBase extends KopProtocolHandlerTestBa
         // create partitioned topic with 1 partition.
         pulsar.getAdminClient().topics().createPartitionedTopic(topicName, 1);
 
-        @Cleanup
-        Consumer<byte[]> consumer = pulsarClient.newConsumer()
-            .topic(pulsarTopicName)
-            .subscriptionName("testKafkaProduce-PulsarConsume")
-            .subscribe();
-
-        final Properties props = new Properties();
-        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getKafkaBrokerPort());
-        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
-        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-        props.put(ProducerConfig.BATCH_SIZE_CONFIG, batchSize); // avoid all messages are in a single batch
-
-        // 1. produce message with Kafka producer.
-        @Cleanup
-        KafkaProducer<Integer, String> producer = new KafkaProducer<>(props);
-
-        int totalMsgs = 100;
-        String messageStrPrefix = "Message_Kop_KafkaProducePulsarConsumeOrder_";
-
-        for (int i = 0; i < totalMsgs; i++) {
-            final int index = i;
-            producer.send(new ProducerRecord<>(topicName, i, messageStrPrefix + i), (recordMetadata, e) -> {
-                assertNull(e);
-                log.info("Success write message {} to offset {}", index, recordMetadata.offset());
-            });
-        }
-
-        // 2. Consume messages use Pulsar client Consumer.
-        if (conf.getEntryFormat().equals("pulsar")) {
-            Message<byte[]> msg = null;
-            int numBatches = 0;
-            for (int i = 0; i < totalMsgs; i++) {
-                msg = consumer.receive(1000, TimeUnit.MILLISECONDS);
-                assertNotNull(msg);
-                Integer key = kafkaIntDeserialize(Base64.getDecoder().decode(msg.getKey()));
-                assertEquals(messageStrPrefix + key.toString(), new String(msg.getValue()));
-
-                if (log.isDebugEnabled()) {
-                    log.debug("Pulsar consumer get i: {} message: {}, key: {}",
-                            i,
-                            new String(msg.getData()),
-                            kafkaIntDeserialize(Base64.getDecoder().decode(msg.getKey())).toString());
-                }
-                assertEquals(i, key.intValue());
-
-                consumer.acknowledge(msg);
-
-                BatchMessageIdImpl id =
-                        (BatchMessageIdImpl) ((TopicMessageIdImpl) msg.getMessageId()).getInnerMessageId();
-                if (id.getBatchIndex() == 0) {
-                    numBatches++;
-                }
+        Consumer<byte[]> consumer = null;
+        try {
+            if (conf.getEntryFormat().equals("pulsar")) {
+                // start the Pulsar Consumer only if we are using Pulsar format
+                // otherwise it will receive messages that cannot be deserialized in the background
+                // consumer loop.
+                consumer = pulsarClient.newConsumer()
+                        .topic(pulsarTopicName)
+                        .subscriptionName("testKafkaProduce-PulsarConsume")
+                        .subscribe();
             }
 
-            // verify have received all messages
-            msg = consumer.receive(100, TimeUnit.MILLISECONDS);
-            assertNull(msg);
-            // Check number of batches is in range (1, totalMsgs) to avoid each batch has only one message or all
-            // messages are batched into a single batch.
-            log.info("Successfully write {} batches of {} messages to bookie", numBatches, totalMsgs);
-            assertTrue(numBatches > 1 && numBatches < totalMsgs);
-        }
+            final Properties props = new Properties();
+            props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getClientPort());
+            props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
+            props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+            props.put(ProducerConfig.BATCH_SIZE_CONFIG, batchSize); // avoid all messages are in a single batch
 
-        // 3. Consume messages use Kafka consumer.
-        @Cleanup
-        KConsumer kConsumer = new KConsumer(topicName, getKafkaBrokerPort(), "testKafkaProduce-KafkaConsume");
-        kConsumer.getConsumer().subscribe(Collections.singleton(topicName));
-        for (int i = 0; i < totalMsgs; ) {
-            ConsumerRecords<Integer, String> records = kConsumer.getConsumer().poll(Duration.ofSeconds(1));
-            if (log.isDebugEnabled()) {
-                for (ConsumerRecord<Integer, String> record : records) {
-                    log.debug("Kafka consumer get i: {} message: {}, key: {}", i, record.value(), record.key());
-                    assertEquals(record.key().intValue(), i);
-                    i++;
+            // 1. produce message with Kafka producer.
+            @Cleanup
+            KafkaProducer<Integer, String> producer = new KafkaProducer<>(props);
+
+            int totalMsgs = 100;
+            String messageStrPrefix = "Message_Kop_KafkaProducePulsarConsumeOrder_";
+
+            for (int i = 0; i < totalMsgs; i++) {
+                final int index = i;
+                producer.send(new ProducerRecord<>(topicName, i, messageStrPrefix + i), (recordMetadata, e) -> {
+                    assertNull(e);
+                    log.info("Success write message {} to offset {}", index, recordMetadata.offset());
+                });
+            }
+
+            // 2. Consume messages use Pulsar client Consumer.
+            if (conf.getEntryFormat().equals("pulsar")) {
+                Message<byte[]> msg = null;
+                int numBatches = 0;
+                for (int i = 0; i < totalMsgs; i++) {
+                    msg = consumer.receive(1000, TimeUnit.MILLISECONDS);
+                    assertNotNull(msg);
+                    Integer key = kafkaIntDeserialize(Base64.getDecoder().decode(msg.getKey()));
+                    assertEquals(messageStrPrefix + key.toString(), new String(msg.getValue()));
+
+                    if (log.isDebugEnabled()) {
+                        log.debug("Pulsar consumer get i: {} message: {}, key: {}",
+                                i,
+                                new String(msg.getData()),
+                                kafkaIntDeserialize(Base64.getDecoder().decode(msg.getKey())).toString());
+                    }
+                    assertEquals(i, key.intValue());
+
+                    consumer.acknowledge(msg);
+
+                    BatchMessageIdImpl id =
+                            (BatchMessageIdImpl) ((TopicMessageIdImpl) msg.getMessageId()).getInnerMessageId();
+                    if (id.getBatchIndex() == 0) {
+                        numBatches++;
+                    }
                 }
-            } else {
-                i += records.count();
+
+                // verify have received all messages
+                msg = consumer.receive(100, TimeUnit.MILLISECONDS);
+                assertNull(msg);
+                // Check number of batches is in range (1, totalMsgs) to avoid each batch has only one message or all
+                // messages are batched into a single batch.
+                log.info("Successfully write {} batches of {} messages to bookie", numBatches, totalMsgs);
+                assertTrue(numBatches > 1 && numBatches < totalMsgs);
+            }
+
+            // 3. Consume messages use Kafka consumer.
+            @Cleanup
+            KConsumer kConsumer = new KConsumer(topicName, getClientPort(), "testKafkaProduce-KafkaConsume");
+            kConsumer.getConsumer().subscribe(Collections.singleton(topicName));
+            for (int i = 0; i < totalMsgs; ) {
+                ConsumerRecords<Integer, String> records = kConsumer.getConsumer().poll(Duration.ofSeconds(1));
+                if (log.isDebugEnabled()) {
+                    for (ConsumerRecord<Integer, String> record : records) {
+                        log.debug("Kafka consumer get i: {} message: {}, key: {}", i, record.value(), record.key());
+                        assertEquals(record.key().intValue(), i);
+                        i++;
+                    }
+                } else {
+                    i += records.count();
+                }
+            }
+        } finally {
+            if (consumer != null) {
+                consumer.close();
             }
         }
     }


### PR DESCRIPTION
Fixes #464 

This patches prevent these errors in the logs:
```
22:10:10.220 [pulsar-client-io-35-1:org.apache.pulsar.client.impl.ClientCnx@282] WARN  org.apache.pulsar.client.impl.ClientCnx - [localhost/127.0.0.1:15002] Got exception java.lang.IllegalStateException: Some required fields are missing
	at org.apache.pulsar.common.api.proto.SingleMessageMetadata.checkRequiredFields(SingleMessageMetadata.java:478)
	at org.apache.pulsar.common.api.proto.SingleMessageMetadata.parseFrom(SingleMessageMetadata.java:473)
	at org.apache.pulsar.common.protocol.Commands.deSerializeSingleMessageInBatch(Commands.java:1635)
	at org.apache.pulsar.client.impl.ConsumerImpl.receiveIndividualMessagesFromBatch(ConsumerImpl.java:1257)
	at org.apache.pulsar.client.impl.ConsumerImpl.messageReceived(ConsumerImpl.java:1084)
	at org.apache.pulsar.client.impl.ClientCnx.handleMessage(ClientCnx.java:448)
	at org.apache.pulsar.common.protocol.PulsarDecoder.channelRead(PulsarDecoder.java:186)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:327)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:314)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:435)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:279)
```

