### PR TITLE
[improve] Check the topic exists from cache

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
@@ -27,8 +27,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.resources.MetadataStoreCacheLoader;
-import org.apache.pulsar.client.admin.PulsarAdmin;
-import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.policies.data.loadbalancer.LoadManagerReport;
 import org.apache.pulsar.policies.data.loadbalancer.ServiceLookupData;
@@ -44,7 +42,7 @@ public class KopBrokerLookupManager {
     private final MetadataStoreCacheLoader metadataStoreCacheLoader;
     private final String selfAdvertisedListeners;
 
-    private final PulsarAdmin adminClient;
+    private final PulsarService pulsar;
 
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
@@ -52,8 +50,8 @@ public class KopBrokerLookupManager {
             LOOKUP_CACHE = new ConcurrentHashMap<>();
 
     public KopBrokerLookupManager(KafkaServiceConfiguration conf, PulsarService pulsarService) throws Exception {
+        this.pulsar = pulsarService;
         this.lookupClient = KafkaProtocolHandler.getLookupClient(pulsarService);
-        this.adminClient = pulsarService.getAdminClient();
         this.metadataStoreCacheLoader = new MetadataStoreCacheLoader(pulsarService.getPulsarResources(),
                 conf.getBrokerLookupTimeoutMs());
         this.selfAdvertisedListeners = conf.getKafkaAdvertisedListeners();
@@ -122,19 +120,29 @@ public class KopBrokerLookupManager {
 
     public CompletableFuture<Boolean> isTopicExists(final String topic) {
         CompletableFuture<Boolean> future = new CompletableFuture<>();
-        this.adminClient.topics().getPartitionedTopicMetadataAsync(topic)
-                .whenComplete((__, ex) -> {
+        TopicName topicName = TopicName.get(topic);
+        this.pulsar.getBrokerService().fetchPartitionedTopicMetadataAsync(TopicName.get(topic))
+                .whenComplete((metadata, ex) -> {
+                    if (metadata.partitions == 0) {
+                        internalCheckTopicExists(topicName).thenAccept(future::complete)
+                                .exceptionally(throwable -> {
+                                    log.error("Check topic exists has exception.", throwable);
+                                    future.complete(true);
+                                    return null;
+                                });
+                    }
                     if (ex != null) {
-                        if (ex instanceof PulsarAdminException.NotFoundException) {
-                            future.complete(false);
-                            return;
-                        }
-                        // Retry when the exception is others exception.
-                        log.error("Get partitioned topic metadata has exception.", ex);
+                        log.error("Fetch partitioned topic metadata has exception.", ex);
+                        future.complete(true);
+                        return;
                     }
                     future.complete(true);
                 });
         return future;
+    }
+
+    protected CompletableFuture<Boolean> internalCheckTopicExists(TopicName topicName) {
+        return this.pulsar.getNamespaceService().checkTopicExists(topicName);
     }
 
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
@@ -135,6 +135,7 @@ public class KopBrokerLookupManager {
                                     future.complete(true);
                                     return null;
                                 });
+                        return;
                     }
                     future.complete(true);
                 });

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
@@ -123,6 +123,11 @@ public class KopBrokerLookupManager {
         TopicName topicName = TopicName.get(topic);
         this.pulsar.getBrokerService().fetchPartitionedTopicMetadataAsync(TopicName.get(topic))
                 .whenComplete((metadata, ex) -> {
+                    if (ex != null) {
+                        log.error("Fetch partitioned topic metadata has exception.", ex);
+                        future.complete(true);
+                        return;
+                    }
                     if (metadata.partitions == 0) {
                         internalCheckTopicExists(topicName).thenAccept(future::complete)
                                 .exceptionally(throwable -> {
@@ -130,11 +135,6 @@ public class KopBrokerLookupManager {
                                     future.complete(true);
                                     return null;
                                 });
-                    }
-                    if (ex != null) {
-                        log.error("Fetch partitioned topic metadata has exception.", ex);
-                        future.complete(true);
-                        return;
                     }
                     future.complete(true);
                 });

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManagerTest.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.util.Collections;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+@Slf4j
+public class KopBrokerLookupManagerTest extends KopProtocolHandlerTestBase {
+
+    private static final String TENANT = "test";
+    private static final String NAMESPACE = TENANT + "/" + "kop-broker-lookup-manager-test";
+
+    private KopBrokerLookupManager kopBrokerLookupManager;
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        log.info("success internal setup");
+        admin.tenants().createTenant(TENANT, TenantInfo.builder()
+                .adminRoles(Collections.emptySet())
+                .allowedClusters(Collections.singleton(configClusterName))
+                .build());
+        admin.namespaces().createNamespace(NAMESPACE);
+        admin.namespaces().setDeduplicationStatus(NAMESPACE, true);
+        kopBrokerLookupManager = new KopBrokerLookupManager(conf, pulsar);
+    }
+
+    @AfterClass
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test(timeOut = 20 * 1000)
+    public void testIsTopicExists() throws Exception {
+        String existsTopic = "persistent://" + NAMESPACE + "/" + "exists-topic";
+        String nonExistentTopic = "persistent://" + NAMESPACE + "/" + "non-existent-topic";
+        String nonPartitionedExistsTopic = "persistent://" + NAMESPACE + "/" + "non-partitioned-exists-topic";
+        admin.topics().createPartitionedTopic(existsTopic, 2);
+        assertTrue(kopBrokerLookupManager.isTopicExists(existsTopic).get());
+        assertFalse(kopBrokerLookupManager.isTopicExists(nonExistentTopic).get());
+
+        admin.topics().createNonPartitionedTopicAsync(nonPartitionedExistsTopic);
+        assertTrue(kopBrokerLookupManager.isTopicExists(existsTopic).get());
+    }
+
+}


### PR DESCRIPTION
### Motivation

Using the admin API to check if the "topic" exists is a heavy operation, we should use the metadata cache to check if the topic exists.

### Modifications

Check the topic exists from cache

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

