### PR TITLE
Bump pulsar to 2.10.0.0-rc12 and fix testListOffsetForEmptyRolloverLedger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
     <pulsar.group.id>io.streamnative</pulsar.group.id>
-    <pulsar.version>2.10.0.0-rc4</pulsar.version>
+    <pulsar.version>2.10.0.0-rc12</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testng.version>6.14.3</testng.version>

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MultiLedgerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MultiLedgerTest.java
@@ -21,6 +21,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -206,6 +207,10 @@ public class MultiLedgerTest extends KopProtocolHandlerTestBase {
         }
         assertEquals(managedLedger.getLedgersInfo().size(), numLedgers);
 
+        // The rollover can only happen when state is LedgerOpened since https://github.com/apache/pulsar/pull/14664
+        Field stateUpdater = ManagedLedgerImpl.class.getDeclaredField("state");
+        stateUpdater.setAccessible(true);
+        stateUpdater.set(managedLedger, ManagedLedgerImpl.State.LedgerOpened);
         // Rollover and delete the old ledgers, wait until there is only one empty ledger
         managedLedger.getConfig().setRetentionTime(0, TimeUnit.MILLISECONDS);
         managedLedger.rollCurrentLedgerIfFull();


### PR DESCRIPTION
Fixes #1175

### Motivation

The `ManagedLedger#rollCurrentLedgerIfFull` can only work when the managed ledger's state is `LedgerOpened` since https://github.com/apache/pulsar/pull/14664. The corner case described in https://github.com/streamnative/kop/pull/894 is still possible when some entries are sent but not persisted after a rollover and retention works. Therefore, we should still keep the `testListOffsetForEmptyRolloverLedger` to avoid the regression in KoP.

### Modifications

- Bump Pulsar to 2.10.0.0-rc12, which includes https://github.com/apache/pulsar/pull/14664
- Change the managed ledger's state to `LedgerOpened` in `testListOffsetForEmptyRolloverLedger`.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

