### PR TITLE
Disable testIdempotentProducer for batch send

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/IdempotentProducerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/IdempotentProducerTest.java
@@ -65,7 +65,9 @@ public class IdempotentProducerTest extends KopProtocolHandlerTestBase {
     protected static Object[][] produceConfigProvider() {
         // isBatch
         return new Object[][]{
-                {true},
+                // TODO: Currently when batching is enabled, the testIdempotentProducer is flaky in CI env, see
+                //  https://github.com/streamnative/kop/issues/1053. Disable the test first.
+                //{true},
                 {false}
         };
     }


### PR DESCRIPTION
### Motivation

It's a workaround for https://github.com/streamnative/kop/issues/1053. Disable the test to make CI stable.

### Modifications

Only run `testIdempotentProducer` for non-batch send.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

