### PR TITLE
[Transaction][branch-2.8.3] Fix endless writing txn marker requests when the topic is deleted

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
@@ -27,6 +27,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.resources.MetadataStoreCacheLoader;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.policies.data.loadbalancer.LoadManagerReport;
 import org.apache.pulsar.policies.data.loadbalancer.ServiceLookupData;
@@ -42,6 +44,8 @@ public class KopBrokerLookupManager {
     private final LookupClient lookupClient;
     private final MetadataStoreCacheLoader metadataStoreCacheLoader;
 
+    private final PulsarAdmin adminClient;
+
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
     public static final ConcurrentHashMap<String, ConcurrentHashMap<String, CompletableFuture<InetSocketAddress>>>
@@ -52,6 +56,7 @@ public class KopBrokerLookupManager {
 
     public KopBrokerLookupManager(KafkaServiceConfiguration conf, PulsarService pulsarService) throws Exception {
         this.advertisedListeners = conf.getKafkaAdvertisedListeners();
+        this.adminClient = pulsarService.getAdminClient();
         this.lookupClient = KafkaProtocolHandler.getLookupClient(pulsarService);
         this.metadataStoreCacheLoader = new MetadataStoreCacheLoader(pulsarService.getPulsarResources(),
                 conf.getBrokerLookupTimeoutMs());
@@ -140,6 +145,23 @@ public class KopBrokerLookupManager {
             return CompletableFuture.completedFuture(null);
         }
         return lookupClient.getBrokerAddress(TopicName.get(topic), listenerName);
+    }
+
+    public CompletableFuture<Boolean> isTopicExists(final String topic) {
+        CompletableFuture<Boolean> future = new CompletableFuture<>();
+        this.adminClient.topics().getPartitionedTopicMetadataAsync(topic)
+                .whenComplete((__, ex) -> {
+                    if (ex != null) {
+                        if (ex instanceof PulsarAdminException.NotFoundException) {
+                            future.complete(false);
+                            return;
+                        }
+                        // Retry when the exception is others exception.
+                        log.error("Get partitioned topic metadata has exception.", ex);
+                    }
+                    future.complete(true);
+                });
+        return future;
     }
 
     private CompletableFuture<Optional<String>> getProtocolDataToAdvertise(

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelHandler.java
@@ -131,7 +131,7 @@ public class TransactionMarkerChannelHandler extends ChannelInboundHandlerAdapte
         }
 
         public void onError(Throwable error) {
-            log.info("[TransactionMarkerChannelHandler] onError {}", error);
+            log.info("[TransactionMarkerChannelHandler] onError", error);
             final List<WriteTxnMarkersRequest.TxnMarkerEntry> markers = request.markers();
             Map<Long, Map<TopicPartition, Errors>> errors = new HashMap<>(markers.size());
             for (WriteTxnMarkersRequest.TxnMarkerEntry entry : markers) {
@@ -151,9 +151,6 @@ public class TransactionMarkerChannelHandler extends ChannelInboundHandlerAdapte
 
     @Override
     public void channelActive(ChannelHandlerContext channelHandlerContext) throws Exception {
-        if (log.isDebugEnabled()) {
-            log.debug("channelActive");
-        }
         log.info("[TransactionMarkerChannelHandler] channelActive to {}", channelHandlerContext.channel());
         handleAuthentication(channelHandlerContext);
         super.channelActive(channelHandlerContext);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
@@ -54,6 +54,7 @@ import org.apache.kafka.common.requests.WriteTxnMarkersRequest;
 import org.apache.kafka.common.requests.WriteTxnMarkersRequest.TxnMarkerEntry;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.impl.AuthenticationUtil;
+import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.netty.ChannelFutures;
 import org.eclipse.jetty.util.BlockingArrayQueue;
@@ -323,7 +324,7 @@ public class TransactionMarkerChannelManager {
                         }
 
                         CompletableFuture<Optional<InetSocketAddress>> addressFuture =
-                                kopBrokerLookupManager.findBroker(pulsarTopic, sslEndPoint);
+                                kopBrokerLookupManager.findBroker(TopicName.get(pulsarTopic), sslEndPoint);
 
                         addressFuture.whenComplete((address, throwable) -> {
                             if (throwable != null) {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderTest.java
@@ -67,7 +67,7 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase {
         this.conf.setOffsetsTopicNumPartitions(50);
         this.conf.setKafkaTxnLogTopicNumPartitions(50);
         this.conf.setKafkaTransactionCoordinatorEnabled(true);
-        this.conf.setBrokerDeduplicationEnabled(true);
+        this.conf.setBrokerDeduplicationEnabled(false);
         super.internalSetup();
         log.info("success internal setup");
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
@@ -306,10 +306,8 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
     }
 
     private KafkaProducer<Integer, String> buildTransactionProducer(String transactionalId) {
-        String kafkaServer = "localhost:" + getKafkaBrokerPort();
-
         Properties producerProps = new Properties();
-        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaServer);
+        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, getKafkaServerAdder());
         producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class.getName());
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         producerProps.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 1000 * 10);
@@ -320,10 +318,8 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
     }
 
     private KafkaConsumer<Integer, String> buildTransactionConsumer(String groupId, String isolation) {
-        String kafkaServer = "localhost:" + getKafkaBrokerPort();
-
         Properties consumerProps = new Properties();
-        consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaServer);
+        consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, getKafkaServerAdder());
         consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class.getName());
         consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         consumerProps.put(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG, 1000 * 10);
@@ -336,10 +332,8 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
     }
 
     private KafkaProducer<Integer, String> buildIdempotenceProducer() {
-        String kafkaServer = "localhost:" + getKafkaBrokerPort();
-
         Properties producerProps = new Properties();
-        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaServer);
+        producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, getKafkaServerAdder());
         producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class.getName());
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         producerProps.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 1000 * 10);
@@ -347,6 +341,13 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
 
         addCustomizeProps(producerProps);
         return new KafkaProducer<>(producerProps);
