### PR TITLE
Fix compaction threshold not configured in metadata namespace

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
@@ -204,28 +204,12 @@ public class MetadataUtils {
 
             // set namespace config only when offset metadata namespace first create
             if (isMetadataNamespace) {
-                int retentionMinutes = (int) conf.getOffsetsRetentionMinutes();
-                int retentionSizeInMB = conf.getSystemTopicRetentionSizeInMB();
-                RetentionPolicies retentionPolicies = namespaces.getRetention(kafkaNamespace);
-
-                if (retentionPolicies == null
-                        || retentionPolicies.getRetentionTimeInMinutes() != retentionMinutes
-                        || retentionPolicies.getRetentionSizeInMB() != retentionSizeInMB
-                ) {
-                    namespaces.setRetention(kafkaNamespace,
-                            new RetentionPolicies((int) conf.getOffsetsRetentionMinutes(), retentionSizeInMB));
-                }
-
-                Long compactionThreshold = namespaces.getCompactionThreshold(kafkaNamespace);
-                if (compactionThreshold != null && compactionThreshold != MAX_COMPACTION_THRESHOLD) {
-                    namespaces.setCompactionThreshold(kafkaNamespace, MAX_COMPACTION_THRESHOLD);
-                }
-
-                int targetMessageTTL = conf.getOffsetsMessageTTL();
-                Integer messageTTL = namespaces.getNamespaceMessageTTL(kafkaNamespace);
-                if (messageTTL == null || messageTTL != targetMessageTTL) {
-                    namespaces.setNamespaceMessageTTL(kafkaNamespace, targetMessageTTL);
-                }
+                namespaces.setRetention(kafkaNamespace, new RetentionPolicies(
+                        (int) conf.getOffsetsRetentionMinutes(),
+                        conf.getSystemTopicRetentionSizeInMB())
+                );
+                namespaces.setCompactionThreshold(kafkaNamespace, MAX_COMPACTION_THRESHOLD);
+                namespaces.setNamespaceMessageTTL(kafkaNamespace, conf.getOffsetsMessageTTL());
             }
         } else {
             List<String> replicationClusters = namespaces.getNamespaceReplicationClusters(kafkaNamespace);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetadataInitTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetadataInitTest.java
@@ -15,7 +15,7 @@ package io.streamnative.pulsar.handlers.kop;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertThrows;
 
 import io.streamnative.pulsar.handlers.kop.utils.MetadataUtils;
 import java.net.URISyntaxException;
@@ -92,11 +92,7 @@ public class MetadataInitTest extends KopProtocolHandlerTestBase {
         conf.setKafkaManageSystemNamespaces(false);
 
         final PulsarService pulsarService = startBroker(conf);
-        try {
-            new MetadataNamespacePolicies(pulsarService);
-        } catch (Exception e) {
-            assertTrue(e instanceof PulsarAdminException.NotFoundException);
-        }
+        assertThrows(PulsarAdminException.NotFoundException.class, () -> new MetadataNamespacePolicies(pulsarService));
         stopBroker(pulsarService);
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetadataInitTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetadataInitTest.java
@@ -1,0 +1,177 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import io.streamnative.pulsar.handlers.kop.utils.MetadataUtils;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.common.policies.data.RetentionPolicies;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class MetadataInitTest extends KopProtocolHandlerTestBase {
+
+    private static final String CLUSTER = "my-cluster";
+    private static final KafkaServiceConfiguration DEFAULT_CONFIG = new KafkaServiceConfiguration();
+    private static final String DEFAULT_METADATA_NS =
+            DEFAULT_CONFIG.getKafkaMetadataTenant() + "/" + DEFAULT_CONFIG.getKafkaMetadataNamespace();
+
+    private String protocolHandlerDirectory;
+
+    @Test(timeOut = 40000)
+    public void testSingleBrokerRestart() throws Exception {
+        log.info("testSingleBrokerRestart");
+        final KafkaServiceConfiguration conf = createConfig();
+        final PulsarService pulsarService = startBroker(conf);
+        new MetadataNamespacePolicies(pulsarService).verify(
+                DEFAULT_METADATA_NS,
+                DEFAULT_CONFIG.getOffsetsRetentionMinutes(),
+                DEFAULT_CONFIG.getSystemTopicRetentionSizeInMB(),
+                DEFAULT_CONFIG.getOffsetsMessageTTL()
+        );
+        stopBroker(pulsarService);
+
+        conf.setOffsetsRetentionMinutes(1001L);
+        conf.setSystemTopicRetentionSizeInMB(1025);
+        conf.setOffsetsMessageTTL(999);
+        final PulsarService pulsarService1 = startBroker(conf);
+        // The policies have already been configured, so the restart won't change them
+        new MetadataNamespacePolicies(pulsarService).verify(
+                DEFAULT_METADATA_NS,
+                DEFAULT_CONFIG.getOffsetsRetentionMinutes(),
+                DEFAULT_CONFIG.getSystemTopicRetentionSizeInMB(),
+                DEFAULT_CONFIG.getOffsetsMessageTTL()
+        );
+        stopBroker(pulsarService1);
+    }
+
+    @Test(timeOut = 30000)
+    public void testCustomPolicies() throws Exception {
+        log.info("testCustomPolicies");
+        final KafkaServiceConfiguration conf = createConfig();
+        conf.setOffsetsRetentionMinutes(1001L);
+        conf.setSystemTopicRetentionSizeInMB(1025);
+        conf.setOffsetsMessageTTL(999);
+        conf.setKafkaMetadataTenant("my-tenant");
+        conf.setKafkaMetadataNamespace("my-ns");
+
+        final PulsarService pulsarService = startBroker(conf);
+        new MetadataNamespacePolicies(pulsarService).verify(
+                "my-tenant/my-ns", 1001L, 1025, 999);
+        stopBroker(pulsarService);
+    }
+
+    @Test(timeOut = 30000)
+    public void testMetadataInitDisabled() throws Exception {
+        final KafkaServiceConfiguration conf = createConfig();
+        conf.setKafkaManageSystemNamespaces(false);
+
+        final PulsarService pulsarService = startBroker(conf);
+        try {
+            new MetadataNamespacePolicies(pulsarService);
+        } catch (Exception e) {
+            assertTrue(e instanceof PulsarAdminException.NotFoundException);
+        }
+        stopBroker(pulsarService);
+    }
+
+    @BeforeClass
+    public void findProtocolHandler() throws Exception {
+        this.protocolHandlerDirectory = getProtocolHandlerDirectory();
+    }
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup(false); // only start ZK and BK
+    }
+
+    @AfterMethod
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    private static String getProtocolHandlerDirectory() throws URISyntaxException {
+        final URL url = MetadataInitTest.class.getClassLoader().getResource("test-protocol-handler.nar");
+        if (url == null) {
+            throw new IllegalStateException("Failed to load test-protocol-handler.nar from resource directory");
+        }
+        return Paths.get(url.toURI()).toFile().getParent();
+    }
+
+    private KafkaServiceConfiguration createConfig() {
+        final int brokerPort = PortManager.nextFreePort();
+        final int webPort = PortManager.nextFreePort();
+        final int kafkaPort = PortManager.nextFreePort();
+        log.info("Create config with brokerPort={}, webPort={}, kafkaPort={}", brokerPort, webPort, kafkaPort);
+
+        final KafkaServiceConfiguration conf = new KafkaServiceConfiguration();
+        conf.setBrokerServicePort(Optional.of(brokerPort));
+        conf.setWebServicePort(Optional.of(webPort));
+        conf.setClusterName(CLUSTER);
+        conf.setZookeeperServers("localhost:2181");
+        conf.setConfigurationStoreServers("localhost:2181");
+
+        conf.setProtocolHandlerDirectory(protocolHandlerDirectory);
+        conf.setMessagingProtocols(Collections.singleton("kafka"));
+        conf.setKafkaListeners(PLAINTEXT_PREFIX + "localhost:" + kafkaPort);
+        return conf;
+    }
+
+    private static class MetadataNamespacePolicies {
+
+        private final String namespace;
+        private final RetentionPolicies retentionPolicies;
+        private final Long compactionThreshold;
+        private final Integer messageTTL;
+
+        public MetadataNamespacePolicies(final PulsarService pulsarService) throws Exception {
+            final PulsarAdmin admin = pulsarService.getAdminClient();
+            final KafkaServiceConfiguration conf = (KafkaServiceConfiguration) pulsarService.getConfiguration();
+            assertNotNull(conf);
+            this.namespace = conf.getKafkaMetadataTenant() + "/" + conf.getKafkaMetadataNamespace();
+            this.retentionPolicies = admin.namespaces().getRetention(namespace);
+            this.compactionThreshold = admin.namespaces().getCompactionThreshold(namespace);
+            this.messageTTL = admin.namespaces().getNamespaceMessageTTL(namespace);
+        }
+
+        public void verify(final String namespace,
+                           final long retentionTimeInMinutes,
+                           final int retentionSizeInMB,
+                           final int messageTTL) {
+            assertEquals(this.namespace, namespace);
+            assertEquals(retentionPolicies.getRetentionTimeInMinutes(), (int) retentionTimeInMinutes);
+            assertEquals(retentionPolicies.getRetentionSizeInMB(), retentionSizeInMB);
+            assertNotNull(compactionThreshold);
+            assertEquals(compactionThreshold.intValue(), MetadataUtils.MAX_COMPACTION_THRESHOLD);
+            assertNotNull(this.messageTTL);
+            assertEquals(this.messageTTL.intValue(), messageTTL);
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/streamnative/kop/issues/1272

### Motivation

https://github.com/streamnative/kop/pull/448 introduced a bug that the
compaction threshold was not set in metadata namespace.

```java
// NOTE: compactionThreshold is always null unless it has been configured
Long compactionThreshold = namespaces.getCompactionThreshold(kafkaMetadataNamespace);
if (compactionThreshold != null && compactionThreshold != MAX_COMPACTION_THRESHOLD) {
    // it never gets here unless compaction threshold has been configured
    namespaces.setCompactionThreshold(kafkaMetadataNamespace, MAX_COMPACTION_THRESHOLD);
}
```

In addition, currently there is no test that ensures the metadata has
been initialized correctly.

### Modifications

- Configure the compaction threshold when the metadata namespace is
  created. Since the policies could only be configured when the
  namespace didn't exist before, there is no need to check the existing
  policy.
- Add `MetadataInitTest` to test the metadata namespace has been
  configured correctly. It also verifies the
  `kafkaManageSystemNamespaces` config, which disables the
  initialization of the metadata namespace.
- Refactor the `internalSetup` method to avoid the redundant start of
  broker.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

