### PR TITLE
[Test] Change JUnit to TestNG

### DIFF
--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataTest.java
@@ -18,11 +18,11 @@ import static io.streamnative.pulsar.handlers.kop.coordinator.group.GroupState.D
 import static io.streamnative.pulsar.handlers.kop.coordinator.group.GroupState.Empty;
 import static io.streamnative.pulsar.handlers.kop.coordinator.group.GroupState.PreparingRebalance;
 import static io.streamnative.pulsar.handlers.kop.coordinator.group.GroupState.Stable;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import com.google.common.collect.Sets;
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupMetadata.CommitRecordMetadataAndOffset;
@@ -35,8 +35,8 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import lombok.val;
 import org.apache.kafka.common.TopicPartition;
-import org.junit.Before;
-import org.junit.Test;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 /**
  * Unit test {@link GroupMetadata}.
@@ -53,7 +53,7 @@ public class GroupMetadataTest {
 
     private GroupMetadata group = null;
 
-    @Before
+    @BeforeMethod
     public void setUp() {
         group = new GroupMetadata(groupId, Empty);
     }
@@ -134,12 +134,12 @@ public class GroupMetadataTest {
         assertState(group, Stable);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expectedExceptions = IllegalStateException.class)
     public void testEmptyToStableIllegalTransition() {
         group.transitionTo(Stable);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expectedExceptions = IllegalStateException.class)
     public void testStableToStableIllegalTransition() {
         group.transitionTo(PreparingRebalance);
         group.transitionTo(CompletingRebalance);
@@ -148,24 +148,24 @@ public class GroupMetadataTest {
         fail("should have failed due to illegal transition");
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expectedExceptions = IllegalStateException.class)
     public void testEmptyToAwaitingRebalanceIllegalTransition() {
         group.transitionTo(CompletingRebalance);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expectedExceptions = IllegalStateException.class)
     public void testPreparingRebalanceToPreparingRebalanceIllegalTransition() {
         group.transitionTo(PreparingRebalance);
         group.transitionTo(PreparingRebalance);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expectedExceptions = IllegalStateException.class)
     public void testPreparingRebalanceToStableIllegalTransition() {
         group.transitionTo(PreparingRebalance);
         group.transitionTo(Stable);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expectedExceptions = IllegalStateException.class)
     public void testAwaitingRebalanceToAwaitingRebalanceIllegalTransition() {
         group.transitionTo(PreparingRebalance);
         group.transitionTo(CompletingRebalance);
@@ -180,21 +180,21 @@ public class GroupMetadataTest {
         assertState(group, Dead);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expectedExceptions = IllegalStateException.class)
     public void testDeadToStableIllegalTransition() {
         group.transitionTo(PreparingRebalance);
         group.transitionTo(Dead);
         group.transitionTo(Stable);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expectedExceptions = IllegalStateException.class)
     public void testDeadToPreparingRebalanceIllegalTransition() {
         group.transitionTo(PreparingRebalance);
         group.transitionTo(Dead);
         group.transitionTo(PreparingRebalance);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expectedExceptions = IllegalStateException.class)
     public void testDeadToAwaitingRebalanceIllegalTransition() {
         group.transitionTo(PreparingRebalance);
         group.transitionTo(Dead);
@@ -218,7 +218,7 @@ public class GroupMetadataTest {
             protocols);
 
         group.add(member);
-        assertEquals("range", group.selectProtocol());
+        assertEquals(group.selectProtocol(), "range");
 
         String otherMemberId = "otherMemberId";
         protocols = new LinkedHashMap<>();
@@ -257,7 +257,7 @@ public class GroupMetadataTest {
         assertEquals("roundrobin", group.selectProtocol());
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expectedExceptions = IllegalStateException.class)
     public void testSelectProtocolRaisesIfNoMembers() {
         group.selectProtocol();
         fail("Should not reach here");

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/MemberMetadataTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/MemberMetadataTest.java
@@ -13,17 +13,17 @@
  */
 package io.streamnative.pulsar.handlers.kop.coordinator.group;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
 
 import com.google.common.collect.Sets;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import org.junit.Test;
