### PR TITLE
Fix metrics description

### DIFF
--- a/docs/reference-metrics.md
+++ b/docs/reference-metrics.md
@@ -25,7 +25,7 @@ The following types of metrics are available:
 
 The KoP metrics are exposed under "/metrics" at port `8000` along with Pulsar metrics. You can use a different port by configuring the `stats_server_port` system property.
 
-### Request metrics
+### Channel metrics
 
 | Name | Type | Description |
 |---|---|---|


### PR DESCRIPTION
### Motivation

The first `Request metrics` section in reference-metrics.md should probably be `Channel metrics` since the metrics are for channels statistics.

### Modifications

Fixed the section name.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 
  
- [x] `doc` 
  
  (If this PR contains doc changes)

