### PR TITLE
Fix transaction state update could be skipped for multiple transaction commits

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerRequestCompletionHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerRequestCompletionHandler.java
@@ -50,7 +50,7 @@ public class TransactionMarkerRequestCompletionHandler {
     public void onComplete(WriteTxnMarkersResponse writeTxnMarkerResponse) {
         log.info("Received WriteTxnMarker response from node with correlation id $correlationId");
 
-        for (TransactionMarkerChannelManager.TxnIdAndMarkerEntry txnIdAndMarker : txnIdAndMarkerEntries) {
+        txnIdAndMarkerEntries.forEach(txnIdAndMarker -> {
             String transactionalId = txnIdAndMarker.getTransactionalId();
             WriteTxnMarkersRequest.TxnMarkerEntry txnMarker = txnIdAndMarker.getEntry();
             Map<TopicPartition, Errors> errors = writeTxnMarkerResponse.errors(txnMarker.producerId());
@@ -114,7 +114,7 @@ public class TransactionMarkerRequestCompletionHandler {
                     txnMarker.coordinatorEpoch(),
                     abortSendOrRetryPartitions.retryPartitions,
                     namespacePrefixForUserTopics);
-        }
+        });
     }
 
     private AbortSendingRetryPartitions hasAbortSendOrRetryPartitions(


### PR DESCRIPTION
Fixes #1412

### Motivation

See https://github.com/streamnative/kop/issues/1412#issuecomment-1189337496

The early return in a for loop of
`TransactionMarkerRequestCompletionHandler#onComplete` could break the
loop so that the left `TxnIdAndMarkerEntry` objects cannot be processed.

### Modification

To avoid wrong usage of `return` in a loop, use `Iterable#forEach`
instead of a range for loop  so that a `return` clause won't break the
whole for loop.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

