### PR TITLE
Fix erlang kafka-client kafka4beam/brod fetch request failed

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -1542,7 +1542,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             });
         }
         TransactionCoordinator transactionCoordinator = null;
-        if (request.isolationLevel().equals(IsolationLevel.READ_COMMITTED)) {
+        if (request.isolationLevel().equals(IsolationLevel.READ_COMMITTED)
+                && kafkaConfig.isKafkaTransactionCoordinatorEnabled()) {
             transactionCoordinator = getTransactionCoordinator();
         }
         String namespacePrefix = currentNamespacePrefix();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndKafkaTest.java
@@ -436,4 +436,23 @@ public class BasicEndToEndKafkaTest extends BasicEndToEndTestBase {
         assertEquals(kafkaReceives.stream().sorted().collect(Collectors.toList()), expectValues);
 
     }
+
+
+    @Test(timeOut = 20000)
+    public void testReadCommitted() throws Exception {
+        final String topic = "test-read-committed";
+
+        pulsar.getAdminClient().topics().createPartitionedTopic(topic, 2);
+
+        @Cleanup
+        final KafkaProducer<String, String> kafkaProducer = newKafkaProducer();
+        sendSingleMessages(kafkaProducer, topic, Arrays.asList("a", "b", "c"));
+
+        List<String> expectValues = Arrays.asList("a", "b", "c");
+
+        @Cleanup
+        final KafkaConsumer<String, String> kafkaConsumer = newKafkaConsumer(topic, "test-group", true);
+        List<String> kafkaReceives = receiveMessages(kafkaConsumer, expectValues.size());
+        assertEquals(kafkaReceives.stream().sorted().collect(Collectors.toList()), expectValues);
+    }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/BasicEndToEndTestBase.java
@@ -94,13 +94,18 @@ public class BasicEndToEndTestBase extends KopProtocolHandlerTestBase {
     }
 
     protected KafkaConsumer<String, String> newKafkaConsumer(final String topic, final String group) {
+        return newKafkaConsumer(topic, group, false);
+    }
+    protected KafkaConsumer<String, String> newKafkaConsumer(final String topic,
+                                                             final String group,
+                                                             final boolean readCommitted) {
         final Properties props =  new Properties();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         props.put(ConsumerConfig.GROUP_ID_CONFIG, (group == null) ? GROUP_ID : group);
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-
+        props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, readCommitted ? "read_committed" : "read_uncommitted");
         final KafkaConsumer<String, String> consumer = new KafkaConsumer<>(props);
         consumer.subscribe(Collections.singleton(topic));
         return consumer;


### PR DESCRIPTION
### Motivation

Currently, the fetch request will fail when we use erlang Kafka-client(`kafka4beam/brod`) to consume the standard message. Because the `kafka4beam/brod` Kafka client always uses `read_commited` to fetch the message even if the client is not using transactions. 

See: https://github.com/kafka4beam/kafka_protocol/blob/713a00e30a5f7ab0d19558c502a7e5cc5b0bfa68/src/kpro_req_lib.erl#L166-L172
```erlang
%% `IsolationLevel = kpro_read_uncommitted' to fetch uncommitted messages.
-spec fetch(vsn(), topic(), partition(), offset(), fetch_opts()) -> req().
fetch(Vsn, Topic, Partition, Offset, Opts) ->
  MaxWaitTime = maps:get(max_wait_time, Opts, timer:seconds(1)),
  MinBytes = maps:get(min_bytes, Opts, 0),
  MaxBytes = maps:get(max_bytes, Opts, 1 bsl 20), %% 1M
  IsolationLevel = maps:get(isolation_level, Opts, ?kpro_read_committed),
```

Error log:
```
java.lang.IllegalArgumentException: Broker has disabled transaction coordinator, please enable it before using transaction.
	at io.streamnative.pulsar.handlers.kop.KafkaRequestHandler.throwIfTransactionCoordinatorDisabled(KafkaRequestHandler.java:2478) ~[ZTCCJ6BUXIIL7zuZcqCOWA/:?]
	at io.streamnative.pulsar.handlers.kop.KafkaRequestHandler.getTransactionCoordinator(KafkaRequestHandler.java:275) ~[ZTCCJ6BUXIIL7zuZcqCOWA/:?]
	at io.streamnative.pulsar.handlers.kop.KafkaRequestHandler.handleFetchRequest(KafkaRequestHandler.java:1551) ~[ZTCCJ6BUXIIL7zuZcqCOWA/:?]
	at io.streamnative.pulsar.handlers.kop.KafkaCommandDecoder.channelRead(KafkaCommandDecoder.java:286) [ZTCCJ6BUXIIL7zuZcqCOWA/:?]
```

In the current KoP implementation, we will check the Kafka transaction coordinator is enabled first. However, for compatibility with kafka4beam/brod, we need to skip this check in fetch request.

### Modifications

Skip checking the Kafka transaction coordinator is enable in the fetch request.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

