### PR TITLE
Fix linter warnings in GroupMetadataManager and GroupCoordinator

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
@@ -111,7 +111,6 @@ public class GroupMetadataManager {
     private final Set<Integer> ownedPartitions = new HashSet<>();
     /* shutting down flag */
     private final AtomicBoolean shuttingDown = new AtomicBoolean(false);
-    private final int groupMetadataTopicPartitionCount;
 
     // Map of <PartitionId, Producer>
     private final ConcurrentMap<Integer, CompletableFuture<Producer<ByteBuffer>>> offsetsProducers =
@@ -236,7 +235,6 @@ public class GroupMetadataManager {
         this.offsetConfig = offsetConfig;
         this.compressionType = offsetConfig.offsetsTopicCompressionType();
         this.groupMetadataCache = new ConcurrentHashMap<>();
-        this.groupMetadataTopicPartitionCount = offsetConfig.offsetsTopicNumPartitions();
         this.metadataTopicProducerBuilder = metadataTopicProducerBuilder;
         this.metadataTopicReaderBuilder = metadataTopicConsumerBuilder;
         this.scheduler = scheduler;
@@ -334,10 +332,6 @@ public class GroupMetadataManager {
         return offsetsTopicName + PARTITIONED_TOPIC_SUFFIX + partitionId;
     }
 
-    public int getGroupMetadataTopicPartitionCount() {
-        return groupMetadataTopicPartitionCount;
-    }
-
     public boolean isGroupLocal(String groupId) {
         return isPartitionOwned(partitionFor(groupId));
     }
@@ -366,13 +360,6 @@ public class GroupMetadataManager {
                 .map(group -> group.inLock(() -> group.is(GroupState.Dead)))
                 .orElse(true)
         );
-    }
-
-    boolean isGroupOpenForProducer(long producerId,
-                                   String groupId) {
-        return openGroupsForProducer.getOrDefault(
-            producerId, Collections.emptySet()
-        ).contains(groupId);
     }
 
     public Optional<GroupMetadata> getGroup(String groupId) {
@@ -471,8 +458,8 @@ public class GroupMetadataManager {
             offsetMetadata.entrySet().stream()
                 .filter(entry -> validateOffsetMetadataLength(entry.getValue().metadata()))
                 .collect(Collectors.toMap(
-                    e -> e.getKey(),
-                    e -> e.getValue()
+                        Map.Entry::getKey,
+                        Map.Entry::getValue
                 ));
 
         group.inLock(() -> {
@@ -492,7 +479,7 @@ public class GroupMetadataManager {
             Map<TopicPartition, Errors> commitStatus = offsetMetadata.entrySet()
                 .stream()
                 .collect(Collectors.toMap(
-                    e -> e.getKey(),
+                        Map.Entry::getKey,
                     e -> Errors.OFFSET_METADATA_TOO_LARGE
                 ));
             return CompletableFuture.completedFuture(commitStatus);
@@ -592,7 +579,7 @@ public class GroupMetadataManager {
             .thenApplyAsync(errors -> offsetMetadata.entrySet()
                 .stream()
                 .collect(Collectors.toMap(
-                    e -> e.getKey(),
+                        Map.Entry::getKey,
                     e -> {
                         if (validateOffsetMetadataLength(e.getValue().metadata())) {
                             return errors;
@@ -653,7 +640,7 @@ public class GroupMetadataManager {
                 group.allOffsets().entrySet()
                     .stream()
                     .collect(Collectors.toMap(
-                        e -> e.getKey(),
+                            Map.Entry::getKey,
                         e -> {
                             OffsetAndMetadata oam = e.getValue();
                             return KafkaResponseUtils.newOffsetFetchPartition(
@@ -966,7 +953,7 @@ public class GroupMetadataManager {
             );
         };
 
-        metadataConsumer.thenComposeAsync(r -> r.readNextAsync()).whenCompleteAsync((message, cause) -> {
+        metadataConsumer.thenComposeAsync(Reader::readNextAsync).whenCompleteAsync((message, cause) -> {
             try {
                 readNextComplete.accept(message, cause);
             } catch (Throwable completeCause) {
@@ -995,11 +982,11 @@ public class GroupMetadataManager {
                         e -> e.getKey().group(),
                         Collectors.toMap(
                             f -> f.getKey().topicPartition(),
-                            f -> f.getValue()
+                                Map.Entry::getValue
                         ))
                     );
             Map<Boolean, Map<String, Map<TopicPartition, CommitRecordMetadataAndOffset>>> partitionedLoadedOffsets =
-                CoreUtils.partition(groupLoadedOffsets, group -> loadedGroups.containsKey(group));
+                CoreUtils.partition(groupLoadedOffsets, loadedGroups::containsKey);
             Map<String, Map<TopicPartition, CommitRecordMetadataAndOffset>> groupOffsets =
                 partitionedLoadedOffsets.get(true);
             Map<String, Map<TopicPartition, CommitRecordMetadataAndOffset>> emptyGroupOffsets =
@@ -1018,7 +1005,7 @@ public class GroupMetadataManager {
                         e -> e.getKey().group,
                         Collectors.toMap(
                             f -> f.getKey().topicPartition(),
-                            f -> f.getValue()
+                                Map.Entry::getValue
                         )
                     ))
                     .forEach((group, offsets) -> {
@@ -1035,9 +1022,9 @@ public class GroupMetadataManager {
             });
 
             Map<Boolean, Map<String, Map<Long, Map<TopicPartition, CommitRecordMetadataAndOffset>>>>
-                partitionedPendingOffsetsByGroup = CoreUtils.partition(
-                pendingOffsetsByGroup,
-                group -> loadedGroups.containsKey(group)
+                    partitionedPendingOffsetsByGroup = CoreUtils.partition(
+                    pendingOffsetsByGroup,
+                    loadedGroups::containsKey
             );
             Map<String, Map<Long, Map<TopicPartition, CommitRecordMetadataAndOffset>>> pendingGroupOffsets =
                 partitionedPendingOffsetsByGroup.get(true);
@@ -1171,7 +1158,7 @@ public class GroupMetadataManager {
                 CompletableFuture<Producer<ByteBuffer>> producer = offsetsProducers.remove(offsetsPartition);
                 CompletableFuture<Reader<ByteBuffer>> reader = offsetsReaders.remove(offsetsPartition);
                 if (producer != null) {
-                    producer.thenApplyAsync(p -> p.closeAsync()).whenCompleteAsync((ignore, t) -> {
+                    producer.thenApplyAsync(Producer::closeAsync).whenCompleteAsync((ignore, t) -> {
                         if (t != null) {
                             log.error("Failed to close producer when remove partition {}.",
                                 producer.join().getTopic());
@@ -1179,7 +1166,7 @@ public class GroupMetadataManager {
                     }, scheduler);
                 }
                 if (reader != null) {
-                    reader.thenApplyAsync(p -> p.closeAsync()).whenCompleteAsync((ignore, t) -> {
+                    reader.thenApplyAsync(Reader::closeAsync).whenCompleteAsync((ignore, t) -> {
                         if (t != null) {
                             log.error("Failed to close reader when remove partition {}.",
                                 reader.join().getTopic());
@@ -1253,7 +1240,7 @@ public class GroupMetadataManager {
                 MemoryRecords records = MemoryRecords.withRecords(
                     magicValue, 0L, compressionType,
                     timestampType,
-                    tombstones.toArray(new SimpleRecord[tombstones.size()])
+                    tombstones.toArray(new SimpleRecord[0])
                 );
                 byte[] groupKey = groupMetadataKey(
                     group.groupId()
@@ -1304,16 +1291,14 @@ public class GroupMetadataManager {
         pendingGroups.forEach(groupId -> {
             CompletableFuture<Void> groupFuture = new CompletableFuture<>();
             groupFutureList.add(groupFuture);
-            getGroup(groupId).map(group -> {
-                return group.inLock(() -> {
-                    if (!group.is(GroupState.Dead)) {
-                        group.completePendingTxnOffsetCommit(producerId, isCommit);
-                        removeProducerGroup(producerId, groupId);
-                    }
-                    groupFuture.complete(null);
-                    return null;
-                });
-            }).orElseGet(() -> {
+            getGroup(groupId).map(group -> group.inLock(() -> {
+                if (!group.is(GroupState.Dead)) {
+                    group.completePendingTxnOffsetCommit(producerId, isCommit);
+                    removeProducerGroup(producerId, groupId);
+                }
+                groupFuture.complete(null);
+                return null;
+            })).orElseGet(() -> {
                 log.info("Group {} has moved away from this coordinator after transaction marker was written"
                         + " but before the cache was updated. The cache on the new group owner will be updated"
                         + " instead.",


### PR DESCRIPTION
### Motivation

Fix linting errors and clean up all the things for the files missed in #1393. These warnings also masked #1401 which fixes a bug.

### Modifications

Fix the linter warnings.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 
  
- [x] `no-need-doc` 
  
  No client facing functionality changes