### PR TITLE
Fix when store group id failed the find coordinator future never complete

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -889,10 +889,10 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                         log.warn("Store groupId failed, the groupId might already stored.", ex);
                     }
                     findBroker(TopicName.get(pulsarTopicName))
-                            .thenAccept(node -> {
-                                if (node.error() != Errors.NONE) {
+                            .whenComplete((node, throwable) -> {
+                                if (node.error() != Errors.NONE || throwable != null) {
                                     log.error("[{}] Request {}: Error while find coordinator.",
-                                            ctx.channel(), findCoordinator.getHeader());
+                                            ctx.channel(), findCoordinator.getHeader(), throwable);
 
                                     resultFuture.complete(KafkaResponseUtils
                                             .newFindCoordinator(Errors.LEADER_NOT_AVAILABLE));

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -882,29 +882,30 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         String groupIdPath = GroupIdUtils.groupIdPathFormat(findCoordinator.getClientHost(),
                 findCoordinator.getHeader().clientId());
 
-        // Store group name to metadata store for current client.
+        // Store group name to metadata store for current client, use to collect consumer metrics.
         storeGroupId(groupId, groupIdPath)
-                .thenAccept(__ -> findBroker(TopicName.get(pulsarTopicName))
-                        .thenAccept(node -> {
-                            if (node.error() != Errors.NONE) {
-                                log.error("[{}] Request {}: Error while find coordinator.",
-                                        ctx.channel(), findCoordinator.getHeader());
+                .whenComplete((__, ex) -> {
+                    if (ex != null) {
+                        log.warn("Store groupId failed, the groupId might already stored.", ex);
+                    }
+                    findBroker(TopicName.get(pulsarTopicName))
+                            .thenAccept(node -> {
+                                if (node.error() != Errors.NONE) {
+                                    log.error("[{}] Request {}: Error while find coordinator.",
+                                            ctx.channel(), findCoordinator.getHeader());
 
-                                resultFuture.complete(KafkaResponseUtils
-                                        .newFindCoordinator(Errors.LEADER_NOT_AVAILABLE));
-                                return;
-                            }
+                                    resultFuture.complete(KafkaResponseUtils
+                                            .newFindCoordinator(Errors.LEADER_NOT_AVAILABLE));
+                                    return;
+                                }
 
-                            if (log.isDebugEnabled()) {
-                                log.debug("[{}] Found node {} as coordinator for key {} partition {}.",
-                                        ctx.channel(), node.leader(), request.coordinatorKey(), partition);
-                            }
+                                if (log.isDebugEnabled()) {
+                                    log.debug("[{}] Found node {} as coordinator for key {} partition {}.",
+                                            ctx.channel(), node.leader(), request.coordinatorKey(), partition);
+                                }
 
-                            resultFuture.complete(KafkaResponseUtils.newFindCoordinator(node.leader()));
-                        }))
-                .exceptionally(ex -> {
-                    log.error("Store groupId failed.", ex);
-                    return null;
+                                resultFuture.complete(KafkaResponseUtils.newFindCoordinator(node.leader()));
+                            });
                 });
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -909,7 +909,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 });
     }
 
-    private CompletableFuture<Void> storeGroupId(String groupId, String groupIdPath) {
+    @VisibleForTesting
+    protected CompletableFuture<Void> storeGroupId(String groupId, String groupIdPath) {
         String path = groupIdStoredPath + groupIdPath;
         CompletableFuture<Void> future = new CompletableFuture<>();
         metadataStore.put(path, groupId.getBytes(UTF_8), Optional.empty())


### PR DESCRIPTION
### Motivation

Currently, when store group id failed, the `resultFuture` will never complete, it will cause client request timeout, we should continue the subsequent operations whether store group id is successful or not. Since the group id is only used to collect consumer metrics.

### Modifications

1. Continue the subsequent operations whether store group id is successful or not.
2. Add units test to verify it.

### Documentation


- [x] `no-need-doc` 
  

