### PR TITLE
Schema Registry - initial port

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
 
     - name: License check
       run: mvn -ntp -B license:check

--- a/kafka-impl/pom.xml
+++ b/kafka-impl/pom.xml
@@ -33,6 +33,12 @@
   <!-- include the dependencies -->
   <dependencies>
     <dependency>
+      <groupId>io.streamnative.pulsar.handlers</groupId>
+      <artifactId>pulsar-kafka-schema-registry</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>${pulsar.group.id}</groupId>
       <artifactId>pulsar-broker</artifactId>
       <scope>provided</scope>

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -27,6 +27,7 @@ import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCo
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
 import io.streamnative.pulsar.handlers.kop.format.EntryFormatter;
 import io.streamnative.pulsar.handlers.kop.format.EntryFormatterFactory;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryChannelInitializer;
 import io.streamnative.pulsar.handlers.kop.stats.PrometheusMetricsProvider;
 import io.streamnative.pulsar.handlers.kop.stats.StatsLogger;
 import io.streamnative.pulsar.handlers.kop.storage.ReplicaManager;
@@ -100,6 +101,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     private KopEventManager kopEventManager;
     private OrderedScheduler sendResponseScheduler;
     private NamespaceBundleOwnershipListenerImpl bundleListener;
+    private SchemaRegistryManager schemaRegistryManager;
 
     private final Map<String, GroupCoordinator> groupCoordinatorsByTenant = new ConcurrentHashMap<>();
     private final Map<String, TransactionCoordinator> transactionCoordinatorByTenant = new ConcurrentHashMap<>();
@@ -275,6 +277,8 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
             kafkaConfig.getKopPrometheusStatsLatencyRolloverSeconds());
         statsProvider.start(conf);
         brokerService.pulsar().addPrometheusRawMetricsProvider(statsProvider);
+        schemaRegistryManager = new SchemaRegistryManager(kafkaConfig, brokerService.getPulsar(),
+                brokerService.getAuthenticationService());
     }
 
     private TransactionCoordinator createAndBootTransactionCoordinator(String tenant) {
@@ -425,6 +429,10 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                     forEach((listener, endPoint) ->
                             builder.put(endPoint.getInetAddress(), newKafkaChannelInitializer(endPoint))
                     );
+            Optional<SchemaRegistryChannelInitializer> schemaRegistryChannelInitializer = schemaRegistryManager.build();
+            if (schemaRegistryChannelInitializer.isPresent()) {
+                builder.put(schemaRegistryManager.getAddress(), schemaRegistryChannelInitializer.get());
+            }
             channelInitializerMap = builder.build();
             return channelInitializerMap;
         } catch (Exception e){
@@ -453,6 +461,9 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
         }
         groupCoordinatorsByTenant.values().forEach(GroupCoordinator::shutdown);
         kopEventManager.close();
+        if (schemaRegistryManager != null) {
+            schemaRegistryManager.close();
+        }
         transactionCoordinatorByTenant.values().forEach(TransactionCoordinator::shutdown);
         KopBrokerLookupManager.clear();
         kafkaTopicManagerSharedState.close();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -123,6 +123,13 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
     private String kafkaMetadataNamespace = "__kafka";
 
     @FieldContext(
+            category = CATEGORY_KOP,
+            required = true,
+            doc = "The namespace used for storing Kafka Schema Registry"
+    )
+    private String kopSchemaRegistryNamespace = "__kafka_schemaregistry";
+
+    @FieldContext(
         category = CATEGORY_KOP,
         doc = "The minimum allowed session timeout for registered consumers."
             + " Shorter timeouts result in quicker failure detection at the cost"
@@ -462,6 +469,24 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
                     + "If it's not set or empty, the allowed namespaces will be \"<kafkaTenant>/<kafkaNamespace>\"."
     )
     private Set<String> kopAllowedNamespaces;
