### PR TITLE
Follow namespace configuration for Auto Topic Creation

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -498,7 +498,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                             if (!allowed) {
                                 log.error("[{}] Automatic topic creation is not allowed on namespace {}",
                                         ctx.channel(), namespace);
-                                future.complete(TopicAndMetadata.AUTHORIZATION_FAILURE);
+                                future.complete(TopicAndMetadata.INVALID_PARTITIONS);
                             } else {
                                 log.info("[{}] Topic {} doesn't exist, auto create it with {} partitions",
                                         ctx.channel(), topicName, defaultNumPartitions);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -44,7 +43,6 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -99,12 +97,9 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
-import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
-import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
@@ -651,11 +646,7 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
     }
 
     private KafkaHeaderAndRequest createTopicMetadataRequest(List<String> topics) {
-        return createTopicMetadataRequest(topics, true);
-    }
-
-    private KafkaHeaderAndRequest createTopicMetadataRequest(List<String> topics, boolean allowAutoTopicCreation) {
-        AbstractRequest.Builder builder = new MetadataRequest.Builder(topics, allowAutoTopicCreation);
+        AbstractRequest.Builder builder = new MetadataRequest.Builder(topics, true);
         return buildRequest(builder);
     }
 
@@ -812,89 +803,7 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
             maxPartitionBytes, maxResponseBytes, messagesPerPartition);
     }
 
-    @DataProvider(name = "allowAutoTopicCreation")
-    public static Object[][] allowAutoTopicCreation() {
-        return new Object[][]{
-                { true, true, true },
-                { true, true, false},
-                { true, false, true },
-                { true, false, false},
-                { true, null, true },
-                { true, null, false},
-                { false, true, true },
-                { false, true, false},
-                { false, false, true },
-                { false, false, false},
-                { false, null, true },
-                { false, null, false}
-        };
-    }
-
     // verify Metadata request handling.
