### PR TITLE
[Test] Fix failed to read all entries after broker restarted

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -157,6 +157,7 @@ public abstract class KopProtocolHandlerTestBase {
         kafkaConfig.setManagedLedgerCacheSizeMB(8);
         kafkaConfig.setActiveConsumerFailoverDelayTimeMillis(0);
         kafkaConfig.setDefaultRetentionTimeInMinutes(7);
+        kafkaConfig.setDefaultRetentionSizeInMB(-1);
         kafkaConfig.setDefaultNumberOfNamespaceBundles(1);
         kafkaConfig.setZookeeperServers("localhost:2181");
         kafkaConfig.setConfigurationStoreServers("localhost:3181");

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/format/KafkaMixedEntryFormatterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/format/KafkaMixedEntryFormatterTest.java
@@ -24,7 +24,7 @@ public class KafkaMixedEntryFormatterTest extends EntryFormatterTestBase {
         super("mixed_kafka");
     }
 
-    @Test(timeOut = 20000, enabled = false)
+    @Test(timeOut = 20000)
     public void testChangeKafkaEntryFormat() throws Exception {
         super.testChangeKafkaEntryFormat();
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/format/KafkaV1EntryFormatterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/format/KafkaV1EntryFormatterTest.java
@@ -24,7 +24,7 @@ public class KafkaV1EntryFormatterTest extends EntryFormatterTestBase {
         super("kafka");
     }
 
-    @Test(timeOut = 20000, enabled = false)
+    @Test(timeOut = 20000)
     public void testChangeKafkaEntryFormat() throws Exception {
         super.testChangeKafkaEntryFormat();
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/format/PulsarEntryFormatterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/format/PulsarEntryFormatterTest.java
@@ -24,7 +24,7 @@ public class PulsarEntryFormatterTest extends EntryFormatterTestBase {
         super("pulsar");
     }
 
-    @Test(timeOut = 20000, enabled = false)
+    @Test(timeOut = 20000)
     public void testChangePulsarEntryFormat() throws Exception {
         super.testChangePulsarEntryFormat();
     }


### PR DESCRIPTION
Fixes #1314

### Motivation

In the KoP unit test, the `defaultRetentionSizeInMB` configuration is `0`, so the ledger might get removed when we restart the broker since we are using the non-durable cursor. We should set `defaultRetentionSizeInMB` to `-1` ( -1 is infinite).

### Modifications

Set `defaultRetentionSizeInMB` to `-1` in unit test.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