+import org.testng.annotations.Test;
 import org.testng.collections.Maps;
 
 /**
@@ -82,8 +82,8 @@ public class MemberMetadataTest {
         protocols.put("roundrobin", new byte[0]);
 
         MemberMetadata member = newMember(protocols);
-        assertEquals("range", member.vote(Sets.newHashSet("range", "roundrobin")));
-        assertEquals("roundrobin", member.vote(Sets.newHashSet("blah", "roundrobin")));
+        assertEquals(member.vote(Sets.newHashSet("range", "roundrobin")), "range");
+        assertEquals(member.vote(Sets.newHashSet("blah", "roundrobin")), "roundrobin");
     }
 
     @Test
@@ -101,7 +101,7 @@ public class MemberMetadataTest {
             memberMetadata.metadata("roundrobin"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void testMetadataRaisesOnUnsupportedProtocol() {
         Map<String, byte[]> protocols = new LinkedHashMap<>();
         protocols.put("range", new byte[0]);
@@ -112,7 +112,7 @@ public class MemberMetadataTest {
         fail("Should not reach here");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void testVoteRaisesOnUnsupportedProtocols() {
         Map<String, byte[]> protocols = new LinkedHashMap<>();
         protocols.put("range", new byte[0]);

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/MemberMetadataTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/MemberMetadataTest.java
@@ -17,7 +17,6 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
-import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
 
 import com.google.common.collect.Sets;
 import java.util.HashMap;
@@ -93,12 +92,12 @@ public class MemberMetadataTest {
         protocols.put("roundrobin", new byte[] { 0xe });
 
         MemberMetadata memberMetadata = newMember(protocols);
-        assertArrayEquals(
-            new byte[] { 0xf },
-            memberMetadata.metadata("range"));
-        assertArrayEquals(
-            new byte[] { 0xe },
-            memberMetadata.metadata("roundrobin"));
+        assertEquals(
+                memberMetadata.metadata("range"),
+                new byte[] { 0xf });
+        assertEquals(
+                memberMetadata.metadata("roundrobin"),
+                new byte[] { 0xe });
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/TestSSLUtils.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/TestSSLUtils.java
@@ -27,8 +27,8 @@ import java.util.List;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
-import org.junit.Test;
 import org.testng.Assert;
+import org.testng.annotations.Test;
 
 /**
  * Test SSLUtils.

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/TestUtils.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/TestUtils.java
@@ -13,7 +13,7 @@
  */
 package io.streamnative.pulsar.handlers.kop.utils;
 
-import static org.junit.Assert.fail;
+import static org.testng.Assert.fail;
 
 import java.util.function.Supplier;
 import lombok.SneakyThrows;

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/delayed/DelayedOperationTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/delayed/DelayedOperationTest.java
@@ -14,9 +14,9 @@
 package io.streamnative.pulsar.handlers.kop.utils.delayed;
 
 import static io.streamnative.pulsar.handlers.kop.utils.CoreUtils.inLock;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
 
 import com.google.common.collect.Lists;
 import io.streamnative.pulsar.handlers.kop.utils.TestUtils;
