### PR TITLE
[doc] add set retention size limit for system topic

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -136,6 +136,7 @@ This section lists configurations about the group coordinator and the `__consume
 |offsetsMessageTTL| The offsets message TTL in seconds. | 259200 |
 |offsetsRetentionCheckIntervalMs| The frequency at which to check for stale offsets.  |600000|
 |offsetsTopicNumPartitions| The number of partitions for the offsets topic.  |50|
+|systemTopicRetentionSizeInMB| The system topic retention size in mb. | -1 |
 
 ## Transaction
 


### PR DESCRIPTION
### Motivation
The previous PR #1218 has added retention size limit for the system topics, we need to add a doc to explain.


### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [x] `doc` 
  
  (If this PR contains doc changes)

