### PR TITLE
[Metrics] add cluster label to all kop metrics in Prometheus status logger

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -275,6 +275,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
         Configuration conf = new PropertiesConfiguration();
         conf.addProperty("prometheusStatsLatencyRolloverSeconds",
             kafkaConfig.getKopPrometheusStatsLatencyRolloverSeconds());
+        conf.addProperty("cluster", kafkaConfig.getClusterName());
         statsProvider.start(conf);
         brokerService.pulsar().addPrometheusRawMetricsProvider(statsProvider);
         schemaRegistryManager = new SchemaRegistryManager(kafkaConfig, brokerService.getPulsar(),

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/stats/PrometheusMetricsProvider.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/stats/PrometheusMetricsProvider.java
@@ -39,7 +39,7 @@ public class PrometheusMetricsProvider implements PrometheusRawMetricsProvider {
     public static final int DEFAULT_PROMETHEUS_STATS_LATENCY_ROLLOVER_SECONDS = 60;
 
     private static final String KOP_PROMETHEUS_STATS_CLUSTER = "cluster";
-    private Map<String, String> defaultStatsLoggerLabels = new HashMap<>();
+    private final Map<String, String> defaultStatsLoggerLabels = new HashMap<>();
 
     private final CollectorRegistry registry;
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/stats/PrometheusMetricsProvider.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/stats/PrometheusMetricsProvider.java
@@ -17,7 +17,8 @@ import com.google.common.annotations.VisibleForTesting;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
-import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executors;
@@ -36,6 +37,9 @@ public class PrometheusMetricsProvider implements PrometheusRawMetricsProvider {
 
     public static final String PROMETHEUS_STATS_LATENCY_ROLLOVER_SECONDS = "prometheusStatsLatencyRolloverSeconds";
     public static final int DEFAULT_PROMETHEUS_STATS_LATENCY_ROLLOVER_SECONDS = 60;
+
+    private static final String KOP_PROMETHEUS_STATS_CLUSTER = "cluster";
+    private Map<String, String> defaultStatsLoggerLabels = new HashMap<>();
 
     private final CollectorRegistry registry;
 
@@ -61,6 +65,9 @@ public class PrometheusMetricsProvider implements PrometheusRawMetricsProvider {
         int latencyRolloverSeconds = conf.getInt(PROMETHEUS_STATS_LATENCY_ROLLOVER_SECONDS,
                 DEFAULT_PROMETHEUS_STATS_LATENCY_ROLLOVER_SECONDS);
 
+        defaultStatsLoggerLabels.putIfAbsent(KOP_PROMETHEUS_STATS_CLUSTER,
+                conf.getString(KOP_PROMETHEUS_STATS_CLUSTER));
+
         executor.scheduleAtFixedRate(() -> {
             rotateLatencyCollection();
         }, 1, latencyRolloverSeconds, TimeUnit.SECONDS);
@@ -72,7 +79,7 @@ public class PrometheusMetricsProvider implements PrometheusRawMetricsProvider {
     }
 
     public StatsLogger getStatsLogger(String scope) {
-        return new PrometheusStatsLogger(PrometheusMetricsProvider.this, scope, Collections.emptyMap());
+        return new PrometheusStatsLogger(PrometheusMetricsProvider.this, scope, defaultStatsLoggerLabels);
     }
 
     @Override

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
@@ -203,8 +203,7 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase {
         //Assert.assertTrue(sb.toString().contains("kop_server_REQUEST_LATENCY{success=\"true\",quantile=\"0.99\", "
         //        + "request=\"Produce\"}"));
         Assert.assertTrue(sb.toString().contains("kop_server_REQUEST_QUEUED_LATENCY_count{success=\"true\", "
-                + "request=\"Produce\"}"));
-
+                + "cluster=\"test\",request=\"Produce\"}"));
         // response stats
         Assert.assertTrue(sb.toString().contains("kop_server_RESPONSE_BLOCKED_TIMES"));
         Assert.assertTrue(sb.toString().contains("kop_server_RESPONSE_BLOCKED_LATENCY"));
@@ -220,25 +219,25 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase {
         Assert.assertTrue(sb.toString().contains("kop_server_FETCH_DECODE"));
 
         // consumer stats
-        Assert.assertTrue(sb.toString().contains("kop_server_MESSAGE_OUT{group=\"DemoKafkaOnPulsarConsumer\","
-                + "partition=\"0\",topic=\"kopKafkaProducePulsarMetrics1\"} 10"));
-        Assert.assertTrue(sb.toString().contains("kop_server_BYTES_OUT{group=\"DemoKafkaOnPulsarConsumer\","
-                + "partition=\"0\",topic=\"kopKafkaProducePulsarMetrics1\"} 1130"));
+        Assert.assertTrue(sb.toString().contains("kop_server_MESSAGE_OUT{cluster=\"test\","
+                + "group=\"DemoKafkaOnPulsarConsumer\",partition=\"0\",topic=\"kopKafkaProducePulsarMetrics1\"} 10"));
+        Assert.assertTrue(sb.toString().contains("kop_server_BYTES_OUT{cluster=\"test\","
+                + "group=\"DemoKafkaOnPulsarConsumer\",partition=\"0\",topic=\"kopKafkaProducePulsarMetrics1\"} 1130"));
         Assert.assertTrue(sb.toString().contains("kop_server_BYTES_OUT"));
         Assert.assertTrue(sb.toString().contains("kop_server_CONSUME_MESSAGE_CONVERSIONS"));
-        Assert.assertTrue(sb.toString().contains("kop_server_CONSUME_MESSAGE_CONVERSIONS{partition=\"0\","
-                + "topic=\"kopKafkaProducePulsarMetrics1\"} 10"));
+        Assert.assertTrue(sb.toString().contains("kop_server_CONSUME_MESSAGE_CONVERSIONS{cluster=\"test\","
+                + "partition=\"0\",topic=\"kopKafkaProducePulsarMetrics1\"} 10"));
         Assert.assertTrue(sb.toString().contains("kop_server_CONSUME_MESSAGE_CONVERSIONS_TIME_NANOS"));
 
         // producer stats
         Assert.assertTrue(sb.toString().contains("kop_server_BATCH_COUNT_PER_MEMORYRECORDS"));
-        Assert.assertTrue(sb.toString().contains("kop_server_MESSAGE_IN{partition=\"0\","
+        Assert.assertTrue(sb.toString().contains("kop_server_MESSAGE_IN{cluster=\"test\",partition=\"0\","
                 + "topic=\"kopKafkaProducePulsarMetrics1\"} 10"));
-        Assert.assertTrue(sb.toString().contains("kop_server_BYTES_IN{partition=\"0\","
+        Assert.assertTrue(sb.toString().contains("kop_server_BYTES_IN{cluster=\"test\",partition=\"0\","
                 + "topic=\"kopKafkaProducePulsarMetrics1\"} 1170"));
         Assert.assertTrue(sb.toString().contains("kop_server_PRODUCE_MESSAGE_CONVERSIONS"));
-        Assert.assertTrue(sb.toString().contains("kop_server_PRODUCE_MESSAGE_CONVERSIONS{partition=\"0\","
-                + "topic=\"kopKafkaProducePulsarMetrics1\"} 10"));
+        Assert.assertTrue(sb.toString().contains("kop_server_PRODUCE_MESSAGE_CONVERSIONS{cluster=\"test\","
+                + "partition=\"0\",topic=\"kopKafkaProducePulsarMetrics1\"} 10"));
         Assert.assertTrue(sb.toString().contains("kop_server_PRODUCE_MESSAGE_CONVERSIONS_TIME_NANOS"));
 
         // network stats


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Master Issue: https://github.com/streamnative/kop/issues/1368

### Motivation

*Add cluster label in kop metrics to identify different pulsar clusters.*

### Modifications

*Get cluster name config from `KafkaServiceConfigurtion` and put into the root of `PrometheusStatsLogger`'s default labels.*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  No new config item is introduced
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

