### PR TITLE
[security] Upgrade jackson-databind to get rid of CVE-2020-36518

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,8 @@
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
 
     <!-- dependencies -->
-    <jackson.version>2.12.1</jackson.version>
+    <jackson.version>2.12.6</jackson.version>
+    <jackson-databind.version>2.12.6.1</jackson-databind.version>
     <kafka.version>2.0.0</kafka.version>
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
@@ -151,7 +152,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${jackson.version}</version>
+        <version>${jackson-databind.version}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,8 @@
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
 
     <!-- dependencies -->
-    <jackson.version>2.12.6</jackson.version>
-    <jackson-databind.version>2.12.6.1</jackson-databind.version>
+    <jackson.version>2.13.2</jackson.version>
+    <jackson-databind.version>2.13.2.1</jackson-databind.version>
     <kafka.version>2.0.0</kafka.version>
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>


### PR DESCRIPTION
See the related pull in Pulsar https://github.com/apache/pulsar/pull/14871

 