### PR TITLE
Upgrade lombok to make KoP compatible with JDK 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <jackson.version>2.13.2</jackson.version>
     <jackson-databind.version>2.13.2.1</jackson-databind.version>
     <kafka.version>2.0.0</kafka.version>
-    <lombok.version>1.18.4</lombok.version>
+    <lombok.version>1.18.22</lombok.version>
     <mockito.version>2.22.0</mockito.version>
     <pulsar.group.id>io.streamnative</pulsar.group.id>
     <pulsar.version>2.10.0.1</pulsar.version>


### PR DESCRIPTION
### Motivation

KoP branch-2.10.1 cannot be compiled with JDK 17.

> Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project kafka-client-api: Fatal error compiling: java.lang.ExceptionInInitializerError: Unable to make field private com.sun.tools.javac.processing.JavacProcessingEnvironment$DiscoveredProcessors com.sun.tools.javac.processing.JavacProcessingEnvironment.discoveredProcs accessible: module jdk.compiler does not "opens com.sun.tools.javac.processing" to unnamed module @46d148bd

It's because lombok 1.18.4 is not compatible with JDK 17. There is no problem in master branch because https://github.com/streamnative/kop/pull/1303 has upgraded lombok to 1.18.22.

### Modifications

Upgrade the lombok version to 1.18.22.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