+
+    @FieldContext(
+            category = CATEGORY_KOP,
+            doc = "Start the Schema Registry service."
+    )
+    private boolean kopSchemaRegistryEnable = false;
+
+    @FieldContext(
+            category = CATEGORY_KOP,
+            doc = "The name of the topic used by the Schema Registry service."
+    )
+    private String kopSchemaRegistryTopicName = "__schema-registry";
+
+    @FieldContext(
+            category = CATEGORY_KOP,
+            doc = "Schema Registry port."
+    )
+    private int kopSchemaRegistryPort = 8001;
 
     @FieldContext(
             category = CATEGORY_KOP,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryManager.java
@@ -56,9 +56,7 @@ import org.apache.pulsar.common.policies.data.ClusterData;
 public class SchemaRegistryManager {
     private final KafkaServiceConfiguration kafkaConfig;
     private final PulsarService pulsar;
-    private final AuthenticationService authenticationService;
     private final SchemaRegistryRequestAuthenticator schemaRegistryRequestAuthenticator;
-    private final Authorizer authorizer;
     private final PulsarClient pulsarClient;
 
     public SchemaRegistryManager(KafkaServiceConfiguration kafkaConfig,
@@ -67,10 +65,9 @@ public class SchemaRegistryManager {
         this.kafkaConfig = kafkaConfig;
         this.pulsarClient = SystemTopicClient.createPulsarClient(pulsar, kafkaConfig, (___) -> {});
         this.pulsar = pulsar;
-        this.authenticationService = authenticationService;
-        this.authorizer = new SimpleAclAuthorizer(pulsar);
+        Authorizer authorizer = new SimpleAclAuthorizer(pulsar);
         this.schemaRegistryRequestAuthenticator = new HttpRequestAuthenticator(this.kafkaConfig,
-                this.authenticationService, this.authorizer);
+                authenticationService, authorizer);
     }
 
     @AllArgsConstructor

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryManager.java
@@ -33,6 +33,12 @@ import io.streamnative.pulsar.handlers.kop.security.auth.Resource;
 import io.streamnative.pulsar.handlers.kop.security.auth.ResourceType;
 import io.streamnative.pulsar.handlers.kop.security.auth.SimpleAclAuthorizer;
 import io.streamnative.pulsar.handlers.kop.utils.MetadataUtils;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import javax.naming.AuthenticationException;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.PulsarService;
@@ -45,12 +51,6 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.api.AuthData;
 import org.apache.pulsar.common.policies.data.ClusterData;
-import java.net.InetSocketAddress;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-import java.util.Optional;
-import java.util.concurrent.ExecutionException;
-import javax.naming.AuthenticationException;
 
 @Slf4j
 public class SchemaRegistryManager {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryManager.java
@@ -45,13 +45,12 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.api.AuthData;
 import org.apache.pulsar.common.policies.data.ClusterData;
-
-import javax.naming.AuthenticationException;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
+import javax.security.sasl.AuthenticationException;
 
 @Slf4j
 public class SchemaRegistryManager {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryManager.java
@@ -1,0 +1,242 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.DummyOptionsCORSProcessor;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryChannelInitializer;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryHandler;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryRequestAuthenticator;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorageAccessor;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl.PulsarSchemaStorageAccessor;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl.SchemaStorageException;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.resources.CompatibilityResource;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.resources.ConfigResource;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.resources.SchemaResource;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.resources.SubjectResource;
+import io.streamnative.pulsar.handlers.kop.security.KafkaPrincipal;
+import io.streamnative.pulsar.handlers.kop.security.auth.Authorizer;
+import io.streamnative.pulsar.handlers.kop.security.auth.Resource;
+import io.streamnative.pulsar.handlers.kop.security.auth.ResourceType;
+import io.streamnative.pulsar.handlers.kop.security.auth.SimpleAclAuthorizer;
+import io.streamnative.pulsar.handlers.kop.utils.MetadataUtils;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.authentication.AuthenticationProvider;
+import org.apache.pulsar.broker.authentication.AuthenticationService;
+import org.apache.pulsar.broker.authentication.AuthenticationState;
+import org.apache.pulsar.broker.service.BrokerService;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.common.api.AuthData;
+import org.apache.pulsar.common.policies.data.ClusterData;
+
+import javax.naming.AuthenticationException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
+@Slf4j
+public class SchemaRegistryManager {
+    private final KafkaServiceConfiguration kafkaConfig;
+    private final PulsarService pulsar;
+    private final AuthenticationService authenticationService;
+    private final SchemaRegistryRequestAuthenticator schemaRegistryRequestAuthenticator;
+    private final Authorizer authorizer;
+    private final PulsarClient pulsarClient;
+
+    public SchemaRegistryManager(KafkaServiceConfiguration kafkaConfig,
+                                 PulsarService pulsar,
+                                 AuthenticationService authenticationService) {
+        this.kafkaConfig = kafkaConfig;
+        this.pulsarClient = SystemTopicClient.createPulsarClient(pulsar, kafkaConfig, (___) -> {});
+        this.pulsar = pulsar;
+        this.authenticationService = authenticationService;
+        this.authorizer = new SimpleAclAuthorizer(pulsar);
+        this.schemaRegistryRequestAuthenticator = new HttpRequestAuthenticator(this.kafkaConfig,
+                this.authenticationService, this.authorizer);
+    }
+
+    @AllArgsConstructor
+    private static final class UsernamePasswordPair {
+        final String username;
+        final String password;
+    }
+
+    @AllArgsConstructor
+    public static class HttpRequestAuthenticator implements SchemaRegistryRequestAuthenticator {
+
+        private final KafkaServiceConfiguration kafkaConfig;
+        private final AuthenticationService authenticationService;
+        private final Authorizer authorizer;
+
+        @Override
+        public String authenticate(FullHttpRequest request) throws SchemaStorageException {
+            if (!kafkaConfig.isAuthenticationEnabled()) {
+                return kafkaConfig.getKafkaMetadataTenant();
+            }
+            String authenticationHeader = request.headers().get(HttpHeaderNames.AUTHORIZATION, "");
+            UsernamePasswordPair usernamePasswordPair = parseUsernamePassword(authenticationHeader);
+            String username = usernamePasswordPair.username;
+            String password = usernamePasswordPair.password;
+
+            AuthenticationProvider authenticationProvider = authenticationService
+                    .getAuthenticationProvider("token");
+            if (authenticationProvider == null) {
+                throw new SchemaStorageException("Pulsar is not configured for Token auth");
+            }
+            try {
+                final AuthenticationState authState = authenticationProvider
+                        .newAuthState(AuthData.of(password.getBytes(StandardCharsets.UTF_8)), null, null);
+                final String role = authState.getAuthRole();
+
+                final String tenant;
+                if (kafkaConfig.isKafkaEnableMultiTenantMetadata()) {
+                    // the tenant is the username
+                    log.debug("SchemaRegistry Authenticated username {} role {} using tenant {} for data",
+                            username, role, username);
+                    tenant = username;
+                } else {
+                    // use system tenant
+                    log.debug("SchemaRegistry Authenticated username {} role {} using system tenant {} for data",
+                            username, role, kafkaConfig.getKafkaMetadataTenant());
+                    tenant = kafkaConfig.getKafkaMetadataTenant();
+                }
+
+                performAuthorizationValidation(username, role, tenant);
+                return tenant;
+            } catch (AuthenticationException err) {
+                throw new SchemaStorageException(err);
+            }
+
+        }
+
+        private void performAuthorizationValidation(String username, String role, String tenant)
+                throws SchemaStorageException {
+            if (kafkaConfig.isAuthorizationEnabled() && kafkaConfig.isKafkaEnableMultiTenantMetadata()) {
+                KafkaPrincipal kafkaPrincipal = new KafkaPrincipal(KafkaPrincipal.USER_TYPE, role, username, null);
+                String topicName = MetadataUtils.constructSchemaRegistryTopicName(tenant, kafkaConfig);
+                try {
+                    Boolean tenantExists =
+                            authorizer.canAccessTenantAsync(kafkaPrincipal, Resource.of(ResourceType.TENANT, tenant))
+                                    .get();
+                    if (tenantExists == null || !tenantExists) {
+                        log.debug("SchemaRegistry username {} role {} tenant {} does not exist",
+                                username, role, tenant, topicName);
+                        throw new SchemaStorageException("Role " + role + " cannot access topic " + topicName + " "
+                                + "tenant " + tenant + " does not exist (wrong username?)",
+                                HttpResponseStatus.FORBIDDEN.code());
+                    }
+                    Boolean hasPermission = authorizer
+                            .canProduceAsync(kafkaPrincipal, Resource.of(ResourceType.TOPIC, topicName))
+                            .get();
+                    if (hasPermission == null || !hasPermission) {
+                        log.debug("SchemaRegistry username {} role {} tenant {} cannot access topic {}",
+                                username, role, tenant, topicName);
+                        throw new SchemaStorageException("Role " + role + " cannot access topic " + topicName,
+                                HttpResponseStatus.FORBIDDEN.code());
+                    }
+                } catch (ExecutionException err) {
+                    throw new SchemaStorageException(err.getCause());
+                } catch (InterruptedException err) {
+                    throw new SchemaStorageException(err);
+                }
+            }
+        }
+
+        private UsernamePasswordPair parseUsernamePassword(String authenticationHeader)
+                throws SchemaStorageException {
+            if (authenticationHeader.isEmpty()) {
+                // no auth
+                throw new SchemaStorageException("Missing AUTHORIZATION header",
+                        HttpResponseStatus.UNAUTHORIZED.code());
+            }
+
+            if (!authenticationHeader.startsWith("Basic ")) {
+                throw new SchemaStorageException("Bad authentication scheme, only Basic is supported",
+                        HttpResponseStatus.UNAUTHORIZED.code());
+            }
+            String strippedAuthenticationHeader = authenticationHeader.substring("Basic ".length());
+
+            String usernamePassword = new String(Base64.getDecoder()
+                    .decode(strippedAuthenticationHeader), StandardCharsets.UTF_8);
+            int colon = usernamePassword.indexOf(":");
+            if (colon <= 0) {
+                throw new SchemaStorageException("Bad authentication header", HttpResponseStatus.BAD_REQUEST.code());
+            }
+            String rawUsername = usernamePassword.substring(0, colon);
+            String rawPassword = usernamePassword.substring(colon + 1);
+            if (!rawPassword.startsWith("token:")) {
+                throw new SchemaStorageException("Password must start with 'token:'",
+                        HttpResponseStatus.UNAUTHORIZED.code());
+            }
+            String token = rawPassword.substring("token:".length());
+
+            UsernamePasswordPair usernamePasswordPair = new UsernamePasswordPair(rawUsername, token);
+            return usernamePasswordPair;
+        }
+    }
+
+    public InetSocketAddress getAddress() {
+        return new InetSocketAddress(kafkaConfig.getKopSchemaRegistryPort());
+    }
+
+    public Optional<SchemaRegistryChannelInitializer> build() throws Exception {
+        if (!kafkaConfig.isKopSchemaRegistryEnable()) {
+            return Optional.empty();
+        }
+        PulsarAdmin pulsarAdmin = pulsar.getAdminClient();
+        SchemaRegistryHandler handler = new SchemaRegistryHandler();
+        SchemaStorageAccessor schemaStorage = new PulsarSchemaStorageAccessor((tenant) -> {
+            try {
+                BrokerService brokerService = pulsar.getBrokerService();
+                final ClusterData clusterData = ClusterData.builder()
+                        .serviceUrl(brokerService.getPulsar().getWebServiceAddress())
+                        .serviceUrlTls(brokerService.getPulsar().getWebServiceAddressTls())
+                        .brokerServiceUrl(brokerService.getPulsar().getBrokerServiceUrl())
+                        .brokerServiceUrlTls(brokerService.getPulsar().getBrokerServiceUrlTls())
+                        .build();
+                MetadataUtils.createSchemaRegistryMetadataIfMissing(tenant,
+                        pulsarAdmin,
+                        clusterData,
+                        kafkaConfig);
+                return pulsarClient;
+            } catch (Exception err) {
+                throw new IllegalStateException(err);
+            }
+        },
+                kafkaConfig.getKopSchemaRegistryNamespace(), kafkaConfig.getKopSchemaRegistryTopicName());
+        new SchemaResource(schemaStorage, schemaRegistryRequestAuthenticator).register(handler);
+        new SubjectResource(schemaStorage, schemaRegistryRequestAuthenticator).register(handler);
+        new ConfigResource(schemaStorage, schemaRegistryRequestAuthenticator).register(handler);
+        new CompatibilityResource(schemaStorage, schemaRegistryRequestAuthenticator).register(handler);
+        handler.addProcessor(new DummyOptionsCORSProcessor());
+
+        return Optional.of(new SchemaRegistryChannelInitializer(handler));
+    }
+
+    public void close() {
+        try {
+            pulsarClient.close();
+        } catch (PulsarClientException err) {
+            log.error("Error while shutting down", err);
+        }
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryManager.java
@@ -50,7 +50,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
-import javax.security.sasl.AuthenticationException;
+import javax.naming.AuthenticationException;
 
 @Slf4j
 public class SchemaRegistryManager {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
@@ -53,6 +53,11 @@ public class MetadataUtils {
                 + "/__transaction_producerid_generator";
     }
 
+    public static String constructSchemaRegistryTopicName(String tenant, KafkaServiceConfiguration conf) {
+        return tenant + "/" + conf.getKopSchemaRegistryNamespace()
+                + "/" + conf.getKopSchemaRegistryTopicName();
+    }
+
     public static String constructMetadataNamespace(String tenant, KafkaServiceConfiguration conf) {
         return tenant + "/" + conf.getKafkaMetadataNamespace();
     }
@@ -67,8 +72,9 @@ public class MetadataUtils {
             throws PulsarAdminException {
         KopTopic kopTopic = new KopTopic(constructOffsetsTopicBaseName(tenant, conf),
                 constructMetadataNamespace(tenant, conf));
-        createKafkaMetadataIfMissing(tenant, pulsarAdmin, clusterData, conf, kopTopic,
-                conf.getOffsetsTopicNumPartitions());
+        String kafkaMetadataNamespace = tenant + "/" + conf.getKafkaMetadataNamespace();
+        createKafkaMetadataIfMissing(tenant, kafkaMetadataNamespace, pulsarAdmin, clusterData, conf, kopTopic,
+                conf.getOffsetsTopicNumPartitions(), false);
     }
 
     public static void createTxnMetadataIfMissing(String tenant,
@@ -78,8 +84,9 @@ public class MetadataUtils {
             throws PulsarAdminException {
         KopTopic kopTopic = new KopTopic(constructTxnLogTopicBaseName(tenant, conf),
                 constructMetadataNamespace(tenant, conf));
-        createKafkaMetadataIfMissing(tenant, pulsarAdmin, clusterData, conf, kopTopic,
-                conf.getKafkaTxnLogTopicNumPartitions());
+        String kafkaMetadataNamespace = tenant + "/" + conf.getKafkaMetadataNamespace();
+        createKafkaMetadataIfMissing(tenant, kafkaMetadataNamespace, pulsarAdmin, clusterData, conf, kopTopic,
+                conf.getKafkaTxnLogTopicNumPartitions(), false);
         if (conf.isKafkaTransactionProducerIdsStoredOnPulsar()) {
             KopTopic producerIdKopTopic = new KopTopic(constructTxnProducerIdTopicBaseName(tenant, conf),
                     constructMetadataNamespace(tenant, conf));
@@ -102,18 +109,19 @@ public class MetadataUtils {
      * </ul>
      */
     private static void createKafkaMetadataIfMissing(String tenant,
+                                                     String kafkaMetadataNamespace,
                                                      PulsarAdmin pulsarAdmin,
                                                      ClusterData clusterData,
                                                      KafkaServiceConfiguration conf,
                                                      KopTopic kopTopic,
-                                                     int partitionNum)
+                                                     int partitionNum,
+                                                     boolean infiniteRetention)
         throws PulsarAdminException {
         if (!conf.isKafkaManageSystemNamespaces()) {
             log.info("Skipping initialization of topic {} for tenant {}", kopTopic.getFullName(), tenant);
             return;
         }
         String cluster = conf.getClusterName();
-        String kafkaMetadataNamespace = tenant + "/" + conf.getKafkaMetadataNamespace();
 
         boolean clusterExists = false;
         boolean tenantExists = false;
@@ -146,7 +154,8 @@ public class MetadataUtils {
 
             // Check if the metadata namespace exists and create it if not
             Namespaces namespaces = pulsarAdmin.namespaces();
-            createNamespaceIfMissing(tenant, conf, cluster, kafkaMetadataNamespace, namespaces, true);
+            createNamespaceIfMissing(tenant, conf, cluster, kafkaMetadataNamespace, namespaces,
+                    infiniteRetention, true);
 
             namespaceExists = true;
 
@@ -193,7 +202,9 @@ public class MetadataUtils {
 
     private static void createNamespaceIfMissing(String tenant, KafkaServiceConfiguration conf,
                                                  String cluster, String kafkaNamespace,
-                                                 Namespaces namespaces, boolean isMetadataNamespace)
+                                                 Namespaces namespaces,
+                                                 boolean infiniteRetention,
+                                                 boolean isMetadataNamespace)
             throws PulsarAdminException {
         if (!namespaces.getNamespaces(tenant).contains(kafkaNamespace)) {
             log.info("Namespaces: {} does not exist in tenant: {}, creating it ...",
@@ -204,10 +215,17 @@ public class MetadataUtils {
 
             // set namespace config only when offset metadata namespace first create
             if (isMetadataNamespace) {
-                namespaces.setRetention(kafkaNamespace, new RetentionPolicies(
-                        (int) conf.getOffsetsRetentionMinutes(),
-                        conf.getSystemTopicRetentionSizeInMB())
-                );
+                if (infiniteRetention) {
+                    log.info("Namespaces: {}, setting infinite retention",
+                            kafkaNamespace, tenant);
+                    namespaces.setRetention(kafkaNamespace, new RetentionPolicies(-1, -1)
+                    );
+                } else {
+                    namespaces.setRetention(kafkaNamespace, new RetentionPolicies(
+                            (int) conf.getOffsetsRetentionMinutes(),
+                            conf.getSystemTopicRetentionSizeInMB())
+                    );
+                }
                 namespaces.setCompactionThreshold(kafkaNamespace, MAX_COMPACTION_THRESHOLD);
                 namespaces.setNamespaceMessageTTL(kafkaNamespace, conf.getOffsetsMessageTTL());
             }
@@ -275,7 +293,7 @@ public class MetadataUtils {
 
             Namespaces namespaces = pulsarAdmin.namespaces();
             // Check if the kafka namespace exists and create it if not
-            createNamespaceIfMissing(tenant, conf, cluster, kafkaNamespace, namespaces, false);
+            createNamespaceIfMissing(tenant, conf, cluster, kafkaNamespace, namespaces, false, false);
             namespaceExists = true;
 
         } catch (PulsarAdminException e) {
@@ -307,5 +325,16 @@ public class MetadataUtils {
             admin.topics().createMissedPartitions(topic);
         } catch (PulsarAdminException ignored) {
         }
+    }
+
+    public static void createSchemaRegistryMetadataIfMissing(String tenant,
+                                                             PulsarAdmin pulsarAdmin,
+                                                             ClusterData clusterData,
+                                                             KafkaServiceConfiguration conf)
+            throws PulsarAdminException {
+        KopTopic kopTopic = new KopTopic(constructSchemaRegistryTopicName(tenant, conf),
+                constructMetadataNamespace(tenant, conf));
+        createKafkaMetadataIfMissing(tenant, conf.getKopSchemaRegistryNamespace(), pulsarAdmin, clusterData,
+                conf, kopTopic, 1, true);
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
@@ -109,7 +109,7 @@ public class MetadataUtils {
      * </ul>
      */
     private static void createKafkaMetadataIfMissing(String tenant,
-                                                     String kafkaMetadataNamespace,
+                                                     String namespace,
                                                      PulsarAdmin pulsarAdmin,
                                                      ClusterData clusterData,
                                                      KafkaServiceConfiguration conf,
@@ -121,6 +121,7 @@ public class MetadataUtils {
             log.info("Skipping initialization of topic {} for tenant {}", kopTopic.getFullName(), tenant);
             return;
         }
+        String kafkaMetadataNamespace = tenant + "/" + namespace;
         String cluster = conf.getClusterName();
 
         boolean clusterExists = false;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
@@ -72,8 +72,7 @@ public class MetadataUtils {
             throws PulsarAdminException {
         KopTopic kopTopic = new KopTopic(constructOffsetsTopicBaseName(tenant, conf),
                 constructMetadataNamespace(tenant, conf));
-        String kafkaMetadataNamespace = tenant + "/" + conf.getKafkaMetadataNamespace();
-        createKafkaMetadataIfMissing(tenant, kafkaMetadataNamespace, pulsarAdmin, clusterData, conf, kopTopic,
+        createKafkaMetadataIfMissing(tenant, conf.getKafkaMetadataNamespace(), pulsarAdmin, clusterData, conf, kopTopic,
                 conf.getOffsetsTopicNumPartitions(), false);
     }
 
@@ -84,8 +83,7 @@ public class MetadataUtils {
             throws PulsarAdminException {
         KopTopic kopTopic = new KopTopic(constructTxnLogTopicBaseName(tenant, conf),
                 constructMetadataNamespace(tenant, conf));
-        String kafkaMetadataNamespace = tenant + "/" + conf.getKafkaMetadataNamespace();
-        createKafkaMetadataIfMissing(tenant, kafkaMetadataNamespace, pulsarAdmin, clusterData, conf, kopTopic,
+        createKafkaMetadataIfMissing(tenant, conf.getKafkaMetadataNamespace(), pulsarAdmin, clusterData, conf, kopTopic,
                 conf.getKafkaTxnLogTopicNumPartitions(), false);
         if (conf.isKafkaTransactionProducerIdsStoredOnPulsar()) {
             KopTopic producerIdKopTopic = new KopTopic(constructTxnProducerIdTopicBaseName(tenant, conf),
@@ -226,9 +224,9 @@ public class MetadataUtils {
                             (int) conf.getOffsetsRetentionMinutes(),
                             conf.getSystemTopicRetentionSizeInMB())
                     );
+                    namespaces.setNamespaceMessageTTL(kafkaNamespace, conf.getOffsetsMessageTTL());
                 }
                 namespaces.setCompactionThreshold(kafkaNamespace, MAX_COMPACTION_THRESHOLD);
-                namespaces.setNamespaceMessageTTL(kafkaNamespace, conf.getOffsetsMessageTTL());
             }
         } else {
             List<String> replicationClusters = namespaces.getNamespaceReplicationClusters(kafkaNamespace);

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <jackson.version>2.13.2</jackson.version>
     <jackson-databind.version>2.13.2.1</jackson-databind.version>
     <kafka.version>2.1.1</kafka.version>
-    <lombok.version>1.18.4</lombok.version>
+    <lombok.version>1.18.22</lombok.version>
     <mockito.version>2.22.0</mockito.version>
     <pulsar.group.id>io.streamnative</pulsar.group.id>
     <pulsar.version>2.10.0.1</pulsar.version>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
     <pulsar.version>2.10.0.1</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
+    <apicurio.version>2.1.1.Final</apicurio.version>
     <testng.version>6.14.3</testng.version>
     <awaitility.version>4.0.3</awaitility.version>
     <grpc.version>1.45.1</grpc.version>
@@ -80,6 +81,7 @@
     <module>kafka-3-0</module>
     <module>kafka-client-api</module>
     <module>kafka-client-factory</module>
+    <module>schema-registry</module>
     <module>kafka-impl</module>
     <module>oauth-client</module>
     <module>tests</module>

--- a/schema-registry/README.md
+++ b/schema-registry/README.md
@@ -1,0 +1,6 @@
+# KOP Schema Registry
+
+This is an implementation of a Schema Registry with an API that is compatible
+with the most widely used Registries in the Kafka Ecosystem.
+
+For details, see [README](../README.md) for detail.

--- a/schema-registry/pom.xml
+++ b/schema-registry/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.streamnative.pulsar.handlers</groupId>
+    <artifactId>pulsar-protocol-handler-kafka-parent</artifactId>
+    <version>2.11.0-SNAPSHOT</version>
+  </parent>
+
+  <groupId>io.streamnative.pulsar.handlers</groupId>
+  <artifactId>pulsar-kafka-schema-registry</artifactId>
+  <name>StreamNative :: Pulsar Protocol Handler :: Schema Registry</name>
+  <description>Kafka Compatible Schema Registry</description>
+
+  <!-- include the dependencies -->
+  <dependencies>
+    <!-- runtime dependencies -->
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-app</artifactId>
+      <version>${apicurio.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-schema-compatibility-protobuf</artifactId>
+      <version>${apicurio.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.jimfs</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.apicurio</groupId>
+      <artifactId>apicurio-registry-schema-compatibility-json</artifactId>
+      <version>${apicurio.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${pulsar.group.id}</groupId>
+      <artifactId>pulsar-broker</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.streamnative.pulsar.handlers</groupId>
+      <artifactId>test-listener</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/DummyOptionsCORSProcessor.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/DummyOptionsCORSProcessor.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry;
+
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import java.util.concurrent.CompletableFuture;
+
+public class DummyOptionsCORSProcessor extends HttpRequestProcessor {
+    @Override
+    protected boolean acceptRequest(FullHttpRequest request) {
+        return request.method().name().equals("OPTIONS");
+    }
+
+    @Override
+    protected CompletableFuture<FullHttpResponse> processRequest(FullHttpRequest request) {
+        return CompletableFuture.completedFuture(buildEmptyResponseNoContentResponse());
+    }
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/HttpJsonRequestProcessor.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/HttpJsonRequestProcessor.java
@@ -20,6 +20,7 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import java.io.DataInput;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -97,6 +98,9 @@ public abstract class HttpJsonRequestProcessor<K, R> extends HttpRequestProcesso
 
     private List<String> detectGroups(FullHttpRequest request) {
         String uri = request.uri();
+        // TODO: here we are discarding the query string part
+        // in the future we will probably have to implement
+        // query string parameters
         int questionMark = uri.lastIndexOf('?');
         if (questionMark > 0) {
             uri = uri.substring(0, questionMark);

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/HttpJsonRequestProcessor.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/HttpJsonRequestProcessor.java
@@ -1,0 +1,125 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import java.io.DataInput;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.common.util.FutureUtil;
+
+@Slf4j
+public abstract class HttpJsonRequestProcessor<K, R> extends HttpRequestProcessor {
+
+    protected static final String RESPONSE_CONTENT_TYPE = "application/vnd.schemaregistry.v1+json";
+
+    private final Class<K> requestModel;
+    private final Pattern pattern;
+    private final String method;
+
+    public HttpJsonRequestProcessor(Class<K> requestModel, String uriPattern, String method) {
+        this.requestModel = requestModel;
+        this.pattern = Pattern.compile(uriPattern);
+        this.method = method;
+    }
+
+    protected static int getInt(int position, List<String> queryStringGroups) {
+        return Integer.parseInt(queryStringGroups.get(position));
+    }
+
+    protected static String getString(int position, List<String> queryStringGroups) {
+        return queryStringGroups.get(position);
+    }
+
+    @Override
+    public boolean acceptRequest(FullHttpRequest request) {
+        if (!request.method().name().equals(method)) {
+            return false;
+        }
+        List<String> groups = detectGroups(request);
+        if (groups == null) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public CompletableFuture<FullHttpResponse> processRequest(FullHttpRequest request) {
+        List<String> groups = detectGroups(request);
+        try (ByteBufInputStream inputStream = new ByteBufInputStream(request.content());) {
+            K decodeRequest;
+            if (requestModel == Void.class) {
+                decodeRequest = null;
+            } else {
+                decodeRequest = MAPPER.readValue((DataInput) inputStream, requestModel);
+            }
+            CompletableFuture<R> result;
+            try {
+                result = processRequest(decodeRequest, groups, request);
+            } catch (Exception err) {
+                result = FutureUtil.failedFuture(err);
+            }
+            return result.thenApply(resp -> {
+                if (resp == null) {
+                    return buildErrorResponse(NOT_FOUND, "Not found", "text/plain");
+                }
+                if (resp.getClass() == String.class) {
+                    return buildStringResponse(((String) resp), RESPONSE_CONTENT_TYPE);
+                } else {
+                    return buildJsonResponse(resp, RESPONSE_CONTENT_TYPE);
+                }
+            }).exceptionally(err -> {
+                log.error("Error while processing request", err);
+                return buildJsonErrorResponse(err);
+            });
+        } catch (Exception err) {
+            log.error("Error while processing request", err);
+            return CompletableFuture.completedFuture(buildErrorResponse(HttpResponseStatus.BAD_REQUEST,
+                    "Cannot decode request: " + err.getMessage(), "text/plain"));
+        }
+    }
+
+    private List<String> detectGroups(FullHttpRequest request) {
+        String uri = request.uri();
+        int questionMark = uri.lastIndexOf('?');
+        if (questionMark > 0) {
+            uri = uri.substring(0, questionMark);
+        }
+        if (uri.endsWith("/")) {
+            // compatibility with Confluent Schema registry
+            uri = uri.substring(0, uri.length() - 1);
+        }
+        Matcher matcher = pattern.matcher(uri);
+        if (!matcher.matches()) {
+            return null;
+        }
+        List<String> groups = new ArrayList<>(matcher.groupCount());
+        for (int i = 0; i < matcher.groupCount(); i++) {
+            groups.add(matcher.group(i + 1));
+        }
+        return groups;
+    }
+
+    protected abstract CompletableFuture<R> processRequest(K payload, List<String> patternGroups,
+                                                           FullHttpRequest request) throws Exception;
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/HttpRequestProcessor.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/HttpRequestProcessor.java
@@ -65,7 +65,8 @@ public abstract class HttpRequestProcessor implements AutoCloseable {
         return httpResponse;
     }
 
-    public static FullHttpResponse buildJsonErrorResponse(Throwable err) {
+    public static FullHttpResponse buildJsonErrorResponse(Throwable throwable) {
+        Throwable err = throwable;
         while (err instanceof CompletionException) {
             err = err.getCause();
         }

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/HttpRequestProcessor.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/HttpRequestProcessor.java
@@ -1,0 +1,138 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.netty.handler.codec.http.HttpResponseStatus.NO_CONTENT;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.CharsetUtil;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl.SchemaStorageException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import lombok.AllArgsConstructor;
+
+public abstract class HttpRequestProcessor implements AutoCloseable {
+
+    protected static final ObjectMapper MAPPER = new ObjectMapper()
+            .configure(SerializationFeature.INDENT_OUTPUT, true);
+
+    public static FullHttpResponse buildStringResponse(String body, String contentType) {
+        FullHttpResponse httpResponse = new DefaultFullHttpResponse(HTTP_1_1, OK,
+                Unpooled.copiedBuffer(body, CharsetUtil.UTF_8));
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, contentType);
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, body.length());
+        addCORSHeaders(httpResponse);
+        return httpResponse;
+    }
+
+    public static FullHttpResponse buildEmptyResponseNoContentResponse() {
+        FullHttpResponse httpResponse = new DefaultFullHttpResponse(HTTP_1_1, NO_CONTENT, Unpooled.EMPTY_BUFFER);
+        httpResponse.headers().set(HttpHeaderNames.ALLOW, "GET, POST, PUT, DELETE");
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, 0);
+        addCORSHeaders(httpResponse);
+        return httpResponse;
+    }
+
+    public static FullHttpResponse buildErrorResponse(HttpResponseStatus error, String body, String contentType) {
+        FullHttpResponse httpResponse = new DefaultFullHttpResponse(HTTP_1_1, error,
+                Unpooled.copiedBuffer(body, CharsetUtil.UTF_8));
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, contentType);
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, body.length());
+        addCORSHeaders(httpResponse);
+        return httpResponse;
+    }
+
+    public static FullHttpResponse buildJsonErrorResponse(Throwable err) {
+        while (err instanceof CompletionException) {
+            err = err.getCause();
+        }
+        int httpStatusCode = err instanceof SchemaStorageException
+                ? ((SchemaStorageException) err).getHttpStatusCode()
+                : INTERNAL_SERVER_ERROR.code();
+        HttpResponseStatus error = HttpResponseStatus.valueOf(httpStatusCode);
+
+        FullHttpResponse httpResponse = null;
+        try {
+            String body = MAPPER.writeValueAsString(new ErrorModel(httpStatusCode, err.getMessage()));
+            httpResponse = new DefaultFullHttpResponse(HTTP_1_1, error,
+                    Unpooled.copiedBuffer(body, CharsetUtil.UTF_8));
+            httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/vnd.schemaregistry.v1+json");
+            httpResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, body.length());
+            addCORSHeaders(httpResponse);
+        } catch (JsonProcessingException impossible) {
+            String body = "Error " + err;
+            httpResponse = new DefaultFullHttpResponse(HTTP_1_1, error,
+                    Unpooled.copiedBuffer(body, CharsetUtil.UTF_8));
+            httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/plain");
+            httpResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, body.length());
+            addCORSHeaders(httpResponse);
+        }
+        return httpResponse;
+    }
+
+    public static void addCORSHeaders(FullHttpResponse httpResponse) {
+        httpResponse.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS, true);
+        httpResponse.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN, "*");
+        httpResponse.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS, "PUT, POST, GET, DELETE");
+        httpResponse.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS, "content-type");
+    }
+
+    protected abstract boolean acceptRequest(FullHttpRequest request);
+
+    protected abstract CompletableFuture<FullHttpResponse> processRequest(FullHttpRequest request);
+
+    protected FullHttpResponse buildJsonResponse(Object content, String contentType) {
+        try {
+            String body = MAPPER.writeValueAsString(content);
+            return buildStringResponse(body, contentType);
+        } catch (JsonProcessingException err) {
+            return buildErrorResponse(INTERNAL_SERVER_ERROR,
+                    "Internal server error - JSON Processing", "text/plain");
+        }
+    }
+
+    @Override
+    public void close() {
+        // nothing
+    }
+
+    @AllArgsConstructor
+    private static final class ErrorModel {
+        // https://docs.confluent.io/platform/current/schema-registry/develop/api.html#schemas
+
+        final int errorCode;
+        final String message;
+
+        @JsonProperty("error_code")
+        public int getErrorCode() {
+            return errorCode;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryChannelInitializer.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryChannelInitializer.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry;
+
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpServerCodec;
+import java.util.function.Consumer;
+import lombok.AllArgsConstructor;
+
+/**
+ * A channel initializer that initialize channels for the Schema Registry service.
+ */
+@AllArgsConstructor
+public class SchemaRegistryChannelInitializer extends ChannelInitializer<SocketChannel> {
+
+    public static final int MAX_FRAME_LENGTH = 5 * 1024 * 1024; // 5MB
+
+    private final SchemaRegistryHandler schemaRegistryHandler;
+    private final Consumer<ChannelPipeline> pipelineCustomizer;
+
+    public SchemaRegistryChannelInitializer(SchemaRegistryHandler schemaRegistryHandler) {
+        this.schemaRegistryHandler = schemaRegistryHandler;
+        this.pipelineCustomizer = null;
+    }
+
+    @Override
+    protected void initChannel(SocketChannel ch) throws Exception {
+        ChannelPipeline p = ch.pipeline();
+        if (pipelineCustomizer != null) {
+            pipelineCustomizer.accept(p);
+        }
+        p.addLast(new HttpServerCodec());
+        p.addLast(new HttpObjectAggregator(MAX_FRAME_LENGTH));
+        p.addLast(schemaRegistryHandler);
+    }
+
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryHandler.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryHandler.java
@@ -34,7 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 @ChannelHandler.Sharable
 public class SchemaRegistryHandler extends SimpleChannelInboundHandler {
 
-    private List<HttpRequestProcessor> processors = new ArrayList<>();
+    private final List<HttpRequestProcessor> processors = new ArrayList<>();
 
     public SchemaRegistryHandler addProcessor(HttpRequestProcessor processor) {
         this.processors.add(processor);

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryHandler.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryHandler.java
@@ -1,0 +1,113 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.util.CharsetUtil;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@ChannelHandler.Sharable
+public class SchemaRegistryHandler extends SimpleChannelInboundHandler {
+
+    private List<HttpRequestProcessor> processors = new ArrayList<>();
+
+    public SchemaRegistryHandler addProcessor(HttpRequestProcessor processor) {
+        this.processors.add(processor);
+        return this;
+    }
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) {
+        ctx.flush();
+    }
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, Object msg) {
+        if (log.isDebugEnabled()) {
+            log.debug("SchemaRegistry at {} request {}", ctx.channel().localAddress(), msg);
+        }
+        FullHttpRequest request = (FullHttpRequest) msg;
+        log.info("SchemaRegistry {} {} from {}", request.method(), request.uri(), ctx.channel().localAddress());
+
+        HttpRequestProcessor processor = null;
+        for (HttpRequestProcessor p : processors) {
+            if (p.acceptRequest(request)) {
+                processor = p;
+                break;
+            }
+        }
+        if (processor == null) {
+            String body = "{\n"
+                    + "  \"message\" : \"Not found\",\n"
+                    + "  \"error_code\" : 404\n"
+                    + "}";
+            FullHttpResponse httpResponse = new DefaultFullHttpResponse(HTTP_1_1,
+                    NOT_FOUND,
+                    Unpooled.copiedBuffer(body, CharsetUtil.UTF_8));
+            httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/vnd.schemaregistry.v1+json");
+            httpResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, body.length());
+            HttpRequestProcessor.addCORSHeaders(httpResponse);
+            log.info("not found {} {} from {}", request.method(), request.uri(), ctx.channel().localAddress());
+            if (log.isDebugEnabled()) {
+                log.debug("SchemaRegistry at {} request {} response {}", ctx.channel().localAddress(), msg,
+                        httpResponse);
+            }
+            ctx.writeAndFlush(httpResponse);
+            return;
+        }
+
+        CompletableFuture<FullHttpResponse> fullHttpResponse = processor.processRequest(request);
+        fullHttpResponse.thenAccept(resp -> {
+            if (log.isDebugEnabled()) {
+                log.debug("SchemaRegistry at {} request {} response {}", ctx.channel().localAddress(), msg,
+                        resp);
+            }
+            log.info("SchemaRegistry {} {} from {} response {} {}", request.method(), request.uri(),
+                    ctx.channel().localAddress(),
+                    resp.status().code(), resp.status().reasonPhrase());
+            ctx.writeAndFlush(resp);
+        }).exceptionally(err -> {
+            FullHttpResponse resp = HttpRequestProcessor.buildJsonErrorResponse(err);
+            if (log.isDebugEnabled()) {
+                log.debug("SchemaRegistry at {} request {} response {}", ctx.channel().localAddress(), msg,
+                        resp);
+            }
+            log.info("SchemaRegistry {} {} from {} response {} {}", request.method(), request.uri(),
+                    ctx.channel().localAddress(),
+                    resp.status().code(), resp.status().reasonPhrase());
+            ctx.writeAndFlush(resp);
+            return null;
+        });
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        log.error("Unhandled error, closing connection to {}", ctx.channel(), cause);
+        ctx.close();
+    }
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryRequestAuthenticator.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryRequestAuthenticator.java
@@ -17,7 +17,7 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl.SchemaStorageException;
 
 /**
- * Authenticates a HTTP Request for the Schema Registry.
+ * Authenticates an HTTP Request for the Schema Registry.
  */
 public interface SchemaRegistryRequestAuthenticator {
 

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryRequestAuthenticator.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryRequestAuthenticator.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry;
+
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl.SchemaStorageException;
+
+/**
+ * Authenticates a HTTP Request for the Schema Registry.
+ */
+public interface SchemaRegistryRequestAuthenticator {
+
+    /**
+     * Validates the HTTP Request.
+     * @param request
+     * @return a tenant name in case of valid request
+     * @throws Exception in case of authentication failure or other system error
+     */
+    String authenticate(FullHttpRequest request) throws SchemaStorageException;
+
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/CompatibilityChecker.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/CompatibilityChecker.java
@@ -90,35 +90,8 @@ public class CompatibilityChecker {
             return true;
         }
         io.apicurio.registry.rules.compatibility.CompatibilityChecker checker = createChecker(type);
-        boolean onlyLatest = false;
-        CompatibilityLevel level;
-        switch (mode) {
-            case BACKWARD:
-                level = CompatibilityLevel.BACKWARD;
-                onlyLatest = true;
-                break;
-            case BACKWARD_TRANSITIVE:
-                level = CompatibilityLevel.BACKWARD_TRANSITIVE;
-                break;
-            case FORWARD:
-                level = CompatibilityLevel.FORWARD;
-                onlyLatest = true;
-                break;
-            case FORWARD_TRANSITIVE:
-                level = CompatibilityLevel.FORWARD_TRANSITIVE;
-                break;
-            case FULL:
-                level = CompatibilityLevel.FULL;
-                onlyLatest = true;
-                break;
-            case FULL_TRANSITIVE:
-                level = CompatibilityLevel.FULL_TRANSITIVE;
-                break;
-            default:
-                level = CompatibilityLevel.NONE;
-                onlyLatest = true;
-                break;
-        }
+        final boolean onlyLatest = mode.checkOnlyLatest();
+        final CompatibilityLevel level = mode.toCompatibilityLevel();
         List<String> schemas = allSchemas
                 .stream()
                 .sorted(Comparator.comparingInt(Schema::getId))
@@ -174,6 +147,29 @@ public class CompatibilityChecker {
 
         public static final Collection<Mode> SUPPORTED_FOR_PROTOBUF =
                 Collections.unmodifiableCollection(Arrays.asList(BACKWARD, BACKWARD_TRANSITIVE, NONE));
+
+        public CompatibilityLevel toCompatibilityLevel() {
+            switch (this) {
+                case BACKWARD:
+                    return CompatibilityLevel.BACKWARD;
+                case BACKWARD_TRANSITIVE:
+                    return CompatibilityLevel.BACKWARD_TRANSITIVE;
+                case FORWARD:
+                    return CompatibilityLevel.FORWARD;
+                case FORWARD_TRANSITIVE:
+                    return CompatibilityLevel.FORWARD_TRANSITIVE;
+                case FULL:
+                    return CompatibilityLevel.FULL;
+                case FULL_TRANSITIVE:
+                    return CompatibilityLevel.FULL_TRANSITIVE;
+                default:
+                    return CompatibilityLevel.NONE;
+            }
+        }
+
+        public boolean checkOnlyLatest() {
+            return this == BACKWARD || this == FORWARD || this == FULL || this == NONE;
+        }
     }
 
     public static final class IncompatibleSchemaChangeException extends RuntimeException {

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/CompatibilityChecker.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/CompatibilityChecker.java
@@ -70,7 +70,7 @@ public class CompatibilityChecker {
         final List<Integer> idsToCheck;
         if (mode == Mode.BACKWARD || mode == Mode.FORWARD) {
             // only latest
-            idsToCheck = Arrays.asList(versions.stream().mapToInt(Integer::intValue).max().getAsInt());
+            idsToCheck = Collections.singletonList(versions.stream().mapToInt(Integer::intValue).max().getAsInt());
         } else {
             // all the versions
             idsToCheck = versions;

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/CompatibilityChecker.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/CompatibilityChecker.java
@@ -144,7 +144,7 @@ public class CompatibilityChecker {
                 }
             }
             return compatibilityExecutionResult.isCompatible();
-        } catch (java.lang.IllegalStateException notSupported) {
+        } catch (IllegalStateException notSupported) {
             return false;
         }
     }

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/CompatibilityChecker.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/CompatibilityChecker.java
@@ -128,15 +128,17 @@ public class CompatibilityChecker {
             // only latest
             schemas = schemas.subList(schemas.size() - 1, schemas.size());
         }
-        log.info("New schema {}", schemaDefinition);
-        for (String s : schemas) {
-            log.info("Existing schema {}", s);
+        if (log.isDebugEnabled()) {
+            log.debug("New schema {}", schemaDefinition);
+            for (String s : schemas) {
+                log.debug("Existing schema {}", s);
+            }
         }
         try {
             CompatibilityExecutionResult compatibilityExecutionResult =
                     checker.testCompatibility(level, schemas, schemaDefinition);
-            log.info("CompatibilityExecutionResult {}", compatibilityExecutionResult.isCompatible());
             if (!compatibilityExecutionResult.isCompatible()) {
+                log.info("CompatibilityExecutionResult {}", compatibilityExecutionResult.isCompatible());
                 for (CompatibilityDifference error : compatibilityExecutionResult.getIncompatibleDifferences()) {
                     log.info("CompatibilityExecutionResult error {}", error);
                 }

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/CompatibilityChecker.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/CompatibilityChecker.java
@@ -1,0 +1,183 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model;
+
+import io.apicurio.registry.rules.compatibility.AvroCompatibilityChecker;
+import io.apicurio.registry.rules.compatibility.CompatibilityDifference;
+import io.apicurio.registry.rules.compatibility.CompatibilityExecutionResult;
+import io.apicurio.registry.rules.compatibility.CompatibilityLevel;
+import io.apicurio.registry.rules.compatibility.JsonSchemaCompatibilityChecker;
+import io.apicurio.registry.rules.compatibility.NoopCompatibilityChecker;
+import io.apicurio.registry.rules.compatibility.ProtobufCompatibilityChecker;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+
+@UtilityClass
+@Slf4j
+public class CompatibilityChecker {
+
+    /**
+     * Verify the compatibility of a Schema, following the request mode.
+     * @param schema
+     * @param subject
+     * @param schemaStorage
+     * @return
+     */
+    public static CompletableFuture<Boolean> verify(Schema schema, String subject, SchemaStorage schemaStorage) {
+        log.info("verify {} {}", subject, schema.getSchemaDefinition());
+        CompletableFuture<CompatibilityChecker.Mode> mode = schemaStorage.getCompatibilityMode(subject);
+        return mode.thenCompose(m -> {
+            return verifyCompatibility(schema, subject, schemaStorage, m);
+        });
+    }
+
+    private static CompletableFuture<Boolean> verifyCompatibility(Schema schema, String subject,
+                                                                  SchemaStorage schemaStorage, Mode mode) {
+        log.info("verify {} {} mode ", subject, mode);
+        if (mode == Mode.NONE) {
+            return CompletableFuture.completedFuture(true);
+        }
+        CompletableFuture<List<Integer>> versions = schemaStorage.getAllVersionsForSubject(subject);
+        return versions.thenCompose(vv -> {
+            return verifyCompatibility(schema, schemaStorage, mode, vv);
+        });
+    }
+
+    private static CompletableFuture<Boolean> verifyCompatibility(Schema schema, SchemaStorage schemaStorage,
+                                                                  Mode mode, List<Integer> versions) {
+        if (versions.isEmpty()) {
+            // no versions ?
+            return CompletableFuture.completedFuture(true);
+        }
+        final List<Integer> idsToCheck;
+        if (mode == Mode.BACKWARD || mode == Mode.FORWARD) {
+            // only latest
+            idsToCheck = Arrays.asList(versions.stream().mapToInt(Integer::intValue).max().getAsInt());
+        } else {
+            // all the versions
+            idsToCheck = versions;
+        }
+        log.info("Compare schema against {} ids", idsToCheck);
+
+        CompletableFuture<List<Schema>>
+                res = schemaStorage.downloadSchemas(idsToCheck);
+
+        return res.thenApply((downloadedSchemas) -> {
+            return verify(schema.getSchemaDefinition(), schema.getType(), mode, downloadedSchemas);
+        });
+    }
+
+    public static boolean verify(String schemaDefinition, String type, Mode mode, List<Schema> allSchemas) {
+        if (allSchemas.isEmpty()) {
+            return true;
+        }
+        io.apicurio.registry.rules.compatibility.CompatibilityChecker checker = createChecker(type);
+        boolean onlyLatest = false;
+        CompatibilityLevel level;
+        switch (mode) {
+            case BACKWARD:
+                level = CompatibilityLevel.BACKWARD;
+                onlyLatest = true;
+                break;
+            case BACKWARD_TRANSITIVE:
+                level = CompatibilityLevel.BACKWARD_TRANSITIVE;
+                break;
+            case FORWARD:
+                level = CompatibilityLevel.FORWARD;
+                onlyLatest = true;
+                break;
+            case FORWARD_TRANSITIVE:
+                level = CompatibilityLevel.FORWARD_TRANSITIVE;
+                break;
+            case FULL:
+                level = CompatibilityLevel.FULL;
+                onlyLatest = true;
+                break;
+            case FULL_TRANSITIVE:
+                level = CompatibilityLevel.FULL_TRANSITIVE;
+                break;
+            default:
+                level = CompatibilityLevel.NONE;
+                onlyLatest = true;
+                break;
+        }
+        List<String> schemas = allSchemas
+                .stream()
+                .sorted(Comparator.comparingInt(Schema::getId))
+                .map(Schema::getSchemaDefinition)
+                .collect(Collectors.toList());
+        if (onlyLatest) {
+            // only latest
+            schemas = schemas.subList(schemas.size() - 1, schemas.size());
+        }
+        log.info("New schema {}", schemaDefinition);
+        for (String s : schemas) {
+            log.info("Existing schema {}", s);
+        }
+        try {
+            CompatibilityExecutionResult compatibilityExecutionResult =
+                    checker.testCompatibility(level, schemas, schemaDefinition);
+            log.info("CompatibilityExecutionResult {}", compatibilityExecutionResult.isCompatible());
+            if (!compatibilityExecutionResult.isCompatible()) {
+                for (CompatibilityDifference error : compatibilityExecutionResult.getIncompatibleDifferences()) {
+                    log.info("CompatibilityExecutionResult error {}", error);
+                }
+            }
+            return compatibilityExecutionResult.isCompatible();
+        } catch (java.lang.IllegalStateException notSupported) {
+            return false;
+        }
+    }
+
+    private static io.apicurio.registry.rules.compatibility.CompatibilityChecker createChecker(String type) {
+        switch (type) {
+            case Schema.TYPE_AVRO:
+                return new AvroCompatibilityChecker();
+            case Schema.TYPE_JSON:
+                return new JsonSchemaCompatibilityChecker();
+            case Schema.TYPE_PROTOBUF:
+                return new ProtobufCompatibilityChecker();
+            default:
+                return new NoopCompatibilityChecker();
+        }
+    }
+
+
+    public enum Mode {
+        NONE,
+        BACKWARD,
+        BACKWARD_TRANSITIVE,
+        FORWARD,
+        FORWARD_TRANSITIVE,
+        FULL,
+        FULL_TRANSITIVE;
+
+        public static final Collection<Mode> SUPPORTED_FOR_PROTOBUF =
+                Collections.unmodifiableCollection(Arrays.asList(BACKWARD, BACKWARD_TRANSITIVE, NONE));
+    }
+
+    public static final class IncompatibleSchemaChangeException extends RuntimeException {
+        public IncompatibleSchemaChangeException(String message) {
+            super(message);
+        }
+    }
+
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/Schema.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/Schema.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@Data
+@AllArgsConstructor
+@Builder
+@EqualsAndHashCode
+@ToString
+public final class Schema {
+
+    public static final String TYPE_AVRO = "AVRO";
+    public static final String TYPE_JSON = "JSON";
+    public static final String TYPE_PROTOBUF = "PROTOBUF";
+    private static final List<String> ALL_TYPES =
+            Collections.unmodifiableList(Arrays.asList(TYPE_AVRO, TYPE_JSON, TYPE_PROTOBUF));
+
+    private final String tenant;
+    private final int id;
+    private final int version;
+    private final String schemaDefinition;
+    private final String subject;
+    private final String type;
+
+    public static List<String> getAllTypes() {
+        return ALL_TYPES;
+    }
+
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/SchemaStorage.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/SchemaStorage.java
@@ -1,0 +1,138 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.BiConsumer;
+import lombok.AllArgsConstructor;
+
+public interface SchemaStorage {
+
+    /**
+     * Get current tenant.
+     * @return
+     */
+    String getTenant();
+
+    /**
+     * Find a schema by unique id.
+     * @param id the id
+     * @return the Schema or null
+     */
+    CompletableFuture<Schema> findSchemaById(int id);
+
+    /**
+     * Find Schemas that have the same definition.
+     * @param schemaDefinition the expected schema
+     * @return the list of schemas
+     */
+    CompletableFuture<List<Schema>> findSchemaByDefinition(String schemaDefinition);
+
+    /**
+     * Get all existing subjects.
+     * @return
+     */
+    CompletableFuture<List<String>> getAllSubjects();
+
+    /**
+     * Get all versions for a given subject.
+     * @param subject the Subject
+     * @return the list of versions
+     */
+    CompletableFuture<List<Integer>> getAllVersionsForSubject(String subject);
+
+    /**
+     * Delete all the versions of a subject.
+     * @param subject the Subject
+     * @return the versions
+     */
+    CompletableFuture<List<Integer>> deleteSubject(String subject);
+
+    /**
+     * Lookup a schema by subject and version.
+     * @param subject the Subject
+     * @param version the Version
+     * @return the Schema
+     */
+    CompletableFuture<Schema> findSchemaBySubjectAndVersion(String subject, int version);
+
+    /**
+     * Create a new schema.
+     * @param subject the Subject
+     * @param schemaType the type
+     * @param schemaDefinition the schema
+     * @param forceCreate require to create a new version, without looking for an existing schema
+     * @return the new Schema
+     */
+    CompletableFuture<Schema> createSchemaVersion(String subject, String schemaType, String schemaDefinition,
+                                                  boolean forceCreate);
+
+    /**
+     * Get current compatibility mode for the given subject.
+     * @param subject
+     * @return the mode
+     */
+    CompletableFuture<CompatibilityChecker.Mode> getCompatibilityMode(String subject);
+
+    /**
+     * Set current compatibility mode for the given subject.
+     * @param subject
+     * @param mode the new mode
+     */
+    CompletableFuture<Void> setCompatibilityMode(String subject, CompatibilityChecker.Mode mode);
+
+    /**
+     * Download multiple schemas.
+     * @param ids
+     * @return the schemas
+     */
+    default CompletableFuture<List<Schema>> downloadSchemas(List<Integer> ids) {
+        if (ids.isEmpty()) {
+            return CompletableFuture.completedFuture(Collections.emptyList());
+        }
+        CompletableFuture<List<Schema>> res = new CompletableFuture<>();
+        List<Schema> schemas = new CopyOnWriteArrayList<>();
+        @AllArgsConstructor
+        class HandleSchema implements BiConsumer<Schema, Throwable> {
+
+            final int index;
+
+            public void accept(Schema downloadedSchema, Throwable err) {
+                if (err != null) {
+                    res.completeExceptionally(err);
+                } else {
+                    schemas.add(downloadedSchema);
+                    if (index == ids.size() - 1) {
+                        res.complete(schemas);
+                        return;
+                    }
+                    // recursion
+                    int id = ids.get(index + 1);
+                    findSchemaById(id)
+                            .whenComplete(new HandleSchema(index + 1));
+
+                }
+            }
+        }
+
+        // download the first
+        int id = ids.get(0);
+        findSchemaById(id)
+                .whenComplete(new HandleSchema(0));
+        return res;
+    }
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/SchemaStorageAccessor.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/SchemaStorageAccessor.java
@@ -18,9 +18,10 @@ import io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl.SchemaStora
 /**
  * Accesses the SchemaStorage instance for a given tenant.
  */
-public interface SchemaStorageAccessor extends Cloneable {
+public interface SchemaStorageAccessor extends AutoCloseable {
 
     SchemaStorage getSchemaStorageForTenant(String tenant) throws SchemaStorageException;
 
+    @Override
     void close();
 }

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/SchemaStorageAccessor.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/SchemaStorageAccessor.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model;
+
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl.SchemaStorageException;
+
+/**
+ * Accesses the SchemaStorage instance for a given tenant.
+ */
+public interface SchemaStorageAccessor extends Cloneable {
+
+    SchemaStorage getSchemaStorageForTenant(String tenant) throws SchemaStorageException;
+
+    void close();
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/MemorySchemaStorage.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/MemorySchemaStorage.java
@@ -1,0 +1,195 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl;
+
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.CompatibilityChecker;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.Schema;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorage;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.common.util.FutureUtil;
+
+@Slf4j
+public class MemorySchemaStorage implements SchemaStorage {
+    private final ConcurrentHashMap<Integer, Schema> schemas = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, CompatibilityChecker.Mode> compatibility = new ConcurrentHashMap<>();
+    private final AtomicInteger schemaIdGenerator = new AtomicInteger();
+    private final String tenant;
+
+
+    public MemorySchemaStorage(String tenant) {
+        this.tenant = tenant;
+    }
+
+    @Override
+    public String getTenant() {
+        return tenant;
+    }
+
+    @Override
+    public CompletableFuture<Schema> findSchemaById(int id) {
+        return CompletableFuture.completedFuture(schemas.get(id));
+    }
+
+    @Override
+    public CompletableFuture<Schema> findSchemaBySubjectAndVersion(String subject, int version) {
+        return CompletableFuture.completedFuture(schemas
+                .values()
+                .stream()
+                .filter(s -> s.getSubject().equals(subject)
+                        && s.getVersion() == version)
+                .findAny()
+                .orElse(null));
+    }
+
+    @Override
+    public CompletableFuture<List<Schema>> findSchemaByDefinition(String schemaDefinition) {
+        return CompletableFuture.completedFuture(schemas
+                .values()
+                .stream()
+                .filter(s -> s.getSchemaDefinition().equals(schemaDefinition))
+                .sorted(Comparator.comparing(Schema::getId)) // this is good for unit tests
+                .collect(Collectors.toList()));
+    }
+
+    @Override
+    public CompletableFuture<List<String>> getAllSubjects() {
+        return CompletableFuture.completedFuture(schemas
+                .values()
+                .stream()
+                .map(Schema::getSubject)
+                .distinct()
+                .collect(Collectors.toList()));
+    }
+
+    @Override
+    public CompletableFuture<List<Integer>> getAllVersionsForSubject(String subject) {
+        return CompletableFuture.completedFuture(schemas
+                .values()
+                .stream()
+                .filter(s -> s.getSubject().equals(subject))
+                .map(Schema::getVersion)
+                .sorted() // this is goodfor unit tests
+                .collect(Collectors.toList()));
+    }
+
+    @Override
+    public CompletableFuture<List<Integer>> deleteSubject(String subject) {
+        // please note that this implementation is not meant to be fully
+        // thread safe, it is only for tests
+        List<Integer> keys = schemas
+                .values()
+                .stream()
+                .filter(s -> s.getSubject().equals(subject))
+                .map(s -> s.getId())
+                .collect(Collectors.toList());
+        List<Integer> versions = new ArrayList<>(keys.size());
+        keys.forEach(key -> {
+            Schema remove = schemas.remove(key);
+            if (remove != null) {
+                versions.add(remove.getVersion());
+            }
+        });
+        return CompletableFuture.completedFuture(versions);
+    }
+
+    @Override
+    public CompletableFuture<Schema> createSchemaVersion(String subject, String schemaType,
+                                                         String schemaDefinition, boolean forceCreate) {
+        // please note that this implementation is not meant to be fully
+        // thread safe, it is only for tests
+
+        if (!forceCreate) {
+            Schema found = schemas
+                    .values()
+                    .stream()
+                    .filter(s -> s.getSubject().equals(subject)
+                            && s.getSchemaDefinition().equals(schemaDefinition))
+                    .sorted(Comparator.comparing(Schema::getVersion).reversed())
+                    .findFirst()
+                    .orElse(null);
+            if (found != null) {
+                return CompletableFuture.completedFuture(found);
+            }
+        }
+
+        final CompatibilityChecker.Mode compatibilityMode = compatibility.getOrDefault(subject,
+                CompatibilityChecker.Mode.NONE);
+        if (compatibilityMode != CompatibilityChecker.Mode.NONE) {
+
+            // we can extract all the versions
+            // we already have them in memory
+            List<Schema> allSchemas = schemas
+                    .values()
+                    .stream()
+                    .filter(s -> s.getSubject().equals(subject))
+                    .sorted(Comparator.comparing(Schema::getId))
+                    .collect(Collectors.toList());
+
+            boolean result = CompatibilityChecker.verify(schemaDefinition, schemaType, compatibilityMode, allSchemas);
+            log.info("schema verification result: {}", result);
+            if (!result) {
+                return FutureUtil.failedFuture(new CompatibilityChecker
+                        .IncompatibleSchemaChangeException("Schema is not compatible according to " + compatibilityMode
+                        + " compatibility mode"));
+            }
+        }
+
+        int newId = schemaIdGenerator.incrementAndGet();
+        int newVersion = schemas
+                .values()
+                .stream()
+                .filter(s -> s.getSubject().equals(subject))
+                .map(Schema::getVersion)
+                .sorted(Comparator.reverseOrder())
+                .findFirst()
+                .orElse(0) + 1;
+        Schema newSchema = Schema
+                .builder()
+                .id(newId)
+                .schemaDefinition(schemaDefinition)
+                .type(schemaType)
+                .subject(subject)
+                .version(newVersion)
+                .tenant(getTenant())
+                .build();
+        schemas.put(newSchema.getId(), newSchema);
+        return CompletableFuture.completedFuture(newSchema);
+    }
+
+    public void storeSchema(Schema schema) {
+        schemas.put(schema.getId(), schema);
+    }
+
+    public void clear() {
+        schemas.clear();
+    }
+
+    @Override
+    public CompletableFuture<CompatibilityChecker.Mode> getCompatibilityMode(String subject) {
+        return CompletableFuture.completedFuture(compatibility.getOrDefault(subject, CompatibilityChecker.Mode.NONE));
+    }
+
+    @Override
+    public CompletableFuture<Void> setCompatibilityMode(String subject, CompatibilityChecker.Mode mode) {
+        compatibility.put(subject, mode);
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/MemorySchemaStorageAccessor.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/MemorySchemaStorageAccessor.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl;
+
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorageAccessor;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class MemorySchemaStorageAccessor implements SchemaStorageAccessor {
+    private final ConcurrentHashMap<String, MemorySchemaStorage> tenants = new ConcurrentHashMap<>();
+
+    @Override
+    public MemorySchemaStorage getSchemaStorageForTenant(String tenant) {
+        return tenants.computeIfAbsent(tenant != null ? tenant : "", t -> new MemorySchemaStorage(t));
+    }
+
+    public void clear() {
+        tenants.clear();
+    }
+
+    public void close() {
+        tenants.clear();
+    }
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/MemorySchemaStorageAccessor.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/MemorySchemaStorageAccessor.java
@@ -28,6 +28,7 @@ public class MemorySchemaStorageAccessor implements SchemaStorageAccessor {
         tenants.clear();
     }
 
+    @Override
     public void close() {
         tenants.clear();
     }

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorage.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorage.java
@@ -202,9 +202,6 @@ public class PulsarSchemaStorage implements SchemaStorage, Closeable {
             });
         } else {
             // we are happy with the result, so return it to the caller
-            if (isDeleted.apply(res)) {
-                return CompletableFuture.completedFuture(null);
-            }
             return CompletableFuture.completedFuture(res);
         }
 
@@ -220,7 +217,7 @@ public class PulsarSchemaStorage implements SchemaStorage, Closeable {
                         .sorted(Comparator.comparing(SchemaEntry::getId)) // this is good for unit tests
                         .collect(Collectors.toList())
                 , (res) -> false  // not applicable
-                , (res) -> res.isEmpty())  // fetch again if nothing found, useful for demos/testing
+                , List::isEmpty)  // fetch again if nothing found, useful for demos/testing
                 .thenApply(l -> {
                     return l
                             .stream()
@@ -427,9 +424,7 @@ public class PulsarSchemaStorage implements SchemaStorage, Closeable {
                         .orElse(null);
 
                 if (found != null) {
-                    List<Map.Entry<Op, SchemaEntry>> cachedRes =
-                            Arrays.asList(new AbstractMap.SimpleImmutableEntry<>((Op) null, found));
-                    return cachedRes;
+                    return Collections.singletonList(new AbstractMap.SimpleImmutableEntry<>((Op) null, found));
                 }
             }
 
@@ -485,7 +480,8 @@ public class PulsarSchemaStorage implements SchemaStorage, Closeable {
                     .tenant(tenant)
                     .build();
 
-            return Arrays.asList(new AbstractMap.SimpleImmutableEntry<>(newSchema, newSchema.toSchemaEntry()));
+            return Collections.singletonList(
+                    new AbstractMap.SimpleImmutableEntry<>(newSchema, newSchema.toSchemaEntry()));
         };
     }
 

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorage.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorage.java
@@ -313,7 +313,7 @@ public class PulsarSchemaStorage implements SchemaStorage, Closeable {
         try {
             return MAPPER.writeValueAsBytes(op);
         } catch (JsonProcessingException err) {
-            throw new RuntimeException(err);
+            throw new IllegalArgumentException(err);
         }
     }
 

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorage.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorage.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -380,8 +381,7 @@ public class PulsarSchemaStorage implements SchemaStorage, Closeable {
                     .filter(s -> s.getTenant().equals(tenant)
                             && s.getSubject().equals(subject)
                             && s.getSchemaDefinition().equals(schemaDefinition))
-                    .sorted(Comparator.comparing(SchemaEntry::getVersion).reversed())
-                    .findFirst()
+                    .max(Comparator.comparing(SchemaEntry::getVersion))
                     .orElse(null));
             return found.thenCompose(schemaEntry -> {
                 if (schemaEntry != null) {
@@ -419,8 +419,7 @@ public class PulsarSchemaStorage implements SchemaStorage, Closeable {
                         .stream()
                         .filter(s -> s.getSubject().equals(subject)
                                 && s.getSchemaDefinition().equals(schemaDefinition))
-                        .sorted(Comparator.comparing(SchemaEntry::getVersion).reversed())
-                        .findFirst()
+                        .max(Comparator.comparing(SchemaEntry::getVersion))
                         .orElse(null);
 
                 if (found != null) {
@@ -467,8 +466,7 @@ public class PulsarSchemaStorage implements SchemaStorage, Closeable {
                     .stream()
                     .filter(s -> s.getSubject().equals(subject))
                     .map(SchemaEntry::getVersion)
-                    .sorted(Comparator.reverseOrder())
-                    .findFirst()
+                    .max(Comparator.reverseOrder())
                     .orElse(0) + 1;
             Op newSchema = Op
                     .builder()

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorage.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorage.java
@@ -1,0 +1,585 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.CompatibilityChecker;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.Schema;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorage;
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerAccessMode;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Reader;
+import org.apache.pulsar.common.util.FutureUtil;
+
+@Slf4j
+public class PulsarSchemaStorage implements SchemaStorage, Closeable {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final ConcurrentHashMap<String, CompatibilityChecker.Mode> compatibility = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Integer, SchemaEntry> schemas = new ConcurrentHashMap<>();
+    private final PulsarClient pulsarClient;
+    private final String topic;
+    private final String tenant;
+    private CompletableFuture<Reader<byte[]>> reader;
+    private CompletableFuture<?> currentReadHandle;
+
+    PulsarSchemaStorage(String tenant, PulsarClient client, String topic) {
+        this.tenant = tenant;
+        this.pulsarClient = client;
+        this.topic = topic;
+    }
+
+    private static CompletableFuture<Schema> getSchemaFromSchemaEntry(CompletableFuture<SchemaEntry> res) {
+        return res.thenApply(PulsarSchemaStorage::getSchemaFromSchemaEntry);
+    }
+
+    private static Schema getSchemaFromSchemaEntry(SchemaEntry res) {
+        if (res == null) {
+            return null;
+        }
+        return Schema
+                .builder()
+                .tenant(res.tenant)
+                .id(res.id)
+                .version(res.version)
+                .subject(res.subject)
+                .schemaDefinition(res.schemaDefinition)
+                .type(res.type)
+                .build();
+    }
+
+    @Override
+    public String getTenant() {
+        return tenant;
+    }
+
+    private synchronized CompletableFuture<Reader<byte[]>> getReaderHandle() {
+        return reader;
+    }
+
+    private synchronized CompletableFuture<Reader<byte[]>> ensureReaderHandle() {
+        if (reader == null) {
+            reader = pulsarClient.newReader()
+                    .topic(topic)
+                    .startMessageId(MessageId.earliest)
+                    .startMessageIdInclusive()
+                    .subscriptionRolePrefix("kafka-schema-registry")
+                    .createAsync();
+        }
+        return reader;
+    }
+
+    private CompletableFuture<?> readNextMessageIfAvailable(Reader<byte[]> reader) {
+        return reader
+                .hasMessageAvailableAsync()
+                .thenCompose(hasMessageAvailable -> {
+                    if (hasMessageAvailable == null
+                            || !hasMessageAvailable) {
+                        return CompletableFuture.completedFuture(null);
+                    } else {
+                        CompletableFuture<Message<byte[]>> opMessage = reader.readNextAsync();
+                        return opMessage.thenCompose(msg -> {
+                            byte[] value = msg.getValue();
+                            applyOpToLocalMemory(value);
+                            return readNextMessageIfAvailable(reader);
+                        });
+                    }
+                });
+    }
+
+    // visible for testing
+    synchronized CompletableFuture<?> ensureLatestData() {
+        return ensureLatestData(false);
+    }
+
+    synchronized CompletableFuture<?> ensureLatestData(boolean beforeWrite) {
+        if (currentReadHandle != null) {
+            if (beforeWrite) {
+                // we are inside a write loop, so
+                // we must ensure that we start to read now
+                // otherwise the write would use non up-to-date data
+                // so let's finish the current loop
+                log.info("A read was already pending, starting a new one in order to ensure consistency");
+                return currentReadHandle
+                        .thenCompose(___ -> ensureLatestData(false));
+            }
+            // if there is an ongoing read operation then complete it
+            return currentReadHandle;
+        }
+        // please note that the read operation is async,
+        // and it is not execute inside this synchronized block
+        CompletableFuture<Reader<byte[]>> readerHandle = ensureReaderHandle();
+        final CompletableFuture<?> newReadHandle =
+                readerHandle.thenCompose(this::readNextMessageIfAvailable);
+        currentReadHandle = newReadHandle;
+        return newReadHandle.whenComplete((a, b) -> {
+            endReadLoop(newReadHandle);
+            if (b != null) {
+                throw new CompletionException(b);
+            }
+        });
+    }
+
+    private synchronized void endReadLoop(CompletableFuture<?> handle) {
+        if (handle == currentReadHandle) {
+            currentReadHandle = null;
+        }
+    }
+
+    @Override
+    public CompletableFuture<Schema> findSchemaById(int id) {
+        return getSchemaFromSchemaEntry(fetchSchemaEntry(() -> schemas.get(id)));
+    }
+
+    @Override
+    public CompletableFuture<Schema> findSchemaBySubjectAndVersion(String subject, int version) {
+        return getSchemaFromSchemaEntry(fetchSchemaEntry(() -> schemas
+                .values()
+                .stream()
+                .filter(s -> s.getSubject().equals(subject)
+                        && s.getVersion() == version)
+                .findAny()
+                .orElse(null)));
+    }
+
+    private CompletableFuture<SchemaEntry> fetchSchemaEntry(Supplier<SchemaEntry> procedure) {
+        return fetch(procedure,
+                (schemaEntry) -> schemaEntry != null && schemaEntry.status == SchemaStatus.DELETED,
+                schemaEntry -> schemaEntry == null);
+    }
+
+    private <T> CompletableFuture<T> fetch(Supplier<T> procedure,
+                                           Function<T, Boolean> isDeleted,
+                                           Function<T, Boolean> requiresFetch) {
+        T res = procedure.get();
+        if (isDeleted.apply(res)) {
+            return CompletableFuture.completedFuture(null);
+        }
+        if (requiresFetch.apply(res)) {
+            // ensure we are in sync with the latest write
+            return ensureLatestData().thenApply(___ -> {
+                T res2 = procedure.get();
+                if (isDeleted.apply(res2)) {
+                    return null;
+                }
+                return res2;
+            });
+        } else {
+            // we are happy with the result, so return it to the caller
+            if (isDeleted.apply(res)) {
+                return CompletableFuture.completedFuture(null);
+            }
+            return CompletableFuture.completedFuture(res);
+        }
+
+    }
+
+    @Override
+    public CompletableFuture<List<Schema>> findSchemaByDefinition(String schemaDefinition) {
+        return fetch(
+                () -> schemas
+                        .values()
+                        .stream()
+                        .filter(s -> s.getSchemaDefinition().equals(schemaDefinition))
+                        .sorted(Comparator.comparing(SchemaEntry::getId)) // this is good for unit tests
+                        .collect(Collectors.toList())
+                , (res) -> false  // not applicable
+                , (res) -> res.isEmpty())  // fetch again if nothing found, useful for demos/testing
+                .thenApply(l -> {
+                    return l
+                            .stream()
+                            .map(PulsarSchemaStorage::getSchemaFromSchemaEntry)
+                            .collect(Collectors.toList());
+                });
+    }
+
+    @Override
+    public CompletableFuture<List<String>> getAllSubjects() {
+        return ensureLatestData().thenApply(___ ->
+                schemas
+                        .values()
+                        .stream()
+                        .map(SchemaEntry::getSubject)
+                        .distinct()
+                        .sorted() // this is good for unit tests
+                        .collect(Collectors.toList()));
+    }
+
+    @Override
+    public CompletableFuture<List<Integer>> getAllVersionsForSubject(String subject) {
+        return ensureLatestData().thenApply(___ -> schemas
+                .values()
+                .stream()
+                .filter(s -> s.getSubject().equals(subject) && s.status != SchemaStatus.DELETED)
+                .map(SchemaEntry::getVersion)
+                .sorted() // this is good for unit tests
+                .collect(Collectors.toList()));
+    }
+
+    private synchronized <T> CompletableFuture<List<T>> executeWriteOp(Supplier<List<Map.Entry<Op, T>>> opBuilder) {
+        log.info("opening exclusive producer to {}", topic);
+        CompletableFuture<Producer<byte[]>> producerHandle = pulsarClient.newProducer()
+                .enableBatching(false)
+                .topic(topic)
+                .accessMode(ProducerAccessMode.WaitForExclusive)
+                .blockIfQueueFull(true)
+                .createAsync();
+        return producerHandle.thenCompose(opProducer -> {
+            // nobody can write now to the topic
+            // wait for local cache to be up-to-date
+            CompletableFuture<List<T>> dummy = ensureLatestData(true)
+                    .thenCompose((___) -> {
+                        // build the Op, this will usually use the contents of the local cache
+                        List<Map.Entry<Op, T>> ops = opBuilder.get();
+                        List<T> res = new ArrayList<>();
+                        List<CompletableFuture<?>> sendHandles = new ArrayList<>();
+                        // write to Pulsar
+                        // if the write fails we lost the lock
+                        for (Map.Entry<Op, T> action : ops) {
+                            Op op = action.getKey();
+                            // if "op" is null, then we do not have to write to Pulsar
+                            if (op != null) {
+                                log.info("writing {} to Pulsar", op);
+                                if (!op.tenant.equals(getTenant())) {
+                                    sendHandles.add(FutureUtil.failedFuture(new SchemaStorageException(
+                                            "Invalid tenant " + op.tenant + ", expected " + tenant)));
+                                } else {
+                                    byte[] serialized = serializeOp(op);
+                                    String key = op.buildMessageKey();
+                                    sendHandles.add(opProducer
+                                            .newMessage()
+                                            .key(key)
+                                            .value(serialized)
+                                            .sendAsync().thenAccept((msgId) -> {
+                                        log.info("written {} as {} with key {} to Pulsar", op, msgId, key);
+                                        // write to local memory
+                                        applyOpToLocalMemory(op);
+                                    }));
+                                }
+                            }
+                            res.add(action.getValue());
+                        }
+
+                        return CompletableFuture
+                                .allOf(sendHandles.toArray(new CompletableFuture[0]))
+                                .thenApply(____ -> res);
+
+                    });
+            // ensure that we release the exclusive producer in any case
+            dummy.whenComplete((___, err) -> {
+                opProducer.closeAsync();
+            });
+            return dummy;
+        });
+
+
+    }
+
+    private byte[] serializeOp(Op op) {
+        try {
+            return MAPPER.writeValueAsBytes(op);
+        } catch (JsonProcessingException err) {
+            throw new RuntimeException(err);
+        }
+    }
+
+    private void applyOpToLocalMemory(byte[] serialized) {
+        try {
+            Op op = MAPPER.readValue(serialized, Op.class);
+            applyOpToLocalMemory(op);
+        } catch (IOException err) {
+            log.error("Ignoring malformed entry {}", new String(serialized, StandardCharsets.UTF_8));
+        }
+    }
+
+    private void applyOpToLocalMemory(Op op) {
+        if (op.isCompatibilityModeChange()) {
+            try {
+                compatibility.put(op.subject, CompatibilityChecker.Mode.valueOf(op.compatibilityMode));
+            } catch (IllegalArgumentException err) {
+                log.error("Unrecognized mode, skip op", op);
+            }
+        } else {
+            SchemaEntry schemaEntry = op.toSchemaEntry();
+            schemas.put(schemaEntry.id, schemaEntry);
+        }
+    }
+
+    @Override
+    public CompletableFuture<List<Integer>> deleteSubject(String subject) {
+        return executeWriteOp(() -> {
+            List<SchemaEntry> entriesToDelete = schemas
+                    .values()
+                    .stream()
+                    .filter(s -> s.getTenant().equals(tenant) && s.getSubject().equals(subject))
+                    .collect(Collectors.toList());
+
+            List<Map.Entry<Op, Integer>> operationsAndResults =
+                    entriesToDelete
+                            .stream()
+                            .map(schemaEntry -> {
+                                return new AbstractMap.SimpleImmutableEntry<>(
+                                        Op.builder()
+                                                .schemaId(schemaEntry.id)
+                                                .subject(schemaEntry.subject)
+                                                .schemaDefinition(null)
+                                                .schemaVersion(schemaEntry.version)
+                                                .status(SchemaStatus.DELETED)
+                                                .tenant(schemaEntry.tenant)
+                                                .build(),
+                                        schemaEntry.getVersion()
+                                );
+                            })
+                            .collect(Collectors.toList());
+
+            return operationsAndResults;
+        });
+    }
+
+    @Override
+    public CompletableFuture<Schema> createSchemaVersion(String subject, String schemaType, String schemaDefinition,
+                                                         boolean forceCreate) {
+        if (!forceCreate) {
+            // read from cache, this is the most common case
+            CompletableFuture<SchemaEntry> found = fetchSchemaEntry(() -> schemas
+                    .values()
+                    .stream()
+                    .filter(s -> s.getTenant().equals(tenant)
+                            && s.getSubject().equals(subject)
+                            && s.getSchemaDefinition().equals(schemaDefinition))
+                    .sorted(Comparator.comparing(SchemaEntry::getVersion).reversed())
+                    .findFirst()
+                    .orElse(null));
+            return found.thenCompose(schemaEntry -> {
+                if (schemaEntry != null) {
+                    return CompletableFuture.completedFuture(getSchemaFromSchemaEntry(schemaEntry));
+                } else {
+                    // execute the operation, in write lock
+                    return executeWriteOp(buildWriteSchemaOp(subject,
+                            schemaType, schemaDefinition, forceCreate))
+                            // this function will always return something
+                            .thenApply(sr -> {
+                                return getSchemaFromSchemaEntry(sr.get(0));
+                            });
+                }
+            });
+        } else {
+            // execute the operation, in write lock
+            return executeWriteOp(buildWriteSchemaOp(subject,
+                    schemaType, schemaDefinition, forceCreate))
+                    // this function will always return something
+                    .thenApply(sr -> {
+                        return getSchemaFromSchemaEntry(sr.get(0));
+                    });
+        }
+    }
+
+    private Supplier<List<Map.Entry<Op, SchemaEntry>>> buildWriteSchemaOp(String subject,
+                                                                          String schemaType,
+                                                                          String schemaDefinition,
+                                                                          boolean forceCreate) {
+        return () -> {
+
+            if (!forceCreate) {
+                SchemaEntry found = schemas
+                        .values()
+                        .stream()
+                        .filter(s -> s.getSubject().equals(subject)
+                                && s.getSchemaDefinition().equals(schemaDefinition))
+                        .sorted(Comparator.comparing(SchemaEntry::getVersion).reversed())
+                        .findFirst()
+                        .orElse(null);
+
+                if (found != null) {
+                    List<Map.Entry<Op, SchemaEntry>> cachedRes =
+                            Arrays.asList(new AbstractMap.SimpleImmutableEntry<>((Op) null, found));
+                    return cachedRes;
+                }
+            }
+
+            // we are inside the lock, so we know that every local variable is up-to-date
+            final CompatibilityChecker.Mode compatibilityMode = compatibility.getOrDefault(subject,
+                    CompatibilityChecker.Mode.NONE);
+            if (compatibilityMode != CompatibilityChecker.Mode.NONE) {
+
+                // we can extract all the versions
+                // we already have them in memory
+                List<Schema> allSchemas = schemas
+                        .values()
+                        .stream()
+                        .filter(s -> s.getSubject().equals(subject))
+                        .sorted(Comparator.comparing(SchemaEntry::getId))
+                        .map(PulsarSchemaStorage::getSchemaFromSchemaEntry)
+                        .collect(Collectors.toList());
+
+                boolean result =
+                        CompatibilityChecker.verify(schemaDefinition, schemaType, compatibilityMode, allSchemas);
+                log.info("schema verification result: {}", result);
+                if (!result) {
+                    throw new CompatibilityChecker
+                            .IncompatibleSchemaChangeException(
+                            "Schema is not compatible according to " + compatibilityMode
+                                    + " compatibility mode");
+                }
+            }
+
+            // select new id, we are inside the write lock
+            // also we are sure that the local cache is up-to-date
+            int newId = schemas
+                    .keySet()
+                    .stream()
+                    .mapToInt(s -> s)
+                    .max()
+                    .orElse(0) + 1;
+            int newVersion = schemas
+                    .values()
+                    .stream()
+                    .filter(s -> s.getSubject().equals(subject))
+                    .map(SchemaEntry::getVersion)
+                    .sorted(Comparator.reverseOrder())
+                    .findFirst()
+                    .orElse(0) + 1;
+            Op newSchema = Op
+                    .builder()
+                    .schemaId(newId)
+                    .schemaDefinition(schemaDefinition)
+                    .type(schemaType)
+                    .subject(subject)
+                    .schemaVersion(newVersion)
+                    .tenant(tenant)
+                    .build();
+
+            return Arrays.asList(new AbstractMap.SimpleImmutableEntry<>(newSchema, newSchema.toSchemaEntry()));
+        };
+    }
+
+    @Override
+    public void close() {
+        CompletableFuture<Reader<byte[]>> currentReadHandle = getReaderHandle();
+        if (currentReadHandle != null) {
+            currentReadHandle.thenAccept(reader -> {
+                try {
+                    reader.close();
+                } catch (Exception err) {
+                    // ignore
+                }
+            });
+        }
+    }
+
+    @Override
+    public CompletableFuture<CompatibilityChecker.Mode> getCompatibilityMode(String subject) {
+        return ensureLatestData()
+                .thenApply(___ -> {
+                    return compatibility.getOrDefault(subject, CompatibilityChecker.Mode.NONE);
+                });
+    }
+
+    @Override
+    public CompletableFuture<Void> setCompatibilityMode(String subject, CompatibilityChecker.Mode mode) {
+        return executeWriteOp(() -> {
+            return Arrays.asList(
+                    new AbstractMap.SimpleImmutableEntry<>(
+                            Op.builder()
+                                    .subject(subject)
+                                    .tenant(tenant)
+                                    .compatibilityMode(mode.name())
+                                    .build(),
+                            null
+                    ));
+        }).thenApply(___ -> null);
+    }
+
+    private enum SchemaStatus {
+        ACTIVE,
+        DELETED
+    }
+
+    @Data
+    @Builder
+    private static final class SchemaEntry {
+        private int id;
+        private SchemaStatus status;
+        private String tenant;
+        private int version;
+        private String subject;
+        private String schemaDefinition;
+        private String type;
+    }
+
+    @Builder
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static final class Op {
+        int schemaId;
+        int schemaVersion;
+        String subject;
+        String tenant;
+        String schemaDefinition;
+        SchemaStatus status;
+        String type;
+        String compatibilityMode;
+
+        boolean isCompatibilityModeChange() {
+            return compatibilityMode != null;
+        }
+
+        SchemaEntry toSchemaEntry() {
+            return SchemaEntry
+                    .builder()
+                    .id(schemaId)
+                    .version(schemaVersion)
+                    .subject(subject)
+                    .tenant(tenant)
+                    .schemaDefinition(schemaDefinition)
+                    .status(status)
+                    .type(type)
+                    .build();
+        }
+
+        String buildMessageKey() {
+            if (compatibilityMode != null) {
+                return tenant + "_" + subject + "_" + "compatibilityMode";
+            } else {
+                return tenant + "_" + subject + "_v" + schemaVersion;
+            }
+        }
+    }
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorageAccessor.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorageAccessor.java
@@ -45,6 +45,7 @@ public class PulsarSchemaStorageAccessor implements SchemaStorageAccessor {
         tenants.clear();
     }
 
+    @Override
     public void close() {
         tenants.clear();
     }

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorageAccessor.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorageAccessor.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl;
+
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorageAccessor;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.PulsarClient;
+
+@AllArgsConstructor
+@Slf4j
+public class PulsarSchemaStorageAccessor implements SchemaStorageAccessor {
+    private final ConcurrentHashMap<String, PulsarSchemaStorage> tenants = new ConcurrentHashMap<>();
+    private final Function<String, PulsarClient> authenticatedClientBuilder;
+    private final String namespaceName;
+    private final String topicName;
+
+    @Override
+    public PulsarSchemaStorage getSchemaStorageForTenant(String tenant) throws SchemaStorageException {
+        if (tenant == null) {
+            throw new SchemaStorageException("Invalid Tenant null");
+        }
+        return tenants.computeIfAbsent(tenant, t -> {
+            String fullTopicName = "persistent://" + t + "/" + namespaceName + "/" + topicName;
+            log.info("Building Pulsar Client for Schema Registry for Tenant {}, data topic {}", tenant, fullTopicName);
+            PulsarClient pulsarClient = authenticatedClientBuilder.apply(t);
+            return new PulsarSchemaStorage(t, pulsarClient, fullTopicName);
+        });
+    }
+
+    public void clear() {
+        tenants.clear();
+    }
+
+    public void close() {
+        tenants.clear();
+    }
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/SchemaStorageException.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/SchemaStorageException.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class SchemaStorageException extends Exception {
+
+    private final int httpStatusCode;
+
+    public SchemaStorageException(Throwable cause) {
+        super(cause);
+        this.httpStatusCode = HttpResponseStatus.INTERNAL_SERVER_ERROR.code();
+    }
+
+    public SchemaStorageException(String message) {
+        super(message);
+        this.httpStatusCode = HttpResponseStatus.INTERNAL_SERVER_ERROR.code();
+    }
+
+    public SchemaStorageException(String message, int httpStatusCode) {
+        super(message);
+        this.httpStatusCode = httpStatusCode;
+    }
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/package-info.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl;

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/package-info.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model;

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/package-info.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry;

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/AbstractResource.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/AbstractResource.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.resources;
+
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryHandler;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryRequestAuthenticator;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorage;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorageAccessor;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl.SchemaStorageException;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public abstract class AbstractResource {
+
+    public static final String INT_PATTERN = "([0-9]+)";
+    public static final String STRING_PATTERN = "(.+)";
+
+    public static final String GET = "GET";
+    public static final String POST = "POST";
+    public static final String DELETE = "DELETE";
+    public static final String PUT = "PUT";
+
+    public static final String DEFAULT_TENANT = "public";
+
+    protected final SchemaStorageAccessor schemaStorageAccessor;
+    protected final SchemaRegistryRequestAuthenticator schemaRegistryRequestAuthenticator;
+
+    protected String getCurrentTenant(FullHttpRequest request) throws Exception {
+        return schemaRegistryRequestAuthenticator.authenticate(request);
+    }
+
+    protected SchemaStorage getSchemaStorage(FullHttpRequest request) throws SchemaStorageException {
+        String currentTenant;
+        try {
+            currentTenant = getCurrentTenant(request);
+        } catch (SchemaStorageException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new SchemaStorageException(e);
+        }
+        if (currentTenant == null) {
+            throw new SchemaStorageException("Missing or failed authentication",
+                    HttpResponseStatus.UNAUTHORIZED.code());
+        }
+        return schemaStorageAccessor.getSchemaStorageForTenant(currentTenant);
+    }
+
+    /**
+     * Register all processors.
+     * @param schemaRegistryHandler
+     */
+    public abstract void register(SchemaRegistryHandler schemaRegistryHandler);
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/CompatibilityResource.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/CompatibilityResource.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.resources;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.HttpJsonRequestProcessor;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryHandler;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryRequestAuthenticator;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.CompatibilityChecker;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.Schema;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorage;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorageAccessor;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+public class CompatibilityResource extends AbstractResource {
+
+    public CompatibilityResource(SchemaStorageAccessor schemaStorageAccessor,
+                                 SchemaRegistryRequestAuthenticator schemaRegistryRequestAuthenticator) {
+        super(schemaStorageAccessor, schemaRegistryRequestAuthenticator);
+    }
+
+    @Override
+    public void register(SchemaRegistryHandler schemaRegistryHandler) {
+        schemaRegistryHandler.addProcessor(new CheckCompatibilityLatestSchema());
+    }
+
+    @Data
+    public static final class CheckCompatibilityLatestSchemaRequest {
+        private String schema;
+    }
+
+    @AllArgsConstructor
+    public static final class CheckCompatibilityLatestSchemaResponse {
+
+        private final boolean isCompatible;
+
+        @JsonProperty("is_compatible")
+        public boolean getIsCompatible() {
+            return isCompatible;
+        }
+    }
+
+    // GET /compatibility/subjects/${subject}/versions/latest
+    public class CheckCompatibilityLatestSchema extends HttpJsonRequestProcessor<CheckCompatibilityLatestSchemaRequest,
+            CheckCompatibilityLatestSchemaResponse> {
+
+        public CheckCompatibilityLatestSchema() {
+            super(CheckCompatibilityLatestSchemaRequest.class,
+                    "/compatibility/subjects/" + STRING_PATTERN + "/versions/latest", POST);
+        }
+
+        @Override
+        protected CompletableFuture<CheckCompatibilityLatestSchemaResponse> processRequest(
+                CheckCompatibilityLatestSchemaRequest payload, List<String> patternGroups, FullHttpRequest request)
+                throws Exception {
+            SchemaStorage schemaStorage = getSchemaStorage(request);
+            String subject = patternGroups.get(0);
+            Schema dummy = Schema.builder()
+                    .schemaDefinition(payload.schema)
+                    .type(Schema.TYPE_AVRO)
+                    .build();
+            return CompatibilityChecker.verify(dummy, subject, schemaStorage)
+                    .thenApply(CheckCompatibilityLatestSchemaResponse::new);
+        }
+
+    }
+
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/ConfigResource.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/ConfigResource.java
@@ -1,0 +1,131 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.resources;
+
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.HttpJsonRequestProcessor;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryHandler;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryRequestAuthenticator;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.CompatibilityChecker;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorage;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorageAccessor;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+public class ConfigResource extends AbstractResource {
+
+    public ConfigResource(SchemaStorageAccessor schemaStorageAccessor,
+                          SchemaRegistryRequestAuthenticator schemaRegistryRequestAuthenticator) {
+        super(schemaStorageAccessor, schemaRegistryRequestAuthenticator);
+    }
+
+    @Override
+    public void register(SchemaRegistryHandler schemaRegistryHandler) {
+        schemaRegistryHandler.addProcessor(new PutConfig());
+        schemaRegistryHandler.addProcessor(new GetSubjectConfig());
+        schemaRegistryHandler.addProcessor(new GetConfig());
+        schemaRegistryHandler.addProcessor(new GetMode());
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static final class GetConfigResponse {
+        private String compatibilityLevel;
+    }
+
+    // GET /config
+    public static class GetConfig extends HttpJsonRequestProcessor<Void, GetConfigResponse> {
+
+        public GetConfig() {
+            super(Void.class, "/config", GET);
+        }
+
+        @Override
+        protected CompletableFuture<GetConfigResponse> processRequest(Void payload, List<String> patternGroups,
+                                                                      FullHttpRequest request)
+                throws Exception {
+            return CompletableFuture.completedFuture(new GetConfigResponse(CompatibilityChecker.Mode.NONE.name()));
+        }
+
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static final class GetModeResponse {
+        private String mode;
+    }
+
+    // GET /mode
+    public static class GetMode extends HttpJsonRequestProcessor<Void, GetModeResponse> {
+
+        public GetMode() {
+            super(Void.class, "/mode", GET);
+        }
+
+        @Override
+        protected CompletableFuture<GetModeResponse> processRequest(Void payload, List<String> patternGroups,
+                                                                    FullHttpRequest request)
+                throws Exception {
+            return CompletableFuture.completedFuture(new GetModeResponse("READWRITE"));
+        }
+
+    }
+
+    @Data
+    public static final class PutConfigRequest {
+        private String compatibility;
+    }
+
+    // GET /config/${subject}
+    public class GetSubjectConfig extends HttpJsonRequestProcessor<Void, GetConfigResponse> {
+
+        public GetSubjectConfig() {
+            super(Void.class, "/config/" + STRING_PATTERN, GET);
+        }
+
+        @Override
+        protected CompletableFuture<GetConfigResponse> processRequest(Void payload, List<String> patternGroups,
+                                                                      FullHttpRequest request)
+                throws Exception {
+            SchemaStorage schemaStorage = getSchemaStorage(request);
+            String subject = patternGroups.get(0);
+            return schemaStorage.getCompatibilityMode(subject).thenApply(r -> new GetConfigResponse(r.name()));
+        }
+
+    }
+
+    // PUT /config/${subject}
+    public class PutConfig extends HttpJsonRequestProcessor<PutConfigRequest, GetConfigResponse> {
+
+        public PutConfig() {
+            super(PutConfigRequest.class, "/config/" + STRING_PATTERN, PUT);
+        }
+
+        @Override
+        protected CompletableFuture<GetConfigResponse> processRequest(PutConfigRequest payload,
+                                                                      List<String> patternGroups,
+                                                                      FullHttpRequest request)
+                throws Exception {
+            SchemaStorage schemaStorage = getSchemaStorage(request);
+            String subject = patternGroups.get(0);
+            CompatibilityChecker.Mode mode = CompatibilityChecker.Mode.valueOf(payload.compatibility);
+            return schemaStorage.setCompatibilityMode(subject, mode)
+                    .thenApply(r -> new GetConfigResponse(payload.compatibility));
+        }
+
+    }
+
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SchemaResource.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SchemaResource.java
@@ -1,0 +1,132 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.resources;
+
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.HttpJsonRequestProcessor;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryHandler;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryRequestAuthenticator;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.Schema;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorage;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorageAccessor;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class SchemaResource extends AbstractResource {
+
+    public SchemaResource(SchemaStorageAccessor schemaStorageAccessor,
+                          SchemaRegistryRequestAuthenticator schemaRegistryRequestAuthenticator) {
+        super(schemaStorageAccessor, schemaRegistryRequestAuthenticator);
+    }
+
+    /**
+     * Register all processors.
+     * @param schemaRegistryHandler
+     */
+    public void register(SchemaRegistryHandler schemaRegistryHandler) {
+        schemaRegistryHandler.addProcessor(new GetSchemaById());
+        schemaRegistryHandler.addProcessor(new GetSchemaTypes());
+        schemaRegistryHandler.addProcessor(new GetSchemaAliases());
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static final class GetSchemaResponse {
+        private String schema;
+    }
+
+    // /schemas/types
+    public static class GetSchemaTypes extends HttpJsonRequestProcessor<Void, List<String>> {
+
+        public GetSchemaTypes() {
+            super(Void.class, "/schemas/types", GET);
+        }
+
+        @Override
+        protected CompletableFuture<List<String>> processRequest(Void payload, List<String> patternGroups,
+                                                                 FullHttpRequest request) {
+            return CompletableFuture.completedFuture(Schema.getAllTypes());
+        }
+
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static final class SubjectVersionPair {
+        private String subject;
+        private int version;
+    }
+
+    // GET /schemas/ids/{int: id}
+    public class GetSchemaById extends HttpJsonRequestProcessor<Void, GetSchemaResponse> {
+
+        public GetSchemaById() {
+            super(Void.class, "/schemas/ids/" + INT_PATTERN, GET);
+        }
+
+        @Override
+        protected CompletableFuture<GetSchemaResponse> processRequest(Void payload, List<String> patternGroups,
+                                                                      FullHttpRequest request)
+                throws Exception {
+            int id = getInt(0, patternGroups);
+            SchemaStorage schemaStorage = getSchemaStorage(request);
+            CompletableFuture<Schema> schemaById = schemaStorage.findSchemaById(id);
+            return schemaById.thenApply(s -> {
+                if (s == null) {
+                    return null;
+                }
+                return new GetSchemaResponse(s.getSchemaDefinition());
+            });
+        }
+
+    }
+
+    // /schemas/ids/{int: id}/versions
+    public class GetSchemaAliases extends HttpJsonRequestProcessor<Void, List<SubjectVersionPair>> {
+
+        public GetSchemaAliases() {
+            super(Void.class, "/schemas/ids/" + INT_PATTERN + "/versions", GET);
+        }
+
+        @Override
+        protected CompletableFuture<List<SubjectVersionPair>> processRequest(Void payload,
+                                                                             List<String> patternGroups,
+                                                                             FullHttpRequest request)
+                throws Exception {
+            SchemaStorage schemaStorage = getSchemaStorage(request);
+            int id = getInt(0, patternGroups);
+            CompletableFuture<Schema> schema = schemaStorage.findSchemaById(id);
+            return schema.thenCompose(s -> {
+                if (s == null) {
+                    return CompletableFuture.completedFuture(null);
+                }
+                CompletableFuture<List<Schema>> schemaAliases =
+                        schemaStorage.findSchemaByDefinition(s.getSchemaDefinition());
+                return schemaAliases.thenApply(sh -> sh
+                        .stream()
+                        .map(sv -> new SubjectVersionPair(sv.getSubject(), sv.getVersion()))
+                        .collect(Collectors.toList()));
+            });
+        }
+
+    }
+
+
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SubjectResource.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SubjectResource.java
@@ -99,8 +99,7 @@ public class SubjectResource extends AbstractResource {
                                                                  FullHttpRequest request)
                 throws Exception {
             SchemaStorage schemaStorage = getSchemaStorage(request);
-            CompletableFuture<List<String>> subjects = schemaStorage.getAllSubjects();
-            return subjects;
+            return schemaStorage.getAllSubjects();
         }
 
     }

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SubjectResource.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SubjectResource.java
@@ -1,0 +1,302 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.resources;
+
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.HttpJsonRequestProcessor;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryHandler;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryRequestAuthenticator;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.CompatibilityChecker;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.Schema;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorage;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorageAccessor;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl.SchemaStorageException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+
+public class SubjectResource extends AbstractResource {
+
+    public SubjectResource(SchemaStorageAccessor schemaStorageAccessor,
+                           SchemaRegistryRequestAuthenticator schemaRegistryRequestAuthenticator) {
+        super(schemaStorageAccessor, schemaRegistryRequestAuthenticator);
+    }
+
+    @Override
+    public void register(SchemaRegistryHandler schemaRegistryHandler) {
+        schemaRegistryHandler.addProcessor(new CreateNewSchema());
+        schemaRegistryHandler.addProcessor(new GetAllSubjects());
+        schemaRegistryHandler.addProcessor(new GetLatestVersion());
+        schemaRegistryHandler.addProcessor(new GetAllVersions());
+        schemaRegistryHandler.addProcessor(new DeleteSubject());
+        schemaRegistryHandler.addProcessor(new GetSchemaBySubjectAndVersion());
+        schemaRegistryHandler.addProcessor(new GetRawSchemaBySubjectAndVersion());
+        schemaRegistryHandler.addProcessor(new CreateOrUpdateSchema());
+    }
+
+    @AllArgsConstructor
+    @Getter
+    public static class GetSchemaBySubjectAndVersionResponse {
+        private int id;
+        private String schema;
+        private String subject;
+        private int version;
+        private String type;
+    }
+
+    @Data
+    public static final class CreateSchemaRequest {
+        String schema;
+        String schemaType = "AVRO";
+        List<SchemaReference> references = new ArrayList<>();
+
+        @Data
+        public static final class SchemaReference {
+            String name;
+            String subject;
+            String version;
+        }
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static final class CreateSchemaResponse {
+        int id;
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static final class CreateSchemaResponseForSubject {
+        int id;
+        int version;
+    }
+
+    // GET /subjects
+    public class GetAllSubjects extends HttpJsonRequestProcessor<Void, List<String>> {
+
+        public GetAllSubjects() {
+            super(Void.class, "/subjects", GET);
+        }
+
+        @Override
+        protected CompletableFuture<List<String>> processRequest(Void payload, List<String> patternGroups,
+                                                                 FullHttpRequest request)
+                throws Exception {
+            SchemaStorage schemaStorage = getSchemaStorage(request);
+            CompletableFuture<List<String>> subjects = schemaStorage.getAllSubjects();
+            return subjects;
+        }
+
+    }
+
+    // GET /subjects/test/versions
+    public class GetAllVersions extends HttpJsonRequestProcessor<Void, List<Integer>> {
+
+        public GetAllVersions() {
+            super(Void.class, "/subjects/" + STRING_PATTERN + "/versions", GET);
+        }
+
+        @Override
+        protected CompletableFuture<List<Integer>> processRequest(Void payload, List<String> patternGroups,
+                                                                  FullHttpRequest request)
+                throws Exception {
+            SchemaStorage schemaStorage = getSchemaStorage(request);
+            String subject = getString(0, patternGroups);
+            CompletableFuture<List<Integer>> versions = schemaStorage.getAllVersionsForSubject(subject);
+            return versions.thenApply(v -> {
+                if (v.isEmpty()) {
+                    return null;
+                }
+                return v;
+            });
+        }
+
+    }
+
+    // GET /subjects/test/versions/latest
+    public class GetLatestVersion extends HttpJsonRequestProcessor<Void, GetSchemaBySubjectAndVersionResponse> {
+
+        public GetLatestVersion() {
+            super(Void.class, "/subjects/" + STRING_PATTERN + "/versions/latest", GET);
+        }
+
+        @Override
+        protected CompletableFuture<GetSchemaBySubjectAndVersionResponse> processRequest(Void payload,
+                                                                                         List<String> patternGroups,
+                                                                                         FullHttpRequest request)
+                throws Exception {
+            SchemaStorage schemaStorage = getSchemaStorage(request);
+            String subject = getString(0, patternGroups);
+            CompletableFuture<List<Integer>> versions = schemaStorage.getAllVersionsForSubject(subject);
+            return versions.thenCompose(v -> {
+                if (v.isEmpty()) {
+                    return CompletableFuture.completedFuture(null);
+                }
+                return schemaStorage.findSchemaBySubjectAndVersion(subject, v.get(v.size() - 1))
+                        .thenApply(s -> s == null ? null : new GetSchemaBySubjectAndVersionResponse(
+                                s.getId(),
+                                s.getSchemaDefinition(),
+                                s.getSubject(), s.getVersion(), s.getType()));
+            });
+        }
+
+    }
+
+    // DELETE /subjects/(string: subject)
+    public class DeleteSubject extends HttpJsonRequestProcessor<Void, List<Integer>> {
+
+        public DeleteSubject() {
+            super(Void.class, "/subjects/" + STRING_PATTERN, DELETE);
+        }
+
+        @Override
+        protected CompletableFuture<List<Integer>> processRequest(Void payload, List<String> patternGroups,
+                                                                  FullHttpRequest request)
+                throws Exception {
+            SchemaStorage schemaStorage = getSchemaStorage(request);
+            String subject = getString(0, patternGroups);
+
+            CompletableFuture<List<Integer>> versions = schemaStorage.deleteSubject(subject);
+            return versions.thenApply(v -> {
+                if (v.isEmpty()) {
+                    return null;
+                }
+                return v;
+            });
+        }
+
+    }
+
+    // GET /subjects/(string: subject)/versions/(versionId: version)
+    public class GetSchemaBySubjectAndVersion
+            extends HttpJsonRequestProcessor<Void, GetSchemaBySubjectAndVersionResponse> {
+
+        public GetSchemaBySubjectAndVersion() {
+            super(Void.class, "/subjects/" + STRING_PATTERN + "/versions/" + INT_PATTERN, GET);
+        }
+
+        @Override
+        protected CompletableFuture<GetSchemaBySubjectAndVersionResponse> processRequest(Void payload,
+                                                                                         List<String> patternGroups,
+                                                                                         FullHttpRequest request)
+                throws Exception {
+            String subject = getString(0, patternGroups);
+            int version = getInt(1, patternGroups);
+            SchemaStorage schemaStorage = getSchemaStorage(request);
+            CompletableFuture<Schema> schema = schemaStorage.findSchemaBySubjectAndVersion(subject, version);
+            return schema.thenApply(s -> {
+                if (s == null) {
+                    return null;
+                }
+                return new GetSchemaBySubjectAndVersionResponse(s.getId(), s.getSchemaDefinition(), s.getSubject(),
+                        s.getVersion(), s.getType());
+            });
+        }
+
+    }
+
+    // GET /subjects/(string: subject)/versions/(versionId: version)
+    public class GetRawSchemaBySubjectAndVersion extends HttpJsonRequestProcessor<Void, String> {
+
+        public GetRawSchemaBySubjectAndVersion() {
+            super(Void.class, "/subjects/" + STRING_PATTERN + "/versions/" + INT_PATTERN + "/schema", GET);
+        }
+
+        @Override
+        protected CompletableFuture<String> processRequest(Void payload, List<String> patternGroups,
+                                                           FullHttpRequest request)
+                throws Exception {
+            String subject = getString(0, patternGroups);
+            int version = getInt(1, patternGroups);
+            SchemaStorage schemaStorage = getSchemaStorage(request);
+            CompletableFuture<Schema> schema = schemaStorage.findSchemaBySubjectAndVersion(subject, version);
+            return schema.thenApply(s -> {
+                if (s == null) {
+                    return null;
+                }
+                return s.getSchemaDefinition();
+            });
+        }
+
+    }
+
+    // POST /subjects/(string: subject)/versions
+    public class CreateNewSchema extends HttpJsonRequestProcessor<CreateSchemaRequest, CreateSchemaResponse> {
+
+        public CreateNewSchema() {
+            super(CreateSchemaRequest.class, "/subjects/" + STRING_PATTERN + "/versions", POST);
+        }
+
+        @Override
+        protected CompletableFuture<CreateSchemaResponse> processRequest(CreateSchemaRequest payload,
+                                                                         List<String> patternGroups,
+                                                                         FullHttpRequest request)
+                throws Exception {
+            String subject = getString(0, patternGroups);
+            SchemaStorage schemaStorage = getSchemaStorage(request);
+            CompletableFuture<Schema> schema = schemaStorage.createSchemaVersion(subject,
+                    payload.schemaType, payload.schema, true);
+            return schema.thenApply(s -> new CreateSchemaResponse(s.getId())).exceptionally(err -> {
+                while (err instanceof CompletionException) {
+                    err = err.getCause();
+                }
+                if (err instanceof CompatibilityChecker.IncompatibleSchemaChangeException) {
+                    throw new CompletionException(
+                            new SchemaStorageException(err.getMessage(), HttpResponseStatus.CONFLICT.code()));
+                } else {
+                    throw new CompletionException(err);
+                }
+            });
+        }
+
+    }
+
+    // POST /subjects/(string: subject)
+    public class CreateOrUpdateSchema
+            extends HttpJsonRequestProcessor<CreateSchemaRequest, CreateSchemaResponseForSubject> {
+
+        public CreateOrUpdateSchema() {
+            super(CreateSchemaRequest.class, "/subjects/" + STRING_PATTERN, POST);
+        }
+
+        @Override
+        protected CompletableFuture<CreateSchemaResponseForSubject> processRequest(CreateSchemaRequest payload,
+                                                                                   List<String> patternGroups,
+                                                                                   FullHttpRequest request)
+                throws Exception {
+            String subject = getString(0, patternGroups);
+            SchemaStorage schemaStorage = getSchemaStorage(request);
+            CompletableFuture<Schema> schema = schemaStorage.createSchemaVersion(subject,
+                    payload.schemaType, payload.schema, false);
+            return schema.thenApply(s -> new CreateSchemaResponseForSubject(s.getId(), s.getVersion()))
+                    .exceptionally(err -> {
+                        while (err instanceof CompletionException) {
+                            err = err.getCause();
+                        }
+                        if (err instanceof CompatibilityChecker.IncompatibleSchemaChangeException) {
+                            throw new CompletionException(
+                                    new SchemaStorageException(err.getMessage(), HttpResponseStatus.CONFLICT.code()));
+                        } else {
+                            throw new CompletionException(err);
+                        }
+                    });
+        }
+
+    }
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/package-info.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.resources;

--- a/schema-registry/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryHandlerTest.java
+++ b/schema-registry/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryHandlerTest.java
@@ -1,0 +1,181 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry;
+
+import static org.testng.Assert.assertEquals;
+
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl.SchemaStorageException;
+import java.io.FileNotFoundException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.apache.pulsar.common.util.FutureUtil;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class SchemaRegistryHandlerTest {
+
+    private SimpleAPIServer server = new SimpleAPIServer(new SchemaRegistryHandler()
+            .addProcessor(new DemoHandler())
+            .addProcessor(new JsonBodyHandler())
+            .addProcessor(new JsonHandler()));
+
+    @BeforeClass(alwaysRun = true)
+    public void startServer() throws Exception {
+        server.startServer();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void stopServer() throws Exception {
+        server.stopServer();
+    }
+
+    @Test
+    public void testBasicGet() throws Exception {
+        assertEquals("ok", server.executeGet("/demo/ok"));
+    }
+
+    @Test
+    public void testBasicJson() throws Exception {
+        assertEquals("{\n"
+                + "  \"value\" : \"/json/test\"\n"
+                + "}", server.executeGet("/json/test"));
+    }
+
+    @Test
+    public void testBasicJsonApi() throws Exception {
+        assertEquals("{\n"
+                        + "  \"subject\" : \"testsubject\",\n"
+                        + "  \"value\" : \"/json/test\"\n"
+                        + "}",
+                server.executePost("/subjects/testsubject", "{\n"
+                        + "  \"value\" : \"/json/test\"\n"
+                        + "}", "application/json"));
+    }
+
+    @Test
+    public void testBasicJsonApiError401() throws Exception {
+        assertEquals("{\n"
+                        + "  \"message\" : \"Bad auth\",\n"
+                        + "  \"error_code\" : 401\n"
+                        + "}",
+                server.executePost("/subjects/errorsubject401", "{\n"
+                        + "  \"value\" : \"/json/test\"\n"
+                        + "}", "application/json", 401));
+    }
+
+    @Test
+    public void testBasicJsonApiError403() throws Exception {
+        assertEquals("{\n"
+                        + "  \"message\" : \"Forbidden\",\n"
+                        + "  \"error_code\" : 403\n"
+                        + "}",
+                server.executePost("/subjects/errorsubject403", "{\n"
+                        + "  \"value\" : \"/json/test\"\n"
+                        + "}", "application/json", 403));
+    }
+
+    @Test
+    public void testBasicJsonApiError500() throws Exception {
+        assertEquals("{\n"
+                        + "  \"message\" : \"Error\",\n"
+                        + "  \"error_code\" : 500\n"
+                        + "}",
+                server.executePost("/subjects/errorsubject500", "{\n"
+                        + "  \"value\" : \"/json/test\"\n"
+                        + "}", "application/json", 500));
+    }
+
+    @Test(expectedExceptions = FileNotFoundException.class)
+    public void testBasicNotFound() throws Exception {
+        server.executeGet("/notfound");
+    }
+
+    private static class DemoHandler extends HttpRequestProcessor {
+
+        @Override
+        public boolean acceptRequest(FullHttpRequest request) {
+            return request.uri().startsWith("/demo");
+        }
+
+        @Override
+        public CompletableFuture<FullHttpResponse> processRequest(FullHttpRequest request) {
+            return CompletableFuture.completedFuture(buildStringResponse("ok", "text/plain; charset=UTF-8"));
+        }
+    }
+
+    private static class JsonHandler extends HttpRequestProcessor {
+
+        @Override
+        public boolean acceptRequest(FullHttpRequest request) {
+            return request.uri().startsWith("/json");
+        }
+
+        @Override
+        public CompletableFuture<FullHttpResponse> processRequest(FullHttpRequest request) {
+            String content = request.uri();
+            return CompletableFuture.completedFuture(
+                    buildJsonResponse(new SchemaPojo(content), "application/json; charset=UTF-8"));
+        }
+
+        @Data
+        @AllArgsConstructor
+        private static class SchemaPojo {
+            String value;
+        }
+    }
+
+    @Data
+    private static class RequestPojo {
+        String value;
+    }
+
+    @Data
+    @AllArgsConstructor
+    private static class ResponsePojo {
+        String subject;
+        String value;
+    }
+
+    private static class JsonBodyHandler extends HttpJsonRequestProcessor<RequestPojo, ResponsePojo> {
+
+        public JsonBodyHandler() {
+            super(RequestPojo.class, "/subjects/(.*)", "POST");
+        }
+
+        @Override
+        protected CompletableFuture<ResponsePojo> processRequest(RequestPojo payload, List<String> groups,
+                                                                 FullHttpRequest request) {
+            String subject = groups.get(0);
+            if (subject.equals("errorsubject401")) {
+                return FutureUtil.failedFuture(
+                        new SchemaStorageException("Bad auth", HttpResponseStatus.UNAUTHORIZED.code()));
+            }
+            if (subject.equals("errorsubject403")) {
+                return FutureUtil.failedFuture(
+                        new SchemaStorageException("Forbidden", HttpResponseStatus.FORBIDDEN.code()));
+            }
+            if (subject.equals("errorsubject500")) {
+                return FutureUtil.failedFuture(new SchemaStorageException("Error"));
+            }
+            return CompletableFuture.completedFuture(new ResponsePojo(subject, payload.value));
+        }
+
+    }
+}

--- a/schema-registry/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SimpleAPIServer.java
+++ b/schema-registry/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SimpleAPIServer.java
@@ -1,0 +1,156 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.ServerSocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
+
+@Slf4j
+public class SimpleAPIServer {
+    private final SchemaRegistryHandler schemaRegistryHandler;
+    private EventLoopGroup group;
+    private ServerSocketChannel serverChannel;
+
+    public SimpleAPIServer(SchemaRegistryHandler schemaRegistryHandler) {
+        this.schemaRegistryHandler = schemaRegistryHandler;
+    }
+
+    public void startServer() throws Exception {
+        group = new NioEventLoopGroup();
+        ServerBootstrap b = new ServerBootstrap();
+        b.group(group, group)
+                .channel(NioServerSocketChannel.class)
+                .handler(new LoggingHandler(LogLevel.INFO))
+                .childHandler(new ChannelInitializer() {
+
+                    @Override
+                    protected void initChannel(Channel ch) throws Exception {
+                        ChannelPipeline p = ch.pipeline();
+                        p.addLast(new HttpServerCodec());
+                        p.addLast(new HttpObjectAggregator(5 * 1024 * 1024 * 1024));
+                        p.addLast(schemaRegistryHandler);
+                    }
+                });
+        ChannelFuture bind = b.bind(0);
+        bind.get();
+        serverChannel = (ServerSocketChannel) bind.channel();
+    }
+
+    public void stopServer() throws Exception {
+        if (serverChannel != null) {
+            serverChannel.close().get();
+        }
+        if (group != null) {
+            group.shutdownGracefully().await();
+            group = null;
+        }
+    }
+
+    public URL url(String base) throws Exception {
+        return new URL("http://localhost:"
+                + serverChannel.localAddress().getPort() + base);
+    }
+
+    public String executeGet(String base) throws Exception {
+        URL url = url(base);
+        Object content = url.getContent();
+        if (content instanceof InputStream) {
+            content = IOUtils.toString((InputStream) content, "utf-8");
+        }
+        return content.toString();
+    }
+
+    public String executePost(String base, String requestContent, String requestContentType) throws Exception {
+        return executePost(base, requestContent, requestContentType, null);
+    }
+
+    public String executePost(String base, String requestContent,
+                              String requestContentType, Integer expectedError) throws Exception {
+        return executeMethod(base, requestContent, "POST", requestContentType, expectedError);
+    }
+
+    public String executeMethod(String base, String requestContent, String method,
+                                String requestContentType, Integer expectedError) throws Exception {
+        URL url = url(base);
+        HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
+        try {
+            urlConnection.setRequestMethod(method);
+            if (requestContent != null) {
+                urlConnection.setDoOutput(true);
+                urlConnection.setRequestProperty("Content-Type", requestContentType);
+                urlConnection.setRequestProperty("Content-Length", requestContent.length() + "");
+            }
+            urlConnection.getOutputStream().write(requestContent.getBytes(StandardCharsets.UTF_8));
+            urlConnection.getOutputStream().close();
+            Object content = urlConnection.getContent();
+            if (content instanceof InputStream) {
+                content = IOUtils.toString((InputStream) content, "utf-8");
+            }
+            if (expectedError != null && expectedError != urlConnection.getResponseCode()) {
+                throw new IOException("Unexpected error code "
+                        + urlConnection.getResponseCode() + ", expected " + expectedError);
+            }
+            return content.toString();
+        } catch (IOException err) {
+            log.info("error", err);
+            if (expectedError == null) {
+                throw err;
+            }
+            if (urlConnection.getResponseCode() != expectedError.intValue()) {
+                throw new IOException("Unexpected error code "
+                        + urlConnection.getResponseCode() + ", expected " + expectedError);
+            }
+            InputStream errorStream = urlConnection.getErrorStream();
+            if (errorStream == null) {
+                return "";
+            }
+            return IOUtils.toString(errorStream, "utf-8");
+        } finally {
+            urlConnection.disconnect();
+        }
+    }
+
+    public String executeDelete(String base) throws Exception {
+        URL url = url(base);
+        HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
+        try {
+            urlConnection.setRequestMethod("DELETE");
+            Object content = urlConnection.getContent();
+            if (content instanceof InputStream) {
+                content = IOUtils.toString((InputStream) content, "utf-8");
+            }
+            return content.toString();
+        } finally {
+            urlConnection.disconnect();
+        }
+    }
+}

--- a/schema-registry/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/CompatibilityCheckerTest.java
+++ b/schema-registry/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/CompatibilityCheckerTest.java
@@ -1,0 +1,201 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl.MemorySchemaStorage;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import org.testng.annotations.Test;
+
+public class CompatibilityCheckerTest {
+
+    private static final String SUBJECT = "ssss";
+
+    private static final String AVRO_SCHEMA = "{\"namespace\": \"example.avro\",\n"
+            + " \"type\": \"record\",\n"
+            + " \"name\": \"user\",\n"
+            + " \"fields\": [\n"
+            + "     {\"name\": \"name\", \"type\": \"string\"},\n"
+            + "     {\"name\": \"favorite_number\",  \"type\": \"int\"}"
+            + " ]\n"
+            + "}";
+
+    private static final String PROTOBUF_SCHEMA = "syntax = \"proto3\";\n"
+            + "package com.acme;\n"
+            + "\n"
+            + "import \"other.proto\";\n"
+            + "\n"
+            + "message MyRecord {\n"
+            + "  string f1 = 1;\n"
+            + "}";
+
+    private static final String JSON_SCHEMA = "{\"type\":\"object\",\"properties\":{\"f1\":{\"type\":\"string\"}}}";
+
+    private static final String AVRO_SCHEMA_ADDED_FIELD_WITH_DEFAULT = "{\"namespace\": \"example.avro\",\n"
+            + " \"type\": \"record\",\n"
+            + " \"name\": \"user\",\n"
+            + " \"fields\": [\n"
+            + "     {\"name\": \"name\", \"type\": \"string\"},\n"
+            + "     {\"name\": \"favorite_number\",  \"type\": \"int\"},\n"
+            + "     {\"name\": \"favorite_color\", \"type\": \"string\", \"default\": \"green\"}\n"
+            + " ]\n"
+            + "}";
+
+    private static final String AVRO_SCHEMA_ADDED_FIELD_NO_DEFAULT = "{\"namespace\": \"example.avro\",\n"
+            + " \"type\": \"record\",\n"
+            + " \"name\": \"user\",\n"
+            + " \"fields\": [\n"
+            + "     {\"name\": \"name\", \"type\": \"string\"},\n"
+            + "     {\"name\": \"favorite_number\",  \"type\": \"int\"},\n"
+            + "     {\"name\": \"favorite_color\", \"type\": \"string\"}\n"
+            + " ]\n"
+            + "}";
+
+    @Test
+    public void testNoOtherVersions() throws Exception {
+        for (CompatibilityChecker.Mode mode : CompatibilityChecker.Mode.values()) {
+            assertTrue(executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA, mode));
+            assertTrue(executeTest(Schema.TYPE_PROTOBUF, PROTOBUF_SCHEMA, mode));
+        }
+    }
+
+    @Test
+    public void testSame() throws Exception {
+        for (CompatibilityChecker.Mode mode : CompatibilityChecker.Mode.values()) {
+            assertTrue(executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA, mode, AVRO_SCHEMA));
+        }
+        for (CompatibilityChecker.Mode mode : CompatibilityChecker.Mode.values()) {
+            assertTrue(executeTest(Schema.TYPE_JSON, JSON_SCHEMA, mode, JSON_SCHEMA));
+        }
+        for (CompatibilityChecker.Mode mode : CompatibilityChecker.Mode.SUPPORTED_FOR_PROTOBUF) {
+            assertTrue(executeTest(Schema.TYPE_PROTOBUF, PROTOBUF_SCHEMA, mode, PROTOBUF_SCHEMA));
+        }
+    }
+
+    @Test
+    public void testAddField() throws Exception {
+        // add optional field
+        assertTrue(
+                executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA_ADDED_FIELD_WITH_DEFAULT, CompatibilityChecker.Mode.BACKWARD,
+                        AVRO_SCHEMA));
+        assertTrue(executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA_ADDED_FIELD_WITH_DEFAULT,
+                CompatibilityChecker.Mode.BACKWARD_TRANSITIVE,
+                AVRO_SCHEMA));
+        assertTrue(
+                executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA_ADDED_FIELD_WITH_DEFAULT, CompatibilityChecker.Mode.FORWARD,
+                        AVRO_SCHEMA));
+        assertTrue(executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA_ADDED_FIELD_WITH_DEFAULT,
+                CompatibilityChecker.Mode.FORWARD_TRANSITIVE,
+                AVRO_SCHEMA));
+        assertTrue(executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA_ADDED_FIELD_WITH_DEFAULT, CompatibilityChecker.Mode.FULL,
+                AVRO_SCHEMA));
+        assertTrue(executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA_ADDED_FIELD_WITH_DEFAULT,
+                CompatibilityChecker.Mode.FULL_TRANSITIVE,
+                AVRO_SCHEMA));
+
+
+        // add non-optional field
+        assertFalse(
+                executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA_ADDED_FIELD_NO_DEFAULT, CompatibilityChecker.Mode.BACKWARD,
+                        AVRO_SCHEMA));
+        // more schemas, but we check only against the latest version with BACKWARD
+        assertTrue(executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA_ADDED_FIELD_NO_DEFAULT, CompatibilityChecker.Mode.BACKWARD,
+                AVRO_SCHEMA, AVRO_SCHEMA_ADDED_FIELD_NO_DEFAULT));
+        // more schemas, we are checking against all previous versions with BACKWARD_TRANSITIVE
+        assertFalse(executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA_ADDED_FIELD_NO_DEFAULT,
+                CompatibilityChecker.Mode.BACKWARD_TRANSITIVE,
+                AVRO_SCHEMA, AVRO_SCHEMA_ADDED_FIELD_NO_DEFAULT));
+
+        assertFalse(executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA_ADDED_FIELD_NO_DEFAULT,
+                CompatibilityChecker.Mode.BACKWARD_TRANSITIVE,
+                AVRO_SCHEMA));
+        assertTrue(executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA_ADDED_FIELD_NO_DEFAULT, CompatibilityChecker.Mode.FORWARD,
+                AVRO_SCHEMA));
+        assertTrue(executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA_ADDED_FIELD_NO_DEFAULT,
+                CompatibilityChecker.Mode.FORWARD_TRANSITIVE,
+                AVRO_SCHEMA));
+        assertFalse(executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA_ADDED_FIELD_NO_DEFAULT, CompatibilityChecker.Mode.FULL,
+                AVRO_SCHEMA));
+        assertFalse(executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA_ADDED_FIELD_NO_DEFAULT,
+                CompatibilityChecker.Mode.FULL_TRANSITIVE,
+                AVRO_SCHEMA));
+    }
+
+    @Test
+    public void testDeleteField() throws Exception {
+        // delete optional field
+        assertTrue(executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA, CompatibilityChecker.Mode.BACKWARD,
+                AVRO_SCHEMA_ADDED_FIELD_WITH_DEFAULT));
+        assertTrue(executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA, CompatibilityChecker.Mode.BACKWARD_TRANSITIVE,
+                AVRO_SCHEMA_ADDED_FIELD_WITH_DEFAULT));
+        assertTrue(executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA, CompatibilityChecker.Mode.FORWARD,
+                AVRO_SCHEMA_ADDED_FIELD_WITH_DEFAULT));
+        assertTrue(executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA, CompatibilityChecker.Mode.FORWARD_TRANSITIVE,
+                AVRO_SCHEMA_ADDED_FIELD_WITH_DEFAULT));
+        assertTrue(executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA, CompatibilityChecker.Mode.FULL,
+                AVRO_SCHEMA_ADDED_FIELD_WITH_DEFAULT));
+        assertTrue(executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA, CompatibilityChecker.Mode.FULL_TRANSITIVE,
+                AVRO_SCHEMA_ADDED_FIELD_WITH_DEFAULT));
+
+        // delete non optional field
+        assertTrue(executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA, CompatibilityChecker.Mode.BACKWARD,
+                AVRO_SCHEMA_ADDED_FIELD_NO_DEFAULT));
+        assertTrue(executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA, CompatibilityChecker.Mode.BACKWARD_TRANSITIVE,
+                AVRO_SCHEMA_ADDED_FIELD_NO_DEFAULT));
+        assertFalse(executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA, CompatibilityChecker.Mode.FORWARD,
+                AVRO_SCHEMA_ADDED_FIELD_NO_DEFAULT));
+        // we are checking only against the latest version with FORWARD
+        assertTrue(executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA, CompatibilityChecker.Mode.FORWARD,
+                AVRO_SCHEMA_ADDED_FIELD_NO_DEFAULT, AVRO_SCHEMA));
+        // we are checking against all the versions with FORWARD_TRANSITIVE
+        assertFalse(executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA, CompatibilityChecker.Mode.FORWARD_TRANSITIVE,
+                AVRO_SCHEMA_ADDED_FIELD_NO_DEFAULT));
+
+        assertFalse(
+                executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA, CompatibilityChecker.Mode.FORWARD_TRANSITIVE, AVRO_SCHEMA,
+                        AVRO_SCHEMA_ADDED_FIELD_NO_DEFAULT));
+        assertFalse(executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA, CompatibilityChecker.Mode.FULL,
+                AVRO_SCHEMA_ADDED_FIELD_NO_DEFAULT));
+        assertFalse(executeTest(Schema.TYPE_AVRO, AVRO_SCHEMA, CompatibilityChecker.Mode.FULL_TRANSITIVE,
+                AVRO_SCHEMA_ADDED_FIELD_NO_DEFAULT));
+    }
+
+    private boolean executeTest(String type, String schemaDefinition, CompatibilityChecker.Mode mode,
+                                String... versions) throws InterruptedException, ExecutionException {
+        SchemaStorage schemaStorage = new MemorySchemaStorage("test");
+        // ensure that we can write everything to the SchemaRegistry
+        schemaStorage.setCompatibilityMode(SUBJECT, CompatibilityChecker.Mode.NONE);
+        Set<Integer> ids = new HashSet<>();
+        for (String version : versions) {
+            Schema schema = schemaStorage.createSchemaVersion(SUBJECT, type, version, true).get();
+            // ensure that we really created a version
+            assertTrue(ids.add(schema.getId()));
+        }
+
+        schemaStorage.setCompatibilityMode(SUBJECT, mode);
+        Schema schema = Schema
+                .builder()
+                .type(type)
+                .schemaDefinition(schemaDefinition)
+                .build();
+        return CompatibilityChecker.verify(schema, SUBJECT, schemaStorage).get();
+
+    }
+
+
+}

--- a/schema-registry/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SchemaResourceTest.java
+++ b/schema-registry/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SchemaResourceTest.java
@@ -74,8 +74,8 @@ public class SchemaResourceTest {
             + "}";
 
     private SimpleAPIServer server;
-    private MemorySchemaStorageAccessor schemaStorage = new MemorySchemaStorageAccessor();
-    private SchemaRegistryRequestAuthenticator schemaRegistryRequestAuthenticator =
+    private final MemorySchemaStorageAccessor schemaStorage = new MemorySchemaStorageAccessor();
+    private final SchemaRegistryRequestAuthenticator schemaRegistryRequestAuthenticator =
             (r) -> SchemaResource.DEFAULT_TENANT;
 
     @BeforeClass(alwaysRun = true)

--- a/schema-registry/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SchemaResourceTest.java
+++ b/schema-registry/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SchemaResourceTest.java
@@ -1,0 +1,527 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.resources;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertThrows;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.DummyOptionsCORSProcessor;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryHandler;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryRequestAuthenticator;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.SimpleAPIServer;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.CompatibilityChecker;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.Schema;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl.MemorySchemaStorageAccessor;
+import java.io.FileNotFoundException;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+@Slf4j
+public class SchemaResourceTest {
+
+    private static final String TEST_SCHEMA = "{\n"
+            + "  \"schema\":"
+            + "    \"{"
+            + "       \\\"type\\\": \\\"record\\\","
+            + "       \\\"name\\\": \\\"test\\\","
+            + "       \\\"fields\\\":"
+            + "         ["
+            + "           {"
+            + "             \\\"type\\\": \\\"string\\\","
+            + "             \\\"name\\\": \\\"field1\\\""
+            + "           }"
+            + "          ]"
+            + "     }\",\n"
+            + "  \"schemaType\": \"AVRO\"\n"
+            + "}";
+
+    private static final String TEST_SCHEMA_WITH_ADDED_NON_DEFAULT_FIELD = "{\n"
+            + "  \"schema\":"
+            + "    \"{"
+            + "       \\\"type\\\": \\\"record\\\","
+            + "       \\\"name\\\": \\\"test\\\","
+            + "       \\\"fields\\\":"
+            + "         ["
+            + "           {"
+            + "             \\\"type\\\": \\\"string\\\","
+            + "             \\\"name\\\": \\\"field1\\\""
+            + "           },"
+            + "           {"
+            + "             \\\"type\\\": \\\"string\\\","
+            + "             \\\"name\\\": \\\"fieldAddedWithoutDefault\\\""
+            + "           }"
+            + "          ]"
+            + "     }\",\n"
+            + "  \"schemaType\": \"AVRO\"\n"
+            + "}";
+
+    private SimpleAPIServer server;
+    private MemorySchemaStorageAccessor schemaStorage = new MemorySchemaStorageAccessor();
+    private SchemaRegistryRequestAuthenticator schemaRegistryRequestAuthenticator =
+            (r) -> SchemaResource.DEFAULT_TENANT;
+
+    @BeforeClass(alwaysRun = true)
+    public void startServer() throws Exception {
+
+        SchemaResource schemaResource = new SchemaResource(schemaStorage, schemaRegistryRequestAuthenticator);
+        SubjectResource subjectResource = new SubjectResource(schemaStorage, schemaRegistryRequestAuthenticator);
+        ConfigResource configResource = new ConfigResource(schemaStorage, schemaRegistryRequestAuthenticator);
+        CompatibilityResource compatibilityResource = new CompatibilityResource(schemaStorage,
+                schemaRegistryRequestAuthenticator);
+        SchemaRegistryHandler schemaRegistryHandler = new SchemaRegistryHandler();
+        schemaResource.register(schemaRegistryHandler);
+        subjectResource.register(schemaRegistryHandler);
+        configResource.register(schemaRegistryHandler);
+        compatibilityResource.register(schemaRegistryHandler);
+        schemaRegistryHandler.addProcessor(new DummyOptionsCORSProcessor());
+        server = new SimpleAPIServer(schemaRegistryHandler);
+        server.startServer();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void stopServer() throws Exception {
+        if (server != null) {
+            server.stopServer();
+        }
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    public void reset() {
+        schemaStorage.clear();
+    }
+
+    @Test
+    public void getSchemaByIdTest() throws Exception {
+        putSchema(1, "{SCHEMA-1}");
+        String result = server.executeGet("/schemas/ids/1");
+        log.info("result {}", result);
+        assertEquals(result, "{\n"
+                + "  \"schema\" : \"{SCHEMA-1}\"\n"
+                + "}");
+    }
+
+    @Test
+    public void getSchemaByIdWithQueryStringTest() throws Exception {
+        putSchema(1, "{SCHEMA-1}");
+        String result = server.executeGet("/schemas/ids/1?fetchMaxId=false");
+        log.info("result {}", result);
+        assertEquals(result, "{\n"
+                + "  \"schema\" : \"{SCHEMA-1}\"\n"
+                + "}");
+    }
+
+    @Test(expectedExceptions = FileNotFoundException.class)
+    public void getSchemaByIdNotFoundTest() throws Exception {
+        server.executeGet("/schemas/ids/1");
+    }
+
+    @Test
+    public void getSchemaBySubjectAndVersion() throws Exception {
+        putSchema(1, "aaa", "{SCHEMA-1}", 17);
+        String result = server.executeGet("/subjects/aaa/versions/17");
+
+        assertEquals(result, "{\n"
+                + "  \"id\" : 1,\n"
+                + "  \"schema\" : \"{SCHEMA-1}\",\n"
+                + "  \"subject\" : \"aaa\",\n"
+                + "  \"version\" : 17,\n"
+                + "  \"type\" : \"AVRO\"\n"
+                + "}");
+    }
+
+    @Test(expectedExceptions = FileNotFoundException.class)
+    public void getSchemaBySubjectAndVersionNotFound() throws Exception {
+        server.executeGet("/subjects/aaa/versions/1");
+    }
+
+    @Test
+    public void getRawSchemaBySubjectAndVersion() throws Exception {
+        putSchema(1, "aaa", "{SCHEMA-1}", 17);
+        String result = server.executeGet("/subjects/aaa/versions/17/schema");
+        log.info("result {}", result);
+        assertEquals(result, "{SCHEMA-1}");
+    }
+
+    @Test(expectedExceptions = FileNotFoundException.class)
+    public void getRawSchemaBySubjectAndVersionNotFound() throws Exception {
+        server.executeGet("/subjects/aaa/versions/1/schema");
+    }
+
+    @Test
+    public void getAllSchemaTypesTest() throws Exception {
+        String result = server.executeGet("/schemas/types");
+        log.info("result {}", result);
+        assertEquals(result, "[ \"AVRO\", \"JSON\", \"PROTOBUF\" ]");
+    }
+
+    @Test(expectedExceptions = FileNotFoundException.class)
+    public void getSchemaAliasesByIdNotFoundTest() throws Exception {
+        String result = server.executeGet("/schemas/ids/1/versions");
+        log.info("result {}", result);
+    }
+
+    @Test
+    public void getSchemaAliasesById() throws Exception {
+        putSchema(1, "{SCHEMA}");
+        putSchema(2, "{SCHEMA}");
+        putSchema(3, "{SCHEMA-OTHER}");
+        String result = server.executeGet("/schemas/ids/1/versions");
+        log.info("result {}", result);
+        assertEquals(result, "[ {\n"
+                + "  \"subject\" : \"test-subject\",\n"
+                + "  \"version\" : 1\n"
+                + "}, {\n"
+                + "  \"subject\" : \"test-subject\",\n"
+                + "  \"version\" : 1\n"
+                + "} ]");
+    }
+
+    @Test
+    public void getAllVersionsSubjects() throws Exception {
+        putSchema(1, "subject1", "{SCHEMA1}", 6);
+        putSchema(2, "subject2", "{SCHEMA2}", 7);
+        putSchema(3, "subject1", "{SCHEMA3}", 8);
+
+        String result = server.executeGet("/subjects/subject1/versions");
+        log.info("result {}", result);
+        assertEquals(result, "[ 6, 8 ]");
+    }
+
+    @Test
+    public void getLatestVersionSubject() throws Exception {
+        putSchema(1, "subject1", "{SCHEMA1}", 6);
+        putSchema(2, "subject2", "{SCHEMA2}", 7);
+        putSchema(3, "subject1", "{SCHEMA3}", 8);
+
+        String result = server.executeGet("/subjects/subject1/versions/latest");
+        log.info("result {}", result);
+        assertEquals(result, "{\n"
+                + "  \"id\" : 3,\n"
+                + "  \"schema\" : \"{SCHEMA3}\",\n"
+                + "  \"subject\" : \"subject1\",\n"
+                + "  \"version\" : 8,\n"
+                + "  \"type\" : \"AVRO\"\n"
+                + "}");
+
+        server.executeMethod("/subjects/subjectnotexists/versions/latest", "GET",
+                null, null, 404);
+    }
+
+    @Test
+    public void createSchemaTest() throws Exception {
+
+        log.info("body {}", TEST_SCHEMA);
+        String jsonResult = server.executePost("/subjects/mysub/versions", TEST_SCHEMA, "application/json");
+        Map<String, Object> parsed = new ObjectMapper().readValue(jsonResult, Map.class);
+        int schemaId = Integer.parseInt(parsed.get("id") + "");
+        String result = server.executeGet("/subjects/mysub/versions");
+        log.info("result {}", result);
+        assertEquals(result, "[ 1 ]");
+
+        result = server.executeGet("/schemas/ids/" + schemaId);
+        log.info("result {}", result);
+        assertEquals(result, "{\n"
+                + "  \"schema\" : \"{       \\\"type\\\": \\\"record\\\",       \\\"name\\\": \\\"test\\\",       "
+                + "\\\"fields\\\":         [           {             \\\"type\\\": \\\"string\\\",             "
+                + "\\\"name\\\": \\\"field1\\\"           }          ]     }\"\n"
+                + "}");
+    }
+
+    @Test
+    public void createOrUpdateSchemaTest() throws Exception {
+
+        log.info("body {}", TEST_SCHEMA);
+        String jsonResult = server.executePost("/subjects/mysub", TEST_SCHEMA, "application/json");
+        Map<String, Object> parsed = new ObjectMapper().readValue(jsonResult, Map.class);
+        int schemaId = Integer.parseInt(parsed.get("id") + "");
+        String result = server.executeGet("/subjects/mysub/versions");
+        log.info("result {}", result);
+        assertEquals(result, "[ 1 ]");
+
+
+        jsonResult = server.executePost("/subjects/mysub", TEST_SCHEMA, "application/json");
+        parsed = new ObjectMapper().readValue(jsonResult, Map.class);
+        int secondSchemaId = Integer.parseInt(parsed.get("id") + "");
+        assertEquals(secondSchemaId, schemaId);
+
+        // new subject
+        jsonResult = server.executePost("/subjects/mysub2", TEST_SCHEMA, "application/json");
+        parsed = new ObjectMapper().readValue(jsonResult, Map.class);
+        int thirdSchemaId = Integer.parseInt(parsed.get("id") + "");
+        assertNotEquals(secondSchemaId, thirdSchemaId);
+
+        result = server.executeGet("/schemas/ids/" + schemaId);
+        log.info("result {}", result);
+        assertEquals(result, "{\n"
+                + "  \"schema\" : \"{       \\\"type\\\": \\\"record\\\",       \\\"name\\\": \\\"test\\\",       "
+                + "\\\"fields\\\":         [           {             \\\"type\\\": \\\"string\\\",             "
+                + "\\\"name\\\": \\\"field1\\\"           }          ]     }\"\n"
+                + "}");
+    }
+
+    @Test
+    public void deleteSubjects() throws Exception {
+        putSchema(1, "subject1", "{SCHEMA1}", 6);
+        putSchema(2, "subject2", "{SCHEMA2}", 7);
+        putSchema(3, "subject1", "{SCHEMA3}", 8);
+
+        String result = server.executeDelete("/subjects/subject1");
+        log.info("result {}", result);
+        assertEquals(result, "[ 6, 8 ]");
+
+        assertThrows(FileNotFoundException.class, () -> {
+            server.executeGet("/subjects/subject1/versions");
+        });
+        String result2 = server.executeGet("/subjects/subject2/versions");
+        assertEquals(result2, "[ 7 ]");
+    }
+
+    @Test(expectedExceptions = FileNotFoundException.class)
+    public void getAllVersionsSubjectsNotFound() throws Exception {
+        server.executeGet("/subjects/subject1/versions");
+    }
+
+    @Test(expectedExceptions = FileNotFoundException.class)
+    public void getDeleteSubjectsNotFound() throws Exception {
+        server.executeDelete("/subjects/subject1/versions");
+    }
+
+    @Test
+    public void testOptionsAndCORS() throws Exception {
+        assertEquals("",
+                server.executeMethod("/subjects/test/versions", "",
+                        "OPTIONS", "tet/plain", 204));
+
+    }
+
+    @Test
+    public void getSetCompatility() throws Exception {
+        // default is NONE in KOP
+        assertEquals("{\n"
+                + "  \"compatibilityLevel\" : \"NONE\"\n"
+                + "}", server.executeGet("/config/sub1"));
+        for (CompatibilityChecker.Mode mode : CompatibilityChecker.Mode.values()) {
+            assertEquals("{\n"
+                    + "  \"compatibilityLevel\" : \"" + mode + "\"\n"
+                    + "}", server.executeMethod("/config/sub1",
+                    "{\n"
+                            + "  \"compatibility\" : \"" + mode + "\"\n"
+                            + "}", "PUT", "application/json",
+                    null
+            ));
+
+            assertEquals("{\n"
+                    + "  \"compatibilityLevel\" : \"" + mode + "\"\n"
+                    + "}", server.executeGet("/config/sub1"));
+        }
+
+
+        // Global configuration
+        assertEquals("{\n"
+                + "  \"compatibilityLevel\" : \"NONE\"\n"
+                + "}", server.executeGet("/config"));
+
+        assertEquals("{\n"
+                + "  \"compatibilityLevel\" : \"NONE\"\n"
+                + "}", server.executeGet("/config/"));
+
+    }
+
+    @Test
+    public void getMode() throws Exception {
+
+        assertEquals("{\n"
+                + "  \"mode\" : \"READWRITE\"\n"
+                + "}", server.executeGet("/mode"));
+    }
+
+    @Test
+    public void checkCreateVersions() throws Exception {
+        assertEquals("{\n"
+                + "  \"id\" : 1\n"
+                + "}", server.executePost(
+                "/subjects/Kafka-value/versions",
+                "{\"schema\": \"{\\\"type\\\": \\\"string\\\"}\"}",
+                "application/vnd.schemaregistry.v1+json"));
+
+        assertEquals("{\n"
+                + "  \"id\" : 2,\n"
+                + "  \"version\" : 2\n"
+                + "}", server.executePost(
+                "/subjects/Kafka-value",
+                "{\"schema\": \"{\\\"type\\\": \\\"int\\\"}\"}",
+                "application/vnd.schemaregistry.v1+json"));
+    }
+
+    @Test
+    public void checkCompatibility() throws Exception {
+
+        // set FULL_TRANSITIVE
+        assertEquals("{\n"
+                + "  \"compatibilityLevel\" : \"" + CompatibilityChecker.Mode.FULL_TRANSITIVE + "\"\n"
+                + "}", server.executeMethod("/config/Kafka-value",
+                "{\n"
+                        + "  \"compatibility\" : \"" + CompatibilityChecker.Mode.FULL_TRANSITIVE + "\"\n"
+                        + "}", "PUT", "application/json",
+                null
+        ));
+
+        assertEquals("{\n"
+                + "  \"id\" : 1\n"
+                + "}", server.executePost(
+                "/subjects/Kafka-value/versions",
+                "{\"schema\": \"{\\\"type\\\": \\\"string\\\"}\"}",
+                "application/vnd.schemaregistry.v1+json"));
+
+        // verify the same schema is compatible
+        assertEquals("{\n"
+                + "  \"is_compatible\" : true\n"
+                + "}", server.executePost(
+                "/compatibility/subjects/Kafka-value/versions/latest",
+                "{\"schema\": \"{\\\"type\\\": \\\"string\\\"}\"}",
+                "application/vnd.schemaregistry.v1+json"));
+
+        // verify a non-compatible schema
+        assertEquals("{\n"
+                + "  \"is_compatible\" : false\n"
+                + "}", server.executePost(
+                "/compatibility/subjects/Kafka-value/versions/latest",
+                "{\"schema\": \"{\\\"type\\\": \\\"long\\\"}\"}",
+                "application/vnd.schemaregistry.v1+json"));
+
+        // set NONE
+        assertEquals("{\n"
+                + "  \"compatibilityLevel\" : \"" + CompatibilityChecker.Mode.NONE + "\"\n"
+                + "}", server.executeMethod("/config/Kafka-value",
+                "{\n"
+                        + "  \"compatibility\" : \"" + CompatibilityChecker.Mode.NONE + "\"\n"
+                        + "}", "PUT", "application/json",
+                null
+        ));
+
+        // verify a non-compatible schema, now the result is 'true'
+        assertEquals("{\n"
+                + "  \"is_compatible\" : true\n"
+                + "}", server.executePost(
+                "/compatibility/subjects/Kafka-value/versions/latest",
+                "{\"schema\": \"{\\\"type\\\": \\\"long\\\"}\"}",
+                "application/vnd.schemaregistry.v1+json"));
+    }
+
+    @Test
+    public void createSchemaWithCheckCompatibility() throws Exception {
+
+        // set FULL_TRANSITIVE
+        assertEquals("{\n"
+                + "  \"compatibilityLevel\" : \"" + CompatibilityChecker.Mode.FULL_TRANSITIVE + "\"\n"
+                + "}", server.executeMethod("/config/mysub",
+                "{\n"
+                        + "  \"compatibility\" : \"" + CompatibilityChecker.Mode.FULL_TRANSITIVE + "\"\n"
+                        + "}", "PUT", "application/json",
+                null
+        ));
+
+        log.info("body {}", TEST_SCHEMA);
+        server.executePost("/subjects/mysub/versions", TEST_SCHEMA, "application/json");
+        server.executePost("/subjects/mysub/versions", TEST_SCHEMA_WITH_ADDED_NON_DEFAULT_FIELD,
+                "application/json", 409);
+
+        // set FORWARD
+        assertEquals("{\n"
+                + "  \"compatibilityLevel\" : \"" + CompatibilityChecker.Mode.FORWARD + "\"\n"
+                + "}", server.executeMethod("/config/mysub",
+                "{\n"
+                        + "  \"compatibility\" : \"" + CompatibilityChecker.Mode.FORWARD + "\"\n"
+                        + "}", "PUT", "application/json",
+                null
+        ));
+
+        server.executePost("/subjects/mysub/versions", TEST_SCHEMA_WITH_ADDED_NON_DEFAULT_FIELD,
+                "application/json");
+
+    }
+
+    @Test
+    public void createUpdateSchemaWithCheckCompatibility() throws Exception {
+
+        // set FULL_TRANSITIVE
+        assertEquals("{\n"
+                + "  \"compatibilityLevel\" : \"" + CompatibilityChecker.Mode.FULL_TRANSITIVE + "\"\n"
+                + "}", server.executeMethod("/config/mysub",
+                "{\n"
+                        + "  \"compatibility\" : \"" + CompatibilityChecker.Mode.FULL_TRANSITIVE + "\"\n"
+                        + "}", "PUT", "application/json",
+                null
+        ));
+
+        log.info("body {}", TEST_SCHEMA);
+        server.executePost("/subjects/mysub", TEST_SCHEMA, "application/json");
+        server.executePost("/subjects/mysub", TEST_SCHEMA_WITH_ADDED_NON_DEFAULT_FIELD,
+                "application/json", 409);
+
+        // set FORWARD
+        assertEquals("{\n"
+                + "  \"compatibilityLevel\" : \"" + CompatibilityChecker.Mode.FORWARD + "\"\n"
+                + "}", server.executeMethod("/config/mysub",
+                "{\n"
+                        + "  \"compatibility\" : \"" + CompatibilityChecker.Mode.FORWARD + "\"\n"
+                        + "}", "PUT", "application/json",
+                null
+        ));
+
+        server.executePost("/subjects/mysub", TEST_SCHEMA_WITH_ADDED_NON_DEFAULT_FIELD,
+                "application/json");
+
+    }
+
+    @Test
+    public void getAllSubjects() throws Exception {
+        putSchema(1, "subject1", "{SCHEMA1}");
+        putSchema(2, "subject2", "{SCHEMA2}");
+        putSchema(3, "subject1", "{SCHEMA3}");
+
+        String result = server.executeGet("/subjects");
+        log.info("result {}", result);
+        assertEquals(result, "[ \"subject1\", \"subject2\" ]");
+    }
+
+
+    protected void putSchema(int id, String definition) throws Exception {
+        putSchema(id, "test-subject", definition);
+    }
+
+    protected void putSchema(int id, String subject, String definition) throws Exception {
+        putSchema(id, subject, definition, 1);
+    }
+
+    protected void putSchema(int id, String subject, String definition, int version) throws Exception {
+        Schema schema = Schema.builder()
+                .id(id)
+                .version(version)
+                .schemaDefinition(definition)
+                .subject(subject)
+                .type(Schema.TYPE_AVRO)
+                .tenant(SchemaResource.DEFAULT_TENANT)
+                .build();
+        schemaStorage.getSchemaStorageForTenant(SchemaResource.DEFAULT_TENANT).storeSchema(schema);
+    }
+
+}

--- a/schema-registry/src/test/resources/log4j2.xml
+++ b/schema-registry/src/test/resources/log4j2.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<Configuration status="INFO">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t:%C@%L] %-5level %logger{36} - %msg%n" />
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="warn">
+            <AppenderRef ref="Console" />
+        </Root>
+        <Logger name="org.eclipse.jetty" level="info"/>
+        <Logger name="io.streamnative" level="trace"/>
+        <Logger name="io.streamnative.pulsar.handlers.kop.format" level="error"/>
+        <Logger name="org.apache.pulsar" level="info"/>
+        <Logger name="org.apache.bookkeeper" level="info"/>
+        <Logger name="org.apache.kafka" level="debug"/>
+    </Loggers>
+</Configuration>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -148,7 +148,7 @@
       </exclusions>
     </dependency>
 
-    <!-- this is needed for the Kakfa Avro Serialiser -->
+    <!-- this is needed for the Kafka Avro Serialiser -->
     <dependency>
       <groupId>org.codehaus.jackson</groupId>
       <artifactId>jackson-mapper-asl</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -134,22 +134,6 @@
 
     <dependency>
       <groupId>io.confluent</groupId>
-      <artifactId>kafka-schema-registry</artifactId>
-      <version>${schema.registry.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.glassfish.jersey.core</groupId>
-          <artifactId>jersey-common</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>io.confluent</groupId>
       <artifactId>kafka-avro-serializer</artifactId>
       <version>${schema.registry.version}</version>
       <exclusions>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -132,6 +132,7 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- needed for kafka.tools in KStreams integration tests -->
     <dependency>
       <groupId>io.confluent</groupId>
       <artifactId>kafka-schema-registry</artifactId>
@@ -205,6 +206,7 @@
     </plugins>
   </build>
 
+  <!-- needed for Kafka Avro Serializer -->
   <repositories>
     <repository>
       <id>io-confluent</id>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -134,6 +134,22 @@
 
     <dependency>
       <groupId>io.confluent</groupId>
+      <artifactId>kafka-schema-registry</artifactId>
+      <version>${schema.registry.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.glassfish.jersey.core</groupId>
+          <artifactId>jersey-common</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>io.confluent</groupId>
       <artifactId>kafka-avro-serializer</artifactId>
       <version>${schema.registry.version}</version>
       <exclusions>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -148,6 +148,14 @@
       </exclusions>
     </dependency>
 
+    <!-- this is needed for the Kakfa Avro Serialiser -->
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-mapper-asl</artifactId>
+      <version>1.9.13</version>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>io.confluent</groupId>
       <artifactId>kafka-avro-serializer</artifactId>

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -19,9 +19,6 @@ import static org.mockito.Mockito.spy;
 
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.MoreExecutors;
-import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
-import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
-import io.confluent.kafka.schemaregistry.rest.SchemaRegistryRestApplication;
 import io.netty.channel.EventLoopGroup;
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupCoordinator;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -78,7 +78,6 @@ import org.apache.pulsar.metadata.impl.ZKMetadataStore;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.MockZooKeeper;
 import org.apache.zookeeper.data.ACL;
-import org.eclipse.jetty.server.Server;
 import org.testng.Assert;
 
 /**

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -110,14 +110,14 @@ public abstract class KopProtocolHandlerTestBase {
     protected NonClosableMockBookKeeper mockBookKeeper;
     protected final String configClusterName = "test";
 
+    protected final String tenant = "public";
+    protected final String namespace = "default";
+
     private SameThreadOrderedSafeExecutor sameThreadOrderedSafeExecutor;
     private OrderedExecutor bkExecutor;
 
-    // Fields about Confluent Schema Registry
+    // Fields about Schema Registry
     protected boolean enableSchemaRegistry = false;
-    private static final String KAFKASTORE_TOPIC = SchemaRegistryConfig.DEFAULT_KAFKASTORE_TOPIC;
-    protected SchemaRegistryRestApplication restApp;
-    protected Server restServer;
     protected String restConnect;
     protected boolean enableBrokerEntryMetadata = true;
 
@@ -141,6 +141,17 @@ public abstract class KopProtocolHandlerTestBase {
 
     protected EndPoint getPlainEndPoint() {
         return new EndPoint(PLAINTEXT_PREFIX + "127.0.0.1:" + kafkaBrokerPort, null);
+    }
+
+
+    /**
+     * Port to be used by clients.
+     * It can be overridden with a different port, in order to pass via the proxy
+     *
+     * @return the port
+     */
+    protected int getClientPort() {
+        return getKafkaBrokerPort();
     }
 
     protected void resetConfig() {
@@ -298,12 +309,6 @@ public abstract class KopProtocolHandlerTestBase {
 
     protected final void internalCleanup() throws Exception {
         try {
-            // if init fails, some of these could be null, and if so would throw
-            // an NPE in shutdown, obscuring the real error
-            if (restServer != null) {
-                restServer.stop();
-                restServer.join();
-            }
             if (admin != null) {
                 admin.close();
             }
@@ -756,7 +761,7 @@ public abstract class KopProtocolHandlerTestBase {
 
     protected Properties newKafkaProducerProperties() {
         final Properties props = new Properties();
-        props.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getKafkaBrokerPort());
+        props.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getClientPort());
         props.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         props.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         return props;
@@ -764,7 +769,7 @@ public abstract class KopProtocolHandlerTestBase {
 
     protected Properties newKafkaConsumerProperties() {
         final Properties props = new Properties();
-        props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getKafkaBrokerPort());
+        props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getClientPort());
         props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "my-group");
         props.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         props.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
@@ -780,7 +785,7 @@ public abstract class KopProtocolHandlerTestBase {
 
     protected Properties newKafkaAdminClientProperties() {
         final Properties adminProps = new Properties();
-        adminProps.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getKafkaBrokerPort());
+        adminProps.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getClientPort());
         return adminProps;
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryTest.java
@@ -37,6 +37,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -60,7 +61,7 @@ public class SchemaRegistryTest extends KopProtocolHandlerTestBase {
         bootstrapServers = "localhost:" + getKafkaBrokerPort();
     }
 
-    @BeforeMethod(alwaysRun = true)
+    @AfterMethod(alwaysRun = true)
     @Override
     protected void cleanup() throws Exception {
         this.internalCleanup();
@@ -98,43 +99,39 @@ public class SchemaRegistryTest extends KopProtocolHandlerTestBase {
 
     @Test(timeOut = 120000)
     public void testAvroProduceAndConsume() throws Throwable {
-        try {
-            String topic = "SchemaRegistryTest-testAvroProduceAndConsume";
-            IndexedRecord avroRecord = createAvroRecord();
-            Object[] objects = new Object[]{avroRecord, true, 130, 345L, 1.23f, 2.34d, "abc", "def".getBytes()};
-            @Cleanup
-            KafkaProducer<Integer, Object> producer = createAvroProducer();
-            for (int i = 0; i < objects.length; i++) {
-                final Object object = objects[i];
-                log.info("Sending {}", object);
-                producer.send(new ProducerRecord<>(topic, i, object), (metadata, e) -> {
-                    if (e != null) {
-                        log.error("Failed to send {}: {}", object, e.getMessage());
-                        fail("Failed to send " + object + ": " + e.getMessage());
-                    } else {
-                        log.info("Success send {} to {}-partition-{}@{}",
-                                object, metadata.topic(), metadata.partition(), metadata.offset());
-                    }
-                }).get(10, TimeUnit.SECONDS);
-                log.info("Success send final {}", object);
-            }
-            producer.close();
-            log.info("finished sending");
-
-            @Cleanup
-            KafkaConsumer<Integer, Object> consumer = createAvroConsumer();
-            consumer.subscribe(Collections.singleton(topic));
-            int i = 0;
-            while (i < objects.length) {
-                for (ConsumerRecord<Integer, Object> record : consumer.poll(Duration.ofSeconds(3))) {
-                    assertEquals(record.key().intValue(), i);
-                    assertEquals(record.value(), objects[i]);
-                    i++;
+        String topic = "SchemaRegistryTest-testAvroProduceAndConsume";
+        IndexedRecord avroRecord = createAvroRecord();
+        Object[] objects = new Object[]{avroRecord, true, 130, 345L, 1.23f, 2.34d, "abc", "def".getBytes()};
+        @Cleanup
+        KafkaProducer<Integer, Object> producer = createAvroProducer();
+        for (int i = 0; i < objects.length; i++) {
+            final Object object = objects[i];
+            log.info("Sending {}", object);
+            producer.send(new ProducerRecord<>(topic, i, object), (metadata, e) -> {
+                if (e != null) {
+                    log.error("Failed to send {}: {}", object, e.getMessage());
+                    fail("Failed to send " + object + ": " + e.getMessage());
+                } else {
+                    log.info("Success send {} to {}-partition-{}@{}",
+                            object, metadata.topic(), metadata.partition(), metadata.offset());
                 }
-            }
-            consumer.close();
-        } catch (Throwable t) {
-            throw t;
+            }).get(10, TimeUnit.SECONDS);
+            log.info("Success send final {}", object);
         }
+        producer.close();
+        log.info("finished sending");
+
+        @Cleanup
+        KafkaConsumer<Integer, Object> consumer = createAvroConsumer();
+        consumer.subscribe(Collections.singleton(topic));
+        int i = 0;
+        while (i < objects.length) {
+            for (ConsumerRecord<Integer, Object> record : consumer.poll(Duration.ofSeconds(3))) {
+                assertEquals(record.key().intValue(), i);
+                assertEquals(record.value(), objects[i]);
+                i++;
+            }
+        }
+        consumer.close();
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryTest.java
@@ -116,7 +116,7 @@ public class SchemaRegistryTest extends KopProtocolHandlerTestBase {
                                 object, metadata.topic(), metadata.partition(), metadata.offset());
                     }
                 }).get(10, TimeUnit.SECONDS);
-                log.info("Success send final {}");
+                log.info("Success send final {}", object);
             }
             producer.close();
             log.info("finished sending");

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryTest.java
@@ -13,9 +13,16 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
@@ -32,14 +39,6 @@ import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import java.time.Duration;
-import java.util.Collections;
-import java.util.Properties;
-import java.util.concurrent.TimeUnit;
-
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
 
 /**
  * Test for KoP with Confluent Schema Registry.

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/MemorySchemaStorageTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/MemorySchemaStorageTest.java
@@ -1,0 +1,20 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl;
+
+public class MemorySchemaStorageTest extends SchemaStorageTestsBase {
+    public MemorySchemaStorageTest() {
+        super(new MemorySchemaStorageAccessor());
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorageTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorageTest.java
@@ -13,21 +13,20 @@
  */
 package io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl;
 
+import static org.testng.Assert.assertEquals;
+
 import io.streamnative.pulsar.handlers.kop.KopProtocolHandlerTestBase;
 import io.streamnative.pulsar.handlers.kop.schemaregistry.model.CompatibilityChecker;
 import io.streamnative.pulsar.handlers.kop.schemaregistry.model.Schema;
 import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorage;
 import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorageAccessor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-
-import static org.testng.Assert.assertEquals;
 
 @Slf4j
 public class PulsarSchemaStorageTest extends KopProtocolHandlerTestBase {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorageTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorageTest.java
@@ -1,0 +1,134 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl;
+
+import io.streamnative.pulsar.handlers.kop.KopProtocolHandlerTestBase;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.CompatibilityChecker;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.Schema;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorage;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorageAccessor;
+import lombok.extern.slf4j.Slf4j;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.testng.Assert.assertEquals;
+
+@Slf4j
+public class PulsarSchemaStorageTest extends KopProtocolHandlerTestBase {
+
+
+    @Test
+    public void testUsingSchemaStorageTestsBase() throws Exception {
+        admin.topics().createNonPartitionedTopic("persistent://public/default/__schemaregistry");
+        SchemaStorageTestsBase tester = new SchemaStorageTestsBase(new SchemaStorageAccessor() {
+            @Override
+            public SchemaStorage getSchemaStorageForTenant(String tenant) throws SchemaStorageException {
+                return new PulsarSchemaStorage(tenant, pulsarClient,
+                        "persistent://public/default/__schemaregistry");
+            }
+
+            @Override
+            public void close() {
+                // nothing to do
+            }
+        });
+        try {
+            tester.testWriteGet();
+        } finally {
+            tester.stopAll();
+        }
+    }
+
+    @Test
+    public void testTwoInstances() throws Exception {
+        String subject1 = "cccc";
+        admin.topics().createNonPartitionedTopic("persistent://public/default/__schemaregistry-2");
+
+        try (PulsarSchemaStorage instance1 = new PulsarSchemaStorage(tenant, pulsarClient,
+                "persistent://public/default/__schemaregistry-2");
+            PulsarSchemaStorage instance2 = new PulsarSchemaStorage(tenant, pulsarClient,
+                    "persistent://public/default/__schemaregistry-2");) {
+
+            // writing using instance1
+            Schema schemaVersion = instance1.createSchemaVersion(subject1,
+                    Schema.TYPE_AVRO, "{test}", true).get();
+
+            // read using instance2
+            Schema lookup2 = instance2.findSchemaById(schemaVersion.getId()).get();
+            assertEquals(schemaVersion, lookup2);
+
+            // read using instance1
+            Schema lookup1 = instance2.findSchemaById(schemaVersion.getId()).get();
+            assertEquals(schemaVersion, lookup1);
+
+            // again, but write from instance2
+            schemaVersion = instance2.createSchemaVersion(subject1,
+                    Schema.TYPE_AVRO, "{test2}", true).get();
+            lookup2 = instance2.findSchemaById(schemaVersion.getId()).get();
+            assertEquals(schemaVersion, lookup2);
+            lookup1 = instance1.findSchemaById(schemaVersion.getId()).get();
+            assertEquals(schemaVersion, lookup1);
+
+            // write using instance2
+            instance2.setCompatibilityMode(subject1, CompatibilityChecker.Mode.FULL_TRANSITIVE).get();
+            assertEquals(CompatibilityChecker.Mode.FULL_TRANSITIVE, instance2.getCompatibilityMode(subject1).get());
+
+            // read using instance1
+            assertEquals(CompatibilityChecker.Mode.FULL_TRANSITIVE, instance1.getCompatibilityMode(subject1).get());
+
+        }
+    }
+
+    @Test
+    public void testMultipleEnsureLatestData() throws Exception {
+        admin.topics().createNonPartitionedTopic("persistent://public/default/__schemaregistry-3");
+
+        try (PulsarSchemaStorage instance1 = new PulsarSchemaStorage(tenant, pulsarClient,
+                "persistent://public/default/__schemaregistry-3");) {
+            instance1.setCompatibilityMode("aaa", CompatibilityChecker.Mode.FULL_TRANSITIVE);
+            // ensure that we are able to not deadlock while issueing many ensureLatestData()
+            // concurrently
+            List<CompletableFuture<?>> handles = new ArrayList<>();
+            for (int i = 0; i < 100; i++) {
+                handles.add(instance1.ensureLatestData());
+                if (i % 5 == 0) {
+                    // add some writes
+                    instance1
+                            .setCompatibilityMode("aaa", CompatibilityChecker.Mode.FULL_TRANSITIVE);
+                }
+            }
+            CompletableFuture.allOf(handles.toArray(new CompletableFuture[0]))
+                    .get();
+        }
+    }
+
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+    }
+
+    @AfterClass
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/SchemaStorageTestsBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/SchemaStorageTestsBase.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl;
+
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.CompatibilityChecker;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.Schema;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorage;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorageAccessor;
+import lombok.AllArgsConstructor;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+@AllArgsConstructor
+public class SchemaStorageTestsBase {
+    private SchemaStorageAccessor storageAccessor;
+
+    private static final String AVRO_SCHEMA = "{\"namespace\": \"example.avro\",\n"
+            + " \"type\": \"record\",\n"
+            + " \"name\": \"user\",\n"
+            + " \"fields\": [\n"
+            + "     {\"name\": \"name\", \"type\": \"string\"},\n"
+            + "     {\"name\": \"favorite_number\",  \"type\": \"int\"}"
+            + " ]\n"
+            + "}";
+
+    private static final String AVRO_SCHEMA_ADDED_FIELD_WITHOUT_DEFAULT = "{\"namespace\": \"example.avro\",\n"
+            + " \"type\": \"record\",\n"
+            + " \"name\": \"user\",\n"
+            + " \"fields\": [\n"
+            + "     {\"name\": \"name\", \"type\": \"string\"},\n"
+            + "     {\"name\": \"favorite_number\",  \"type\": \"int\"},\n"
+            + "     {\"name\": \"favorite_color\", \"type\": \"string\"}\n"
+            + " ]\n"
+            + "}";
+
+    @Test
+    public void testWriteGet() throws Exception {
+        SchemaStorage storage = storageAccessor.getSchemaStorageForTenant("test-tenant");
+        String subject1 = "aa";
+        Schema schemaVersion = storage.createSchemaVersion(subject1, Schema.TYPE_AVRO, "{test}", true).get();
+        Schema lookup = storage.findSchemaById(schemaVersion.getId()).get();
+        assertEquals(schemaVersion, lookup);
+        List<Integer> versions = storage.deleteSubject(subject1).get();
+        assertEquals(1, versions.size());
+        lookup = storage.findSchemaById(schemaVersion.getId()).get();
+        assertNull(lookup);
+
+        String subject2 = "bb";
+        Schema schemaVersion2 = storage.createSchemaVersion(subject2, Schema.TYPE_AVRO, "{test}", true).get();
+        Schema lookup2 = storage.findSchemaById(schemaVersion2.getId()).get();
+        assertEquals(schemaVersion2, lookup2);
+
+
+        Schema schemaVersion3 = storage.createSchemaVersion(subject2, Schema.TYPE_AVRO, "{test}", false).get();
+        Schema lookup3 = storage.findSchemaById(schemaVersion3.getId()).get();
+        assertEquals(schemaVersion3, lookup3);
+
+        // we must have received the same schema id
+        assertEquals(lookup2, lookup3);
+
+        Schema schemaVersion4 = storage.createSchemaVersion(subject2, Schema.TYPE_AVRO, "{test}", true).get();
+        Schema lookup4 = storage.findSchemaById(schemaVersion4.getId()).get();
+        assertEquals(schemaVersion4, lookup4);
+
+        assertNotEquals(lookup3.getId(), lookup4.getId());
+
+        Schema lookupNonExistingSchema = storage.findSchemaById(-10).get();
+        assertNull(lookupNonExistingSchema);
+
+
+        assertEquals(CompatibilityChecker.Mode.NONE, storage.getCompatibilityMode(subject1).get());
+
+        for (CompatibilityChecker.Mode mode : CompatibilityChecker.Mode.values()) {
+            storage.setCompatibilityMode(subject1, mode).get();
+            assertEquals(mode, storage.getCompatibilityMode(subject1).get());
+        }
+
+        String subject3 = "cc";
+        storage.setCompatibilityMode(subject3, CompatibilityChecker.Mode.FULL_TRANSITIVE).get();
+        storage.createSchemaVersion(subject3, Schema.TYPE_AVRO, AVRO_SCHEMA, true).get();
+
+        ExecutionException executionException = expectThrows(ExecutionException.class, () -> {
+            storage.createSchemaVersion(subject3, Schema.TYPE_AVRO, AVRO_SCHEMA_ADDED_FIELD_WITHOUT_DEFAULT, true)
+                    .get();
+        });
+        assertTrue(
+                executionException.getCause() instanceof CompatibilityChecker.IncompatibleSchemaChangeException,
+                "Unexcepted exception " + executionException.getCause().getClass());
+
+
+    }
+
+    @AfterClass
+    public void stopAll() {
+        storageAccessor.close();
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/SchemaStorageTestsBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/SchemaStorageTestsBase.java
@@ -13,22 +13,21 @@
  */
 package io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl;
 
-import io.streamnative.pulsar.handlers.kop.schemaregistry.model.CompatibilityChecker;
-import io.streamnative.pulsar.handlers.kop.schemaregistry.model.Schema;
-import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorage;
-import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorageAccessor;
-import lombok.AllArgsConstructor;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.Test;
-
-import java.util.List;
-import java.util.concurrent.ExecutionException;
-
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
+
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.CompatibilityChecker;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.Schema;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorage;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.SchemaStorageAccessor;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import lombok.AllArgsConstructor;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
 
 @AllArgsConstructor
 public class SchemaStorageTestsBase {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/package-info.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl;


### PR DESCRIPTION
This is the initial port of the SchemaRegistry.
I have ported the code from my repo (https://github.com/datastax/starlight-for-kafka).

I hope that we can merge this code in the current form and then apply other improvements as needed.
This code is already running in production so at least I would prefer to not change the way we store the data or configure the service.

Summary of changes:
- Implement the SchemaRegistry, implementing the same API as the Confluent® Schema Registry
- This SchemaRegistry has already been battle tested against standard Kafka Clients, KSQL, KStreams and many Kafka IDEs, like [Conduktor](https://www.conduktor.io/)
- The SchemaRegistry supports JWT authentication and multi-tenancy
- The registry is stored on a Pulsar Topic in a specific namespace, that requires Infinite retention
- The Schema Validation is implemented using the Apicurio project library
- Unfortunately Apicurio requires JDK11, so I had to switch CI to run using JDK11
- the AVRO tests now use our SchemaRegistry implementation and not the Confluent REST Application

### Documentation

Check the box below.

Need to update docs? 

- [x] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)
