### PR TITLE
[Transaction] Return INVALID_PRODUCER_EPOCH error when the transaction produces epoch fence happened

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -529,8 +529,10 @@ public class TransactionCoordinator {
     }
 
     private Errors producerEpochFenceErrors() {
-        return Errors.forException(new Throwable("There is a newer producer with the same transactionalId "
-                + "which fences the current one."));
+        if (log.isDebugEnabled()) {
+            log.debug("There is a newer producer with the same transactionalId which fences the current one.");
+        }
+        return Errors.INVALID_PRODUCER_EPOCH;
     }
 
     public void handleEndTransaction(String transactionalId,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMetadata.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMetadata.java
@@ -369,7 +369,7 @@ public class TransactionMetadata {
                         + "producer epoch {} or previous producer epoch {}",
                         expectedProducerEpoch, producerEpoch, lastProducerEpoch);
                 // TODO the error should be Errors.PRODUCER_FENCED
-                errorsOrBumpEpochResult = Either.left(Errors.UNKNOWN_SERVER_ERROR);
+                errorsOrBumpEpochResult = Either.left(Errors.INVALID_PRODUCER_EPOCH);
             }
         }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinatorTest.java
@@ -445,7 +445,7 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
                 errorsCallback
         );
         // TODO: Should have PRODUCER_FENCED
-        assertEquals(Errors.UNKNOWN_SERVER_ERROR, error);
+        assertEquals(Errors.INVALID_PRODUCER_EPOCH, error);
     }
 
     @Test(timeOut = defaultTestTimeout)
@@ -473,7 +473,7 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
                 errorsCallback
         );
         // TODO: Should have PRODUCER_FENCED
-        assertEquals(Errors.UNKNOWN_SERVER_ERROR, error);
+        assertEquals(Errors.INVALID_PRODUCER_EPOCH, error);
     }
 
     @Test(timeOut = defaultTestTimeout)
@@ -622,7 +622,7 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
                 TransactionResult.COMMIT,
                 errorsCallback);
         // TODO: Should have PRODUCER_FENCED
-        assertEquals(Errors.UNKNOWN_SERVER_ERROR, error);
+        assertEquals(Errors.INVALID_PRODUCER_EPOCH, error);
         verify(transactionManager, atLeastOnce())
                 .getTransactionState(eq(transactionalId));
     }
@@ -947,7 +947,7 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
                 TransactionResult.COMMIT,
                 errorsCallback);
         // TODO: Should have PRODUCER_FENCED
-        assertEquals(Errors.UNKNOWN_SERVER_ERROR, error);
+        assertEquals(Errors.INVALID_PRODUCER_EPOCH, error);
         verify(transactionManager, atLeastOnce())
                 .getTransactionState(eq(transactionalId));
     }
@@ -1165,7 +1165,7 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
                 -1L,
                 (short) -1,
                 // TODO: Should be Errors.PRODUCER_FENCED
-                Errors.UNKNOWN_SERVER_ERROR), result);
+                Errors.INVALID_PRODUCER_EPOCH), result);
         verify(transactionManager, atLeastOnce()).validateTransactionTimeoutMs(anyInt());
         verify(transactionManager, times(2)).getTransactionState(eq(transactionalId));
     }
@@ -1384,7 +1384,7 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
                 Optional.of(new ProducerIdAndEpoch(producerId, producerEpoch)), initProducerIdMockCallback);
         // TODO: Should be Errors.PRODUCER_FENCED
         assertEquals(new TransactionCoordinator.InitProducerIdResult(
-                RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, Errors.UNKNOWN_SERVER_ERROR), result);
+                RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, Errors.INVALID_PRODUCER_EPOCH), result);
     }
 
     @Test(timeOut = defaultTestTimeout)
@@ -1414,7 +1414,7 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
                 Optional.of(new ProducerIdAndEpoch(producerId, producerEpoch)), initProducerIdMockCallback);
         // TODO: Should be Errors.PRODUCER_FENCED
         assertEquals(new TransactionCoordinator.InitProducerIdResult(
-                RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, Errors.UNKNOWN_SERVER_ERROR), result);
+                RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, Errors.INVALID_PRODUCER_EPOCH), result);
     }
 
     @Test(timeOut = defaultTestTimeout)
@@ -1508,7 +1508,7 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
                 Optional.of(new ProducerIdAndEpoch(producerId, (short) 10)), initProducerIdMockCallback);
         // TODO: Should be Errors.PRODUCER_FENCED
         assertEquals(new TransactionCoordinator.InitProducerIdResult(
-                RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, Errors.UNKNOWN_SERVER_ERROR), result);
+                RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, Errors.INVALID_PRODUCER_EPOCH), result);
     }
 
     @Test(timeOut = defaultTestTimeout)
@@ -1621,7 +1621,7 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
                 initProducerIdMockCallback);
         assertEquals(new TransactionCoordinator
                 .InitProducerIdResult(RecordBatch.NO_PRODUCER_ID,
-                RecordBatch.NO_PRODUCER_EPOCH, Errors.UNKNOWN_SERVER_ERROR), result);
+                RecordBatch.NO_PRODUCER_EPOCH, Errors.INVALID_PRODUCER_EPOCH), result);
     }
 
     @Test(timeOut = defaultTestTimeout)
@@ -1731,7 +1731,7 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
         AtomicBoolean isCalledOnComplete = new AtomicBoolean(false);
         transactionCoordinator.abortTimedOutTransactions((__, error) -> {
                 isCalledOnComplete.set(true);
-                assertEquals(Errors.UNKNOWN_SERVER_ERROR, error);
+                assertEquals(Errors.INVALID_PRODUCER_EPOCH, error);
                 // We can't test in here, because current API don't support PRODUCER_FENCED,
                 // we need upgrade kafka dependency.
 


### PR DESCRIPTION
Fixes: #1424

### Motivation

When the KoP handled the end transaction request, it returned the `UNKNOWN_SERVER_ERROR` error.

I can't reproduce this in Flink Jobs, but when I review the end transaction code, it is possible to be caused by the produce epoch fence since we are using the `UNKNOWN_SERVER_ERROR` error as the produce epoch fence error.

However, in Kafka, when the produce epoch fence, it will return an `INVALID_PRODUCER_EPOCH` error, we should keep it the same.

Error log:
```
2022-08-05T08:37:26,952+0000 [pulsar-ph-kafka-64-30] ERROR io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator - Aborting append of COMMIT to transaction log with coordinator and returning UNKNOWN_SERVER_ERROR error to client for Source: Custom Source -> Sink: Unnamed-7df19f87deec5680128845fd9a6ca18d-4's EndTransaction request
```

### Modifications

* Replace `UNKNOWN_SERVER_ERROR` error to `INVALID_PRODUCER_EPOCH`

### Documentation
- [x] `no-need-doc` 


