### PR TITLE
add send queue config for system client

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -184,6 +184,12 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
 
     @FieldContext(
             category = CATEGORY_KOP,
+            doc = "send queue size of system client to produce system topic."
+    )
+    private int maxPendingMessages = 10000;
+
+    @FieldContext(
+            category = CATEGORY_KOP,
             doc = "Zookeeper path for storing kop consumer group"
     )
     private String groupIdZooKeeperPath = "/client_group_id";

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -186,7 +186,7 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
             category = CATEGORY_KOP,
             doc = "send queue size of system client to produce system topic."
     )
-    private int maxPendingMessages = 10000;
+    private int kafkaMetaMaxPendingMessages = 10000;
 
     @FieldContext(
             category = CATEGORY_KOP,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SystemTopicClient.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SystemTopicClient.java
@@ -30,7 +30,7 @@ public class SystemTopicClient extends AbstractPulsarClient {
     public SystemTopicClient(final PulsarService pulsarService, final KafkaServiceConfiguration kafkaConfig) {
         // Disable stats recorder for producer and readers
         super(createPulsarClient(pulsarService, kafkaConfig, conf -> conf.setStatsIntervalSeconds(0L)));
-        maxPendingMessages = kafkaConfig.getMaxPendingMessages();
+        maxPendingMessages = kafkaConfig.getKafkaMetaMaxPendingMessages();
     }
 
     public ProducerBuilder<ByteBuffer> newProducerBuilder() {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SystemTopicClient.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SystemTopicClient.java
@@ -25,13 +25,18 @@ import org.apache.pulsar.client.api.Schema;
  */
 public class SystemTopicClient extends AbstractPulsarClient {
 
+    private final int maxPendingMessages;
+
     public SystemTopicClient(final PulsarService pulsarService, final KafkaServiceConfiguration kafkaConfig) {
         // Disable stats recorder for producer and readers
         super(createPulsarClient(pulsarService, kafkaConfig, conf -> conf.setStatsIntervalSeconds(0L)));
+        maxPendingMessages = kafkaConfig.getMaxPendingMessages();
     }
 
     public ProducerBuilder<ByteBuffer> newProducerBuilder() {
-        return getPulsarClient().newProducer(Schema.BYTEBUFFER);
+        return getPulsarClient().newProducer(Schema.BYTEBUFFER)
+                .maxPendingMessages(maxPendingMessages)
+                .blockIfQueueFull(true);
     }
 
     public ReaderBuilder<ByteBuffer> newReaderBuilder() {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
@@ -578,11 +578,9 @@ public class GroupMetadataManager {
                     });
                 }
 
-                if (log.isDebugEnabled()) {
-                    log.debug("Offset commit {} from group {}, consumer {} with generation {} failed"
-                            + " when appending to log due to ",
+                log.error("Offset commit {} from group {}, consumer {} with generation {} failed"
+                                + " when appending to log due to ",
                         filteredOffsetMetadata, group.groupId(), consumerId, group.generationId(), cause);
-                }
 
                 return Errors.UNKNOWN_SERVER_ERROR;
             })


### PR DESCRIPTION
Fixes #1146

### Motivation

See #1146

### Modifications

1. Add `blockIfQueueFull` when create system producer
2. Add `maxPendingMessages` configuration for system producer. I suggest change the default value from 1000 to 10000, since offset topic's payload is small (less than 200 bytes), it won't take mush memory and could avoid send queue full happen.

### Documentation
  
- [x] `no-need-doc` 

