### PR TITLE
Fix authorization failed when using oauth2

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -439,7 +439,7 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
             doc = "The fully qualified name of a SASL server callback handler class that implements the "
                     + "AuthenticateCallbackHandler interface, which is used for OAuth2 authentication. "
                     + "If it's not set, the class will be Kafka's default server callback handler for "
-                    + "OAUTHBEARER mechanism: OAuthBearerUnsecuredValidatorCallbackHandler."
+                    + "OAUTHBEARER mechanism: KopOAuthBearerUnsecuredValidatorCallbackHandler."
     )
     private String kopOauth2AuthenticateCallbackHandler;
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
@@ -22,6 +22,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import io.streamnative.pulsar.handlers.kop.security.oauth.KopOAuthBearerSaslServer;
+import io.streamnative.pulsar.handlers.kop.security.oauth.KopOAuthBearerUnsecuredValidatorCallbackHandler;
 import io.streamnative.pulsar.handlers.kop.utils.KafkaResponseUtils;
 import java.nio.ByteBuffer;
 import java.util.Collections;
@@ -53,8 +54,6 @@ import org.apache.kafka.common.requests.SaslAuthenticateRequest;
 import org.apache.kafka.common.requests.SaslHandshakeRequest;
 import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
-import org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerSaslServer;
-import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredValidatorCallbackHandler;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
@@ -254,7 +253,7 @@ public class SaslAuthenticator {
                 throw new RuntimeException("Failed to cast " + className + ": " + e.getMessage());
             }
         } else {
-            handler = new OAuthBearerUnsecuredValidatorCallbackHandler();
+            handler = new KopOAuthBearerUnsecuredValidatorCallbackHandler();
         }
 
         final Properties props = config.getKopOauth2Properties();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
@@ -21,6 +21,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
+import io.streamnative.pulsar.handlers.kop.security.oauth.KopOAuthBearerSaslServer;
 import io.streamnative.pulsar.handlers.kop.utils.KafkaResponseUtils;
 import java.nio.ByteBuffer;
 import java.util.Collections;
@@ -277,7 +278,7 @@ public class SaslAuthenticator {
                 throw new IllegalArgumentException("No OAuth2CallbackHandler found when mechanism is "
                         + OAuthBearerLoginModule.OAUTHBEARER_MECHANISM);
             }
-            saslServer = new OAuthBearerSaslServer(oauth2CallbackHandler);
+            saslServer = new KopOAuthBearerSaslServer(oauth2CallbackHandler);
         } else {
             throw new AuthenticationException("KoP doesn't support '" + mechanism + "' mechanism");
         }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerSaslServer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerSaslServer.java
@@ -1,24 +1,34 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.streamnative.pulsar.handlers.kop.security.oauth;
 
-import lombok.extern.slf4j.Slf4j;
-import org.apache.kafka.common.errors.SaslAuthenticationException;
-import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
-import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
-import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallback;
-import org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerClientInitialResponse;
-import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredValidatorCallbackHandler;
+import static io.streamnative.pulsar.handlers.kop.security.SaslAuthenticator.AUTH_DATA_SOURCE_PROP;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Objects;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.sasl.SaslException;
 import javax.security.sasl.SaslServer;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Objects;
