### PR TITLE
Fix flaky testDeletePartition by sending to specific partitions

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
@@ -424,12 +424,12 @@ public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
         kafkaReceives = receiveMessages(kafkaConsumer, expectValues.size());
         assertEquals(kafkaReceives.stream().sorted().collect(Collectors.toList()), expectValues);
 
-
-        sendSingleMessages(kafkaProducer, topic, Arrays.asList("g", "h", "i"));
-
+        kafkaProducer.send(new ProducerRecord<>(topic, 0, null, "g")).get();
+        kafkaProducer.send(new ProducerRecord<>(topic, 1, null, "h")).get();
+        kafkaProducer.send(new ProducerRecord<>(topic, 0, null, "i")).get();
 
         pulsar.getAdminClient().topics().delete(topic + "-partition-1", true);
-        // "h" is usually written to Partition 1, so deleting partition-1 means that we lose "h"
+        // "h" is written to Partition 1, so deleting partition-1 means that we lose "h"
         expectValues = Arrays.asList("g", "i");
 
         kafkaReceives = receiveMessages(kafkaConsumer, expectValues.size());


### PR DESCRIPTION
Fixes #1161

### Motivation

The `testDeletePartition` relies on the fact that `h` has been sent to partition 1. However, Kafka's default partition assignor cannot guarantee that. See example debug logs:

```
KafkaProducer send 'g' to test-delete-partition-partition-1@3
KafkaProducer send 'h' to test-delete-partition-partition-0@3
KafkaProducer send 'i' to test-delete-partition-partition-1@3
```

These three messages (`g`, `h`, `i`) were sent in a round robin way. However, `h` was sent to partition 0 while `g` and `i` were sent to partition 1, which was deleted later. Then the Kafka consumer can only receive 1 message and `receiveMessages` will be stuck because the expected number of messages is 2.

### Modifications

Send `g`, `h`, `i` to the specific partitions directly using the following overload of `ProducerRecord`:

```java
ProducerRecord(String topic, Integer partition, K key, V value);
```


### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)