### PR TITLE
[Test] Fix unit test in JDK 17 env

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,15 @@
   <properties>
     <javac.target>1.8</javac.target>
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
-
+    <!-- required for running tests on JDK11+ -->
+    <test.additional.args>
+      --add-opens java.base/jdk.internal.loader=ALL-UNNAMED
+      --add-opens java.base/java.lang=ALL-UNNAMED <!--Mockito-->
+      --add-opens java.base/java.io=ALL-UNNAMED <!--Bookkeeper NativeIO-->
+      --add-opens java.base/java.util=ALL-UNNAMED <!--System Lambda-->
+      --add-opens java.base/sun.net=ALL-UNNAMED <!--netty.DnsResolverUtil-->
+      --add-opens java.management/sun.management=ALL-UNNAMED <!--JvmDefaultGCMetricsLogger-->
+    </test.additional.args>
     <!-- dependencies -->
     <jackson.version>2.13.2</jackson.version>
     <jackson-databind.version>2.13.2.1</jackson-databind.version>
@@ -315,6 +323,7 @@
             -Dpulsar.allocator.pooled=false
             -Dpulsar.allocator.leak_detection=Advanced
             -Dlog4j.configurationFile="log4j2.xml"
+            ${test.additional.args}
           </argLine>
           <reuseForks>false</reuseForks>
           <forkCount>1</forkCount>

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaListenerNameTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaListenerNameTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.mock;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
-import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -66,12 +65,10 @@ public class KafkaListenerNameTest extends KopProtocolHandlerTestBase {
 
     @Test(timeOut = 30000)
     public void testMetadataRequestForMultiListeners() throws Exception {
-        final Map<Integer, InetSocketAddress> bindPortToAdvertisedAddress = new HashMap<>();
+        final Map<Integer, String> bindPortToAdvertisedAddress = new HashMap<>();
         final int anotherKafkaPort = PortManager.nextFreePort();
-        bindPortToAdvertisedAddress.put(kafkaBrokerPort,
-                InetSocketAddress.createUnresolved("192.168.0.1", PortManager.nextFreePort()));
-        bindPortToAdvertisedAddress.put(anotherKafkaPort,
-                InetSocketAddress.createUnresolved("192.168.0.2", PortManager.nextFreePort()));
+        bindPortToAdvertisedAddress.put(kafkaBrokerPort, "192.168.0.1:" + PortManager.nextFreePort());
+        bindPortToAdvertisedAddress.put(anotherKafkaPort, "192.168.0.2:" + PortManager.nextFreePort());
 
         super.resetConfig();
         conf.setKafkaListeners("PLAINTEXT://0.0.0.0:" + kafkaBrokerPort + ",GW://0.0.0.0:" + anotherKafkaPort);
@@ -95,7 +92,7 @@ public class KafkaListenerNameTest extends KopProtocolHandlerTestBase {
                 doReturn(mock(Channel.class)).when(mockCtx).channel();
                 requestHandler.ctx = mockCtx;
 
-                final InetSocketAddress expectedAddress = bindPortToAdvertisedAddress.get(inetSocketAddress.getPort());
+                final String expectedAddress = bindPortToAdvertisedAddress.get(inetSocketAddress.getPort());
 
                 final KafkaHeaderAndRequest metadataRequest = KafkaApisTest.buildRequest(
                         new MetadataRequest.Builder(Collections.singletonList(topic), true),
@@ -106,12 +103,10 @@ public class KafkaListenerNameTest extends KopProtocolHandlerTestBase {
                 Assert.assertEquals(metadataResponse.brokers().size(), 1);
                 final List<Node> brokers = new ArrayList<>(metadataResponse.brokers());
                 Assert.assertEquals(brokers.size(), 1);
-                Assert.assertEquals(brokers.get(0).host(), expectedAddress.getHostName());
-                Assert.assertEquals(brokers.get(0).port(), expectedAddress.getPort());
+                Assert.assertEquals(brokers.get(0).host() + ":" + brokers.get(0).port(), expectedAddress);
 
                 Node controller = metadataResponse.controller();
-                Assert.assertEquals(controller.host(), expectedAddress.getHostName());
-                Assert.assertEquals(controller.port(), expectedAddress.getPort());
+                Assert.assertEquals(controller.host() + ":" + controller.port(), expectedAddress);
 
                 final List<MetadataResponse.TopicMetadata> topicMetadataList =
                         new ArrayList<>(metadataResponse.topicMetadata());
@@ -123,8 +118,8 @@ public class KafkaListenerNameTest extends KopProtocolHandlerTestBase {
                 for (int i = 0; i < numPartitions; i++) {
                     final PartitionMetadata partitionMetadata = partitionMetadataList.get(i);
                     Assert.assertEquals(partitionMetadata.error(), Errors.NONE);
-                    Assert.assertEquals(partitionMetadata.leader().host(), expectedAddress.getHostName());
-                    Assert.assertEquals(partitionMetadata.leader().port(), expectedAddress.getPort());
+                    Assert.assertEquals(partitionMetadata.leader().host() + ":" + partitionMetadata.leader().port(),
+                            expectedAddress);
                 }
             } catch (Exception e) {
                 Assert.fail(e.getMessage());


### PR DESCRIPTION
### Motivation

There are two errors will happen when we use JDK 17 to run the KoP unit test:

1. listener `'PLAINTEXT://192.168.0.1/<unresolved>:15007'` is invalid
```
org.apache.pulsar.broker.PulsarServerException: org.apache.pulsar.broker.PulsarServerException: java.lang.IllegalStateException: listener 'PLAINTEXT://192.168.0.1/<unresolved>:15007' is invalid

	at org.apache.pulsar.broker.PulsarService.start(PulsarService.java:824)
	at io.streamnative.pulsar.handlers.kop.KopProtocolHandlerTestBase.startBroker(KopProtocolHandlerTestBase.java:368)
	at io.streamnative.pulsar.handlers.kop.KopProtocolHandlerTestBase.startBroker(KopProtocolHandlerTestBase.java:359)
	at io.streamnative.pulsar.handlers.kop.KopProtocolHandlerTestBase.internalSetup(KopProtocolHandlerTestBase.java:298)
	at io.streamnative.pulsar.handlers.kop.KopProtocolHandlerTestBase.internalSetup(KopProtocolHandlerTestBase.java:263)
	at io.streamnative.pulsar.handlers.kop.KafkaListenerNameTest.testMetadataRequestForMultiListeners(KafkaListenerNameTest.java:83)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:124)
	at org.testng.internal.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:54)
	at org.testng.internal.InvokeMethodRunnable.run(InvokeMethodRunnable.java:44)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: org.apache.pulsar.broker.PulsarServerException: java.lang.IllegalStateException: listener 'PLAINTEXT://192.168.0.1/<unresolved>:15007' is invalid
	at org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl.start(ModularLoadManagerImpl.java:907)
	at org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerWrapper.start(ModularLoadManagerWrapper.java:103)
	at org.apache.pulsar.broker.PulsarService.startLoadManagementService(PulsarService.java:1076)
	at org.apache.pulsar.broker.PulsarService.start(PulsarService.java:779)
	... 17 more
Caused by: java.lang.IllegalStateException: listener 'PLAINTEXT://192.168.0.1/<unresolved>:15007' is invalid
	at com.google.common.base.Preconditions.checkState(Preconditions.java:502)
	at io.streamnative.pulsar.handlers.kop.EndPoint.matcherListener(EndPoint.java:190)
...
```
2. Unable to make protected native java.lang.Object java.lang.Object.clone() throws java.lang.CloneNotSupportedException accessible: module java.base does not "opens java.lang" to unnamed module @694e1548
```
java.lang.reflect.InaccessibleObjectException: Unable to make protected native java.lang.Object java.lang.Object.clone() throws java.lang.CloneNotSupportedException accessible: module java.base does not "opens java.lang" to unnamed module @694e1548

	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
	at java.base/java.lang.reflect.Method.checkCanSetAccessible(Method.java:199)
	at java.base/java.lang.reflect.Method.setAccessible(Method.java:193)
	at org.powermock.reflect.internal.WhiteboxImpl.doGetAllMethods(WhiteboxImpl.java:1508)
	at org.powermock.reflect.internal.WhiteboxImpl.getAllMethods(WhiteboxImpl.java:1482)
	at org.powermock.reflect.internal.WhiteboxImpl.findMethodOrThrowException(WhiteboxImpl.java:862)
	at org.powermock.reflect.internal.WhiteboxImpl.doInvokeMethod(WhiteboxImpl.java:822)
	at org.powermock.reflect.internal.WhiteboxImpl.invokeMethod(WhiteboxImpl.java:690)
	at org.powermock.reflect.Whitebox.invokeMethod(Whitebox.java:401)
	at io.streamnative.pulsar.handlers.kop.coordinator.transaction.PulsarStorageProducerIdManagerImplTest.testGetProducerIdWithTTL(PulsarStorageProducerIdManagerImplTest.java:190)
...
```

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

