### PR TITLE
[Bugfix] Delete group id stored in metadata storage when consumer close

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -376,7 +376,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 metadataStore.delete(path, Optional.empty())
                         .whenComplete((__, ex) -> {
                             if (ex != null) {
-                                if (ex instanceof MetadataStoreException.NotFoundException) {
+                                if (ex.getCause() instanceof MetadataStoreException.NotFoundException) {
                                     return;
                                 }
                                 log.error("Delete groupId failed. Path: [{}]", path, ex);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -377,6 +377,9 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                         .whenComplete((__, ex) -> {
                             if (ex != null) {
                                 if (ex.getCause() instanceof MetadataStoreException.NotFoundException) {
+                                    if (log.isDebugEnabled()) {
+                                        log.debug("The groupId store path doesn't exist. Path: [{}]", path);
+                                    }
                                     return;
                                 }
                                 log.error("Delete groupId failed. Path: [{}]", path, ex);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
@@ -32,7 +32,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.bookkeeper.util.SafeRunnable;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
@@ -240,7 +239,7 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase {
         final String group1 = "my-group-1";
         final String group2 = "my-group-2";
 
-        tryConsume(topic, clientId, group1, SafeRunnable.safeRun(() -> {
+        tryConsume(topic, clientId, group1, () -> {
             try {
                 List<String> children = mockZooKeeper.getChildren(conf.getGroupIdZooKeeperPath(), false);
                 Assert.assertEquals(children.size(), 1);
@@ -251,7 +250,7 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase {
             } catch (Exception ex) {
                 fail("Should not have exception." + ex.getMessage());
             }
-        }));
+        });
 
         Awaitility.await().untilAsserted(() -> {
             List<String> children1 = mockZooKeeper.getChildren(conf.getGroupIdZooKeeperPath(), false);
@@ -259,7 +258,7 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase {
         });
 
         // Create a consumer with the same hostname and client id, the existed z-node will be updated
-        tryConsume(topic, clientId, group2, SafeRunnable.safeRun(() -> {
+        tryConsume(topic, clientId, group2, () -> {
             try {
                 List<String> children = mockZooKeeper.getChildren(conf.getGroupIdZooKeeperPath(), false);
                 Assert.assertEquals(children.size(), 1);
@@ -270,7 +269,7 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase {
             } catch (Exception ex) {
                 fail("Should not have exception." + ex.getMessage());
             }
-        }));
+        });
 
         Awaitility.await().untilAsserted(() -> {
             List<String> children1 = mockZooKeeper.getChildren(conf.getGroupIdZooKeeperPath(), false);
@@ -281,7 +280,7 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase {
     private void tryConsume(final String topic,
                             final String clientId,
                             final String groupId,
-                            SafeRunnable runBeforeClose) {
+                            Runnable runBeforeClose) {
         final Properties props = newKafkaConsumerProperties();
         props.put(ConsumerConfig.CLIENT_ID_CONFIG, clientId);
         props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
@@ -13,6 +13,8 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
+import static org.testng.AssertJUnit.fail;
+
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -30,6 +32,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.util.SafeRunnable;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
@@ -41,6 +44,7 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.protocol.ApiKeys;
+import org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -230,29 +234,54 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase {
     }
 
     @Test(timeOut = 20000)
-    public void testUpdateGroupId() throws Exception {
+    public void testUpdateGroupId() {
         final String topic = "testUpdateGroupId";
         final String clientId = "my-client";
         final String group1 = "my-group-1";
         final String group2 = "my-group-2";
 
-        tryConsume(topic, clientId, group1);
-        List<String> children = mockZooKeeper.getChildren(conf.getGroupIdZooKeeperPath(), false);
-        Assert.assertEquals(children.size(), 1);
-        Assert.assertEquals(children.get(0), "127.0.0.1-" + clientId);
-        byte[] data = mockZooKeeper.getData(conf.getGroupIdZooKeeperPath() + "/" + children.get(0), false, null);
-        Assert.assertEquals(new String(data, StandardCharsets.UTF_8), group1);
+        tryConsume(topic, clientId, group1, SafeRunnable.safeRun(() -> {
+            try {
+                List<String> children = mockZooKeeper.getChildren(conf.getGroupIdZooKeeperPath(), false);
+                Assert.assertEquals(children.size(), 1);
+                Assert.assertEquals(children.get(0), "127.0.0.1-" + clientId);
+                byte[] data = mockZooKeeper
+                        .getData(conf.getGroupIdZooKeeperPath() + "/" + children.get(0), false, null);
+                Assert.assertEquals(new String(data, StandardCharsets.UTF_8), group1);
+            } catch (Exception ex) {
+                fail("Should not have exception." + ex.getMessage());
+            }
+        }));
+
+        Awaitility.await().untilAsserted(() -> {
+            List<String> children1 = mockZooKeeper.getChildren(conf.getGroupIdZooKeeperPath(), false);
+            Assert.assertEquals(children1.size(), 0);
+        });
 
         // Create a consumer with the same hostname and client id, the existed z-node will be updated
-        tryConsume(topic, clientId, group2);
-        children = mockZooKeeper.getChildren(conf.getGroupIdZooKeeperPath(), false);
-        Assert.assertEquals(children.size(), 1);
-        Assert.assertEquals(children.get(0), "127.0.0.1-" + clientId);
-        data = mockZooKeeper.getData(conf.getGroupIdZooKeeperPath() + "/" + children.get(0), false, null);
-        Assert.assertEquals(new String(data, StandardCharsets.UTF_8), group2);
+        tryConsume(topic, clientId, group2, SafeRunnable.safeRun(() -> {
+            try {
+                List<String> children = mockZooKeeper.getChildren(conf.getGroupIdZooKeeperPath(), false);
+                Assert.assertEquals(children.size(), 1);
+                Assert.assertEquals(children.get(0), "127.0.0.1-" + clientId);
+                byte[] data = mockZooKeeper
+                        .getData(conf.getGroupIdZooKeeperPath() + "/" + children.get(0), false, null);
+                Assert.assertEquals(new String(data, StandardCharsets.UTF_8), group2);
+            } catch (Exception ex) {
+                fail("Should not have exception." + ex.getMessage());
+            }
+        }));
+
+        Awaitility.await().untilAsserted(() -> {
+            List<String> children1 = mockZooKeeper.getChildren(conf.getGroupIdZooKeeperPath(), false);
+            Assert.assertEquals(children1.size(), 0);
+        });
     }
 
-    private void tryConsume(final String topic, final String clientId, final String groupId) {
+    private void tryConsume(final String topic,
+                            final String clientId,
+                            final String groupId,
+                            SafeRunnable runBeforeClose) {
         final Properties props = newKafkaConsumerProperties();
         props.put(ConsumerConfig.CLIENT_ID_CONFIG, clientId);
         props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
@@ -260,6 +289,10 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase {
         final KafkaConsumer<String, String> consumer = new KafkaConsumer<>(props);
         consumer.subscribe(Collections.singleton(topic));
         consumer.poll(Duration.ofSeconds(3));
+
+        if (runBeforeClose != null) {
+            runBeforeClose.run();
+        }
         consumer.close();
     }
 }


### PR DESCRIPTION
Fixes #769 

### Motivation

Currently, KoP must store group name in zookeeper when KoP handle fetch request because in the current implementation, to monitor consumer stats must have group name when consumer fetch data.

But this data is never deleted in zookeeper. As time goes by, the amount of data becomes larger and larger. Then may cause the cluster crash.

We should find a way to delete this group name when the group is not active.

### Modifications

Delete the group id path when the consumer close.


### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

