### PR TITLE
[CI] Cancel previous CI workflow if new commit pushed

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -10,6 +10,10 @@ on:
       - master
       - branch-*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 


### PR DESCRIPTION
Fixes #1361

### Motivation

We don't need to waste time verifying the previous commit.

### Modifications

See:
https://github.com/apache/pulsar/blob/b2146fd51d1934a18083e8469e9d50946097fefd/.github/workflows/pulsar-ci.yaml#L29-L31

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