-    @Test(timeOut = 20000, dataProvider = "allowAutoTopicCreation")
-    public void testBrokerHandleTopicMetadataRequestAllowAutoTopicCreation(boolean brokerAllowAutoTopicCreation,
-                                                     Boolean overrideNameSpaceAutoTopicCreation,
-                                                     boolean allowAutoTopicCreationInRequest) throws Exception {
-        boolean original = conf.isAllowAutoTopicCreation();
-        try {
-            conf.setAllowAutoTopicCreation(brokerAllowAutoTopicCreation);
-            boolean expectedAllowTopicCreation = overrideNameSpaceAutoTopicCreation != null
-                    ? overrideNameSpaceAutoTopicCreation : conf.isAllowAutoTopicCreation();
-            if (overrideNameSpaceAutoTopicCreation != null) {
-                // override per-namespace
-                admin.namespaces().setAutoTopicCreation("public/default", AutoTopicCreationOverride
-                        .builder()
-                        .allowAutoTopicCreation(overrideNameSpaceAutoTopicCreation)
-                        .defaultNumPartitions(conf.getDefaultNumPartitions())
-                        .topicType("partitioned")
-                        .build());
-                Policies policies = admin.namespaces().getPolicies("public/default");
-                assertEquals(policies.autoTopicCreationOverride.isAllowAutoTopicCreation(),
-                        overrideNameSpaceAutoTopicCreation.booleanValue());
-            } else {
-                admin.namespaces().removeAutoTopicCreation("public/default");
-                Policies policies = admin.namespaces().getPolicies("public/default");
-                assertNull(policies.autoTopicCreationOverride);
-            }
-
-            String topicName = "kopBrokerHandleTopicMetadataRequest-" + brokerAllowAutoTopicCreation + "-"
-                    + overrideNameSpaceAutoTopicCreation + "-"
-                    + allowAutoTopicCreationInRequest;
-            List<String> kafkaTopics = Arrays.asList(topicName);
-            KafkaHeaderAndRequest metadataRequest =
-                    createTopicMetadataRequest(kafkaTopics, allowAutoTopicCreationInRequest);
-            CompletableFuture<AbstractResponse> responseFuture = new CompletableFuture<>();
-            kafkaRequestHandler.handleTopicMetadataRequest(metadataRequest, responseFuture);
-            MetadataResponse metadataResponse = (MetadataResponse) responseFuture.get();
-
-            final Errors expectedError;
-            if (expectedAllowTopicCreation) {
-                if (allowAutoTopicCreationInRequest) {
-                    // topic will be created
-                    expectedError = null;
-                    assertEquals(1, metadataResponse.topicMetadata().size());
-                    assertEquals(topicName, metadataResponse.topicMetadata().iterator().next().topic());
-                } else {
-                    // topic does not exist and it is not created
-                    expectedError = Errors.UNKNOWN_TOPIC_OR_PARTITION;
-                }
-            } else {
-                if (allowAutoTopicCreationInRequest) {
-                    expectedError = Errors.TOPIC_AUTHORIZATION_FAILED;
-                } else {
-                    // topic does not exist and it is not created
-                    expectedError = Errors.UNKNOWN_TOPIC_OR_PARTITION;
-                }
-            }
-            log.info("errors {}", metadataResponse.errors());
-            assertEquals(expectedError, metadataResponse.errors().get(topicName));
-        } finally {
-            conf.setAllowAutoTopicCreation(original);
-            admin.namespaces().removeAutoTopicCreation("public/default");
-        }
-    }
-
-    // verify Metadata request handling
     @Test(timeOut = 20000)
     public void testBrokerHandleTopicMetadataRequest() throws Exception {
         String topicName = "kopBrokerHandleTopicMetadataRequest";

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -38,9 +38,11 @@ import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupMetadataManage
 import io.streamnative.pulsar.handlers.kop.offset.OffsetAndMetadata;
 import io.streamnative.pulsar.handlers.kop.utils.TopicNameUtils;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -84,6 +86,8 @@ import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.types.Struct;
+import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.requests.AbstractResponse;
 import org.apache.kafka.common.requests.ApiVersionsRequest;
 import org.apache.kafka.common.requests.ApiVersionsResponse;
@@ -104,6 +108,8 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
+import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.testng.Assert;
@@ -1082,6 +1088,121 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
         }
         assertNotNull(causeException);
         assertTrue(causeException instanceof RecordTooLargeException);
