### PR TITLE
Clean up errors sent to the client during Topic Unload

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManager.java
@@ -229,10 +229,12 @@ public class KafkaTopicConsumerManager implements Closeable {
         final ManagedLedger ledger = topic.getManagedLedger();
 
         if (((ManagedLedgerImpl) ledger).getState() == ManagedLedgerImpl.State.Closed) {
-            log.error("[{}] Async get cursor for offset {} failed, because current managedLedger has been closed",
-                    requestHandler.ctx.channel(), offset);
+            log.error("[{}] Async get cursor for offset {} for topic {} failed, "
+                            + "because current managedLedger has been closed",
+                    requestHandler.ctx.channel(), offset, topic.getName());
             CompletableFuture<Pair<ManagedCursor, Long>> future = new CompletableFuture<>();
-            future.completeExceptionally(new Exception("Current managedLedger has been closed."));
+            future.completeExceptionally(new Exception("Current managedLedger for "
+                    + topic.getName() + " has been closed."));
             return future;
         }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -351,17 +351,10 @@ public final class MessageFetchContext {
                 } else {
                     cursorFuture.whenComplete((cursorLongPair, ex) -> {
                         if (ex != null) {
-                            log.error("KafkaTopicConsumerManager.asyncGetCursorByOffset({}) failed for topic {}.",
-                                    offset, topicPartition, ex);
-                            try {
-                                registerPrepareMetadataFailedEvent(startPrepareMetadataNanos);
-                                requestHandler.getKafkaTopicManagerSharedState()
-                                        .getKafkaTopicConsumerManagerCache().removeAndCloseByTopic(fullTopicName);
-                                addErrorPartitionResponse(topicPartition, Errors.NOT_LEADER_FOR_PARTITION);
-                            } catch (Throwable t) {
-                                log.error("Unhandled error here", t);
-                                addErrorPartitionResponse(topicPartition, Errors.NOT_LEADER_FOR_PARTITION);
-                            }
+                            registerPrepareMetadataFailedEvent(startPrepareMetadataNanos);
+                            requestHandler.getKafkaTopicManagerSharedState()
+                                    .getKafkaTopicConsumerManagerCache().removeAndCloseByTopic(fullTopicName);
+                            addErrorPartitionResponse(topicPartition, Errors.NOT_LEADER_FOR_PARTITION);
                         } else if (cursorLongPair == null) {
                             log.warn("KafkaTopicConsumerManager.remove({}) return null for topic {}. "
                                             + "Fetch for topic return error.",

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/PulsarEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/PulsarEntryFormatter.java
@@ -91,8 +91,8 @@ public class PulsarEntryFormatter extends AbstractEntryFormatter {
                 sequenceId = Commands.initBatchMessageMetadata(msgMetadata, message.getMessageBuilder());
             }
             currentBatchSizeBytes += message.getDataBuffer().readableBytes();
-            if (log.isDebugEnabled()) {
-                log.debug("recordsToByteBuf , sequenceId: {}, numMessagesInBatch: {}, currentBatchSizeBytes: {} ",
+            if (log.isTraceEnabled()) {
+                log.trace("recordsToByteBuf , sequenceId: {}, numMessagesInBatch: {}, currentBatchSizeBytes: {} ",
                         sequenceId, numMessagesInBatch, currentBatchSizeBytes);
             }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
@@ -514,7 +514,9 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
             topicConsumerManager.removeCursorFuture(totalMessages - 1).get();
             fail("should have failed");
         } catch (ExecutionException ex) {
-            assertTrue(ex.getCause().getMessage().contains("Current managedLedger has been closed."));
+            log.info("error", ex);
+            assertTrue(ex.getCause().getMessage().contains("Current managedLedger for "
+                    + fullTopicName + " has been closed."));
         }
 
     }


### PR DESCRIPTION
### Motivation

While investigating on #1281 I have found a couple of enhancements:
- we should add more logging to troubleshoot unknown errors during topic unload
- we can improve some logging
- in case of CursorAlreadyClosedException  we return UNKNOWN_SERVER_ERROR and NOT_LEADER_FOR_PARTITION and this generates a "received an unknown error" log line on the client, that is pretty scary

### Modifications

- improve the toString representation of the callback passed to asyncFindPosition
- return NOT_LEADER_FOR_PARTITION in case of CursorAlreadyClosedException and ManagedLedgerFencedException
- reduce log level of some parts of the code

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.