### PR TITLE
[Transaction] Fix wrong partition hash method in transaction state manager.

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManager.java
@@ -45,7 +45,6 @@ import org.apache.kafka.common.requests.ProduceResponse;
 import org.apache.kafka.common.requests.TransactionResult;
 import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.common.utils.Utils;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.Reader;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManager.java
@@ -608,7 +608,7 @@ public class TransactionStateManager {
     }
 
     public int partitionFor(String transactionalId) {
-        return Utils.abs(transactionalId.hashCode()) % transactionTopicPartitionCount;
+        return TransactionCoordinator.partitionFor(transactionalId, transactionTopicPartitionCount);
     }
 
     /**

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
@@ -56,6 +56,9 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
     @BeforeClass
     @Override
     protected void setup() throws Exception {
+        this.conf.setDefaultNumberOfNamespaceBundles(4);
+        this.conf.setOffsetsTopicNumPartitions(50);
+        this.conf.setKafkaTxnLogTopicNumPartitions(50);
         this.conf.setKafkaTransactionCoordinatorEnabled(true);
         this.conf.setBrokerDeduplicationEnabled(true);
         super.internalSetup();
@@ -85,6 +88,14 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
     @Test(timeOut = 1000 * 10, dataProvider = "produceConfigProvider")
     public void readUncommittedTest(boolean isBatch) throws Exception {
         basicProduceAndConsumeTest("read-uncommitted-test", "txn-12", "read_uncommitted", isBatch);
+    }
+
+    @Test(timeOut = 1000 * 10)
+    public void testInitTransaction() {
+        final KafkaProducer<Integer, String> producer = buildTransactionProducer("prod-1");
+
+        producer.initTransactions();
+        producer.close();
     }
 
     public void basicProduceAndConsumeTest(String topicName,


### PR DESCRIPTION
Fixes #1333 #1371 

### Motivation

Currently, the KoP `TransactionCoordinator` and `TransactionStateManager` used two different hash methods for the `partitionFor` method, which will cause serious problems, because the transaction system topic lookup is using the `TransactionCoordinator#partitionFor` and when the transaction init producer ID, it will use another hash method, so the system topic might haven't been immigration yet.

### Modifications

Use the same partition hash method in `TransactionStateManager`.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

