### PR TITLE
[Docs] - The KoP metrics are exposed at port 8080, not 8000

### DIFF
--- a/docs/reference-metrics.md
+++ b/docs/reference-metrics.md
@@ -23,7 +23,7 @@ The following types of metrics are available:
 
 ## KoP metrics
 
-The KoP metrics are exposed under "/metrics" at port `8000` along with Pulsar metrics. You can use a different port by configuring the `stats_server_port` system property.
+The KoP metrics are exposed under "/metrics" at port `8080` along with Pulsar metrics. You can use a different port by configuring the `stats_server_port` system property.
 
 ### Channel metrics
 


### PR DESCRIPTION
Fixes #1459


### Motivation

* The KoP metrics are exposed at port `8080`, not `8000`. However, the document shows `8000`.

### Modifications

* Change the port from `8000` to `8080` in docs/reference-metrics.md

### Verifying this change

* To access the document docs/reference-metrics.md and you can find `8080` port.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
Please refer to docs/reference-metrics.md
  
- [ ] `no-need-doc` 
  
Please refer to docs/reference-metrics.md
  
- [x] `doc` 
  
Please refer to docs/reference-metrics.md

