### PR TITLE
[improve] Make TransactionMarkerChannelInitializer LengthFieldPrepender singleton

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelInitializer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelInitializer.java
@@ -33,6 +33,7 @@ public class TransactionMarkerChannelInitializer extends ChannelInitializer<Sock
     private final boolean enableTls;
     private final SslContextFactory.Client sslContextFactory;
     private final TransactionMarkerChannelManager transactionMarkerChannelManager;
+    private final LengthFieldPrepender lengthFieldPrepender;
 
     public TransactionMarkerChannelInitializer(KafkaServiceConfiguration kafkaConfig,
                                                boolean enableTls,
@@ -44,6 +45,7 @@ public class TransactionMarkerChannelInitializer extends ChannelInitializer<Sock
         } else {
             sslContextFactory = null;
         }
+        this.lengthFieldPrepender = new LengthFieldPrepender(4);
     }
 
     @Override
@@ -52,7 +54,7 @@ public class TransactionMarkerChannelInitializer extends ChannelInitializer<Sock
             ch.pipeline().addLast(TLS_HANDLER,
                     new SslHandler(SSLUtils.createClientSslEngine(sslContextFactory)));
         }
-        ch.pipeline().addLast(new LengthFieldPrepender(4));
+        ch.pipeline().addLast(lengthFieldPrepender);
         ch.pipeline().addLast("frameDecoder",
                 new LengthFieldBasedFrameDecoder(MAX_FRAME_LENGTH, 0, 4, 0, 4));
         ch.pipeline().addLast("txnHandler", new TransactionMarkerChannelHandler(transactionMarkerChannelManager));


### PR DESCRIPTION
### Motivation

The `LengthFieldPrepender` is a sharable handler, so we can make it singleton to avoid too many objects created.


### Modifications

Make the LengthFieldPrepender singleton

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

