### PR TITLE
[Tests] Configure a different metadata namespace with the default namespace

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CacheInvalidatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CacheInvalidatorTest.java
@@ -76,17 +76,23 @@ public class CacheInvalidatorTest extends KopProtocolHandlerTestBase {
 
         assertFalse(KopBrokerLookupManager.LOOKUP_CACHE.isEmpty());
 
-        BundlesData bundles = pulsar.getAdminClient().namespaces().getBundles(
-                conf.getKafkaTenant() + "/" + conf.getKafkaNamespace());
+        log.info("Before unload, LOOKUP_CACHE is {}", KopBrokerLookupManager.LOOKUP_CACHE);
+        String namespace = conf.getKafkaTenant() + "/" + conf.getKafkaNamespace();
+        BundlesData bundles = pulsar.getAdminClient().namespaces().getBundles(namespace);
         List<String> boundaries = bundles.getBoundaries();
         for (int i = 0; i < boundaries.size() - 1; i++) {
             String bundle = String.format("%s_%s", boundaries.get(i), boundaries.get(i + 1));
-            pulsar.getAdminClient().namespaces()
-                    .unloadNamespaceBundle(conf.getKafkaTenant() + "/" + conf.getKafkaMetadataNamespace(), bundle);
+            pulsar.getAdminClient().namespaces().unloadNamespaceBundle(namespace, bundle);
+        }
+        namespace = conf.getKafkaMetadataTenant() + "/" + conf.getKafkaMetadataNamespace();
+        bundles = pulsar.getAdminClient().namespaces().getBundles(namespace);
+        boundaries = bundles.getBoundaries();
+        for (int i = 0; i < boundaries.size() - 1; i++) {
+            String bundle = String.format("%s_%s", boundaries.get(i), boundaries.get(i + 1));
+            pulsar.getAdminClient().namespaces().unloadNamespaceBundle(namespace, bundle);
         }
 
         Awaitility.await().untilAsserted(() -> {
-            log.info("LOOKUP_CACHE {}", KopBrokerLookupManager.LOOKUP_CACHE);
             assertTrue(KopBrokerLookupManager.LOOKUP_CACHE.isEmpty());
         });
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CacheInvalidatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CacheInvalidatorTest.java
@@ -82,7 +82,7 @@ public class CacheInvalidatorTest extends KopProtocolHandlerTestBase {
         for (int i = 0; i < boundaries.size() - 1; i++) {
             String bundle = String.format("%s_%s", boundaries.get(i), boundaries.get(i + 1));
             pulsar.getAdminClient().namespaces()
-                    .unloadNamespaceBundle(conf.getKafkaTenant() + "/" + conf.getKafkaNamespace(), bundle);
+                    .unloadNamespaceBundle(conf.getKafkaTenant() + "/" + conf.getKafkaMetadataNamespace(), bundle);
         }
 
         Awaitility.await().untilAsserted(() -> {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CustomOAuthBearerCallbackHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CustomOAuthBearerCallbackHandlerTest.java
@@ -82,7 +82,7 @@ public class CustomOAuthBearerCallbackHandlerTest extends KopProtocolHandlerTest
 
         super.internalSetup();
         admin.namespaces().grantPermissionOnNamespace(
-                tenant + "/" + namespace,
+                conf.getKafkaTenant() + "/" + conf.getKafkaNamespace(),
                 USER,
                 Sets.newHashSet(AuthAction.consume, AuthAction.produce)
         );

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
@@ -27,7 +27,6 @@ import static org.testng.Assert.fail;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
-import io.streamnative.pulsar.handlers.kop.utils.MetadataUtils;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -59,7 +58,6 @@ import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdminException;
-import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.awaitility.Awaitility;
 import org.testng.annotations.AfterMethod;
@@ -79,8 +77,9 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
     @Override
     protected void setup() throws Exception {
         super.internalSetup();
-        this.triggerTopicLookup(MetadataUtils.constructOffsetsTopicBaseName(
-                TopicName.PUBLIC_TENANT, this.conf), this.conf.getOffsetsTopicNumPartitions());
+        // Perform topic lookup to let broker acquire the ownership of namespace bundles so that
+        // `BrokerService#getOrCreateTopic` won't fail with "Namespace bundle not served by this instance".
+        this.triggerTopicLookup(conf.getKafkaTenant() + "/" + conf.getKafkaNamespace() + "/setup-topic", 16);
         kafkaRequestHandler = newRequestHandler();
 
         ChannelHandlerContext mockCtx = mock(ChannelHandlerContext.class);
@@ -100,7 +99,10 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
 
     private void registerPartitionedTopic(final String topic) throws PulsarAdminException {
         admin.topics().createPartitionedTopic(topic, 1);
-        pulsar.getBrokerService().getOrCreateTopic(topic);
+        pulsar.getBrokerService().getOrCreateTopic(topic).exceptionally(e -> {
+            log.error("Failed to create topic {}", topic, e);
+            return null;
+        });
     }
 
     @Test

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -113,9 +113,6 @@ public abstract class KopProtocolHandlerTestBase {
     protected NonClosableMockBookKeeper mockBookKeeper;
     protected final String configClusterName = "test";
 
-    protected final String tenant = "public";
-    protected final String namespace = "default";
-
     private SameThreadOrderedSafeExecutor sameThreadOrderedSafeExecutor;
     private OrderedExecutor bkExecutor;
 
@@ -172,9 +169,6 @@ public abstract class KopProtocolHandlerTestBase {
 
         kafkaConfig.setForceDeleteTenantAllowed(true);
         kafkaConfig.setForceDeleteNamespaceAllowed(true);
-
-        kafkaConfig.setKafkaMetadataTenant(tenant);
-        kafkaConfig.setKafkaMetadataNamespace(namespace);
 
         // kafka related settings.
         kafkaConfig.setOffsetsTopicNumPartitions(1);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MultiLedgerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MultiLedgerTest.java
@@ -47,6 +47,7 @@ import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.TopicMessageIdImpl;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.awaitility.Awaitility;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -70,6 +71,10 @@ public class MultiLedgerTest extends KopProtocolHandlerTestBase {
     @Override
     protected void setup() throws Exception {
         super.internalSetup();
+        // Use infinite retention to avoid rollover ledgers being deleted immediately
+        admin.namespaces().setRetention(
+                conf.getKafkaTenant() + "/" + conf.getKafkaNamespace(),
+                new RetentionPolicies(-1, -1));
         log.info("success internal setup");
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOauthDefaultHandlersTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOauthDefaultHandlersTest.java
@@ -64,7 +64,7 @@ public class SaslOauthDefaultHandlersTest extends SaslOauthBearerTestBase {
         super.internalSetup();
 
         admin.namespaces().grantPermissionOnNamespace(
-                tenant + "/" + namespace,
+                conf.getKafkaTenant() + "/" + conf.getKafkaNamespace(),
                 USER,
                 Sets.newHashSet(AuthAction.consume, AuthAction.produce)
         );


### PR DESCRIPTION
### Motivation

Currently in KoP tests, the metadata namespace configured by
`kafkaMetadataNamespace` is "default", which is same with the default
namespace of Pulsar and KoP (`kafkaNamespace`).

https://github.com/streamnative/kop/blob/64001937c92d80ed4f652becd8d6b9768918b875/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java#L176-L177

It's a terrible config because some topic policies might be changed with
the metadata namespace and the offset topic is created during starting.
We should avoid the namespace for normal topics being affected by these
implicit operations.

### Modifications

Remove the configs for `kafkaMetadataTenant` and
`kafkaMetadataNamespace`, then fix the following tests:

- `MultiLedgerTest`: set the infinite retention to avoid rollover
  ledgers being removed automatically.
- `KafkaTopicConsumerManagerTest`: trigger the topic lookup before
  creating `PersistentTopic` objects in `BrokerService` so that broker
  can acquire the ownership of namespace bundles.
- `CacheInvalidatorTest`: unload the metadata namespace instead of the
  default namespace.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

