### PR TITLE
Fix linting errors in io.streamnative.pulsar.handlers.kop.coordinator.group 

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/DelayedHeartbeat.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/DelayedHeartbeat.java
@@ -25,7 +25,7 @@ class DelayedHeartbeat extends DelayedOperation {
     private final GroupCoordinator coordinator;
     private final GroupMetadata group;
     private final MemberMetadata member;
-    private long heartbeatDeadline;
+    private final long heartbeatDeadline;
 
     DelayedHeartbeat(GroupCoordinator coordinator,
                      GroupMetadata group,
@@ -52,7 +52,7 @@ class DelayedHeartbeat extends DelayedOperation {
 
     @Override
     public boolean tryComplete() {
-        return coordinator.tryCompleteHeartbeat(group, member, heartbeatDeadline, () -> forceComplete());
+        return coordinator.tryCompleteHeartbeat(group, member, heartbeatDeadline, this::forceComplete);
     }
 
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/DelayedJoin.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/DelayedJoin.java
@@ -51,7 +51,7 @@ class DelayedJoin extends DelayedOperation {
 
     @Override
     public boolean tryComplete() {
-        return coordinator.tryCompleteJoin(group, () -> forceComplete());
+        return coordinator.tryCompleteJoin(group, this::forceComplete);
     }
 
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinator.java
@@ -1106,7 +1106,7 @@ public class GroupCoordinator {
 
     private void maybePrepareRebalance(GroupMetadata group) {
         group.inLock(() -> {
-            if (group.canReblance()) {
+            if (group.canRebalance()) {
                 prepareRebalance(group);
             }
             return null;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadata.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadata.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static io.streamnative.pulsar.handlers.kop.coordinator.group.GroupState.Dead;
 import static io.streamnative.pulsar.handlers.kop.coordinator.group.GroupState.PreparingRebalance;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.base.Supplier;
@@ -661,7 +662,7 @@ public class GroupMetadata {
                 .map(e -> e.offsetAndMetadata);
     }
 
-    // visible for testing
+    @VisibleForTesting
     Optional<CommitRecordMetadataAndOffset> offsetWithRecordMetadata(TopicPartition topicPartition) {
         return Optional.ofNullable(offsets.get(topicPartition));
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadata.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadata.java
@@ -333,7 +333,7 @@ public class GroupMetadata {
         }
     }
 
-    public boolean canReblance() {
+    public boolean canRebalance() {
         return validPreviousStates.get(PreparingRebalance).contains(state);
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadata.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadata.java
@@ -344,13 +344,13 @@ public class GroupMetadata {
 
     private void assertValidTransition(GroupState targetState) {
         if (!validPreviousStates.get(targetState).contains(state)) {
-            throw new IllegalStateException(("Group %s should be in the %s states before moving"
-                + " to %s state. Instead it is in %s state"
-            ).format(
-                groupId,
-                StringUtils.join(validPreviousStates.get(targetState), ","),
-                targetState,
-                state));
+            throw new IllegalStateException(String.format(
+                    "Group %s should be in the %s states before moving"
+                            + " to %s state. Instead it is in %s state",
+                    groupId,
+                    StringUtils.join(validPreviousStates.get(targetState), ","),
+                    targetState,
+                    state));
         }
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadata.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadata.java
@@ -235,16 +235,14 @@ public class GroupMetadata {
     }
 
     public List<MemberMetadata> allMemberMetadata() {
-        return members.values().stream().collect(Collectors.toList());
+        return new ArrayList<>(members.values());
     }
 
     public int rebalanceTimeoutMs() {
         if (members.isEmpty()) {
             return 0;
         }
-        return members.values().stream().mapToInt(member ->
-            member.rebalanceTimeoutMs()
-        ).max().getAsInt();
+        return members.values().stream().mapToInt(MemberMetadata::rebalanceTimeoutMs).max().getAsInt();
     }
 
     public boolean is(GroupState groupState) {
@@ -285,11 +283,7 @@ public class GroupMetadata {
     private Set<String> candidateProtocols() {
         return members.values().stream()
             .map(MemberMetadata::protocols)
-            .reduce((p1, p2) -> {
-                Set<String> newProtocols = new HashSet<>();
-                newProtocols.addAll(Sets.intersection(p1, p2));
-                return newProtocols;
-            })
+            .reduce((p1, p2) -> new HashSet<>(Sets.intersection(p1, p2)))
             .orElse(Collections.emptySet());
     }
 
@@ -382,7 +376,7 @@ public class GroupMetadata {
         }
         return members.entrySet().stream()
             .collect(Collectors.toMap(
-                e -> e.getKey(),
+                    Entry::getKey,
                 e -> e.getValue().metadata(protocol.get())
             ));
     }
@@ -408,7 +402,7 @@ public class GroupMetadata {
         } else {
             List<MemberSummary> summaries = members.values()
                 .stream()
-                .map(member -> member.summaryNoMetadata())
+                .map(MemberMetadata::summaryNoMetadata)
                 .collect(Collectors.toList());
 
             return new GroupSummary(
@@ -536,9 +530,7 @@ public class GroupMetadata {
             pendingTransactionalOffsetCommits.remove(producerId);
         if (isCommit) {
             if (null != pendingOffsets) {
-                pendingOffsets.entrySet().forEach(e -> {
-                    TopicPartition topicPartition = e.getKey();
-                    CommitRecordMetadataAndOffset commitRecordMetadataAndOffset = e.getValue();
+                pendingOffsets.forEach((topicPartition, commitRecordMetadataAndOffset) -> {
                     if (!commitRecordMetadataAndOffset.appendedBatchOffset.isPresent()) {
                         throw new IllegalStateException(String.format("Trying to complete a transactional offset"
                                 + " commit for producerId %s and groupId %s even though the offset commit record"
@@ -549,16 +541,16 @@ public class GroupMetadata {
                     if (currentOffsetOpt == null || currentOffsetOpt.olderThan(commitRecordMetadataAndOffset)) {
                         if (log.isTraceEnabled()) {
                             log.trace("TxnOffsetCommit for producer {} and group {} with offset {} "
-                                + "committed and loaded into the cache.",
-                                producerId, groupId, commitRecordMetadataAndOffset);
+                                            + "committed and loaded into the cache.",
+                                    producerId, groupId, commitRecordMetadataAndOffset);
                         }
                         offsets.put(topicPartition, commitRecordMetadataAndOffset);
                     } else {
                         if (log.isTraceEnabled()) {
                             log.trace("TxnOffsetCommit for producer {} and group {} with offset {} "
-                                    + "committed, but not loaded since its offset is older than current offset"
-                                    + " {}.",
-                                producerId, groupId, commitRecordMetadataAndOffset, currentOffsetOpt);
+                                            + "committed, but not loaded since its offset is older than current offset"
+                                            + " {}.",
+                                    producerId, groupId, commitRecordMetadataAndOffset, currentOffsetOpt);
                         }
                     }
                 });
@@ -586,9 +578,7 @@ public class GroupMetadata {
     public Map<TopicPartition, OffsetAndMetadata> removeOffsets(Stream<TopicPartition> topicPartitions) {
         return topicPartitions.map(topicPartition -> {
             pendingOffsetCommits.remove(topicPartition);
-            pendingTransactionalOffsetCommits.forEach((pid, pendingOffsets) -> {
-                pendingOffsets.remove(topicPartition);
-            });
+            pendingTransactionalOffsetCommits.forEach((pid, pendingOffsets) -> pendingOffsets.remove(topicPartition));
             CommitRecordMetadataAndOffset removedOffset = offsets.remove(topicPartition);
             // removedOffset.offsetAndMetadata() have an NPE
             if (removedOffset == null) {
@@ -602,8 +592,8 @@ public class GroupMetadata {
                 removedOffset.offsetAndMetadata()
             );
         }).collect(Collectors.toMap(
-            e -> e.getKey(),
-            e -> e.getValue()
+                KeyValue::getKey,
+                KeyValue::getValue
         ));
     }
 
@@ -615,11 +605,10 @@ public class GroupMetadata {
         ).collect(Collectors.toList()));
 
         pendingTransactionalOffsetCommits.values().stream().map(Map::keySet)
-                .collect(Collectors.toList()).forEach(partitionSet -> {
-            topicPartitions.addAll(partitionSet.stream().filter(
-                    topicPartition -> topics.contains(topicPartition.topic()))
-                    .collect(Collectors.toList()));
-        });
+                .collect(Collectors.toList())
+                .forEach(partitionSet -> topicPartitions.addAll(partitionSet.stream().filter(
+                                topicPartition -> topics.contains(topicPartition.topic()))
+                        .collect(Collectors.toList())));
 
         topicPartitions.addAll(offsets.keySet().stream().filter(
                 topicPartition -> topics.contains(topicPartition.topic())
@@ -637,17 +626,17 @@ public class GroupMetadata {
                 e.getValue().offsetAndMetadata()
             ))
             .collect(Collectors.toMap(
-                kv -> kv.getKey(),
-                kv -> kv.getValue()
+                    KeyValue::getKey,
+                    KeyValue::getValue
             ));
 
-        expiredOffsets.keySet().forEach(tp -> offsets.remove(tp));
+        expiredOffsets.keySet().forEach(offsets::remove);
         return expiredOffsets;
     }
 
     public Map<TopicPartition, OffsetAndMetadata> allOffsets() {
         return offsets.entrySet().stream().collect(Collectors.toMap(
-            e -> e.getKey(),
+                Entry::getKey,
             e -> e.getValue().offsetAndMetadata()
         ));
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataConstants.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataConstants.java
@@ -202,8 +202,8 @@ public final class GroupMetadataConstants {
         return Lists.newArrayList(kvs)
             .stream()
             .collect(Collectors.toMap(
-                e -> e.getKey(),
-                e -> e.getValue()
+                    KeyValue::getKey,
+                    KeyValue::getValue
             ));
     }
 
@@ -310,7 +310,7 @@ public final class GroupMetadataConstants {
         value.set(PROTOCOL_KEY, groupMetadata.protocolOrNull());
         value.set(LEADER_KEY, groupMetadata.leaderOrNull());
 
-        List<Struct> memberStructs = groupMetadata.allMemberMetadata().stream().map(memberMetadata -> {
+        value.set(MEMBERS_KEY, groupMetadata.allMemberMetadata().stream().map(memberMetadata -> {
             Struct memberStruct = value.instance(MEMBERS_KEY);
             memberStruct.set(MEMBER_ID_KEY, memberMetadata.memberId());
             memberStruct.set(CLIENT_ID_KEY, memberMetadata.clientId());
@@ -332,15 +332,13 @@ public final class GroupMetadataConstants {
 
             byte[] memberAssignment = assignment.get(memberMetadata.memberId());
             checkState(
-                memberAssignment != null,
-                "Member assignment is null for member %s", memberMetadata.memberId());
+                    memberAssignment != null,
+                    "Member assignment is null for member %s", memberMetadata.memberId());
 
             memberStruct.set(ASSIGNMENT_KEY, ByteBuffer.wrap(memberAssignment));
 
             return memberStruct;
-        }).collect(Collectors.toList());
-
-        value.set(MEMBERS_KEY, memberStructs.toArray());
+        }).toArray());
 
         ByteBuffer byteBuffer = ByteBuffer.allocate(2 /* version */ + value.sizeOf());
         byteBuffer.putShort(version);

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataTest.java
@@ -60,20 +60,20 @@ public class GroupMetadataTest {
 
     @Test
     public void testCanRebalanceWhenStable() {
-        assertTrue(group.canReblance());
+        assertTrue(group.canRebalance());
     }
 
     @Test
     public void testCanRebalanceWhenCompletingRebalance() {
         group.transitionTo(PreparingRebalance);
         group.transitionTo(CompletingRebalance);
-        assertTrue(group.canReblance());
+        assertTrue(group.canRebalance());
     }
 
     @Test
     public void testCannotRebalanceWhenPreparingRebalance() {
         group.transitionTo(PreparingRebalance);
-        assertFalse(group.canReblance());
+        assertFalse(group.canRebalance());
     }
 
     @Test
@@ -81,7 +81,7 @@ public class GroupMetadataTest {
         group.transitionTo(PreparingRebalance);
         group.transitionTo(Empty);
         group.transitionTo(Dead);
-        assertFalse(group.canReblance());
+        assertFalse(group.canRebalance());
     }
 
     @Test


### PR DESCRIPTION
### Motivation

Reading through the code in `io.streamnative.pulsar.handlers.kop.coordinator.group` and there are a lot of linting errors. These are annoying and could mask potential bugs, e.g., #1394.

### Modifications

Fix the linter warnings. Most changes should be trivial cleanup, but there is one real bug where `String.format()` is misused.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as `GroupMetadataTest`.

### Documentation

Check the box below.

Need to update docs? 
  
- [x] `no-need-doc` 
  
 No client facing functionality changes
