### PR TITLE
Rename most usages of "Oauth" to "OAuth"

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -106,13 +106,13 @@ If you want to enable the authentication feature for KoP using the `OAUTHBEARER`
 
     The properties here are same to that of the `PLAIN` mechanism except `brokerClientAuthenticationPlugin` and `brokerClientAuthenticationParameters`.
 
-    |Property|Description|Required or optional|Example value
-    |---|---|---|---
-    | `type` | Oauth 2.0 authentication type <br><br> The **default** value is `client_credentials`| Optional | `client_credentials`  |
+    |Property| Description                                                                                                                                                                                              |Required or optional|Example value
+    |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---|---|---
+    | `type` | OAuth 2.0 authentication type <br><br> The **default** value is `client_credentials`                                                                                                                     | Optional | `client_credentials`  |
     | `privateKey` | URL to a JSON credential file <br><br>The following pattern formats are supported:<br> - `file:///path/to/file` <br> - `file:/path/to/file` <br> - `data:application/json;base64,<base64-encoded value>` |   Required |file:///path/to/credentials_file.json
-    | `issuerUrl` | URL of the authentication provider which allows the Pulsar client to obtain an access token | Required | `https://accounts.google.com` |
-    | `audience`  | An OAuth 2.0 "resource server" identifier for the Pulsar cluster | Optional |`https://broker.example.com` |
-    | `scope` | The scope of the access request that is expressed as a list of space-delimited, case-sensitive strings | Optional | `api://pulsar-cluster-1/.default` |
+    | `issuerUrl` | URL of the authentication provider which allows the Pulsar client to obtain an access token                                                                                                              | Required | `https://accounts.google.com` |
+    | `audience`  | An OAuth 2.0 "resource server" identifier for the Pulsar cluster                                                                                                                                         | Optional |`https://broker.example.com` |
+    | `scope` | The scope of the access request that is expressed as a list of space-delimited, case-sensitive strings                                                                                                   | Optional | `api://pulsar-cluster-1/.default` |
 
 
     ```properties

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
@@ -172,7 +172,7 @@ public class SaslAuthenticator {
         this.allowedMechanisms = allowedMechanisms;
         this.proxyRoles = config.getProxyRoles();
         this.oauth2CallbackHandler = allowedMechanisms.contains(OAuthBearerLoginModule.OAUTHBEARER_MECHANISM)
-                ? createOauth2CallbackHandler(config) : null;
+                ? createOAuth2CallbackHandler(config) : null;
         this.enableKafkaSaslAuthenticateHeaders = false;
         this.defaultKafkaMetadataTenant = config.getKafkaMetadataTenant();
     }
@@ -194,7 +194,7 @@ public class SaslAuthenticator {
         this.admin = admin;
         this.allowedMechanisms = allowedMechanisms;
         this.oauth2CallbackHandler = allowedMechanisms.contains(OAuthBearerLoginModule.OAUTHBEARER_MECHANISM)
-                ? createOauth2CallbackHandler(config) : null;
+                ? createOAuth2CallbackHandler(config) : null;
         this.enableKafkaSaslAuthenticateHeaders = false;
     }
 
@@ -261,7 +261,7 @@ public class SaslAuthenticator {
         }
     }
 
-    private @NonNull AuthenticateCallbackHandler createOauth2CallbackHandler(
+    private @NonNull AuthenticateCallbackHandler createOAuth2CallbackHandler(
             @NonNull final KafkaServiceConfiguration config) {
         AuthenticateCallbackHandler handler;
         if (config.getKopOauth2AuthenticateCallbackHandler() != null) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/OauthValidatorCallbackHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/OauthValidatorCallbackHandler.java
@@ -145,7 +145,7 @@ public class OauthValidatorCallbackHandler implements AuthenticateCallbackHandle
                 }
             });
         } catch (AuthenticationException e) {
-            log.error("Oauth validator callback handler new auth state failed: ", e);
+            log.error("OAuth validator callback handler new auth state failed: ", e);
             throw new OAuthBearerIllegalTokenException(OAuthBearerValidationResult.newFailure(e.getMessage()));
         }
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOAuthBearerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOAuthBearerTestBase.java
@@ -37,27 +37,27 @@ import org.apache.kafka.common.errors.TimeoutException;
  * Base class for SASL-OAUTHBEARER tests.
  */
 @Slf4j
-public abstract class SaslOauthBearerTestBase extends KopProtocolHandlerTestBase {
+public abstract class SaslOAuthBearerTestBase extends KopProtocolHandlerTestBase {
 
-    public SaslOauthBearerTestBase() {
+    public SaslOAuthBearerTestBase() {
         super("kafka");
     }
 
-    protected abstract void configureOauth2(Properties props);
+    protected abstract void configureOAuth2(Properties props);
 
     protected void testSimpleProduceConsume() throws Exception {
         final String topic = "testSimpleProduceConsume";
         final String message = "hello";
 
         final Properties producerProps = newKafkaProducerProperties();
-        configureOauth2(producerProps);
+        configureOAuth2(producerProps);
         @Cleanup
         final KafkaProducer<String, String> producer = new KafkaProducer<>(producerProps);
         RecordMetadata metadata = producer.send(new ProducerRecord<>(topic, message)).get();
         log.info("Send to {}-partition-{}@{}", metadata.topic(), metadata.partition(), metadata.offset());
 
         final Properties consumerProps = newKafkaConsumerProperties();
-        configureOauth2(consumerProps);
+        configureOAuth2(consumerProps);
         @Cleanup
         final KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consumerProps);
         consumer.subscribe(Collections.singleton(topic));

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOAuthDefaultHandlersTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOAuthDefaultHandlersTest.java
@@ -37,7 +37,7 @@ import org.testng.annotations.Test;
  * @see org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredValidatorCallbackHandler
  */
 @Slf4j
-public class SaslOauthDefaultHandlersTest extends SaslOauthBearerTestBase {
+public class SaslOAuthDefaultHandlersTest extends SaslOAuthBearerTestBase {
 
     private static final String ADMIN_USER = "admin_user";
     private static final String USER = "user";
@@ -97,7 +97,7 @@ public class SaslOauthDefaultHandlersTest extends SaslOauthBearerTestBase {
     }
 
     @Override
-    protected void configureOauth2(final Properties props) {
+    protected void configureOAuth2(final Properties props) {
         final String jaasTemplate = "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule"
                 + " required unsecuredLoginStringClaim_sub=\"%s\";";
         props.setProperty("security.protocol", "SASL_PLAINTEXT");

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionWithOAuthBearerAuthTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionWithOAuthBearerAuthTest.java
@@ -47,7 +47,7 @@ public class TransactionWithOAuthBearerAuthTest extends TransactionTest {
         conf.setBrokerDeduplicationEnabled(true);
         conf.setAuthenticationEnabled(true);
         conf.setAuthorizationEnabled(true);
-        conf.setAuthorizationProvider(SaslOauthKopHandlersTest.OauthMockAuthorizationProvider.class.getName());
+        conf.setAuthorizationProvider(SaslOAuthKopHandlersTest.OAuthMockAuthorizationProvider.class.getName());
         conf.setAuthenticationProviders(Sets.newHashSet(AuthenticationProviderToken.class.getName()));
         conf.setBrokerClientAuthenticationPlugin(AuthenticationOAuth2.class.getName());
         conf.setBrokerClientAuthenticationParameters(String.format("{\"type\":\"client_credentials\","


### PR DESCRIPTION
### Motivation

The canonical spelling should be `OAuth` (which is also what Kafka uses) instead of `Oauth`.

### Modifications

This changes all the non user facing usages to `OAuth`. Unfortunately to keep backwards compatibility user facing usages can't be changed (maybe we can alias them?).

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 

- [x] `no-need-doc` 
  
Doesn't contain user facing changes.