### PR TITLE
Improve handle OAuth callback throw authentication exception behavior

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -417,26 +417,18 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     protected void maybeDelayCloseOnAuthenticationFailure() {
         if (this.failedAuthenticationDelayMs > 0) {
             this.ctx.executor().schedule(
-                    this::handleCloseOnAuthenticationFailure,
+                    this::completeCloseOnAuthenticationFailure,
                     this.failedAuthenticationDelayMs,
                     TimeUnit.MILLISECONDS);
         } else {
-            handleCloseOnAuthenticationFailure();
-        }
-    }
-
-    private void handleCloseOnAuthenticationFailure() {
-        try {
             this.completeCloseOnAuthenticationFailure();
-        } finally {
-            this.close();
         }
     }
 
     @Override
     protected void completeCloseOnAuthenticationFailure() {
         if (isActive.get() && authenticator != null) {
-            authenticator.sendAuthenticationFailureResponse();
+            authenticator.sendAuthenticationFailureResponse(__ -> this.close());
         }
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/PlainSaslServer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/PlainSaslServer.java
@@ -121,6 +121,9 @@ public class PlainSaslServer implements SaslServer {
 
     @Override
     public String getAuthorizationID() {
+        if (!complete) {
+            throw new IllegalStateException("Authentication exchange has not completed");
+        }
         return authorizationId;
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/OauthValidatorCallbackHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/OauthValidatorCallbackHandler.java
@@ -58,10 +58,13 @@ public class OauthValidatorCallbackHandler implements AuthenticateCallbackHandle
         if (options == null) {
             throw new IllegalArgumentException("JAAS configuration options is null");
         }
-        if (configs == null || configs.isEmpty() || !configs.containsKey("AuthenticationService")) {
-            throw new IllegalArgumentException("Configs do not contains AuthenticationService.");
+
+        if (configs == null || configs.isEmpty()
+                || !configs.containsKey(SaslAuthenticator.AUTHENTICATION_SERVER_OBJ)) {
+            throw new IllegalArgumentException("Configs map do not contains AuthenticationService.");
         }
-        authenticationService = (AuthenticationService) configs.get(SaslAuthenticator.AUTHENTICATION_SERVER_OBJ);
+
+        this.authenticationService = (AuthenticationService) configs.get(SaslAuthenticator.AUTHENTICATION_SERVER_OBJ);
         this.config = new ServerConfig(options);
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOauthKopHandlersTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOauthKopHandlersTest.java
@@ -13,9 +13,12 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
+import static org.mockito.Mockito.doReturn;
+
 import com.google.common.collect.Sets;
 import io.streamnative.pulsar.handlers.kop.security.oauth.OauthLoginCallbackHandler;
 import io.streamnative.pulsar.handlers.kop.security.oauth.OauthValidatorCallbackHandler;
+import io.streamnative.pulsar.handlers.kop.security.oauth.ServerConfig;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -26,21 +29,27 @@ import java.util.Collections;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import javax.naming.AuthenticationException;
 import javax.security.auth.login.LoginException;
 import lombok.Cleanup;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.broker.authentication.AuthenticationProviderToken;
+import org.apache.pulsar.broker.authentication.AuthenticationService;
 import org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider;
+import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationFactoryOAuth2;
 import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2;
+import org.apache.pulsar.common.api.AuthData;
 import org.apache.pulsar.common.policies.data.AuthAction;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -207,6 +216,39 @@ public class SaslOauthKopHandlersTest extends SaslOauthBearerTestBase {
             Assert.assertNotNull(e.getCause());
             Assert.assertTrue(e.getCause().getCause() instanceof LoginException);
         }
+    }
+
+    @Test
+    public void testAuthenticationHasException() throws Exception {
+
+        // Mock the AuthenticationProvider, make sure throw a AuthenticationException.
+        AuthenticationProviderToken mockedAuthenticationProviderToken = Mockito.mock(AuthenticationProviderToken.class);
+        Mockito.doThrow(new AuthenticationException("Mock authentication exception."))
+                .when(mockedAuthenticationProviderToken)
+                .newAuthState(Mockito.any(AuthData.class), Mockito.isNull(), Mockito.isNull());
+
+        AuthenticationService mockedAuthenticationServer = Mockito.mock(AuthenticationService.class);
+        Mockito.when(mockedAuthenticationServer.getAuthenticationProvider(Mockito.eq(
+                ServerConfig.DEFAULT_OAUTH_VALIDATE_METHOD))).thenReturn(mockedAuthenticationProviderToken);
+        BrokerService brokerService = Mockito.spy(pulsar.getBrokerService());
+        Mockito.doReturn(mockedAuthenticationServer).when(brokerService).getAuthenticationService();
+        doReturn(brokerService).when(pulsar).getBrokerService();
+
+        final String namespace = conf.getKafkaTenant() + "/" + conf.getKafkaNamespace();
+        final String topic = "test-authentication-has-exception";
+        final String role = "test-role-" + System.currentTimeMillis();
+        final String clientCredentialPath = createOAuthClient(role, "secret");
+
+        admin.namespaces().grantPermissionOnNamespace(namespace, role, Collections.singleton(AuthAction.consume));
+        final Properties consumerProps = newKafkaConsumerProperties();
+        internalConfigureOauth2(consumerProps, clientCredentialPath);
+        @Cleanup
+        final KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consumerProps);
+        consumer.subscribe(Collections.singleton(topic));
+
+        Assert.assertThrows(SaslAuthenticationException.class, () -> consumer.poll(Duration.ofSeconds(5)));
+
+        Mockito.reset(brokerService);
     }
 
     @Test(timeOut = 15000)

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOauthKopHandlersTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOauthKopHandlersTest.java
@@ -14,6 +14,8 @@
 package io.streamnative.pulsar.handlers.kop;
 
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Sets;
 import io.streamnative.pulsar.handlers.kop.security.oauth.OauthLoginCallbackHandler;
@@ -223,15 +225,15 @@ public class SaslOauthKopHandlersTest extends SaslOauthBearerTestBase {
 
         // Mock the AuthenticationProvider, make sure throw a AuthenticationException.
         AuthenticationProviderToken mockedAuthenticationProviderToken = Mockito.mock(AuthenticationProviderToken.class);
-        Mockito.doThrow(new AuthenticationException("Mock authentication exception."))
+        doThrow(new AuthenticationException("Mock authentication exception."))
                 .when(mockedAuthenticationProviderToken)
                 .newAuthState(Mockito.any(AuthData.class), Mockito.isNull(), Mockito.isNull());
 
         AuthenticationService mockedAuthenticationServer = Mockito.mock(AuthenticationService.class);
-        Mockito.when(mockedAuthenticationServer.getAuthenticationProvider(Mockito.eq(
+        when(mockedAuthenticationServer.getAuthenticationProvider(Mockito.eq(
                 ServerConfig.DEFAULT_OAUTH_VALIDATE_METHOD))).thenReturn(mockedAuthenticationProviderToken);
         BrokerService brokerService = Mockito.spy(pulsar.getBrokerService());
-        Mockito.doReturn(mockedAuthenticationServer).when(brokerService).getAuthenticationService();
+        doReturn(mockedAuthenticationServer).when(brokerService).getAuthenticationService();
         doReturn(brokerService).when(pulsar).getBrokerService();
 
         final String namespace = conf.getKafkaTenant() + "/" + conf.getKafkaNamespace();


### PR DESCRIPTION
### Motivation

Currently, when the `OauthValidatorCallbackHandler#handleCallback` method throws an exception, the client will receive warn log below and it will always try to reconnect.
```
15:51:14.143 [kafka-consumer-2] WARN org.apache.kafka.clients.NetworkClient - [Consumer clientId=consumer-topic-1-1, groupId=topic-1] Connection to node 782843879 (localhost/127.0.0.1:9092) terminated during authentication. This may happen due to any of the following reasons: (1) Authentication failed due to invalid credentials with brokers older than 1.0.0, (2) Firewall blocking Kafka TLS traffic (eg it may only allow HTTPS traffic), (3) Transient network issue.
```

Broker side log:
```
2022-05-09T14:29:39,673+0800 [pulsar-io-18-10] ERROR io.streamnative.pulsar.handlers.kop.KafkaRequestHandler - Caught error in handler, closing channel
java.lang.IllegalStateException: Authentication exchange has not completed
	at io.streamnative.pulsar.handlers.kop.security.oauth.KopOAuthBearerSaslServer.getAuthorizationID(KopOAuthBearerSaslServer.java:94) ~[?:?]
	at io.streamnative.pulsar.handlers.kop.security.SaslAuthenticator.handleSaslToken(SaslAuthenticator.java:503) ~[?:?]
	at io.streamnative.pulsar.handlers.kop.security.SaslAuthenticator.authenticate(SaslAuthenticator.java:223) ~[?:?]
	at io.streamnative.pulsar.handlers.kop.KafkaRequestHandler.channelPrepare(KafkaRequestHandler.java:382) ~[?:?]
// ...
```

In this case, we should have `SaslAuthenticationException` instead of the warning log.



### Modifications

* Make sure to send the authentication error response to the client before closing the channel.
* Add check to make sure the `SaslServer` is complete before getting the authorization ID.
* Add units test to cover this case.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

