### PR TITLE
Fix handle offset commit fail when offset producer closed

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
@@ -584,6 +584,7 @@ public class GroupMetadataManager {
                         filteredOffsetMetadata, group.groupId(), consumerId, group.generationId(), cause);
 
                 if (cause.getCause() instanceof PulsarClientException.AlreadyClosedException) {
+                    this.offsetsProducers.remove(partitionFor(group.groupId()));
                     return Errors.NOT_COORDINATOR;
                 }
                 return Errors.UNKNOWN_SERVER_ERROR;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
@@ -82,6 +82,7 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerBuilder;
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.client.api.ReaderBuilder;
 import org.apache.pulsar.client.impl.MessageIdImpl;
@@ -582,6 +583,9 @@ public class GroupMetadataManager {
                                 + " when appending to log due to ",
                         filteredOffsetMetadata, group.groupId(), consumerId, group.generationId(), cause);
 
+                if (cause.getCause() instanceof PulsarClientException.AlreadyClosedException) {
+                    return Errors.NOT_COORDINATOR;
+                }
                 return Errors.UNKNOWN_SERVER_ERROR;
             })
             .thenApplyAsync(errors -> offsetMetadata.entrySet()

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -54,7 +54,10 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
@@ -74,6 +77,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigResource;
@@ -106,6 +110,7 @@ import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Time;
 import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.AutoTopicCreationOverride;
@@ -1173,6 +1178,65 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
             conf.setAllowAutoTopicCreation(original);
             admin.namespaces().removeAutoTopicCreation("public/default");
         }
+    }
+
+    @Test(timeOut = 30000)
+    public void testCommitOffsetRetryWhenProducerClosed()
+            throws ExecutionException, InterruptedException, PulsarAdminException {
+        String topic = "testCommitOffsetRetryWhenProducerClosed";
+        String groupId = "test-group";
+        admin.topics().createPartitionedTopic(topic, 1);
+        int numMessages = 10;
+        @Cleanup
+        final KafkaProducer<String, String> producer = new KafkaProducer<>(newKafkaProducerProperties());
+        for (int i = 0; i < numMessages; i++) {
+            producer.send(new ProducerRecord<>(topic, "value")).get();
+        }
+
+        @Cleanup
+        final KafkaConsumer<String, String> consumer = new KafkaConsumer<>(newKafkaConsumerProperties(groupId));
+        consumer.subscribe(Collections.singleton(topic));
+
+        int fetchMessages = 0;
+
+        // Need open another thread to clear the offset producers
+        Executors.newSingleThreadExecutor().submit(() -> {
+            try {
+                TimeUnit.SECONDS.sleep(5);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            handler.getGroupCoordinator().getOffsetsProducers().clear();
+        });
+
+        // Make sure only close once.
+        final AtomicBoolean flag = new AtomicBoolean(true);
+
+        while (fetchMessages < numMessages) {
+            try {
+                ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(1000));
+                records.forEach(record -> {
+                    record.offset();
+                    record.partition();
+                    consumer.commitSync();
+                    if (flag.get()) {
+                        handler.getGroupCoordinator().getOffsetsProducers().values()
+                                .forEach(producerCompletableFuture -> {
+                            try {
+                                producerCompletableFuture.get().close();
+                            } catch (PulsarClientException | InterruptedException | ExecutionException e) {
+                                log.error("Close offset producer failed.");
+                            }
+                        });
+                        flag.set(false);
+                    }
+                });
+                fetchMessages += records.count();
+            } catch (KafkaException ex) {
+                fail("Should not have kafka exception.");
+            }
+        }
+        assertEquals(fetchMessages, numMessages);
     }
 
     private KafkaHeaderAndRequest createTopicMetadataRequest(List<String> topics, boolean allowAutoTopicCreation) {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -1184,7 +1184,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
     public void testCommitOffsetRetryWhenProducerClosed()
             throws ExecutionException, InterruptedException, PulsarAdminException {
         String topic = "testCommitOffsetRetryWhenProducerClosed";
-        String groupId = "test-group";
+        String groupId = "test-commit-offset-group";
         admin.topics().createPartitionedTopic(topic, 1);
         int numMessages = 10;
         @Cleanup


### PR DESCRIPTION
Fixes #1211

### Motivation
Currently, when we get offset producer, then the unload happened, the current producer we get might already close, so the commit offset request will fail.

### Modifications

1. When the producer closed, we should return Errors.NOT_COORDINATOR.
2. Add a units test to cover it.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

