### PR TITLE
Do not boot default coordinators if kafkaManageSystemNamespaces is false

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -249,8 +249,10 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
         });
         namespaceService.addNamespaceBundleOwnershipListener(bundleListener);
 
-        // initialize default Group Coordinator
-        getGroupCoordinator(kafkaConfig.getKafkaMetadataTenant());
+        if (kafkaConfig.isKafkaManageSystemNamespaces()) {
+            // initialize default Group Coordinator
+            getGroupCoordinator(kafkaConfig.getKafkaMetadataTenant());
+        }
 
         // init KopEventManager
         kopEventManager = new KopEventManager(adminManager,
@@ -260,7 +262,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 groupCoordinatorsByTenant);
         kopEventManager.start();
 
-        if (kafkaConfig.isKafkaTransactionCoordinatorEnabled()) {
+        if (kafkaConfig.isKafkaTransactionCoordinatorEnabled() && kafkaConfig.isKafkaManageSystemNamespaces()) {
             getTransactionCoordinator(kafkaConfig.getKafkaMetadataTenant());
         }
 


### PR DESCRIPTION
### Motivation

in `kafkaManageSystemNamespaces=false` mode KOP won't create default namespaces, and so you cannot boot the coordinator of "default" namespace. So the KOP protocol handler fails to boot.

### Modifications
Do not try to boot the Coordinator (Group and TX) in case of  `kafkaManageSystemNamespaces=false` mode.
The system administrator will have time to initialise the KOP namespaces after a successful bootstrap of the Pulsar brokers.

### Verifying this change
- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation
- [x] `no-need-doc` 
  