-
-import static io.streamnative.pulsar.handlers.kop.security.SaslAuthenticator.AUTH_DATA_SOURCE_PROP;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.errors.SaslAuthenticationException;
+import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
+import org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerClientInitialResponse;
 
 @Slf4j
 public class KopOAuthBearerSaslServer implements SaslServer {
@@ -26,7 +36,8 @@ public class KopOAuthBearerSaslServer implements SaslServer {
     // Copy from OAuthBearerSaslClient.BYTE_CONTROL_A
     private static final byte BYTE_CONTROL_A = (byte) 0x01;
     private static final String NEGOTIATED_PROPERTY_KEY_TOKEN = OAuthBearerLoginModule.OAUTHBEARER_MECHANISM + ".token";
-    private static final String INTERNAL_ERROR_ON_SERVER = "Authentication could not be performed due to an internal error on the server";
+    private static final String INTERNAL_ERROR_ON_SERVER =
+            "Authentication could not be performed due to an internal error on the server";
 
     private final AuthenticateCallbackHandler callbackHandler;
 
@@ -35,9 +46,10 @@ public class KopOAuthBearerSaslServer implements SaslServer {
     private String errorMessage = null;
 
     public KopOAuthBearerSaslServer(CallbackHandler callbackHandler) {
-        if (!(Objects.requireNonNull(callbackHandler) instanceof AuthenticateCallbackHandler))
+        if (!(Objects.requireNonNull(callbackHandler) instanceof AuthenticateCallbackHandler)) {
             throw new IllegalArgumentException(String.format("Callback handler must be castable to %s: %s",
                     AuthenticateCallbackHandler.class.getName(), callbackHandler.getClass().getName()));
+        }
         this.callbackHandler = (AuthenticateCallbackHandler) callbackHandler;
     }
 
@@ -57,8 +69,9 @@ public class KopOAuthBearerSaslServer implements SaslServer {
     @Override
     public byte[] evaluateResponse(byte[] response) throws SaslException, SaslAuthenticationException {
         if (response.length == 1 && response[0] == BYTE_CONTROL_A && errorMessage != null) {
-            if (log.isDebugEnabled())
+            if (log.isDebugEnabled()){
                 log.debug("Received %x01 response from client after it received our error");
+            }
             throw new SaslAuthenticationException(errorMessage);
         }
         errorMessage = null;
@@ -74,8 +87,9 @@ public class KopOAuthBearerSaslServer implements SaslServer {
 
     @Override
     public String getAuthorizationID() {
-        if (!complete)
+        if (!complete) {
             throw new IllegalStateException("Authentication exchange has not completed");
+        }
         return tokenForNegotiatedProperty.principalName();
     }
 
@@ -86,7 +100,7 @@ public class KopOAuthBearerSaslServer implements SaslServer {
 
     @Override
     public Object getNegotiatedProperty(String propName) {
-        if (!complete){
+        if (!complete) {
             throw new IllegalStateException("Authentication exchange has not completed");
         }
 
@@ -103,15 +117,17 @@ public class KopOAuthBearerSaslServer implements SaslServer {
 
     @Override
     public byte[] unwrap(byte[] incoming, int offset, int len) throws SaslException {
-        if (!complete)
+        if (!complete) {
             throw new IllegalStateException("Authentication exchange has not completed");
+        }
         return Arrays.copyOfRange(incoming, offset, offset + len);
     }
 
     @Override
     public byte[] wrap(byte[] outgoing, int offset, int len) throws SaslException {
-        if (!complete)
+        if (!complete) {
             throw new IllegalStateException("Authentication exchange has not completed");
+        }
         return Arrays.copyOfRange(outgoing, offset, offset + len);
     }
 
@@ -124,45 +140,51 @@ public class KopOAuthBearerSaslServer implements SaslServer {
     private byte[] process(String tokenValue, String authorizationId) throws SaslException {
         KopOAuthBearerValidatorCallback callback = new KopOAuthBearerValidatorCallback(tokenValue);
         try {
-            callbackHandler.handle(new Callback[] {callback});
+            callbackHandler.handle(new Callback[]{callback});
         } catch (IOException | UnsupportedCallbackException e) {
             String msg = String.format("%s: %s", INTERNAL_ERROR_ON_SERVER, e.getMessage());
-            if (log.isDebugEnabled())
+            if (log.isDebugEnabled()) {
                 log.debug(msg, e);
+            }
             throw new SaslException(msg);
         }
         KopOAuthBearerToken token = callback.token();
         if (token == null) {
             errorMessage = jsonErrorResponse(callback.errorStatus(), callback.errorScope(),
                     callback.errorOpenIDConfiguration());
-            if (log.isDebugEnabled())
+            if (log.isDebugEnabled()) {
                 log.debug(errorMessage);
+            }
             return errorMessage.getBytes(StandardCharsets.UTF_8);
         }
         /*
          * We support the client specifying an authorization ID as per the SASL
          * specification, but it must match the principal name if it is specified.
          */
-        if (!authorizationId.isEmpty() && !authorizationId.equals(token.principalName())){
+        if (!authorizationId.isEmpty() && !authorizationId.equals(token.principalName())) {
             throw new SaslAuthenticationException(String.format(
-                    "Authentication failed: Client requested an authorization id (%s) that is different from the token's principal name (%s)",
+                    "Authentication failed: Client requested an authorization id (%s) "
+                            + "that is different from the token's principal name (%s)",
                     authorizationId, token.principalName()));
         }
 
         tokenForNegotiatedProperty = token;
         complete = true;
-        if (log.isDebugEnabled())
+        if (log.isDebugEnabled()) {
             log.debug("Successfully authenticate User={}", token.principalName());
+        }
         return new byte[0];
     }
 
     private static String jsonErrorResponse(String errorStatus, String errorScope, String errorOpenIDConfiguration) {
         String jsonErrorResponse = String.format("{\"status\":\"%s\"", errorStatus);
-        if (errorScope != null)
+        if (errorScope != null) {
             jsonErrorResponse = String.format("%s, \"scope\":\"%s\"", jsonErrorResponse, errorScope);
-        if (errorOpenIDConfiguration != null)
+        }
+        if (errorOpenIDConfiguration != null) {
             jsonErrorResponse = String.format("%s, \"openid-configuration\":\"%s\"", jsonErrorResponse,
                     errorOpenIDConfiguration);
+        }
         jsonErrorResponse = String.format("%s}", jsonErrorResponse);
         return jsonErrorResponse;
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerSaslServer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerSaslServer.java
@@ -14,6 +14,7 @@
 package io.streamnative.pulsar.handlers.kop.security.oauth;
 
 import static io.streamnative.pulsar.handlers.kop.security.SaslAuthenticator.AUTH_DATA_SOURCE_PROP;
+import static io.streamnative.pulsar.handlers.kop.security.SaslAuthenticator.USER_NAME_PROP;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -40,17 +41,19 @@ public class KopOAuthBearerSaslServer implements SaslServer {
             "Authentication could not be performed due to an internal error on the server";
 
     private final AuthenticateCallbackHandler callbackHandler;
+    private final String defaultKafkaMetadataTenant;
 
     private boolean complete;
     private KopOAuthBearerToken tokenForNegotiatedProperty = null;
     private String errorMessage = null;
 
-    public KopOAuthBearerSaslServer(CallbackHandler callbackHandler) {
+    public KopOAuthBearerSaslServer(CallbackHandler callbackHandler, String defaultKafkaMetadataTenant) {
         if (!(Objects.requireNonNull(callbackHandler) instanceof AuthenticateCallbackHandler)) {
             throw new IllegalArgumentException(String.format("Callback handler must be castable to %s: %s",
                     AuthenticateCallbackHandler.class.getName(), callbackHandler.getClass().getName()));
         }
         this.callbackHandler = (AuthenticateCallbackHandler) callbackHandler;
+        this.defaultKafkaMetadataTenant = defaultKafkaMetadataTenant;
     }
 
     /**
@@ -106,6 +109,9 @@ public class KopOAuthBearerSaslServer implements SaslServer {
 
         if (AUTH_DATA_SOURCE_PROP.equals(propName)) {
             return tokenForNegotiatedProperty.authDataSource();
+        }
+        if (USER_NAME_PROP.equals(propName)) {
+            return defaultKafkaMetadataTenant;
         }
         return NEGOTIATED_PROPERTY_KEY_TOKEN.equals(propName) ? tokenForNegotiatedProperty : null;
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerSaslServer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerSaslServer.java
@@ -122,17 +122,6 @@ public class KopOAuthBearerSaslServer implements SaslServer {
     }
 
     private byte[] process(String tokenValue, String authorizationId) throws SaslException {
-//        if (callbackHandler instanceof OAuthBearerUnsecuredValidatorCallbackHandler) {
-//            OAuthBearerValidatorCallback callback = new OAuthBearerValidatorCallback(tokenValue);
-//            try {
-//                callbackHandler.handle(new Callback[] {callback});
-//            } catch (IOException | UnsupportedCallbackException e) {
-//                String msg = String.format("%s: %s", INTERNAL_ERROR_ON_SERVER, e.getMessage());
-//                if (log.isDebugEnabled())
-//                    log.debug(msg, e);
-//                throw new SaslException(msg);
-//            }
-//        }
         KopOAuthBearerValidatorCallback callback = new KopOAuthBearerValidatorCallback(tokenValue);
         try {
             callbackHandler.handle(new Callback[] {callback});

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerSaslServer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerSaslServer.java
@@ -1,0 +1,181 @@
+package io.streamnative.pulsar.handlers.kop.security.oauth;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.errors.SaslAuthenticationException;
+import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallback;
+import org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerClientInitialResponse;
+import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredValidatorCallbackHandler;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.SaslException;
+import javax.security.sasl.SaslServer;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Objects;
+
+import static io.streamnative.pulsar.handlers.kop.security.SaslAuthenticator.AUTH_DATA_SOURCE_PROP;
+
+@Slf4j
+public class KopOAuthBearerSaslServer implements SaslServer {
+
+    // Copy from OAuthBearerSaslClient.BYTE_CONTROL_A
+    private static final byte BYTE_CONTROL_A = (byte) 0x01;
+    private static final String NEGOTIATED_PROPERTY_KEY_TOKEN = OAuthBearerLoginModule.OAUTHBEARER_MECHANISM + ".token";
+    private static final String INTERNAL_ERROR_ON_SERVER = "Authentication could not be performed due to an internal error on the server";
+
+    private final AuthenticateCallbackHandler callbackHandler;
+
+    private boolean complete;
+    private KopOAuthBearerToken tokenForNegotiatedProperty = null;
+    private String errorMessage = null;
+
+    public KopOAuthBearerSaslServer(CallbackHandler callbackHandler) {
+        if (!(Objects.requireNonNull(callbackHandler) instanceof AuthenticateCallbackHandler))
+            throw new IllegalArgumentException(String.format("Callback handler must be castable to %s: %s",
+                    AuthenticateCallbackHandler.class.getName(), callbackHandler.getClass().getName()));
+        this.callbackHandler = (AuthenticateCallbackHandler) callbackHandler;
+    }
+
+    /**
+     * @throws SaslAuthenticationException
+     *             if access token cannot be validated
+     *             <p>
+     *             <b>Note:</b> This method may throw
+     *             {@link SaslAuthenticationException} to provide custom error
+     *             messages to clients. But care should be taken to avoid including
+     *             any information in the exception message that should not be
+     *             leaked to unauthenticated clients. It may be safer to throw
+     *             {@link SaslException} in some cases so that a standard error
+     *             message is returned to clients.
+     *             </p>
+     */
+    @Override
+    public byte[] evaluateResponse(byte[] response) throws SaslException, SaslAuthenticationException {
+        if (response.length == 1 && response[0] == BYTE_CONTROL_A && errorMessage != null) {
+            if (log.isDebugEnabled())
+                log.debug("Received %x01 response from client after it received our error");
+            throw new SaslAuthenticationException(errorMessage);
+        }
+        errorMessage = null;
+        OAuthBearerClientInitialResponse clientResponse;
+        try {
+            clientResponse = new OAuthBearerClientInitialResponse(response);
+        } catch (SaslException e) {
+            log.debug(e.getMessage());
+            throw e;
+        }
+        return process(clientResponse.tokenValue(), clientResponse.authorizationId());
+    }
+
+    @Override
+    public String getAuthorizationID() {
+        if (!complete)
+            throw new IllegalStateException("Authentication exchange has not completed");
+        return tokenForNegotiatedProperty.principalName();
+    }
+
+    @Override
+    public String getMechanismName() {
+        return OAuthBearerLoginModule.OAUTHBEARER_MECHANISM;
+    }
+
+    @Override
+    public Object getNegotiatedProperty(String propName) {
+        if (!complete){
+            throw new IllegalStateException("Authentication exchange has not completed");
+        }
+
+        if (AUTH_DATA_SOURCE_PROP.equals(propName)) {
+            return tokenForNegotiatedProperty.authDataSource();
+        }
+        return NEGOTIATED_PROPERTY_KEY_TOKEN.equals(propName) ? tokenForNegotiatedProperty : null;
+    }
+
+    @Override
+    public boolean isComplete() {
+        return complete;
+    }
+
+    @Override
+    public byte[] unwrap(byte[] incoming, int offset, int len) throws SaslException {
+        if (!complete)
+            throw new IllegalStateException("Authentication exchange has not completed");
+        return Arrays.copyOfRange(incoming, offset, offset + len);
+    }
+
+    @Override
+    public byte[] wrap(byte[] outgoing, int offset, int len) throws SaslException {
+        if (!complete)
+            throw new IllegalStateException("Authentication exchange has not completed");
+        return Arrays.copyOfRange(outgoing, offset, offset + len);
+    }
+
+    @Override
+    public void dispose() throws SaslException {
+        complete = false;
+        tokenForNegotiatedProperty = null;
+    }
+
+    private byte[] process(String tokenValue, String authorizationId) throws SaslException {
+//        if (callbackHandler instanceof OAuthBearerUnsecuredValidatorCallbackHandler) {
+//            OAuthBearerValidatorCallback callback = new OAuthBearerValidatorCallback(tokenValue);
+//            try {
+//                callbackHandler.handle(new Callback[] {callback});
+//            } catch (IOException | UnsupportedCallbackException e) {
+//                String msg = String.format("%s: %s", INTERNAL_ERROR_ON_SERVER, e.getMessage());
+//                if (log.isDebugEnabled())
+//                    log.debug(msg, e);
+//                throw new SaslException(msg);
+//            }
+//        }
+        KopOAuthBearerValidatorCallback callback = new KopOAuthBearerValidatorCallback(tokenValue);
+        try {
+            callbackHandler.handle(new Callback[] {callback});
+        } catch (IOException | UnsupportedCallbackException e) {
+            String msg = String.format("%s: %s", INTERNAL_ERROR_ON_SERVER, e.getMessage());
+            if (log.isDebugEnabled())
+                log.debug(msg, e);
+            throw new SaslException(msg);
+        }
+        KopOAuthBearerToken token = callback.token();
+        if (token == null) {
+            errorMessage = jsonErrorResponse(callback.errorStatus(), callback.errorScope(),
+                    callback.errorOpenIDConfiguration());
+            if (log.isDebugEnabled())
+                log.debug(errorMessage);
+            return errorMessage.getBytes(StandardCharsets.UTF_8);
+        }
+        /*
+         * We support the client specifying an authorization ID as per the SASL
+         * specification, but it must match the principal name if it is specified.
+         */
+        if (!authorizationId.isEmpty() && !authorizationId.equals(token.principalName())){
+            throw new SaslAuthenticationException(String.format(
+                    "Authentication failed: Client requested an authorization id (%s) that is different from the token's principal name (%s)",
+                    authorizationId, token.principalName()));
+        }
+
+        tokenForNegotiatedProperty = token;
+        complete = true;
+        if (log.isDebugEnabled())
+            log.debug("Successfully authenticate User={}", token.principalName());
+        return new byte[0];
+    }
+
+    private static String jsonErrorResponse(String errorStatus, String errorScope, String errorOpenIDConfiguration) {
+        String jsonErrorResponse = String.format("{\"status\":\"%s\"", errorStatus);
+        if (errorScope != null)
+            jsonErrorResponse = String.format("%s, \"scope\":\"%s\"", jsonErrorResponse, errorScope);
+        if (errorOpenIDConfiguration != null)
+            jsonErrorResponse = String.format("%s, \"openid-configuration\":\"%s\"", jsonErrorResponse,
+                    errorOpenIDConfiguration);
+        jsonErrorResponse = String.format("%s}", jsonErrorResponse);
+        return jsonErrorResponse;
+    }
+
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerToken.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerToken.java
@@ -1,6 +1,7 @@
 package io.streamnative.pulsar.handlers.kop.security.oauth;
 
 import org.apache.kafka.common.annotation.InterfaceStability;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 
 import java.util.Set;
@@ -33,61 +34,7 @@ import java.util.Set;
  *      Section 2.1</a>
  */
 @InterfaceStability.Evolving
-public interface KopOAuthBearerToken {
-    /**
-     * The <code>b64token</code> value as defined in
-     * <a href="https://tools.ietf.org/html/rfc6750#section-2.1">RFC 6750 Section
-     * 2.1</a>
-     *
-     * @return <code>b64token</code> value as defined in
-     *         <a href="https://tools.ietf.org/html/rfc6750#section-2.1">RFC 6750
-     *         Section 2.1</a>
-     */
-    String value();
-
-    /**
-     * The token's scope of access, as per
-     * <a href="https://tools.ietf.org/html/rfc6749#section-1.4">RFC 6749 Section
-     * 1.4</a>
-     *
-     * @return the token's (always non-null but potentially empty) scope of access,
-     *         as per <a href="https://tools.ietf.org/html/rfc6749#section-1.4">RFC
-     *         6749 Section 1.4</a>. Note that all values in the returned set will
-     *         be trimmed of preceding and trailing whitespace, and the result will
-     *         never contain the empty string.
-     */
-    Set<String> scope();
-
-    /**
-     * The token's lifetime, expressed as the number of milliseconds since the
-     * epoch, as per <a href="https://tools.ietf.org/html/rfc6749#section-1.4">RFC
-     * 6749 Section 1.4</a>
-     *
-     * @return the token'slifetime, expressed as the number of milliseconds since
-     *         the epoch, as per
-     *         <a href="https://tools.ietf.org/html/rfc6749#section-1.4">RFC 6749
-     *         Section 1.4</a>.
-     */
-    long lifetimeMs();
-
-    /**
-     * The name of the principal to which this credential applies
-     *
-     * @return the always non-null/non-empty principal name
-     */
-    String principalName();
-
+public interface KopOAuthBearerToken extends OAuthBearerToken {
     AuthenticationDataSource authDataSource();
-
-    /**
-     * When the credential became valid, in terms of the number of milliseconds
-     * since the epoch, if known, otherwise null. An expiring credential may not
-     * necessarily indicate when it was created -- just when it expires -- so we
-     * need to support a null return value here.
-     *
-     * @return the time when the credential became valid, in terms of the number of
-     *         milliseconds since the epoch, if known, otherwise null
-     */
-    Long startTimeMs();
 }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerToken.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerToken.java
@@ -1,40 +1,31 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.streamnative.pulsar.handlers.kop.security.oauth;
 
 import org.apache.kafka.common.annotation.InterfaceStability;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 
-import java.util.Set;
-
 /**
- * The <code>b64token</code> value as defined in
- * <a href="https://tools.ietf.org/html/rfc6750#section-2.1">RFC 6750 Section
- * 2.1</a> along with the token's specific scope and lifetime and principal
- * name.
- * <p>
- * A network request would be required to re-hydrate an opaque token, and that
- * could result in (for example) an {@code IOException}, but retrievers for
- * various attributes ({@link #scope()}, {@link #lifetimeMs()}, etc.) declare no
- * exceptions. Therefore, if a network request is required for any of these
- * retriever methods, that request could be performed at construction time so
- * that the various attributes can be reliably provided thereafter. For example,
- * a constructor might declare {@code throws IOException} in such a case.
- * Alternatively, the retrievers could throw unchecked exceptions.
- * <p>
- * This interface was introduced in 2.0.0 and, while it feels stable, it could
- * evolve. We will try to evolve the API in a compatible manner (easier now that
- * Java 7 and its lack of default methods doesn't have to be supported), but we
- * reserve the right to make breaking changes in minor releases, if necessary.
- * We will update the {@code InterfaceStability} annotation and this notice once
- * the API is considered stable.
- *
- * @see <a href="https://tools.ietf.org/html/rfc6749#section-1.4">RFC 6749
- *      Section 1.4</a> and
- *      <a href="https://tools.ietf.org/html/rfc6750#section-2.1">RFC 6750
- *      Section 2.1</a>
+ * Support pass the auth data to oauth server.
  */
 @InterfaceStability.Evolving
 public interface KopOAuthBearerToken extends OAuthBearerToken {
+
+    /**
+     * Pass the auth data to oauth server.
+     */
     AuthenticationDataSource authDataSource();
 }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerToken.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerToken.java
@@ -1,0 +1,93 @@
+package io.streamnative.pulsar.handlers.kop.security.oauth;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
+
+import java.util.Set;
+
+/**
+ * The <code>b64token</code> value as defined in
+ * <a href="https://tools.ietf.org/html/rfc6750#section-2.1">RFC 6750 Section
+ * 2.1</a> along with the token's specific scope and lifetime and principal
+ * name.
+ * <p>
+ * A network request would be required to re-hydrate an opaque token, and that
+ * could result in (for example) an {@code IOException}, but retrievers for
+ * various attributes ({@link #scope()}, {@link #lifetimeMs()}, etc.) declare no
+ * exceptions. Therefore, if a network request is required for any of these
+ * retriever methods, that request could be performed at construction time so
+ * that the various attributes can be reliably provided thereafter. For example,
+ * a constructor might declare {@code throws IOException} in such a case.
+ * Alternatively, the retrievers could throw unchecked exceptions.
+ * <p>
+ * This interface was introduced in 2.0.0 and, while it feels stable, it could
+ * evolve. We will try to evolve the API in a compatible manner (easier now that
+ * Java 7 and its lack of default methods doesn't have to be supported), but we
+ * reserve the right to make breaking changes in minor releases, if necessary.
+ * We will update the {@code InterfaceStability} annotation and this notice once
+ * the API is considered stable.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc6749#section-1.4">RFC 6749
+ *      Section 1.4</a> and
+ *      <a href="https://tools.ietf.org/html/rfc6750#section-2.1">RFC 6750
+ *      Section 2.1</a>
+ */
+@InterfaceStability.Evolving
+public interface KopOAuthBearerToken {
+    /**
+     * The <code>b64token</code> value as defined in
+     * <a href="https://tools.ietf.org/html/rfc6750#section-2.1">RFC 6750 Section
+     * 2.1</a>
+     *
+     * @return <code>b64token</code> value as defined in
+     *         <a href="https://tools.ietf.org/html/rfc6750#section-2.1">RFC 6750
+     *         Section 2.1</a>
+     */
+    String value();
+
+    /**
+     * The token's scope of access, as per
+     * <a href="https://tools.ietf.org/html/rfc6749#section-1.4">RFC 6749 Section
+     * 1.4</a>
+     *
+     * @return the token's (always non-null but potentially empty) scope of access,
+     *         as per <a href="https://tools.ietf.org/html/rfc6749#section-1.4">RFC
+     *         6749 Section 1.4</a>. Note that all values in the returned set will
+     *         be trimmed of preceding and trailing whitespace, and the result will
+     *         never contain the empty string.
+     */
+    Set<String> scope();
+
+    /**
+     * The token's lifetime, expressed as the number of milliseconds since the
+     * epoch, as per <a href="https://tools.ietf.org/html/rfc6749#section-1.4">RFC
+     * 6749 Section 1.4</a>
+     *
+     * @return the token'slifetime, expressed as the number of milliseconds since
+     *         the epoch, as per
+     *         <a href="https://tools.ietf.org/html/rfc6749#section-1.4">RFC 6749
+     *         Section 1.4</a>.
+     */
+    long lifetimeMs();
+
+    /**
+     * The name of the principal to which this credential applies
+     *
+     * @return the always non-null/non-empty principal name
+     */
+    String principalName();
+
+    AuthenticationDataSource authDataSource();
+
+    /**
+     * When the credential became valid, in terms of the number of milliseconds
+     * since the epoch, if known, otherwise null. An expiring credential may not
+     * necessarily indicate when it was created -- just when it expires -- so we
+     * need to support a null return value here.
+     *
+     * @return the time when the credential became valid, in terms of the number of
+     *         milliseconds since the epoch, if known, otherwise null
+     */
+    Long startTimeMs();
+}
+

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerUnsecuredJws.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerUnsecuredJws.java
@@ -1,13 +1,33 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.streamnative.pulsar.handlers.kop.security.oauth;
 
 import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerIllegalTokenException;
 import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredJws;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 
+/**
+ * A simple unsecured JWS implementation.
+ * The '{@code nbf}' claim is ignored if it is given because the related logic is not required for Kafka testing and
+ * development purposes.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc7515">RFC 7515</a>
+ */
 public class KopOAuthBearerUnsecuredJws extends OAuthBearerUnsecuredJws implements KopOAuthBearerToken {
 
     /**
-     * Constructor with the given principal and scope claim names
+     * Constructor with the given principal and scope claim names.
      *
      * @param compactSerialization the compact serialization to parse as an unsecured JWS
      * @param principalClaimName   the required principal claim name
@@ -19,7 +39,8 @@ public class KopOAuthBearerUnsecuredJws extends OAuthBearerUnsecuredJws implemen
      *                                          after decoding; or the mandatory '{@code alg}' header value is
      *                                          not "{@code none}")
      */
-    public KopOAuthBearerUnsecuredJws(String compactSerialization, String principalClaimName, String scopeClaimName) throws OAuthBearerIllegalTokenException {
+    public KopOAuthBearerUnsecuredJws(String compactSerialization, String principalClaimName, String scopeClaimName)
+            throws OAuthBearerIllegalTokenException {
         super(compactSerialization, principalClaimName, scopeClaimName);
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerUnsecuredJws.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerUnsecuredJws.java
@@ -15,6 +15,7 @@ package io.streamnative.pulsar.handlers.kop.security.oauth;
 
 import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerIllegalTokenException;
 import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredJws;
+import org.apache.pulsar.broker.authentication.AuthenticationDataCommand;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 
 /**
@@ -26,6 +27,7 @@ import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
  */
 public class KopOAuthBearerUnsecuredJws extends OAuthBearerUnsecuredJws implements KopOAuthBearerToken {
 
+    private final AuthenticationDataCommand authData;
     /**
      * Constructor with the given principal and scope claim names.
      *
@@ -42,10 +44,11 @@ public class KopOAuthBearerUnsecuredJws extends OAuthBearerUnsecuredJws implemen
     public KopOAuthBearerUnsecuredJws(String compactSerialization, String principalClaimName, String scopeClaimName)
             throws OAuthBearerIllegalTokenException {
         super(compactSerialization, principalClaimName, scopeClaimName);
+        this.authData = new AuthenticationDataCommand(compactSerialization);
     }
 
     @Override
     public AuthenticationDataSource authDataSource() {
-        return null;
+        return authData;
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerUnsecuredJws.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerUnsecuredJws.java
@@ -1,0 +1,30 @@
+package io.streamnative.pulsar.handlers.kop.security.oauth;
+
+import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerIllegalTokenException;
+import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredJws;
+import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
+
+public class KopOAuthBearerUnsecuredJws extends OAuthBearerUnsecuredJws implements KopOAuthBearerToken {
+
+    /**
+     * Constructor with the given principal and scope claim names
+     *
+     * @param compactSerialization the compact serialization to parse as an unsecured JWS
+     * @param principalClaimName   the required principal claim name
+     * @param scopeClaimName       the required scope claim name
+     * @throws OAuthBearerIllegalTokenException if the compact serialization is not a valid unsecured JWS
+     *                                          (meaning it did not have 3 dot-separated Base64URL sections
+     *                                          without an empty digital signature; or the header or claims
+     *                                          either are not valid Base 64 URL encoded values or are not JSON
+     *                                          after decoding; or the mandatory '{@code alg}' header value is
+     *                                          not "{@code none}")
+     */
+    public KopOAuthBearerUnsecuredJws(String compactSerialization, String principalClaimName, String scopeClaimName) throws OAuthBearerIllegalTokenException {
+        super(compactSerialization, principalClaimName, scopeClaimName);
+    }
+
+    @Override
+    public AuthenticationDataSource authDataSource() {
+        return null;
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerUnsecuredValidatorCallbackHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerUnsecuredValidatorCallbackHandler.java
@@ -1,24 +1,35 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.streamnative.pulsar.handlers.kop.security.oauth;
 
-import lombok.extern.slf4j.Slf4j;
-import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
-import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
-import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallback;
-import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerConfigException;
-import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerIllegalTokenException;
-import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerScopeUtils;
-import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredJws;
-import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerValidationResult;
-import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerValidationUtils;
-import org.apache.kafka.common.utils.Time;
-import javax.security.auth.callback.Callback;
-import javax.security.auth.callback.UnsupportedCallbackException;
-import javax.security.auth.login.AppConfigurationEntry;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.AppConfigurationEntry;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
+import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerConfigException;
+import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerIllegalTokenException;
+import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerScopeUtils;
+import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerValidationResult;
+import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerValidationUtils;
+import org.apache.kafka.common.utils.Time;
 
 @Slf4j
 public class KopOAuthBearerUnsecuredValidatorCallbackHandler implements AuthenticateCallbackHandler {
@@ -33,7 +44,7 @@ public class KopOAuthBearerUnsecuredValidatorCallbackHandler implements Authenti
     private boolean configured = false;
 
     /**
-     * For testing
+     * For testing.
      *
      * @param time
      *            the mandatory time to set
@@ -43,7 +54,7 @@ public class KopOAuthBearerUnsecuredValidatorCallbackHandler implements Authenti
     }
 
     /**
-     * Return true if this instance has been configured, otherwise false
+     * Return true if this instance has been configured, otherwise false.
      *
      * @return true if this instance has been configured, otherwise false
      */
@@ -54,12 +65,14 @@ public class KopOAuthBearerUnsecuredValidatorCallbackHandler implements Authenti
     @SuppressWarnings("unchecked")
     @Override
     public void configure(Map<String, ?> configs, String saslMechanism, List<AppConfigurationEntry> jaasConfigEntries) {
-        if (!OAuthBearerLoginModule.OAUTHBEARER_MECHANISM.equals(saslMechanism))
+        if (!OAuthBearerLoginModule.OAUTHBEARER_MECHANISM.equals(saslMechanism)) {
             throw new IllegalArgumentException(String.format("Unexpected SASL mechanism: %s", saslMechanism));
-        if (Objects.requireNonNull(jaasConfigEntries).size() != 1 || jaasConfigEntries.get(0) == null)
+        }
+        if (Objects.requireNonNull(jaasConfigEntries).size() != 1 || jaasConfigEntries.get(0) == null) {
             throw new IllegalArgumentException(
                     String.format("Must supply exactly 1 non-null JAAS mechanism configuration (size was %d)",
                             jaasConfigEntries.size()));
+        }
         final Map<String, String> unmodifiableModuleOptions = Collections
                 .unmodifiableMap((Map<String, String>) jaasConfigEntries.get(0).getOptions());
         this.moduleOptions = unmodifiableModuleOptions;
@@ -68,8 +81,9 @@ public class KopOAuthBearerUnsecuredValidatorCallbackHandler implements Authenti
 
     @Override
     public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-        if (!configured())
+        if (!configured()) {
             throw new IllegalStateException("Callback handler not configured");
+        }
         for (Callback callback : callbacks) {
             if (callback instanceof KopOAuthBearerValidatorCallback) {
                 KopOAuthBearerValidatorCallback validationCallback = (KopOAuthBearerValidatorCallback) callback;
@@ -81,8 +95,9 @@ public class KopOAuthBearerUnsecuredValidatorCallbackHandler implements Authenti
                     validationCallback.error(failureScope != null ? "insufficient_scope" : "invalid_token",
                             failureScope, failureReason.failureOpenIdConfig());
                 }
-            } else
+            } else {
                 throw new UnsupportedCallbackException(callback);
+            }
         }
     }
 
@@ -93,8 +108,9 @@ public class KopOAuthBearerUnsecuredValidatorCallbackHandler implements Authenti
 
     private void handleCallback(KopOAuthBearerValidatorCallback callback) {
         String tokenValue = callback.tokenValue();
-        if (tokenValue == null)
+        if (tokenValue == null) {
             throw new IllegalArgumentException("Callback missing required token value");
+        }
         String principalClaimName = principalClaimName();
         String scopeClaimName = scopeClaimName();
         List<String> requiredScope = requiredScope();
@@ -154,8 +170,9 @@ public class KopOAuthBearerUnsecuredValidatorCallbackHandler implements Authenti
     }
 
     private String option(String key) {
-        if (!configured)
+        if (!configured){
             throw new IllegalStateException("Callback handler not configured");
+        }
         return moduleOptions.get(Objects.requireNonNull(key));
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerUnsecuredValidatorCallbackHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerUnsecuredValidatorCallbackHandler.java
@@ -1,0 +1,161 @@
+package io.streamnative.pulsar.handlers.kop.security.oauth;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallback;
+import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerConfigException;
+import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerIllegalTokenException;
+import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerScopeUtils;
+import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredJws;
+import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerValidationResult;
+import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerValidationUtils;
+import org.apache.kafka.common.utils.Time;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.AppConfigurationEntry;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+@Slf4j
+public class KopOAuthBearerUnsecuredValidatorCallbackHandler implements AuthenticateCallbackHandler {
+
+    private static final String OPTION_PREFIX = "unsecuredValidator";
+    private static final String PRINCIPAL_CLAIM_NAME_OPTION = OPTION_PREFIX + "PrincipalClaimName";
+    private static final String SCOPE_CLAIM_NAME_OPTION = OPTION_PREFIX + "ScopeClaimName";
+    private static final String REQUIRED_SCOPE_OPTION = OPTION_PREFIX + "RequiredScope";
+    private static final String ALLOWABLE_CLOCK_SKEW_MILLIS_OPTION = OPTION_PREFIX + "AllowableClockSkewMs";
+    private Time time = Time.SYSTEM;
+    private Map<String, String> moduleOptions = null;
+    private boolean configured = false;
+
+    /**
+     * For testing
+     *
+     * @param time
+     *            the mandatory time to set
+     */
+    void time(Time time) {
+        this.time = Objects.requireNonNull(time);
+    }
+
+    /**
+     * Return true if this instance has been configured, otherwise false
+     *
+     * @return true if this instance has been configured, otherwise false
+     */
+    public boolean configured() {
+        return configured;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void configure(Map<String, ?> configs, String saslMechanism, List<AppConfigurationEntry> jaasConfigEntries) {
+        if (!OAuthBearerLoginModule.OAUTHBEARER_MECHANISM.equals(saslMechanism))
+            throw new IllegalArgumentException(String.format("Unexpected SASL mechanism: %s", saslMechanism));
+        if (Objects.requireNonNull(jaasConfigEntries).size() != 1 || jaasConfigEntries.get(0) == null)
+            throw new IllegalArgumentException(
+                    String.format("Must supply exactly 1 non-null JAAS mechanism configuration (size was %d)",
+                            jaasConfigEntries.size()));
+        final Map<String, String> unmodifiableModuleOptions = Collections
+                .unmodifiableMap((Map<String, String>) jaasConfigEntries.get(0).getOptions());
+        this.moduleOptions = unmodifiableModuleOptions;
+        configured = true;
+    }
+
+    @Override
+    public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+        if (!configured())
+            throw new IllegalStateException("Callback handler not configured");
+        for (Callback callback : callbacks) {
+            if (callback instanceof KopOAuthBearerValidatorCallback) {
+                KopOAuthBearerValidatorCallback validationCallback = (KopOAuthBearerValidatorCallback) callback;
+                try {
+                    handleCallback(validationCallback);
+                } catch (OAuthBearerIllegalTokenException e) {
+                    OAuthBearerValidationResult failureReason = e.reason();
+                    String failureScope = failureReason.failureScope();
+                    validationCallback.error(failureScope != null ? "insufficient_scope" : "invalid_token",
+                            failureScope, failureReason.failureOpenIdConfig());
+                }
+            } else
+                throw new UnsupportedCallbackException(callback);
+        }
+    }
+
+    @Override
+    public void close() {
+        // empty
+    }
+
+    private void handleCallback(KopOAuthBearerValidatorCallback callback) {
+        String tokenValue = callback.tokenValue();
+        if (tokenValue == null)
+            throw new IllegalArgumentException("Callback missing required token value");
+        String principalClaimName = principalClaimName();
+        String scopeClaimName = scopeClaimName();
+        List<String> requiredScope = requiredScope();
+        int allowableClockSkewMs = allowableClockSkewMs();
+        KopOAuthBearerUnsecuredJws unsecuredJwt = new KopOAuthBearerUnsecuredJws(tokenValue, principalClaimName,
+                scopeClaimName);
+        long now = time.milliseconds();
+        OAuthBearerValidationUtils
+                .validateClaimForExistenceAndType(unsecuredJwt, true, principalClaimName, String.class)
+                .throwExceptionIfFailed();
+        OAuthBearerValidationUtils.validateIssuedAt(unsecuredJwt, false, now, allowableClockSkewMs)
+                .throwExceptionIfFailed();
+        OAuthBearerValidationUtils.validateExpirationTime(unsecuredJwt, now, allowableClockSkewMs)
+                .throwExceptionIfFailed();
+        OAuthBearerValidationUtils.validateTimeConsistency(unsecuredJwt).throwExceptionIfFailed();
+        OAuthBearerValidationUtils.validateScope(unsecuredJwt, requiredScope).throwExceptionIfFailed();
+        log.info("Successfully validated token with principal {}: {}", unsecuredJwt.principalName(),
+                unsecuredJwt.claims().toString());
+        callback.token(unsecuredJwt);
+    }
+
+    private String principalClaimName() {
+        String principalClaimNameValue = option(PRINCIPAL_CLAIM_NAME_OPTION);
+        return principalClaimNameValue != null && !principalClaimNameValue.trim().isEmpty()
+                ? principalClaimNameValue.trim()
+                : "sub";
+    }
+
+    private String scopeClaimName() {
+        String scopeClaimNameValue = option(SCOPE_CLAIM_NAME_OPTION);
+        return scopeClaimNameValue != null && !scopeClaimNameValue.trim().isEmpty()
+                ? scopeClaimNameValue.trim()
+                : "scope";
+    }
+
+    private List<String> requiredScope() {
+        String requiredSpaceDelimitedScope = option(REQUIRED_SCOPE_OPTION);
+        return requiredSpaceDelimitedScope == null || requiredSpaceDelimitedScope.trim().isEmpty()
+                ? Collections.<String>emptyList()
+                : OAuthBearerScopeUtils.parseScope(requiredSpaceDelimitedScope.trim());
+    }
+
+    private int allowableClockSkewMs() {
+        String allowableClockSkewMsValue = option(ALLOWABLE_CLOCK_SKEW_MILLIS_OPTION);
+        int allowableClockSkewMs = 0;
+        try {
+            allowableClockSkewMs = allowableClockSkewMsValue == null || allowableClockSkewMsValue.trim().isEmpty() ? 0
+                    : Integer.parseInt(allowableClockSkewMsValue.trim());
+        } catch (NumberFormatException e) {
+            throw new OAuthBearerConfigException(e.getMessage(), e);
+        }
+        if (allowableClockSkewMs < 0) {
+            throw new OAuthBearerConfigException(
+                    String.format("Allowable clock skew millis must not be negative: %s", allowableClockSkewMsValue));
+        }
+        return allowableClockSkewMs;
+    }
+
+    private String option(String key) {
+        if (!configured)
+            throw new IllegalStateException("Callback handler not configured");
+        return moduleOptions.get(Objects.requireNonNull(key));
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerValidatorCallback.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerValidatorCallback.java
@@ -1,0 +1,142 @@
+package io.streamnative.pulsar.handlers.kop.security.oauth;
+
+import org.apache.kafka.common.annotation.InterfaceStability;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
+
+import javax.security.auth.callback.Callback;
+import java.util.Objects;
+
+/**
+ * Copy from OAuthBearerValidatorCallback.
+ *
+ * A {@code Callback} for use by the {@code SaslServer} implementation when it
+ * needs to provide an OAuth 2 bearer token compact serialization for
+ * validation. Callback handlers should use the
+ * {@link #error(String, String, String)} method to communicate errors back to
+ * the SASL Client as per
+ * <a href="https://tools.ietf.org/html/rfc6749#section-5.2">RFC 6749: The OAuth
+ * 2.0 Authorization Framework</a> and the <a href=
+ * "https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml#extensions-error">IANA
+ * OAuth Extensions Error Registry</a>. Callback handlers should communicate
+ * other problems by raising an {@code IOException}.
+ * <p>
+ * This class was introduced in 2.0.0 and, while it feels stable, it could
+ * evolve. We will try to evolve the API in a compatible manner, but we reserve
+ * the right to make breaking changes in minor releases, if necessary. We will
+ * update the {@code InterfaceStability} annotation and this notice once the API
+ * is considered stable.
+ */
+@InterfaceStability.Evolving
+public class KopOAuthBearerValidatorCallback implements Callback {
+
+    private final String tokenValue;
+    private KopOAuthBearerToken token = null;
+    private String errorStatus = null;
+    private String errorScope = null;
+    private String errorOpenIDConfiguration = null;
+
+    /**
+     * Constructor
+     *
+     * @param tokenValue
+     *            the mandatory/non-blank token value
+     */
+    public KopOAuthBearerValidatorCallback(String tokenValue) {
+        if (Objects.requireNonNull(tokenValue).isEmpty())
+            throw new IllegalArgumentException("token value must not be empty");
+        this.tokenValue = tokenValue;
+    }
+
+    /**
+     * Return the (always non-null) token value
+     *
+     * @return the (always non-null) token value
+     */
+    public String tokenValue() {
+        return tokenValue;
+    }
+
+    /**
+     * Return the (potentially null) token
+     *
+     * @return the (potentially null) token
+     */
+    public KopOAuthBearerToken token() {
+        return token;
+    }
+
+    /**
+     * Return the (potentially null) error status value as per
+     * <a href="https://tools.ietf.org/html/rfc7628#section-3.2.2">RFC 7628: A Set
+     * of Simple Authentication and Security Layer (SASL) Mechanisms for OAuth</a>
+     * and the <a href=
+     * "https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml#extensions-error">IANA
+     * OAuth Extensions Error Registry</a>.
+     *
+     * @return the (potentially null) error status value
+     */
+    public String errorStatus() {
+        return errorStatus;
+    }
+
+    /**
+     * Return the (potentially null) error scope value as per
+     * <a href="https://tools.ietf.org/html/rfc7628#section-3.2.2">RFC 7628: A Set
+     * of Simple Authentication and Security Layer (SASL) Mechanisms for OAuth</a>.
+     *
+     * @return the (potentially null) error scope value
+     */
+    public String errorScope() {
+        return errorScope;
+    }
+
+    /**
+     * Return the (potentially null) error openid-configuration value as per
+     * <a href="https://tools.ietf.org/html/rfc7628#section-3.2.2">RFC 7628: A Set
+     * of Simple Authentication and Security Layer (SASL) Mechanisms for OAuth</a>.
+     *
+     * @return the (potentially null) error openid-configuration value
+     */
+    public String errorOpenIDConfiguration() {
+        return errorOpenIDConfiguration;
+    }
+
+    /**
+     * Set the token. The token value is unchanged and is expected to match the
+     * provided token's value. All error values are cleared.
+     *
+     * @param token
+     *            the mandatory token to set
+     */
+    public void token(KopOAuthBearerToken token) {
+        this.token = Objects.requireNonNull(token);
+        this.errorStatus = null;
+        this.errorScope = null;
+        this.errorOpenIDConfiguration = null;
+    }
+
+    /**
+     * Set the error values as per
+     * <a href="https://tools.ietf.org/html/rfc7628#section-3.2.2">RFC 7628: A Set
+     * of Simple Authentication and Security Layer (SASL) Mechanisms for OAuth</a>.
+     * Any token is cleared.
+     *
+     * @param errorStatus
+     *            the mandatory error status value from the <a href=
+     *            "https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml#extensions-error">IANA
+     *            OAuth Extensions Error Registry</a> to set
+     * @param errorScope
+     *            the optional error scope value to set
+     * @param errorOpenIDConfiguration
+     *            the optional error openid-configuration value to set
+     */
+    public void error(String errorStatus, String errorScope, String errorOpenIDConfiguration) {
+        if (Objects.requireNonNull(errorStatus).isEmpty())
+            throw new IllegalArgumentException("error status must not be empty");
+        this.errorStatus = errorStatus;
+        this.errorScope = errorScope;
+        this.errorOpenIDConfiguration = errorOpenIDConfiguration;
+        this.token = null;
+    }
+}
+

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerValidatorCallback.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerValidatorCallback.java
@@ -19,7 +19,7 @@ import org.apache.kafka.common.annotation.InterfaceStability;
 
 
 /**
- * Copy from OAuthBearerValidatorCallback.
+ * Copied from {@link org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallback}.
  *
  * A {@code Callback} for use by the {@code SaslServer} implementation when it
  * needs to provide an OAuth 2 bearer token compact serialization for

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerValidatorCallback.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerValidatorCallback.java
@@ -1,10 +1,22 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.streamnative.pulsar.handlers.kop.security.oauth;
 
-import org.apache.kafka.common.annotation.InterfaceStability;
-import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
-
-import javax.security.auth.callback.Callback;
 import java.util.Objects;
+import javax.security.auth.callback.Callback;
+import org.apache.kafka.common.annotation.InterfaceStability;
+
 
 /**
  * Copy from OAuthBearerValidatorCallback.
@@ -36,19 +48,20 @@ public class KopOAuthBearerValidatorCallback implements Callback {
     private String errorOpenIDConfiguration = null;
 
     /**
-     * Constructor
+     * Constructor.
      *
      * @param tokenValue
      *            the mandatory/non-blank token value
      */
     public KopOAuthBearerValidatorCallback(String tokenValue) {
-        if (Objects.requireNonNull(tokenValue).isEmpty())
+        if (Objects.requireNonNull(tokenValue).isEmpty()) {
             throw new IllegalArgumentException("token value must not be empty");
+        }
         this.tokenValue = tokenValue;
     }
 
     /**
-     * Return the (always non-null) token value
+     * Return the (always non-null) token value.
      *
      * @return the (always non-null) token value
      */
@@ -57,7 +70,7 @@ public class KopOAuthBearerValidatorCallback implements Callback {
     }
 
     /**
-     * Return the (potentially null) token
+     * Return the (potentially null) token.
      *
      * @return the (potentially null) token
      */
@@ -131,8 +144,9 @@ public class KopOAuthBearerValidatorCallback implements Callback {
      *            the optional error openid-configuration value to set
      */
     public void error(String errorStatus, String errorScope, String errorOpenIDConfiguration) {
-        if (Objects.requireNonNull(errorStatus).isEmpty())
+        if (Objects.requireNonNull(errorStatus).isEmpty()) {
             throw new IllegalArgumentException("error status must not be empty");
+        }
         this.errorStatus = errorStatus;
         this.errorScope = errorScope;
         this.errorOpenIDConfiguration = errorOpenIDConfiguration;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/OauthValidatorCallbackHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/OauthValidatorCallbackHandler.java
@@ -26,8 +26,6 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.AppConfigurationEntry;
 import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
-import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
-import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallback;
 import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerIllegalTokenException;
 import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerValidationResult;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CustomOAuthBearerCallbackHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CustomOAuthBearerCallbackHandlerTest.java
@@ -19,7 +19,8 @@ import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.Sets;
 import io.jsonwebtoken.SignatureAlgorithm;
-import java.io.IOException;
+import io.streamnative.pulsar.handlers.kop.security.oauth.KopOAuthBearerToken;
+import io.streamnative.pulsar.handlers.kop.security.oauth.KopOAuthBearerValidatorCallback;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -31,15 +32,10 @@ import javax.crypto.SecretKey;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.AppConfigurationEntry;
-
-import io.streamnative.pulsar.handlers.kop.security.oauth.KopOAuthBearerToken;
-import io.streamnative.pulsar.handlers.kop.security.oauth.KopOAuthBearerValidatorCallback;
 import lombok.Cleanup;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
-import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
-import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallback;
 import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredJws;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.broker.authentication.AuthenticationProviderToken;
@@ -148,7 +144,7 @@ public class CustomOAuthBearerCallbackHandlerTest extends KopProtocolHandlerTest
         }
 
         @Override
-        public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+        public void handle(Callback[] callbacks) throws UnsupportedCallbackException {
             for (Callback callback : callbacks) {
                 if (callback instanceof KopOAuthBearerValidatorCallback) {
                     KopOAuthBearerValidatorCallback validationCallback = (KopOAuthBearerValidatorCallback) callback;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CustomOAuthBearerCallbackHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CustomOAuthBearerCallbackHandlerTest.java
@@ -37,6 +37,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
 import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredJws;
+import org.apache.pulsar.broker.authentication.AuthenticationDataCommand;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.broker.authentication.AuthenticationProviderToken;
 import org.apache.pulsar.broker.authentication.utils.AuthTokenUtils;
@@ -173,7 +174,7 @@ public class CustomOAuthBearerCallbackHandlerTest extends KopProtocolHandlerTest
 
                         @Override
                         public AuthenticationDataSource authDataSource() {
-                            return null;
+                            return new AuthenticationDataCommand(validationCallback.tokenValue());
                         }
 
                         @Override

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOauthKopHandlersTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOauthKopHandlersTest.java
@@ -14,6 +14,7 @@
 package io.streamnative.pulsar.handlers.kop;
 
 import com.google.common.collect.Sets;
+import io.streamnative.pulsar.handlers.kop.security.auth.KafkaMockAuthorizationProvider;
 import io.streamnative.pulsar.handlers.kop.security.oauth.OauthLoginCallbackHandler;
 import io.streamnative.pulsar.handlers.kop.security.oauth.OauthValidatorCallbackHandler;
 import java.net.URL;
@@ -50,8 +51,8 @@ public class SaslOauthKopHandlersTest extends SaslOauthBearerTestBase {
         // Broker's config
         conf.setAuthenticationEnabled(true);
         conf.setAuthorizationEnabled(true);
+        conf.setAuthorizationProvider(OauthMockAuthorizationProvider.class.getName());
         conf.setAuthenticationProviders(Sets.newHashSet(AuthenticationProviderToken.class.getName()));
-        conf.setSuperUserRoles(Sets.newHashSet(ADMIN_USER));
         conf.setBrokerClientAuthenticationPlugin(AuthenticationOAuth2.class.getName());
         conf.setBrokerClientAuthenticationParameters(String.format("{\"type\":\"client_credentials\","
                 + "\"privateKey\":\"%s\",\"issuerUrl\":\"%s\",\"audience\":\"%s\"}",
@@ -113,5 +114,13 @@ public class SaslOauthKopHandlersTest extends SaslOauthBearerTestBase {
                 "file://" + Paths.get("./src/test/resources/credentials_file.json").toAbsolutePath(),
                 "https://dev-kt-aa9ne.us.auth0.com/api/v2/"
         ));
+    }
+
+    public static class OauthMockAuthorizationProvider extends KafkaMockAuthorizationProvider {
+
+        @Override
+        public boolean roleAuthorized(String role) {
+            return role.equals(ADMIN_USER);
+        }
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/KafkaMockAuthorizationProvider.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/KafkaMockAuthorizationProvider.java
@@ -28,6 +28,7 @@ import org.apache.pulsar.common.policies.data.PolicyOperation;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.policies.data.TenantOperation;
 import org.apache.pulsar.common.policies.data.TopicOperation;
+import org.testng.Assert;
 
 
 @Slf4j
@@ -42,6 +43,7 @@ public class KafkaMockAuthorizationProvider implements AuthorizationProvider {
     public CompletableFuture<Boolean> isSuperUser(String role,
                                                   AuthenticationDataSource authenticationData,
                                                   ServiceConfiguration serviceConfiguration) {
+        Assert.assertNotNull(authenticationData);
         return roleAuthorizedAsync(role);
     }
 
@@ -53,12 +55,14 @@ public class KafkaMockAuthorizationProvider implements AuthorizationProvider {
     @Override
     public CompletableFuture<Boolean> isTenantAdmin(String tenant, String role, TenantInfo tenantInfo,
                                                     AuthenticationDataSource authenticationData) {
+        Assert.assertNotNull(authenticationData);
         return roleAuthorizedAsync(role);
     }
 
     @Override
     public CompletableFuture<Boolean> canProduceAsync(TopicName topicName, String role,
                                                       AuthenticationDataSource authenticationData) {
+        Assert.assertNotNull(authenticationData);
         return roleAuthorizedAsync(role);
     }
 
@@ -66,30 +70,35 @@ public class KafkaMockAuthorizationProvider implements AuthorizationProvider {
     public CompletableFuture<Boolean> canConsumeAsync(TopicName topicName, String role,
                                                       AuthenticationDataSource authenticationData,
                                                       String subscription) {
+        Assert.assertNotNull(authenticationData);
         return roleAuthorizedAsync(role);
     }
 
     @Override
     public CompletableFuture<Boolean> canLookupAsync(TopicName topicName, String role,
                                                      AuthenticationDataSource authenticationData) {
+        Assert.assertNotNull(authenticationData);
         return roleAuthorizedAsync(role);
     }
 
     @Override
     public CompletableFuture<Boolean> allowFunctionOpsAsync(NamespaceName namespaceName, String role,
                                                             AuthenticationDataSource authenticationData) {
+        Assert.assertNotNull(authenticationData);
         return roleAuthorizedAsync(role);
     }
 
     @Override
     public CompletableFuture<Boolean> allowSourceOpsAsync(NamespaceName namespaceName, String role,
                                                           AuthenticationDataSource authenticationData) {
+        Assert.assertNotNull(authenticationData);
         return roleAuthorizedAsync(role);
     }
 
     @Override
     public CompletableFuture<Boolean> allowSinkOpsAsync(NamespaceName namespaceName, String role,
                                                         AuthenticationDataSource authenticationData) {
+        Assert.assertNotNull(authenticationData);
         return roleAuthorizedAsync(role);
     }
 
@@ -121,26 +130,30 @@ public class KafkaMockAuthorizationProvider implements AuthorizationProvider {
     @Override
     public CompletableFuture<Boolean> allowTenantOperationAsync(String tenantName, String originalRole, String role,
                                                                 TenantOperation operation,
-                                                                AuthenticationDataSource authData) {
+                                                                AuthenticationDataSource authenticationData) {
+        Assert.assertNotNull(authenticationData);
         return roleAuthorizedAsync(role);
     }
 
     @Override
     public Boolean allowTenantOperation(String tenantName, String originalRole, String role, TenantOperation operation,
-                                        AuthenticationDataSource authData) {
+                                        AuthenticationDataSource authenticationData) {
+        Assert.assertNotNull(authenticationData);
         return roleAuthorized(role);
     }
 
     @Override
     public CompletableFuture<Boolean> allowTenantOperationAsync(String tenantName, String role,
                                                                 TenantOperation operation,
-                                                                AuthenticationDataSource authData) {
+                                                                AuthenticationDataSource authenticationData) {
+        Assert.assertNotNull(authenticationData);
         return roleAuthorizedAsync(role);
     }
 
     @Override
     public Boolean allowTenantOperation(String tenantName, String role, TenantOperation operation,
-                                        AuthenticationDataSource authData) {
+                                        AuthenticationDataSource authenticationData) {
+        Assert.assertNotNull(authenticationData);
         return roleAuthorized(role);
     }
 
@@ -148,7 +161,8 @@ public class KafkaMockAuthorizationProvider implements AuthorizationProvider {
     public CompletableFuture<Boolean> allowNamespaceOperationAsync(NamespaceName namespaceName,
                                                                    String role,
                                                                    NamespaceOperation operation,
-                                                                   AuthenticationDataSource authData) {
+                                                                   AuthenticationDataSource authenticationData) {
+        Assert.assertNotNull(authenticationData);
         return roleAuthorizedAsync(role);
     }
 
@@ -156,7 +170,8 @@ public class KafkaMockAuthorizationProvider implements AuthorizationProvider {
     public Boolean allowNamespaceOperation(NamespaceName namespaceName,
                                            String role,
                                            NamespaceOperation operation,
-                                           AuthenticationDataSource authData) {
+                                           AuthenticationDataSource authenticationData) {
+        Assert.assertNotNull(authenticationData);
         return roleAuthorized(role);
     }
 
@@ -166,7 +181,8 @@ public class KafkaMockAuthorizationProvider implements AuthorizationProvider {
                                                                    String originalRole,
                                                                    String role,
                                                                    NamespaceOperation operation,
-                                                                   AuthenticationDataSource authData) {
+                                                                   AuthenticationDataSource authenticationData) {
+        Assert.assertNotNull(authenticationData);
         return roleAuthorizedAsync(role);
     }
 
@@ -175,7 +191,8 @@ public class KafkaMockAuthorizationProvider implements AuthorizationProvider {
                                            String originalRole,
                                            String role,
                                            NamespaceOperation operation,
-                                           AuthenticationDataSource authData) {
+                                           AuthenticationDataSource authenticationData) {
+        Assert.assertNotNull(authenticationData);
         return roleAuthorized(role);
     }
 
@@ -184,7 +201,8 @@ public class KafkaMockAuthorizationProvider implements AuthorizationProvider {
                                                                          PolicyName policy,
                                                                          PolicyOperation operation,
                                                                          String role,
-                                                                         AuthenticationDataSource authData) {
+                                                                         AuthenticationDataSource authenticationData) {
+        Assert.assertNotNull(authenticationData);
         return roleAuthorizedAsync(role);
     }
 
@@ -193,7 +211,8 @@ public class KafkaMockAuthorizationProvider implements AuthorizationProvider {
                                                  PolicyName policy,
                                                  PolicyOperation operation,
                                                  String role,
-                                                 AuthenticationDataSource authData) {
+                                                 AuthenticationDataSource authenticationData) {
+        Assert.assertNotNull(authenticationData);
         return roleAuthorized(role);
     }
 
@@ -203,7 +222,8 @@ public class KafkaMockAuthorizationProvider implements AuthorizationProvider {
                                                                          PolicyOperation operation,
                                                                          String originalRole,
                                                                          String role,
-                                                                         AuthenticationDataSource authData) {
+                                                                         AuthenticationDataSource authenticationData) {
+        Assert.assertNotNull(authenticationData);
         return roleAuthorizedAsync(role);
     }
 
@@ -213,7 +233,8 @@ public class KafkaMockAuthorizationProvider implements AuthorizationProvider {
                                                  PolicyOperation operation,
                                                  String originalRole,
                                                  String role,
-                                                 AuthenticationDataSource authData) {
+                                                 AuthenticationDataSource authenticationData) {
+        Assert.assertNotNull(authenticationData);
         return roleAuthorized(role);
     }
 
@@ -221,7 +242,8 @@ public class KafkaMockAuthorizationProvider implements AuthorizationProvider {
     public CompletableFuture<Boolean> allowTopicOperationAsync(TopicName topic,
                                                                String role,
                                                                TopicOperation operation,
-                                                               AuthenticationDataSource authData) {
+                                                               AuthenticationDataSource authenticationData) {
+        Assert.assertNotNull(authenticationData);
         return roleAuthorizedAsync(role);
     }
 
@@ -229,7 +251,8 @@ public class KafkaMockAuthorizationProvider implements AuthorizationProvider {
     public Boolean allowTopicOperation(TopicName topicName,
                                        String role,
                                        TopicOperation operation,
-                                       AuthenticationDataSource authData) {
+                                       AuthenticationDataSource authenticationData) {
+        Assert.assertNotNull(authenticationData);
         return roleAuthorized(role);
     }
 
@@ -238,7 +261,8 @@ public class KafkaMockAuthorizationProvider implements AuthorizationProvider {
                                                                String originalRole,
                                                                String role,
                                                                TopicOperation operation,
-                                                               AuthenticationDataSource authData) {
+                                                               AuthenticationDataSource authenticationData) {
+        Assert.assertNotNull(authenticationData);
         return roleAuthorizedAsync(role);
     }
 
@@ -247,7 +271,8 @@ public class KafkaMockAuthorizationProvider implements AuthorizationProvider {
                                        String originalRole,
                                        String role,
                                        TopicOperation operation,
-                                       AuthenticationDataSource authData) {
+                                       AuthenticationDataSource authenticationData) {
+        Assert.assertNotNull(authenticationData);
         return roleAuthorized(role);
     }
 
@@ -267,7 +292,8 @@ public class KafkaMockAuthorizationProvider implements AuthorizationProvider {
             String role,
             PolicyName policy,
             PolicyOperation operation,
-            AuthenticationDataSource authData) {
+            AuthenticationDataSource authenticationData) {
+        Assert.assertNotNull(authenticationData);
         return roleAuthorizedAsync(role);
     }
 
@@ -277,7 +303,8 @@ public class KafkaMockAuthorizationProvider implements AuthorizationProvider {
             String role,
             PolicyName policy,
             PolicyOperation operation,
-            AuthenticationDataSource authData) {
+            AuthenticationDataSource authenticationData) {
+        Assert.assertNotNull(authenticationData);
         return roleAuthorized(role);
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/KafkaMockAuthorizationProvider.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/KafkaMockAuthorizationProvider.java
@@ -13,49 +13,250 @@
  */
 package io.streamnative.pulsar.handlers.kop.security.auth;
 
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import org.apache.pulsar.broker.auth.MockAuthorizationProvider;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
+import org.apache.pulsar.broker.authorization.AuthorizationProvider;
+import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.AuthAction;
+import org.apache.pulsar.common.policies.data.NamespaceOperation;
 import org.apache.pulsar.common.policies.data.PolicyName;
 import org.apache.pulsar.common.policies.data.PolicyOperation;
+import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.apache.pulsar.common.policies.data.TenantOperation;
 import org.apache.pulsar.common.policies.data.TopicOperation;
 
 
-public class KafkaMockAuthorizationProvider extends MockAuthorizationProvider {
+@Slf4j
+public class KafkaMockAuthorizationProvider implements AuthorizationProvider {
+
     @Override
-    public CompletableFuture<Boolean> allowTopicOperationAsync(
-            TopicName topic, String role, TopicOperation operation, AuthenticationDataSource authData) {
-        return CompletableFuture.completedFuture(true);
+    public void close() {}
+
+    @Override
+    public CompletableFuture<Boolean> isSuperUser(String role,
+                                                  AuthenticationDataSource authenticationData,
+                                                  ServiceConfiguration serviceConfiguration) {
+        return roleAuthorizedAsync(role);
     }
 
     @Override
-    public Boolean allowTopicOperation(
-            TopicName topicName,
-            String role,
-            TopicOperation operation,
-            AuthenticationDataSource authData) {
-        return true;
+    public CompletableFuture<Boolean> isSuperUser(String role, ServiceConfiguration serviceConfiguration) {
+        return roleAuthorizedAsync(role);
     }
 
     @Override
-    public CompletableFuture<Boolean> allowTopicOperationAsync(
-            TopicName topic,
-            String originalRole,
-            String role,
-            TopicOperation operation,
-            AuthenticationDataSource authData) {
-        return CompletableFuture.completedFuture(true);
+    public CompletableFuture<Boolean> isTenantAdmin(String tenant, String role, TenantInfo tenantInfo,
+                                                    AuthenticationDataSource authenticationData) {
+        return roleAuthorizedAsync(role);
     }
 
     @Override
-    public Boolean allowTopicOperation(
-            TopicName topicName,
-            String originalRole,
-            String role,
-            TopicOperation operation,
-            AuthenticationDataSource authData) {
-        return true;
+    public CompletableFuture<Boolean> canProduceAsync(TopicName topicName, String role,
+                                                      AuthenticationDataSource authenticationData) {
+        return roleAuthorizedAsync(role);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> canConsumeAsync(TopicName topicName, String role,
+                                                      AuthenticationDataSource authenticationData,
+                                                      String subscription) {
+        return roleAuthorizedAsync(role);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> canLookupAsync(TopicName topicName, String role,
+                                                     AuthenticationDataSource authenticationData) {
+        return roleAuthorizedAsync(role);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> allowFunctionOpsAsync(NamespaceName namespaceName, String role,
+                                                            AuthenticationDataSource authenticationData) {
+        return roleAuthorizedAsync(role);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> allowSourceOpsAsync(NamespaceName namespaceName, String role,
+                                                          AuthenticationDataSource authenticationData) {
+        return roleAuthorizedAsync(role);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> allowSinkOpsAsync(NamespaceName namespaceName, String role,
+                                                        AuthenticationDataSource authenticationData) {
+        return roleAuthorizedAsync(role);
+    }
+
+    @Override
+    public CompletableFuture<Void> grantPermissionAsync(NamespaceName namespace, Set<AuthAction> actions, String role,
+                                                        String authDataJson) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> grantSubscriptionPermissionAsync(NamespaceName namespace,
+                                                                    String subscriptionName, Set<String> roles,
+                                                                    String authDataJson) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> revokeSubscriptionPermissionAsync(NamespaceName namespace, String subscriptionName,
+                                                                     String role, String authDataJson) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> grantPermissionAsync(TopicName topicName, Set<AuthAction> actions, String role,
+                                                        String authDataJson) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> allowTenantOperationAsync(String tenantName, String originalRole, String role,
+                                                                TenantOperation operation,
+                                                                AuthenticationDataSource authData) {
+        return roleAuthorizedAsync(role);
+    }
+
+    @Override
+    public Boolean allowTenantOperation(String tenantName, String originalRole, String role, TenantOperation operation,
+                                        AuthenticationDataSource authData) {
+        return roleAuthorized(role);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> allowTenantOperationAsync(String tenantName, String role,
+                                                                TenantOperation operation,
+                                                                AuthenticationDataSource authData) {
+        return roleAuthorizedAsync(role);
+    }
+
+    @Override
+    public Boolean allowTenantOperation(String tenantName, String role, TenantOperation operation,
+                                        AuthenticationDataSource authData) {
+        return roleAuthorized(role);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> allowNamespaceOperationAsync(NamespaceName namespaceName,
+                                                                   String role,
+                                                                   NamespaceOperation operation,
+                                                                   AuthenticationDataSource authData) {
+        return roleAuthorizedAsync(role);
+    }
+
+    @Override
+    public Boolean allowNamespaceOperation(NamespaceName namespaceName,
+                                           String role,
+                                           NamespaceOperation operation,
+                                           AuthenticationDataSource authData) {
+        return roleAuthorized(role);
+    }
+
+
+    @Override
+    public CompletableFuture<Boolean> allowNamespaceOperationAsync(NamespaceName namespaceName,
+                                                                   String originalRole,
+                                                                   String role,
+                                                                   NamespaceOperation operation,
+                                                                   AuthenticationDataSource authData) {
+        return roleAuthorizedAsync(role);
+    }
+
+    @Override
+    public Boolean allowNamespaceOperation(NamespaceName namespaceName,
+                                           String originalRole,
+                                           String role,
+                                           NamespaceOperation operation,
+                                           AuthenticationDataSource authData) {
+        return roleAuthorized(role);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> allowNamespacePolicyOperationAsync(NamespaceName namespaceName,
+                                                                         PolicyName policy,
+                                                                         PolicyOperation operation,
+                                                                         String role,
+                                                                         AuthenticationDataSource authData) {
+        return roleAuthorizedAsync(role);
+    }
+
+    @Override
+    public Boolean allowNamespacePolicyOperation(NamespaceName namespaceName,
+                                                 PolicyName policy,
+                                                 PolicyOperation operation,
+                                                 String role,
+                                                 AuthenticationDataSource authData) {
+        return roleAuthorized(role);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> allowNamespacePolicyOperationAsync(NamespaceName namespaceName,
+                                                                         PolicyName policy,
+                                                                         PolicyOperation operation,
+                                                                         String originalRole,
+                                                                         String role,
+                                                                         AuthenticationDataSource authData) {
+        return roleAuthorizedAsync(role);
+    }
+
+    @Override
+    public Boolean allowNamespacePolicyOperation(NamespaceName namespaceName,
+                                                 PolicyName policy,
+                                                 PolicyOperation operation,
+                                                 String originalRole,
+                                                 String role,
+                                                 AuthenticationDataSource authData) {
+        return roleAuthorized(role);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> allowTopicOperationAsync(TopicName topic,
+                                                               String role,
+                                                               TopicOperation operation,
+                                                               AuthenticationDataSource authData) {
+        return roleAuthorizedAsync(role);
+    }
+
+    @Override
+    public Boolean allowTopicOperation(TopicName topicName,
+                                       String role,
+                                       TopicOperation operation,
+                                       AuthenticationDataSource authData) {
+        return roleAuthorized(role);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> allowTopicOperationAsync(TopicName topic,
+                                                               String originalRole,
+                                                               String role,
+                                                               TopicOperation operation,
+                                                               AuthenticationDataSource authData) {
+        return roleAuthorizedAsync(role);
+    }
+
+    @Override
+    public Boolean allowTopicOperation(TopicName topicName,
+                                       String originalRole,
+                                       String role,
+                                       TopicOperation operation,
+                                       AuthenticationDataSource authData) {
+        return roleAuthorized(role);
+    }
+
+    CompletableFuture<Boolean> roleAuthorizedAsync(String role) {
+        CompletableFuture<Boolean> promise = new CompletableFuture<>();
+        try {
+            promise.complete(roleAuthorized(role));
+        } catch (Exception e) {
+            promise.completeExceptionally(e);
+        }
+        return promise;
     }
 
     @Override
@@ -65,7 +266,7 @@ public class KafkaMockAuthorizationProvider extends MockAuthorizationProvider {
             PolicyName policy,
             PolicyOperation operation,
             AuthenticationDataSource authData) {
-        return CompletableFuture.completedFuture(true);
+        return roleAuthorizedAsync(role);
     }
 
     @Override
@@ -75,6 +276,22 @@ public class KafkaMockAuthorizationProvider extends MockAuthorizationProvider {
             PolicyName policy,
             PolicyOperation operation,
             AuthenticationDataSource authData) {
-        return true;
+        return roleAuthorized(role);
+    }
+
+    public boolean roleAuthorized(String role) {
+        String[] parts = role.split("\\.");
+        if (parts.length == 2) {
+            switch (parts[1]) {
+                case "pass":
+                    return true;
+                case "fail":
+                    return false;
+                case "error":
+                    throw new RuntimeException("Error in authn");
+            }
+        }
+        throw new IllegalArgumentException(
+                "Not a valid principle. Should be [pass|fail|error].[pass|fail|error], found " + role);
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/KafkaMockAuthorizationProvider.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/KafkaMockAuthorizationProvider.java
@@ -34,7 +34,9 @@ import org.apache.pulsar.common.policies.data.TopicOperation;
 public class KafkaMockAuthorizationProvider implements AuthorizationProvider {
 
     @Override
-    public void close() {}
+    public void close() {
+        // no-op
+    }
 
     @Override
     public CompletableFuture<Boolean> isSuperUser(String role,
@@ -288,7 +290,9 @@ public class KafkaMockAuthorizationProvider implements AuthorizationProvider {
                 case "fail":
                     return false;
                 case "error":
-                    throw new RuntimeException("Error in authn");
+                    throw new IllegalStateException("Error in authn");
+                default:
+                   return false;
             }
         }
         throw new IllegalArgumentException(


### PR DESCRIPTION
### Motivation

Currently, when KoP uses the oauth2 authentication, the authorization will fail, because we have customized negotiated properties in `SaslServer` but the oauth2 server is not implemented yet. See: https://github.com/streamnative/kop/blob/b6344dc06ec7b8e4f2e64e43ec1227476f70e8fb/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/PlainSaslServer.java#L143-L154

Error log:
```
2022-04-12T02:36:14,551+0000 [pulsar-io-4-1] ERROR io.streamnative.pulsar.handlers.kop.KafkaCommandDecoder - error while handle command:
java.lang.NullPointerException: null
        at io.streamnative.pulsar.broker.AuthUtils.getToken(AuthUtils.java:29) ~[pulsar-broker-auth-oauth2-2.9.2.7.jar:?]
        at io.streamnative.pulsar.broker.authorization.AuthorizationProviderOAuth.isSuperUser(AuthorizationProviderOAuth.java:87) ~[pulsar-broker-auth-oauth2-2.9.2.7.jar:?]
        at org.apache.pulsar.broker.authorization.AuthorizationService.canLookupAsync(AuthorizationService.java:301) ~[io.streamnative-pulsar-broker-common-2.9.2.7.jar:2.9.2.7]
        at io.streamnative.pulsar.handlers.kop.security.auth.SimpleAclAuthorizer.canLookupAsync(SimpleAclAuthorizer.java:145) ~[_iJkmHjzCXmJbuMTkIuXqA/:?]
        at io.streamnative.pulsar.handlers.kop.KafkaRequestHandler.authorize(KafkaRequestHandler.java:2456) ~[_iJkmHjzCXmJbuMTkIuXqA/:?]
        at io.streamnative.pulsar.handlers.kop.KafkaRequestHandler.authorize(KafkaRequestHandler.java:2435) ~[_iJkmHjzCXmJbuMTkIuXqA/:?]
```


### Modifications

Support customized negotiated properties in KopOAuthBearerSaslServer 


### Verifying this change

Modify the SaslOauthKopHandlersTest, and set super users with empty.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

