### PR TITLE
Metrics: expose per-tenant metrics

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -62,7 +62,7 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
     private final LinkedBlockingQueue<ResponseAndRequest> requestQueue;
     @Getter
     @Setter
-    protected RequestStats requestStats;
+    protected volatile RequestStats requestStats;
     @Getter
     protected final KafkaServiceConfiguration kafkaConfig;
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -60,8 +60,9 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
     protected AtomicBoolean isActive = new AtomicBoolean(false);
     // Queue to make response get responseFuture in order and limit the max request size
     private final LinkedBlockingQueue<ResponseAndRequest> requestQueue;
-
-    protected final RequestStats requestStats;
+    @Getter
+    @Setter
+    protected RequestStats requestStats;
     @Getter
     protected final KafkaServiceConfiguration kafkaConfig;
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -381,6 +381,9 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         if (authenticator != null) {
             authenticator.authenticate(ctx, requestBuf, registerRequestParseLatency, registerRequestLatency,
                     this::validateTenantAccessForSession);
+            if (authenticator.complete() && kafkaConfig.isKafkaEnableMultiTenantMetadata()) {
+                setRequestStats(requestStats.forTenant(getCurrentTenant()));
+            }
         }
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/RequestStats.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/RequestStats.java
@@ -205,4 +205,8 @@ public class RequestStats {
     public Set<ApiKeys> getApiKeysSet() {
         return new TreeSet<>(apiKeysToStatsLogger.keySet());
     }
+
+    public RequestStats forTenant(String tenant) {
+        return new RequestStats(statsLogger.scopeLabel("tenant", tenant));
+    }
 }


### PR DESCRIPTION
### Motivation

We want to track metrics per tenant, in order to be able to debug and inspect the resource usage by each tenant, and also possibly troubleshot problems.

### Modifications

In case of "authentication enabled" and "kafkaEnableMultiTenantMetadata enabled" when a connection  (a `KafkaRequestHandler`) completes authentication with success, we start pushing metrics with a "tenant=pulsar-tenant" label.

The Tenant is the username used for authentication

### Verifying this change

TODO (I will add tests when we agree on this feature)

### Documentation

- [x ] `doc-required` 
 