### PR TITLE
Add useNativeGit to Git Commit Id Plugin - to support working with worktrees

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -406,6 +406,8 @@
             <includeOnlyProperty>^git.build.user.(email|name)$</includeOnlyProperty>
           </includeOnlyProperties>
           <commitIdGenerationMode>full</commitIdGenerationMode>
+          <!-- A workaround to make build work in a Git worktree, see https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/215 -->
+          <useNativeGit>true</useNativeGit>
         </configuration>
       </plugin>
 


### PR DESCRIPTION

### Motivation
You cannot use git worktrees in KOP development.

### Modifications
see  https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/215


### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation
- [x ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)