### PR TITLE
[improve] Consolidate Netty channel flushes to mitigate syscall overhead

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
@@ -20,6 +20,7 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
+import io.netty.handler.flush.FlushConsolidationHandler;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperation;
@@ -102,6 +103,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
 
     @Override
     protected void initChannel(SocketChannel ch) throws Exception {
+        ch.pipeline().addLast("consolidation", new FlushConsolidationHandler(1024, true));
         ch.pipeline().addLast("idleStateHandler",
                 new IdleStateHandler(
                         kafkaConfig.getConnectionMaxIdleMs(),

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelInitializer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelInitializer.java
@@ -20,6 +20,7 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
+import io.netty.handler.flush.FlushConsolidationHandler;
 import io.netty.handler.ssl.SslHandler;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import io.streamnative.pulsar.handlers.kop.utils.ssl.SSLUtils;
@@ -48,6 +49,7 @@ public class TransactionMarkerChannelInitializer extends ChannelInitializer<Sock
 
     @Override
     protected void initChannel(SocketChannel ch) throws Exception {
+        ch.pipeline().addLast("consolidation", new FlushConsolidationHandler(1024, true));
         if (this.enableTls) {
             ch.pipeline().addLast(TLS_HANDLER,
                     new SslHandler(SSLUtils.createClientSslEngine(sslContextFactory)));


### PR DESCRIPTION
TODO: We still need to test to find out the best `explicitFlushAfterFlushes` config value.

The better option is migration the [`org.apache.cassandra.transport.Flusher`](https://github.com/apache/cassandra/blob/trunk/src/java/org/apache/cassandra/transport/Flusher.java). It can reduce the flush count and reduce the `FlushConsolidationHandler` latency.

### Motivation

When we are writing/reading a lot of small entries, one of the main bottlenecks in kop becomes CPU usage. A big part of it is caused by the syscall overhead when writing to the socket.

The reason is that we have many independent (and small) operations happening on the connection and each time we call `writeAndFlush()` on each of them, causing many `write()` calls on the socket.

Netty has a mechanism to consolidate the flushes on the channel and it improves the handling of many small entries.

### Modifications



### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

