### PR TITLE
[Feature] Support set retention size limit for system namespace

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -52,6 +52,7 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
     private static final int GroupInitialRebalanceDelayMs = 3000;
     // offset configuration
     private static final int OffsetsRetentionMinutes = 3 * 24 * 60;
+    private static final int DefaultSystemTopicRetentionSizeInMb = -1;
     public static final int DefaultOffsetsTopicNumPartitions = 50;
     private static final int OffsetsMessageTTL = 3 * 24 * 3600;
     // txn configuration
@@ -169,6 +170,12 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
         doc = "Offsets older than this retention period will be discarded"
     )
     private long offsetsRetentionMinutes = OffsetsRetentionMinutes;
+
+    @FieldContext(
+            category = CATEGORY_KOP,
+            doc = "System topic retention size in mb"
+    )
+    private int systemTopicRetentionSizeInMB = DefaultSystemTopicRetentionSizeInMb;
 
     @FieldContext(
         category = CATEGORY_KOP,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
@@ -205,10 +205,15 @@ public class MetadataUtils {
             // set namespace config only when offset metadata namespace first create
             if (isMetadataNamespace) {
                 int retentionMinutes = (int) conf.getOffsetsRetentionMinutes();
+                int retentionSizeInMB = conf.getSystemTopicRetentionSizeInMB();
                 RetentionPolicies retentionPolicies = namespaces.getRetention(kafkaNamespace);
-                if (retentionPolicies == null || retentionPolicies.getRetentionTimeInMinutes() != retentionMinutes) {
+
+                if (retentionPolicies == null
+                        || retentionPolicies.getRetentionTimeInMinutes() != retentionMinutes
+                        || retentionPolicies.getRetentionSizeInMB() != retentionSizeInMB
+                ) {
                     namespaces.setRetention(kafkaNamespace,
-                            new RetentionPolicies((int) conf.getOffsetsRetentionMinutes(), -1));
+                            new RetentionPolicies((int) conf.getOffsetsRetentionMinutes(), retentionSizeInMB));
                 }
 
                 Long compactionThreshold = namespaces.getCompactionThreshold(kafkaNamespace);

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtilsTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtilsTest.java
@@ -57,6 +57,7 @@ public class MetadataUtilsTest {
         conf.setSuperUserRoles(Sets.newHashSet("admin"));
         conf.setOffsetsTopicNumPartitions(8);
         conf.setKafkaNamespace("userNamespace");
+        conf.setSystemTopicRetentionSizeInMB(1000);
 
         final KopTopic offsetsTopic = new KopTopic(MetadataUtils
                 .constructOffsetsTopicBaseName(conf.getKafkaMetadataTenant(), conf), namespacePrefix);
@@ -103,13 +104,16 @@ public class MetadataUtilsTest {
         // create user topics namespace
         MetadataUtils.createKafkaNamespaceIfMissing(mockPulsarAdmin, clusterData, conf);
 
+        RetentionPolicies retentionPolicies =
+                new RetentionPolicies((int) conf.getOffsetsRetentionMinutes(), conf.getSystemTopicRetentionSizeInMB());
+
         verify(mockTenants, times(1)).createTenant(eq(conf.getKafkaMetadataTenant()), any(TenantInfo.class));
         verify(mockNamespaces, times(1)).createNamespace(eq(conf.getKafkaMetadataTenant() + "/"
             + conf.getKafkaMetadataNamespace()), any(Set.class));
         verify(mockNamespaces, times(1)).setNamespaceReplicationClusters(eq(conf.getKafkaMetadataTenant()
             + "/" + conf.getKafkaMetadataNamespace()), any(Set.class));
         verify(mockNamespaces, times(1)).setRetention(eq(conf.getKafkaMetadataTenant() + "/"
-            + conf.getKafkaMetadataNamespace()), any(RetentionPolicies.class));
+            + conf.getKafkaMetadataNamespace()), eq(retentionPolicies));
         verify(mockNamespaces, times(1)).setNamespaceMessageTTL(eq(conf.getKafkaMetadataTenant() + "/"
             + conf.getKafkaMetadataNamespace()), any(Integer.class));
         verify(mockTopics, times(1)).createPartitionedTopic(
@@ -122,7 +126,7 @@ public class MetadataUtilsTest {
         verify(mockNamespaces, times(1)).setNamespaceReplicationClusters(eq(conf.getKafkaTenant()
                 + "/" + conf.getKafkaNamespace()), any(Set.class));
         verify(mockNamespaces, times(0)).setRetention(eq(conf.getKafkaTenant() + "/"
-                + conf.getKafkaNamespace()), any(RetentionPolicies.class));
+                + conf.getKafkaNamespace()), eq(retentionPolicies));
         verify(mockNamespaces, times(0)).setNamespaceMessageTTL(eq(conf.getKafkaTenant() + "/"
                 + conf.getKafkaNamespace()), any(Integer.class));
 


### PR DESCRIPTION
### Motivation

Support set retention size limit for system/metadata namespace.

### Modifications

* Add config name systemTopicRetentionSizeInMB 
* Add units test to verfiy it.

### Documentation

Check the box below.

Need to update docs? 

- [x] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

