### PR TITLE
[Authorization] Remove unexpected produce permission validation

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/InternalProducer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/InternalProducer.java
@@ -38,6 +38,24 @@ public class InternalProducer extends Producer {
         this.serverCnx = cnx;
     }
 
+    // Don't add the `@Override` annotation so that it can be cherry-picked into older branches. This method was first
+    // introduced from https://github.com/apache/pulsar/pull/13885.
+    public CompletableFuture<Void> checkPermissionsAsync() {
+        // `Producer#checkPermissionsAsync` is called in `PersistentTopic#onPoliciesUpdate`. The default implementation
+        // calls `AuthenticationService#canProduce` with the internal `appId` as the auth role and the authentication
+        // data source from the `cnx` field.
+        // `InternalProducer` is just a mock to record the producer stats. The authorization on this class is not
+        // necessary and might lead to some unexpected behaviors (like NPE if the authorization provider assumes the
+        // auth role is not null).
+        return CompletableFuture.completedFuture(null);
+    }
+
+    // Add this method because in some older versions of Pulsar (before https://github.com/apache/pulsar/pull/13885),
+    // `checkPermissions` is a method of `Producer` while `checkPermissionsAsync` is not.
+    public void checkPermissions() {
+        // No ops
+    }
+
     // this will call back by bundle unload
     @Override
     public CompletableFuture<Void> disconnect() {


### PR DESCRIPTION
Fixes https://github.com/streamnative/kop/issues/1295

### Motivation

Currently KoP registers a `InternalProducer` that inherits the broker's
`Producer`  with a unique name for each topic to record the stats so
that REST API. However, when the authoriazion is enabled,
`checkPermissionAsync` will be called on the `InternalProducer` object
when the policies are update in `PersistentTopic#onPoliciesUpdate`.

```java
return cnx.getBrokerService().getAuthorizationService()
        .canProduceAsync(topicName, appId, cnx.getAuthenticationData())
```

The code snippet above is from `Producer#checkPermissionAsync`, we can
see the auth role is the `appId` field (`null` in `InternalProducer`'s
constructor) and the authentication data is from the `cnx` field, which
is the `InternalServerCnx` object in KoP. The role and auth data are
both `null`, if the authorization provider doesn't assume they are not
null, NPE will happen in the `metadata-store` thread

However, before https://github.com/apache/pulsar/pull/13885, a
synchronous method `checkPermission` is called, the NPE will be caught
and `disconnect` will be called after that.

```java
if (cnx.getBrokerService().getAuthorizationService() != null) {
    try {
        if (cnx.getBrokerService().getAuthorizationService().canProduce(topicName, appId,
                cnx.getAuthenticationData())) {
            return;
        }
    } catch (Exception e) {
        // 1. NPE is caught here
        log.warn("[{}] Get unexpected error while autorizing [{}]  {}", appId, topic.getName(), e.getMessage(),
                e);
    }
    log.info("[{}] is not allowed to produce on topic [{}] anymore", appId, topic.getName());
    disconnect(); // 2. The channel will be closed
}
```

So sometimes the `testGrantAndRevokePermission` could fail because the
`KafkaProducer#send` might throw `NetworkException` instead of
`TopicAuthorizationException`.

### Modifications

Override the `checkPermissionAsync` and `checkPermission` methods with
an empty implementation so that this PR can be cherry-picked into
branch-2.8 and branch-2.9.

Then add a test to save the exception stack in
`OauthMockAuthorizationProvider#isSuperUser`. Without this patch, a stack
trace of NPE will be saved in `NULL_ROLE_STACKS`.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

