### PR TITLE
Fix message disorder issue

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -278,7 +278,11 @@ public class PartitionLog {
         } else {
             offsetFuture = publishNormalMessage(persistentTopic, byteBuf, appendInfo);
         }
-
+        try {
+            TimeUnit.MILLISECONDS.sleep(400);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
         offsetFuture.whenComplete((offset, e) -> {
             appendRecordsContext.getCompleteSendOperationForThrottling().accept(byteBuf.readableBytes());
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/IdempotentProducerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/IdempotentProducerTest.java
@@ -85,7 +85,6 @@ public class IdempotentProducerTest extends KopProtocolHandlerTestBase {
         Properties producerProperties = newKafkaProducerProperties();
         producerProperties.put(ProducerConfig.CLIENT_ID_CONFIG, "test-client");
         producerProperties.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
-        producerProperties.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1);
 
         try (KafkaProducer<String, String> producer = new KafkaProducer<>(producerProperties)) {
             for (int i = 0; i < maxMessageNum; i++) {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/IdempotentProducerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/IdempotentProducerTest.java
@@ -65,9 +65,7 @@ public class IdempotentProducerTest extends KopProtocolHandlerTestBase {
     protected static Object[][] produceConfigProvider() {
         // isBatch
         return new Object[][]{
-                // TODO: Currently when batching is enabled, the testIdempotentProducer is flaky in CI env, see
-                //  https://github.com/streamnative/kop/issues/1053. Disable the test first.
-                //{true},
+                {true},
                 {false}
         };
     }
@@ -87,6 +85,7 @@ public class IdempotentProducerTest extends KopProtocolHandlerTestBase {
         Properties producerProperties = newKafkaProducerProperties();
         producerProperties.put(ProducerConfig.CLIENT_ID_CONFIG, "test-client");
         producerProperties.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
+        producerProperties.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1);
 
         try (KafkaProducer<String, String> producer = new KafkaProducer<>(producerProperties)) {
             for (int i = 0; i < maxMessageNum; i++) {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
@@ -910,7 +910,7 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
         verifySendMessageToPartition(topicPartition,
                 newIdempotentRecords(0, (short) 0, 0, 1), Errors.NONE, 1);
         verifySendMessageToPartition(topicPartition,
-                newIdempotentRecords(0, (short) 0, 0, 1), Errors.DUPLICATE_SEQUENCE_NUMBER, -1);
+                newIdempotentRecords(0, (short) 0, 0, 1), Errors.OUT_OF_ORDER_SEQUENCE_NUMBER, -1);
         verifySendMessageToPartition(topicPartition,
                 newIdempotentRecords(0, (short) 0, 1, 1), Errors.NONE, 2);
         verifySendMessageToPartition(topicPartition,
@@ -924,7 +924,7 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
         verifySendMessageToPartition(topicPartition,
                 newIdempotentRecords(2, (short) 0, 10, 10), Errors.NONE, 15);
         verifySendMessageToPartition(topicPartition,
-                newIdempotentRecords(2, (short) 0, 10, 10), Errors.DUPLICATE_SEQUENCE_NUMBER, -1);
+                newIdempotentRecords(2, (short) 0, 10, 10), Errors.OUT_OF_ORDER_SEQUENCE_NUMBER, -1);
     }
 
     private void verifySendMessageToPartition(final TopicPartition topicPartition,


### PR DESCRIPTION
### Motivation

Currently, the produced message might be disorder, because `topicFuture ` might already done, so we have not queued the produce future.  this future finish might disorder.

See:
https://github.com/streamnative/kop/blob/c03cd9ec2c8da8078b45151f598469b8af4dfb6d/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java#L224-L231

We can add a sleep in `publishMessages` method, it will increase the reproduction probability.
```java
// For control message we don't need to check deduplication.
if (appendInfo.isControlBatch()) {
    offsetFuture = publishControlMessage(persistentTopic, byteBuf, numMessages);
} else {
    offsetFuture = publishNormalMessage(persistentTopic, byteBuf, appendInfo);
}
try {
    TimeUnit.MILLISECONDS.sleep(400);
} catch (InterruptedException e) {
    e.printStackTrace();
}
```

The second problem is we need to use `Errors.OUT_OF_ORDER_SEQUENCE_NUMBER ` instead of `Errors.DUPLICATE_SEQUENCE_NUMBER `, the `DUPLICATE_SEQUENCE_NUMBER` is used to client-side exception.

### Modifications

1. Make sure all produce future are queued
2. Use `Errors.OUT_OF_ORDER_SEQUENCE_NUMBER` instead of `Errors.DUPLICATE_SEQUENCE_NUMBER`
3. Handle `MessageDeduplication.MessageDupUnknownException` exception


### Documentation

Need to update docs? 

- [ ] `doc-required` 
  
- [x] `no-need-doc` 
  
- [ ] `doc` 

