### PR TITLE
Bump pulsar to 2.9.2.8 and fix test list offset for empty rollover ledger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
     <pulsar.group.id>io.streamnative</pulsar.group.id>
-    <pulsar.version>2.9.2.1</pulsar.version>
+    <pulsar.version>2.9.2.8</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testng.version>6.14.3</testng.version>

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MultiLedgerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MultiLedgerTest.java
@@ -21,6 +21,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -206,6 +207,10 @@ public class MultiLedgerTest extends KopProtocolHandlerTestBase {
         }
         assertEquals(managedLedger.getLedgersInfo().size(), numLedgers);
 
+        // The rollover can only happen when state is LedgerOpened since https://github.com/apache/pulsar/pull/14664
+        Field stateUpdater = ManagedLedgerImpl.class.getDeclaredField("state");
+        stateUpdater.setAccessible(true);
+        stateUpdater.set(managedLedger, ManagedLedgerImpl.State.LedgerOpened);
         // Rollover and delete the old ledgers, wait until there is only one empty ledger
         managedLedger.getConfig().setRetentionTime(0, TimeUnit.MILLISECONDS);
         managedLedger.rollCurrentLedgerIfFull();


### PR DESCRIPTION
cherry-pick #1176
### Motivation

Bump pulsar to 2.9.2.8 and fix test list offset for empty rollover ledger

### Documentation

- [x] `no-need-doc` 
 