+    }
+
+    /**
+     * Get the Kafka server address.
+     */
+    private String getKafkaServerAdder() {
+        return "localhost:" + getKafkaBrokerPort();
     }
 
     protected void addCustomizeProps(Properties producerProps) {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManagerTest.java
@@ -1,0 +1,133 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.coordinator.transaction;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import com.google.common.collect.Sets;
+import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
+import io.streamnative.pulsar.handlers.kop.KopBrokerLookupManager;
+import io.streamnative.pulsar.handlers.kop.utils.timer.MockTime;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.apache.bookkeeper.common.util.OrderedScheduler;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.requests.TransactionResult;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Unit test {@link TransactionMarkerChannelManager}.
+ */
+public class TransactionMarkerChannelManagerTest {
+
+    private TransactionMarkerChannelManager transactionMarkerChannelManager;
+
+    private KopBrokerLookupManager kopBrokerLookupManager;
+
+    private TransactionStateManager txnStateManager;
+
+    private OrderedScheduler scheduler;
+    private final MockTime time = new MockTime();
+    private final Set<TopicPartition> partitions = Sets.newHashSet(new TopicPartition("topic1", 0));
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        txnStateManager = mock(TransactionStateManager.class);
+        when(txnStateManager.partitionFor(any())).thenReturn(0);
+
+        kopBrokerLookupManager = mock(KopBrokerLookupManager.class);
+        scheduler = mock(OrderedScheduler.class);
+        KafkaServiceConfiguration conf = new KafkaServiceConfiguration();
+        transactionMarkerChannelManager = spy(new TransactionMarkerChannelManager(
+                "public",
+                conf,
+                txnStateManager,
+                kopBrokerLookupManager,
+                false,
+                "public/default",
+                scheduler
+                ));
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        transactionMarkerChannelManager = null;
+        kopBrokerLookupManager = null;
+        scheduler.shutdown();
+        scheduler = null;
+        txnStateManager = null;
+    }
+
+    @DataProvider
+    public static Object[] isTopicExistsList() {
+        return new Object[] {true, false};
+    }
+
+    @Test(dataProvider = "isTopicExistsList")
+    public void testTopicDeletedBeforeWriteMarker(boolean isTopicExists) {
+        when(kopBrokerLookupManager.isTopicExists(any())).thenReturn(CompletableFuture.completedFuture(isTopicExists));
+        String transactionalId = "known";
+        long producerId = 10L;
+        short producerEpoch = 1;
+        int txnTimeoutMs = 1;
+        TransactionMetadata txnMetadata = TransactionMetadata.builder()
+                .transactionalId(transactionalId)
+                .producerId(producerId)
+                .lastProducerId(producerId)
+                .producerEpoch(producerEpoch)
+                .lastProducerEpoch(RecordBatch.NO_PRODUCER_EPOCH)
+                .txnTimeoutMs(txnTimeoutMs)
+                .state(TransactionState.PREPARE_COMMIT)
+                .topicPartitions(partitions)
+                .txnStartTimestamp(time.milliseconds())
+                .txnLastUpdateTimestamp(time.milliseconds())
+                .build();
+        TransactionMetadata.TxnTransitMetadata transition = TransactionMetadata.TxnTransitMetadata.builder()
+                .producerId(producerId)
+                .lastProducerId(producerId)
+                .producerEpoch(producerEpoch)
+                .lastProducerEpoch(RecordBatch.NO_PRODUCER_EPOCH)
+                .txnTimeoutMs(txnTimeoutMs)
+                .txnState(TransactionState.COMPLETE_COMMIT)
+                .topicPartitions(partitions)
+                .txnStartTimestamp(time.milliseconds())
+                .txnLastUpdateTimestamp(time.milliseconds())
+                .build();
+
+        int coordinatorEpoch = 0;
+        TransactionStateManager.CoordinatorEpochAndTxnMetadata epochAndTxnMetadata =
+                new TransactionStateManager.CoordinatorEpochAndTxnMetadata(coordinatorEpoch, txnMetadata);
+        when(txnStateManager.getTransactionState(transactionalId))
+                .thenReturn(new ErrorsAndData<>(Optional.of(epochAndTxnMetadata)));
+        transactionMarkerChannelManager.addTxnMarkersToSend(
+                coordinatorEpoch,
+                TransactionResult.COMMIT,
+                txnMetadata,
+                transition,
+                "public/default"
+                );
+
+        assertEquals(transactionMarkerChannelManager.getTransactionsWithPendingMarkers().isEmpty(), !isTopicExists);
+    }
+
+}


### PR DESCRIPTION
Fixes #1386 

### Motivation

Since the transaction operation will write into the transaction log first, 
the marker will write after the response to the client, 
however, when we commit the transaction and delete the topic Immediately, 
the marker write operation will always fail, 
so the write operation will always retry.

We need to check the topic exists when we try to write the marker.

### Modifications

* Add some debug log for writing marker log.
* Reusing publish message method.
* Add unit test for `TransactionMarkerChannelManager `.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

