### PR TITLE
Add basic IN/OUT bytes metrics

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -184,6 +184,7 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         // Get a buffer that contains the full frame
         ByteBuf buffer = (ByteBuf) msg;
+        requestStats.getTotalBytesIn().add(buffer.readableBytes());
 
         // Update parse request latency metrics
         final BiConsumer<Long, Throwable> registerRequestParseLatency = (timeBeforeParse, throwable) -> {
@@ -432,6 +433,7 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
 
                     final ByteBuf result = responseToByteBuf(response, request);
                     channel.writeAndFlush(result).addListener(future -> {
+                        requestStats.getTotalBytesOut().add(result.readableBytes());
                         if (response instanceof ResponseCallbackWrapper) {
                             ((ResponseCallbackWrapper) response).responseComplete();
                         }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopServerStats.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopServerStats.java
@@ -92,4 +92,10 @@ public interface KopServerStats {
     String KOP_EVENT_QUEUE_SIZE = "KOP_EVENT_QUEUE_SIZE";
     String KOP_EVENT_QUEUED_LATENCY = "KOP_EVENT_QUEUED_LATENCY";
     String KOP_EVENT_LATENCY = "KOP_EVENT_LATENCY";
+
+    /**
+     * Network stats.
+     */
+    String KOP_TOTAL_BYTES_IN = "KOP_TOTAL_BYTES_IN";
+    String KOP_TOTAL_BYTES_OUT = "KOP_TOTAL_BYTES_OUT";
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/RequestStats.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/RequestStats.java
@@ -18,6 +18,8 @@ import static io.streamnative.pulsar.handlers.kop.KopServerStats.ALIVE_CHANNEL_C
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.BATCH_COUNT_PER_MEMORYRECORDS;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.CATEGORY_SERVER;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.FETCH_DECODE;
+import static io.streamnative.pulsar.handlers.kop.KopServerStats.KOP_TOTAL_BYTES_IN;
+import static io.streamnative.pulsar.handlers.kop.KopServerStats.KOP_TOTAL_BYTES_OUT;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.MESSAGE_PUBLISH;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.MESSAGE_QUEUED_LATENCY;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.MESSAGE_READ;
@@ -138,6 +140,8 @@ public class RequestStats {
         this.prepareMetadataStats = statsLogger.getOpStatsLogger(PREPARE_METADATA);
         this.messageReadStats = statsLogger.getOpStatsLogger(MESSAGE_READ);
         this.fetchDecodeStats  = statsLogger.getOpStatsLogger(FETCH_DECODE);
+        this.totalBytesIn = statsLogger.getCounter(KOP_TOTAL_BYTES_IN);
+        this.totalBytesOut = statsLogger.getCounter(KOP_TOTAL_BYTES_OUT);
 
         statsLogger.registerGauge(REQUEST_QUEUE_SIZE, new Gauge<Number>() {
             @Override
@@ -187,6 +191,18 @@ public class RequestStats {
             }
         });
     }
+
+    @StatsDoc(
+            name = KOP_TOTAL_BYTES_IN,
+            help = "total bytes received"
+    )
+    private final Counter totalBytesIn;
+
+    @StatsDoc(
+            name = KOP_TOTAL_BYTES_OUT,
+            help = "total bytes received"
+    )
+    private final Counter totalBytesOut;
 
     /**
      * Get the stats logger for Kafka requests.


### PR DESCRIPTION
### Motivation

We need a way to measure the network traffic originating directly from KOP clients

### Modifications

Add two simple metrics KOP_TOTAL_BYTES_IN and KOP_TOTAL_BYTES_OUT

### Documentation

- [x] `doc-required` 
 