### PR TITLE
fix client reconnect fail after bundle unload

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
@@ -141,8 +141,8 @@ public class KopBrokerLookupManager {
             log.error("No node for broker {} under loadBalance", internalListenerAddress);
             return null;
         }
-        if (serviceLookupData.get().getProtocol(KafkaProtocolHandler.PROTOCOL_NAME).isPresent() &&
-                serviceLookupData.get().getProtocol(KafkaProtocolHandler.PROTOCOL_NAME).get()
+        if (serviceLookupData.get().getProtocol(KafkaProtocolHandler.PROTOCOL_NAME).isPresent()
+                && serviceLookupData.get().getProtocol(KafkaProtocolHandler.PROTOCOL_NAME).get()
                         .equals(selfAdvertisedListeners)){
             // the topic is owned by this broker, cache the look up result
             LOOKUP_CACHE.put(topic, CompletableFuture.completedFuture(internalListenerAddress));


### PR DESCRIPTION
Fixes #1111

### Motivation
refer to #1111 
When there are 3 brokers or more in cluster, one broker may not receive the bundle load and unload event if the bundle is not owned by the broker, in this case the broker will not able to invalidate the look up cache for the topics in this bundle.

### Modifications
We should not cache all topics' look up result, only to cache those topics' look up result which are owned by the broker.

### Verifying this change
I have checked in my local clusters with 3 brokers.
We need to add the third broker in `DistributedClusterTest` to verify this issue in unit test later.

### Documentation
  
- [x] `no-need-doc` 


