### PR TITLE
[bugfix][flaky-test] Fix handle produce request npe

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -863,7 +863,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             }
             final String fullPartitionName = KopTopic.toString(topicPartition, namespacePrefix);
             authorize(AclOperation.WRITE, Resource.of(ResourceType.TOPIC, fullPartitionName))
-                    .whenComplete((isAuthorized, ex) -> {
+                    .whenCompleteAsync((isAuthorized, ex) -> {
                         if (ex != null) {
                             log.error("Write topic authorize failed, topic - {}. {}",
                                     fullPartitionName, ex.getMessage());
@@ -880,7 +880,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                         }
                         authorizedRequestInfo.put(topicPartition, records);
                         completeOne.run();
-                    });
+                    }, ctx.executor());
         });
 
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
@@ -29,6 +29,9 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.DefaultEventLoop;
+import io.netty.channel.EventLoopGroup;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupCoordinator;
 import io.streamnative.pulsar.handlers.kop.security.auth.Resource;
 import io.streamnative.pulsar.handlers.kop.security.auth.ResourceType;
@@ -85,6 +88,7 @@ import org.apache.pulsar.client.impl.auth.AuthenticationToken;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
+import org.apache.pulsar.common.util.netty.EventLoopUtil;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -158,10 +162,16 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
 
         log.info("created namespaces, init handler");
 
+        DefaultThreadFactory defaultThreadFactory = new DefaultThreadFactory("pulsar-ph-kafka");
+        EventLoopGroup dedicatedWorkerGroup =
+                EventLoopUtil.newEventLoopGroup(1, false, defaultThreadFactory);
+        DefaultEventLoop eventExecutors = new DefaultEventLoop(dedicatedWorkerGroup);
+
         handler = newRequestHandler();
         ChannelHandlerContext mockCtx = mock(ChannelHandlerContext.class);
         Channel mockChannel = mock(Channel.class);
         doReturn(mockChannel).when(mockCtx).channel();
+        doReturn(eventExecutors).when(mockCtx).executor();
         handler.ctx = mockCtx;
 
         serviceAddress = new InetSocketAddress(pulsar.getBindAddress(), kafkaBrokerPort);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -509,13 +509,14 @@ public abstract class KopProtocolHandlerTestBase {
         public KProducer(String topic, Boolean isAsync, String host,
                          int port, String username, String password,
                          Boolean retry, String keySer, String valueSer,
-                         String transactionalId) {
+                         String transactionalId, int batchSize) {
             Properties props = new Properties();
             props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, host + ":" + port);
             props.put(ProducerConfig.CLIENT_ID_CONFIG, "DemoKafkaOnPulsarProducer");
             props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySer);
             props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSer);
             props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 10000);
+            props.put(ProducerConfig.BATCH_SIZE_CONFIG, batchSize);
             if (transactionalId != null) {
                 props.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId);
             }
@@ -541,6 +542,13 @@ public abstract class KopProtocolHandlerTestBase {
 
         public KProducer(String topic, Boolean isAsync, String host,
                          int port, String username, String password,
+                         Boolean retry, String keySer, String valueSer,
+                         String transactionalId) {
+            this(topic, isAsync, host, port, username, password, retry, keySer, valueSer, transactionalId, 16384);
+        }
+
+        public KProducer(String topic, Boolean isAsync, String host,
+                         int port, String username, String password,
                          Boolean retry, String keySer, String valueSer) {
             this(topic, isAsync, host, port, username, password, retry, keySer, valueSer, null);
         }
@@ -549,6 +557,12 @@ public abstract class KopProtocolHandlerTestBase {
                          int port, String username, String password) {
             this(topic, isAsync, host, port, username, password, false,
                     IntegerSerializer.class.getName(), StringSerializer.class.getName());
+        }
+
+        public KProducer(String topic, Boolean isAsync, String host,
+                         int port, String username, String password, int batchSize) {
+            this(topic, isAsync, host, port, username, password, false,
+                    IntegerSerializer.class.getName(), StringSerializer.class.getName(), null, batchSize);
         }
 
         public KProducer(String topic, Boolean isAsync, String host, int port) {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslPlainTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslPlainTestBase.java
@@ -138,9 +138,9 @@ public abstract class SaslPlainTestBase extends KopProtocolHandlerTestBase {
     }
 
     @Test(timeOut = 40000)
-    void simpleProduceAndConsume() throws Exception {
+    void simpleProduceAndConsume() {
         KProducer kProducer = new KProducer(TOPIC, false, "localhost", getKafkaBrokerPort(),
-            TENANT + "/" + NAMESPACE, "token:" + userToken);
+            TENANT + "/" + NAMESPACE, "token:" + userToken, 1);
         int totalMsgs = 10;
         String messageStrPrefix = TOPIC + "_message_";
 


### PR DESCRIPTION
### Motivation

Currently, the `SaslPlainTestBase.simpleProduceAndConsume` units test are flaky, see: https://github.com/streamnative/kop/runs/6317175411?check_suite_focus=true#step:12:160

Error log:
```
04:09:22.533 [Thread-8:io.streamnative.pulsar.handlers.kop.storage.PartitionLog@228] ERROR io.streamnative.pulsar.handlers.kop.storage.PartitionLog - Failed to handle produce request for persistent://SaslPlainTest/ns1/topic1-0
java.lang.NullPointerException: null
	at io.streamnative.pulsar.handlers.kop.PendingTopicFutures.addListener(PendingTopicFutures.java:74) ~[pulsar-protocol-handler-kafka-2.11.0-SNAPSHOT.jar:?]
	at io.streamnative.pulsar.handlers.kop.storage.PartitionLog.appendRecords(PartitionLog.java:226) ~[pulsar-protocol-handler-kafka-2.11.0-SNAPSHOT.jar:?]
	at io.streamnative.pulsar.handlers.kop.storage.ReplicaManager.lambda$appendRecords$5(ReplicaManager.java:110) ~[pulsar-protocol-handler-kafka-2.11.0-SNAPSHOT.jar:?]
	at java.util.concurrent.ConcurrentHashMap.forEach(ConcurrentHashMap.java:1597) ~[?:1.8.0_332]
	at io.streamnative.pulsar.handlers.kop.storage.ReplicaManager.appendRecords(ReplicaManager.java:101) ~[pulsar-protocol-handler-kafka-2.11.0-SNAPSHOT.jar:?]
	at io.streamnative.pulsar.handlers.kop.KafkaRequestHandler.lambda$handleProduceRequest$37(KafkaRequestHandler.java:833) ~[pulsar-protocol-handler-kafka-2.11.0-SNAPSHOT.jar:?]
	at io.streamnative.pulsar.handlers.kop.KafkaRequestHandler.lambda$null$38(KafkaRequestHandler.java:882) ~[pulsar-protocol-handler-kafka-2.11.0-SNAPSHOT.jar:?]
	at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:774) [?:1.8.0_332]
...
```

After investigation, we find the `PendingTopicFutures#addListener` method has concurrent calls, when the authorization is complete, the `getReplicaManager().appendRecords` will call in a different thread.


### Modifications

Use `ctx.executor()` as `PendingTopicFutures#addListener` method call thread.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

