### PR TITLE
[Bugfix] Fix incorrect publish latency unit

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessagePublishContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessagePublishContext.java
@@ -105,7 +105,7 @@ public final class MessagePublishContext implements PublishContext {
                     topic.getName(), producerName, ledgerId, entryId);
             }
 
-            topic.recordAddLatency(System.nanoTime() - startTimeNs, TimeUnit.MICROSECONDS);
+            topic.recordAddLatency(System.nanoTime() - startTimeNs, TimeUnit.NANOSECONDS);
 
             // duplicated message
             if (ledgerId == -1 && entryId == -1) {


### PR DESCRIPTION
### Motivation

We have record add latency when publishing complete, but the latency unit is wrong, we should use `TimeUnit.NANOSECONDS` instead of `TimeUnit. MICROSECONDS`.

### Modifications

Use `TimeUnit.NANOSECONDS` instead of `TimeUnit. MICROSECONDS`.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

