### PR TITLE
Set default validate method value for OAuth

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -145,7 +145,7 @@ If you want to enable the authentication feature for KoP using the `OAUTHBEARER`
     kopOauth2ConfigFile=conf/kop-handler.properties
     ```
 
-(3) Specify the authentication method name of the provider (that is, `oauth.validate.method`) in the `conf/kop-handler.properties` file. The default oauth validate method is `token`, if you are using the `token` method, then don't need to specify this setting.
+(3) Specify the authentication method name of the provider (that is, `oauth.validate.method`) in the `conf/kop-handler.properties` file. By default, it uses the `token` authentication method. If you have configured the `token` authentication  method, you do not need to specify the authentication method name.
 
    - If you use `AuthenticationProviderToken`, since `AuthenticationProviderToken#getAuthMethodName()` returns `token`, set the `oauth.validate.method` as the token.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -145,7 +145,7 @@ If you want to enable the authentication feature for KoP using the `OAUTHBEARER`
     kopOauth2ConfigFile=conf/kop-handler.properties
     ```
 
-(3) Specify the authentication method name of the provider (that is, `oauth.validate.method`) in the `conf/kop-handler.properties` file.
+(3) Specify the authentication method name of the provider (that is, `oauth.validate.method`) in the `conf/kop-handler.properties` file. The default oauth validate method is `token`, if you are using the `token` method, then don't need to specify this setting.
 
    - If you use `AuthenticationProviderToken`, since `AuthenticationProviderToken#getAuthMethodName()` returns `token`, set the `oauth.validate.method` as the token.
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/ServerConfig.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/ServerConfig.java
@@ -31,11 +31,6 @@ public class ServerConfig {
     private final String validateMethod;
 
     public ServerConfig(Map<String, String> configs) {
-        String tempValidateMethod;
-        tempValidateMethod = configs.get(OAUTH_VALIDATE_METHOD);
-        if (tempValidateMethod == null) {
-            tempValidateMethod = DEFAULT_OAUTH_VALIDATE_METHOD;
-        }
-        this.validateMethod = tempValidateMethod;
+        this.validateMethod = configs.getOrDefault(OAUTH_VALIDATE_METHOD, DEFAULT_OAUTH_VALIDATE_METHOD);
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/ServerConfig.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/ServerConfig.java
@@ -15,7 +15,6 @@ package io.streamnative.pulsar.handlers.kop.security.oauth;
 
 import java.util.Map;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * The server configs associated with OauthValidatorCallbackHandler.
@@ -23,7 +22,6 @@ import lombok.extern.slf4j.Slf4j;
  * @see OauthValidatorCallbackHandler
  */
 @Getter
-@Slf4j
 public class ServerConfig {
 
     public static final String DEFAULT_OAUTH_VALIDATE_METHOD = "token";

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/ServerConfig.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/ServerConfig.java
@@ -15,6 +15,7 @@ package io.streamnative.pulsar.handlers.kop.security.oauth;
 
 import java.util.Map;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * The server configs associated with OauthValidatorCallbackHandler.
@@ -22,16 +23,21 @@ import lombok.Getter;
  * @see OauthValidatorCallbackHandler
  */
 @Getter
+@Slf4j
 public class ServerConfig {
+
+    public static final String DEFAULT_OAUTH_VALIDATE_METHOD = "token";
 
     public static final String OAUTH_VALIDATE_METHOD = "oauth.validate.method";
 
     private final String validateMethod;
 
     public ServerConfig(Map<String, String> configs) {
-        this.validateMethod = configs.get(OAUTH_VALIDATE_METHOD);
-        if (this.validateMethod == null) {
-            throw new IllegalArgumentException("no key for " + OAUTH_VALIDATE_METHOD);
+        String tempValidateMethod;
+        tempValidateMethod = configs.get(OAUTH_VALIDATE_METHOD);
+        if (tempValidateMethod == null) {
+            tempValidateMethod = DEFAULT_OAUTH_VALIDATE_METHOD;
         }
+        this.validateMethod = tempValidateMethod;
     }
 }

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/security/oauth/ServerConfigTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/security/oauth/ServerConfigTest.java
@@ -35,11 +35,8 @@ public class ServerConfigTest {
     }
 
     @Test
-    public void testInvalidConfig() {
-        try {
-            new ServerConfig(new HashMap<>());
-        } catch (IllegalArgumentException e) {
-            Assert.assertEquals(e.getMessage(), "no key for " + ServerConfig.OAUTH_VALIDATE_METHOD);
-        }
+    public void testGetDefaultValidateMethod() {
+        ServerConfig serverConfig = new ServerConfig(new HashMap<>());
+        Assert.assertEquals(ServerConfig.DEFAULT_OAUTH_VALIDATE_METHOD, serverConfig.getValidateMethod());
     }
 }


### PR DESCRIPTION
### Motivation

Currently, when we use OAuth in KoP, we must set the `kopOauth2ConfigFile`, but most of the time we only use `token` as the validate method. 

We should set the default validate method when `kopOauth2ConfigFile` is not configured.

### Modifications

Set `token` as the default validate method value.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [x] `doc` 
  
  (If this PR contains doc changes)