@@ -41,9 +41,9 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.SneakyThrows;
 import org.apache.kafka.common.utils.Time;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 /**
  * Unit test {@link DelayedOperation}.
@@ -134,14 +134,14 @@ public class DelayedOperationTest {
     DelayedOperationPurgatory<MockDelayedOperation> purgatory = null;
     ScheduledExecutorService executorService = null;
 
-    @Before
+    @BeforeMethod
     public void setup() {
         purgatory = DelayedOperationPurgatory.<MockDelayedOperation>builder()
             .purgatoryName("mock")
             .build();
     }
 
-    @After
+    @AfterMethod
     public void teardown() {
         purgatory.shutdown();
         if (null != executorService) {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndTestBase.java
@@ -311,7 +311,7 @@ public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
             ConsumerRecords<Integer, String> records = kConsumer.getConsumer().poll(Duration.ofSeconds(1));
             for (ConsumerRecord<Integer, String> record : records) {
                 Integer key = record.key();
-                assertEquals(messageStrPrefix + key.toString(), record.value());
+                assertEquals(record.value(), messageStrPrefix + key.toString());
 
                 if (log.isDebugEnabled()) {
                     log.debug("Kafka consumer get message: {}, key: {} at offset {}",

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DelayAuthorizationFailedCloseTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DelayAuthorizationFailedCloseTest.java
@@ -15,6 +15,7 @@ package io.streamnative.pulsar.handlers.kop;
 
 import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import com.google.common.collect.Sets;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -44,7 +45,6 @@ import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.impl.auth.AuthenticationToken;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.awaitility.Awaitility;
-import org.junit.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -198,7 +198,7 @@ public class DelayAuthorizationFailedCloseTest extends KopProtocolHandlerTestBas
         try {
             selector.poll(50);
         } catch (IOException e) {
-            Assert.fail("Caught unexpected exception " + e);
+            fail("Caught unexpected exception " + e);
         }
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
@@ -15,8 +15,8 @@ package io.streamnative.pulsar.handlers.kop;
 
 import static org.apache.kafka.common.internals.Topic.GROUP_METADATA_TOPIC_NAME;
 import static org.apache.pulsar.common.naming.TopicName.PARTITIONED_TOPIC_SUFFIX;
-import static org.junit.Assert.assertTrue;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -39,7 +39,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
-import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
@@ -173,7 +172,7 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
         }
 
         List<String> brokers =  admin.brokers().getActiveBrokers(configClusterName);
-        Assert.assertEquals(brokers.size(), 2);
+        assertEquals(2, brokers.size());
         log.info("broker1: {} broker2: {}", brokers.get(0), brokers.get(1));
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/IdempotentProducerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/IdempotentProducerTest.java
@@ -13,7 +13,7 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import java.time.Duration;
 import java.util.Collections;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
@@ -16,7 +16,6 @@ package io.streamnative.pulsar.handlers.kop;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.DEFAULT_FETCH_MAX_BYTES;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.DEFAULT_MAX_PARTITION_FETCH_BYTES;
 import static org.apache.pulsar.common.naming.TopicName.PARTITIONED_TOPIC_SUFFIX;
-import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -26,6 +25,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaIdleConnectionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaIdleConnectionTest.java
@@ -13,6 +13,7 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
+import static org.testng.Assert.fail;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 
@@ -29,7 +30,6 @@ import org.apache.kafka.common.network.Selector;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.awaitility.Awaitility;
-import org.junit.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -114,7 +114,7 @@ public class KafkaIdleConnectionTest extends KopProtocolHandlerTestBase {
         try {
             selector.poll(50);
         } catch (IOException e) {
-            Assert.fail("Caught unexpected exception " + e);
+            fail("Caught unexpected exception " + e);
         }
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/KStreamAggregationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/KStreamAggregationTest.java
@@ -16,8 +16,8 @@ package io.streamnative.pulsar.handlers.kop.streams;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/utils/timer/TimerTaskListTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/utils/timer/TimerTaskListTest.java
@@ -13,14 +13,14 @@
  */
 package io.streamnative.pulsar.handlers.kop.utils.timer;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import io.streamnative.pulsar.handlers.kop.utils.timer.TimerTaskList.TimerTaskEntry;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 /**
  * Unit test {@link TimerTaskList}.
@@ -59,50 +59,50 @@ public class TimerTaskListTest {
         List<TimerTask> tasks = IntStream.rangeClosed(1, 10).mapToObj(i -> {
             TestTask task = new TestTask(0L);
             list1.add(new TimerTaskEntry(task, 10L));
-            assertEquals(i, sharedCounter.get());
+            assertEquals(sharedCounter.get(), i);
             return task;
         }).collect(Collectors.toList());
 
-        assertEquals(tasks.size(), sharedCounter.get());
+        assertEquals(sharedCounter.get(), tasks.size());
 
         // reinserting the existing tasks shouldn't change the task count.
         tasks.subList(0, 4).forEach(task -> {
             int prevCount = sharedCounter.get();
             // new TimerTaskEntry(task) will remove the existing entry from the list
             list2.add(new TimerTaskEntry(task, 10L));
-            assertEquals(prevCount, sharedCounter.get());
+            assertEquals(sharedCounter.get(), prevCount);
         });
-        assertEquals(10 - 4, size(list1));
-        assertEquals(4, size(list2));
-        assertEquals(tasks.size(), sharedCounter.get());
+        assertEquals(size(list1), 10 - 4);
+        assertEquals(size(list2), 4);
+        assertEquals(sharedCounter.get(), tasks.size());
 
         // reinserting the existing tasks shouldn't change the task count
         tasks.subList(4, 10).forEach(task -> {
             int prevCount = sharedCounter.get();
             // new TimerTaskEntry(task) will remove the existing entry from the list
             list3.add(new TimerTaskEntry(task, 10L));
-            assertEquals(prevCount, sharedCounter.get());
+            assertEquals(sharedCounter.get(), prevCount);
         });
-        assertEquals(0, size(list1));
-        assertEquals(4, size(list2));
-        assertEquals(6, size(list3));
-        assertEquals(tasks.size(), sharedCounter.get());
+        assertEquals(size(list1), 0);
+        assertEquals(size(list2), 4);
+        assertEquals(size(list3), 6);
+        assertEquals(sharedCounter.get(), tasks.size());
 
         // cancel tasks in the lists
         list1.forEach(TimerTask::cancel);
-        assertEquals(0, size(list1));
-        assertEquals(4, size(list2));
-        assertEquals(6, size(list3));
+        assertEquals(size(list1), 0);
+        assertEquals(size(list2), 4);
+        assertEquals(size(list3), 6);
 
         list2.forEach(TimerTask::cancel);
-        assertEquals(0, size(list1));
-        assertEquals(0, size(list2));
-        assertEquals(6, size(list3));
+        assertEquals(size(list1), 0);
+        assertEquals(size(list2), 0);
+        assertEquals(size(list3), 6);
 
         list3.forEach(TimerTask::cancel);
-        assertEquals(0, size(list1));
-        assertEquals(0, size(list2));
-        assertEquals(0, size(list3));
+        assertEquals(size(list1), 0);
+        assertEquals(size(list2), 0);
+        assertEquals(size(list3), 0);
     }
 
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/utils/timer/TimerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/utils/timer/TimerTest.java
@@ -13,8 +13,9 @@
  */
 package io.streamnative.pulsar.handlers.kop.utils.timer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.testng.Assert.fail;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
@@ -27,9 +28,9 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.utils.Time;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 /**
  * Unit test {@link Timer}.
@@ -65,7 +66,7 @@ public class TimerTest {
 
     private Timer timer = null;
 
-    @Before
+    @BeforeMethod
     public void setup() {
         this.timer = SystemTimer.builder()
             .executorName("test")
@@ -75,7 +76,7 @@ public class TimerTest {
             .build();
     }
 
-    @After
+    @AfterMethod
     public void teardown() {
         timer.shutdown();
     }
@@ -93,10 +94,7 @@ public class TimerTest {
 
         latches.forEach(latch -> {
             try {
-                assertEquals(
-                    "already expired tasks should run immediately",
-                    true,
-                    latch.await(3, TimeUnit.SECONDS));
+                assertTrue("already expired tasks should run immediately", latch.await(3, TimeUnit.SECONDS));
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 fail("Should not reach here");


### PR DESCRIPTION
### Motivation

We should use TestNG instead of JUnit in the KoP units test.

### Modifications

Change all Junit to TestNG

### Documentation

- [x] `no-need-doc` 
  

