### PR TITLE
Allow regular producers with a dedup enabled namespace

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessagePublishContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessagePublishContext.java
@@ -45,6 +45,12 @@ public final class MessagePublishContext implements PublishContext {
     private long sequenceId;
     private long highestSequenceId;
     private String producerName;
+    private boolean enableDeduplication;
+
+    @Override
+    public boolean isMarkerMessage() {
+        return !this.enableDeduplication;
+    }
 
     @Override
     public long getSequenceId() {
@@ -120,6 +126,7 @@ public final class MessagePublishContext implements PublishContext {
     public static MessagePublishContext get(CompletableFuture<Long> offsetFuture,
                                             Topic topic,
                                             String producerName,
+                                            boolean enableDeduplication,
                                             long sequenceId,
                                             long highestSequenceId,
                                             int numberOfMessages,
@@ -134,6 +141,7 @@ public final class MessagePublishContext implements PublishContext {
         callback.sequenceId = sequenceId;
         callback.highestSequenceId = highestSequenceId;
         callback.peekOffsetError = null;
+        callback.enableDeduplication = enableDeduplication;
         return callback;
     }
 
@@ -169,6 +177,7 @@ public final class MessagePublishContext implements PublishContext {
         sequenceId = -1;
         highestSequenceId = -1;
         peekOffsetError = null;
+        enableDeduplication = false;
         recyclerHandle.recycle(this);
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessagePublishContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessagePublishContext.java
@@ -47,6 +47,13 @@ public final class MessagePublishContext implements PublishContext {
     private String producerName;
     private boolean enableDeduplication;
 
+    /**
+     * On Pulsar side, the replicator marker message will skip the deduplication check,
+     * For support produce a regular message in KoP when Pulsar deduplication is enabled,
+     * KoP uses this method to support this feature.
+     *
+     * See: https://github.com/streamnative/kop/issues/1225
+     */
     @Override
     public boolean isMarkerMessage() {
         return !this.enableDeduplication;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -331,9 +331,13 @@ public class PartitionLog {
                 .add(String.valueOf(appendInfo.producerId().orElse(-1L)))
                 .add(String.valueOf(appendInfo.producerEpoch())).toString();
 
+
         persistentTopic.publishMessage(byteBuf,
                 MessagePublishContext.get(
-                        offsetFuture, persistentTopic, producerName,
+                        offsetFuture,
+                        persistentTopic,
+                        producerName,
+                        appendInfo.producerId().isPresent(),
                         appendInfo.firstSequence(),
                         appendInfo.lastSequence(),
                         appendInfo.numMessages(),

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/IdempotentProducerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/IdempotentProducerTest.java
@@ -85,12 +85,12 @@ public class IdempotentProducerTest extends KopProtocolHandlerTestBase {
         int maxMessageNum = 1000;
 
         Properties producerProperties = newKafkaProducerProperties();
+
+        // in this case we want to verify that the producer works even with
+        // deduplication enabled on the namespace
         if (useIdempotent) {
             producerProperties.put(ProducerConfig.CLIENT_ID_CONFIG, "test-client");
             producerProperties.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
-        } else {
-            // in this case we want to verify that the producer works even with
-            // deduplication enabled on the namespace
         }
 
         try (KafkaProducer<String, String> producer = new KafkaProducer<>(producerProperties)) {


### PR DESCRIPTION
Fixes #1225 

### Motivation
Fix  #1225 

### Modifications

When `MessagePublishContext.isMarkerMessage` is true, the pulsar deduplication check will always pass, so we can produce a regular message in KoP when dedup is enabled.

But the isMarkerMessage is not designed for this case, it uses to check the replicator marker. We might need more disscuss.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