+    }
+
+
+    @DataProvider(name = "allowAutoTopicCreation")
+    public static Object[][] allowAutoTopicCreation() {
+        return new Object[][]{
+                { true, true, true },
+                { true, true, false },
+                { true, false, true },
+                { true, false, false },
+                { true, null, true },
+                { true, null, false },
+                { false, true, true },
+                { false, true, false },
+                { false, false, true },
+                { false, false, false },
+                { false, null, true },
+                { false, null, false }
+        };
+    }
+
+    // verify Metadata request handling.
+    @Test(timeOut = 20000, dataProvider = "allowAutoTopicCreation")
+    public void testBrokerHandleTopicMetadataRequestAllowAutoTopicCreation(boolean brokerAllowAutoTopicCreation,
+                                                                           Boolean overrideNameSpaceAutoTopicCreation,
+                                                                           boolean allowAutoTopicCreationInRequest)
+            throws Exception {
+        boolean original = conf.isAllowAutoTopicCreation();
+        try {
+            conf.setAllowAutoTopicCreation(brokerAllowAutoTopicCreation);
+            boolean expectedAllowTopicCreation = overrideNameSpaceAutoTopicCreation != null
+                    ? overrideNameSpaceAutoTopicCreation : conf.isAllowAutoTopicCreation();
+            if (overrideNameSpaceAutoTopicCreation != null) {
+                // override per-namespace
+                admin.namespaces().setAutoTopicCreation("public/default", AutoTopicCreationOverride
+                        .builder()
+                        .allowAutoTopicCreation(overrideNameSpaceAutoTopicCreation)
+                        .defaultNumPartitions(conf.getDefaultNumPartitions())
+                        .topicType("partitioned")
+                        .build());
+                Policies policies = admin.namespaces().getPolicies("public/default");
+                assertEquals(policies.autoTopicCreationOverride.isAllowAutoTopicCreation(),
+                        overrideNameSpaceAutoTopicCreation.booleanValue());
+            } else {
+                admin.namespaces().removeAutoTopicCreation("public/default");
+                Policies policies = admin.namespaces().getPolicies("public/default");
+                assertNull(policies.autoTopicCreationOverride);
+            }
+
+            String topicName = "kopBrokerHandleTopicMetadataRequest-" + brokerAllowAutoTopicCreation + "-"
+                    + overrideNameSpaceAutoTopicCreation + "-"
+                    + allowAutoTopicCreationInRequest;
+            List<String> kafkaTopics = Arrays.asList(topicName);
+            KafkaHeaderAndRequest metadataRequest =
+                    createTopicMetadataRequest(kafkaTopics, allowAutoTopicCreationInRequest);
+            CompletableFuture<AbstractResponse> responseFuture = new CompletableFuture<>();
+            handler.handleTopicMetadataRequest(metadataRequest, responseFuture);
+            MetadataResponse metadataResponse = (MetadataResponse) responseFuture.get();
+
+            final Errors expectedError;
+            if (expectedAllowTopicCreation) {
+                if (allowAutoTopicCreationInRequest) {
+                    // topic will be created
+                    expectedError = null;
+                    assertEquals(1, metadataResponse.topicMetadata().size());
+                    assertEquals(topicName, metadataResponse.topicMetadata().iterator().next().topic());
+                } else {
+                    // topic does not exist and it is not created
+                    expectedError = Errors.UNKNOWN_TOPIC_OR_PARTITION;
+                }
+            } else {
+                if (allowAutoTopicCreationInRequest) {
+                    // topic does not exist and it cannot be created
+                    expectedError = Errors.UNKNOWN_TOPIC_OR_PARTITION;
+                } else {
+                    // topic does not exist and it is not created
+                    expectedError = Errors.UNKNOWN_TOPIC_OR_PARTITION;
+                }
+            }
+            log.info("errors {}", metadataResponse.errors());
+            assertEquals(expectedError, metadataResponse.errors().get(topicName));
+        } finally {
+            conf.setAllowAutoTopicCreation(original);
+            admin.namespaces().removeAutoTopicCreation("public/default");
+        }
+    }
+
+    private KafkaHeaderAndRequest createTopicMetadataRequest(List<String> topics, boolean allowAutoTopicCreation) {
+        AbstractRequest.Builder builder = new MetadataRequest.Builder(topics, allowAutoTopicCreation);
+        return buildRequest(builder);
+    }
+
+
+    private KafkaHeaderAndRequest buildRequest(AbstractRequest.Builder builder) {
+        SocketAddress serviceAddress = InetSocketAddress.createUnresolved("localhost", 1111);
+        return buildRequest(builder, serviceAddress);
+    }
+
+    public static KafkaHeaderAndRequest buildRequest(AbstractRequest.Builder builder,
+                                                     SocketAddress serviceAddress) {
+        AbstractRequest request = builder.build();
+        builder.apiKey();
+
+        ByteBuffer serializedRequest = request
+                .serialize(new RequestHeader(builder.apiKey(), request.version(), "fake_client_id", 0));
+
+        ByteBuf byteBuf = Unpooled.copiedBuffer(serializedRequest);
+
+        RequestHeader header = RequestHeader.parse(serializedRequest);
+
+        ApiKeys apiKey = header.apiKey();
+        short apiVersion = header.apiVersion();
+        Struct struct = apiKey.parseRequest(apiVersion, serializedRequest);
+        AbstractRequest body = AbstractRequest.parseRequest(apiKey, apiVersion, struct);
+        return new KafkaHeaderAndRequest(header, body, byteBuf, serviceAddress);
     }
 
 }


### PR DESCRIPTION
### Motivation

Currently KOP does not follow the configuration set on the Namespace for autoTopicCreation, but only broker.conf

### Modifications

Verify namespace Policies in case of Topic Not Found error, and behave like Pulsar.

### Verifying this change

This change added tests

### Documentation

Need to update docs? 

- [x] `no-need-doc` 
