### PR TITLE
Exclude grpc package from pulsar-broker

### DIFF
--- a/kafka-impl/pom.xml
+++ b/kafka-impl/pom.xml
@@ -88,6 +88,12 @@
     </dependency>
 
     <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,27 @@
         <groupId>${pulsar.group.id}</groupId>
         <artifactId>pulsar-broker</artifactId>
         <version>${pulsar.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-all</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-core</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-testing</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-all</artifactId>
+        <version>1.45.1</version>
+        <scope>provided</scope>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,8 @@
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testng.version>6.14.3</testng.version>
     <awaitility.version>4.0.3</awaitility.version>
+    <grpc.version>1.45.1</grpc.version>
+    <junit.version>4.13.1</junit.version>
     <!-- plugin dependencies -->
     <license-maven-plugin.version>3.0.rc1</license-maven-plugin.version>
     <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
@@ -109,13 +111,24 @@
             <groupId>io.grpc</groupId>
             <artifactId>grpc-testing</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-auth</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 
       <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-all</artifactId>
-        <version>1.45.1</version>
+        <version>${grpc.version}</version>
+        <scope>provided</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>${junit.version}</version>
         <scope>provided</scope>
       </dependency>
 


### PR DESCRIPTION
### Motivation

Currently, the pulsar-broker has a conflict dependency problem. This will cause failure when building the project. And we need to resolve the dependency problem in Pulsar, after Pulsar fixes the problem, we could improve this change.

```
Cannot resolve Could not resolve version conflict among

io.streamnative:pulsar-broker:jar:2.9.2.14 -> io.streamnative:pulsar-zookeeper-utils:jar:2.9.2.14 -> org.apache.bookkeeper:stream-storage-server:jar:4.14.4 -> org.apache.bookkeeper:stream-storage-java-client:jar:4.14.4 -> io.grpc:grpc-core:jar:1.42.1
io.streamnative:pulsar-broker:jar:2.9.2.14 -> io.streamnative:pulsar-zookeeper-utils:jar:2.9.2.14 -> org.apache.bookkeeper:stream-storage-server:jar:4.14.4 -> org.apache.bookkeeper:stream-storage-java-client:jar:4.14.4 -> io.grpc:grpc-testing:jar:1.42.1 -> io.grpc:grpc-core:jar:[1.42.1,1.42.1]
io.streamnative:pulsar-broker:jar:2.9.2.14 -> io.streamnative:pulsar-zookeeper-utils:jar:2.9.2.14 -> io.grpc:grpc-all:jar:1.45.1 -> io.grpc:grpc-core:jar:[1.45.1,1.45.1]
io.streamnative:pulsar-broker:jar:2.9.2.14 -> io.streamnative:pulsar-zookeeper-utils:jar:2.9.2.14 -> io.grpc:grpc-all:jar:1.45.1 -> io.grpc:grpc-grpclb:jar:1.45.1 -> io.grpc:grpc-core:jar:[1.45.1,1.45.1]
io.streamnative:pulsar-broker:jar:2.9.2.14 -> io.streamnative:pulsar-zookeeper-utils:jar:2.9.2.14 -> io.grpc:grpc-all:jar:1.45.1 -> io.grpc:grpc-netty:jar:1.45.1 -> io.grpc:grpc-core:jar:[1.45.1,1.45.1]
io.streamnative:pulsar-broker:jar:2.9.2.14 -> io.streamnative:pulsar-zookeeper-utils:jar:2.9.2.14 -> io.grpc:grpc-all:jar:1.45.1 -> io.grpc:grpc-rls:jar:1.45.1 -> io.grpc:grpc-core:jar:[1.45.1,1.45.1]
io.streamnative:pulsar-broker:jar:2.9.2.14 -> io.streamnative:pulsar-zookeeper-utils:jar:2.9.2.14 -> io.grpc:grpc-all:jar:1.45.1 -> io.grpc:grpc-services:jar:1.45.1 -> io.grpc:grpc-core:jar:[1.45.1,1.45.1]
io.streamnative:pulsar-broker:jar:2.9.2.14 -> io.streamnative:pulsar-zookeeper-utils:jar:2.9.2.14 -> io.grpc:grpc-all:jar:1.45.1 -> io.grpc:grpc-xds:jar:1.45.1 -> io.grpc:grpc-core:jar:1.45.1
io.streamnative:pulsar-broker:jar:2.9.2.14 -> io.streamnative:pulsar-zookeeper-utils:jar:2.9.2.14 -> io.grpc:grpc-all:jar:1.45.1 -> io.grpc:grpc-xds:jar:1.45.1 -> io.grpc:grpc-netty-shaded:jar:[1.45.1,1.45.1] -> io.grpc:grpc-core:jar:[1.45.1,1.45.1]
```

### Modifications

Exclude the grpc package from pulsar-broker.