### PR TITLE
[branch-2.8.3] Fix branch 2.8.3 KafkaMockAuthorizationProvider compilation error

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/KafkaMockAuthorizationProvider.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/KafkaMockAuthorizationProvider.java
@@ -13,12 +13,14 @@
  */
 package io.streamnative.pulsar.handlers.kop.security.auth;
 
+import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.broker.authorization.AuthorizationProvider;
+import org.apache.pulsar.broker.cache.ConfigurationCacheService;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.AuthAction;
@@ -57,6 +59,11 @@ public class KafkaMockAuthorizationProvider implements AuthorizationProvider {
                                                     AuthenticationDataSource authenticationData) {
         Assert.assertNotNull(authenticationData);
         return roleAuthorizedAsync(role);
+    }
+
+    @Override
+    public void initialize(ServiceConfiguration conf, ConfigurationCacheService configCache) throws IOException {
+        // No-op
     }
 
     @Override


### PR DESCRIPTION
### Motivation

The 2.8.3 branch's AuthorizationProvider has an abstract method `initialize`, which is changed to the default method in the future. 

We need to implement this method in the 2.8.3 branch to fix the compilation error.
```
[INFO] -------------------------------------------------------------
[INFO] -------------------------------------------------------------
Error:  COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
Error:  /home/runner/work/kop/kop/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/KafkaMockAuthorizationProvider.java:[35,8] io.streamnative.pulsar.handlers.kop.security.auth.KafkaMockAuthorizationProvider is not abstract and does not override abstract method initialize(org.apache.pulsar.broker.ServiceConfiguration,org.apache.pulsar.broker.cache.ConfigurationCacheService) in org.apache.pulsar.broker.authorization.AuthorizationProvider
```
See: https://github.com/streamnative/kop/runs/6000118135?check_suite_focus=true#step:5:890

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

