### PR TITLE
[feature] Support disable group-level consumer metrics

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -120,6 +120,7 @@ The `pulsar.version` should be same with the version of your `pulsar-client` dep
 | Name                                     | Description                                                  | Default |
 | ---------------------------------------- | ------------------------------------------------------------ | ------- |
 | kopPrometheusStatsLatencyRolloverSeconds | Kop metrics exposed to prometheus rollover latency in seconds. | 60      |
+| kopEnableGroupLevelConsumerMetrics       | Enable the group level consumer metrics.                     | false   |
 
 ## Group Coordinator
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -371,25 +371,27 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 log.debug("Try to remove all stored groupID on the metadata store. Current connected clientIds: {}",
                         currentConnectedClientId);
             }
-            currentConnectedClientId.forEach(clientId -> {
-                String path = groupIdStoredPath + GroupIdUtils.groupIdPathFormat(clientHost, clientId);
-                metadataStore.delete(path, Optional.empty())
-                        .whenComplete((__, ex) -> {
-                            if (ex != null) {
-                                if (ex.getCause() instanceof MetadataStoreException.NotFoundException) {
-                                    if (log.isDebugEnabled()) {
-                                        log.debug("The groupId store path doesn't exist. Path: [{}]", path);
+            if (kafkaConfig.isKopEnableGroupLevelConsumerMetrics()) {
+                currentConnectedClientId.forEach(clientId -> {
+                    String path = groupIdStoredPath + GroupIdUtils.groupIdPathFormat(clientHost, clientId);
+                    metadataStore.delete(path, Optional.empty())
+                            .whenComplete((__, ex) -> {
+                                if (ex != null) {
+                                    if (ex.getCause() instanceof MetadataStoreException.NotFoundException) {
+                                        if (log.isDebugEnabled()) {
+                                            log.debug("The groupId store path doesn't exist. Path: [{}]", path);
+                                        }
+                                        return;
                                     }
+                                    log.error("Delete groupId failed. Path: [{}]", path, ex);
                                     return;
                                 }
-                                log.error("Delete groupId failed. Path: [{}]", path, ex);
-                                return;
-                            }
-                            if (log.isDebugEnabled()) {
-                                log.debug("Delete groupId success. Path: [{}]", path);
-                            }
-                        });
-            });
+                                if (log.isDebugEnabled()) {
+                                    log.debug("Delete groupId success. Path: [{}]", path);
+                                }
+                            });
+                });
+            }
 
             // update alive channel count stat
             RequestStats.ALIVE_CHANNEL_COUNT_INSTANCE.decrementAndGet();
@@ -919,13 +921,18 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         } else if (request.coordinatorType() == FindCoordinatorRequest.CoordinatorType.GROUP) {
             partition = getGroupCoordinator().partitionFor(request.coordinatorKey());
             pulsarTopicName = getGroupCoordinator().getTopicPartitionName(partition);
-            String groupId = request.coordinatorKey();
-            String groupIdPath = GroupIdUtils.groupIdPathFormat(findCoordinator.getClientHost(),
-                    findCoordinator.getHeader().clientId());
-            currentConnectedClientId.add(findCoordinator.getHeader().clientId());
+            if (kafkaConfig.isKopEnableGroupLevelConsumerMetrics()) {
+                String groupId = request.coordinatorKey();
+                String groupIdPath = GroupIdUtils.groupIdPathFormat(findCoordinator.getClientHost(),
+                        findCoordinator.getHeader().clientId());
+                currentConnectedClientId.add(findCoordinator.getHeader().clientId());
 
-            // Store group name to metadata store for current client, use to collect consumer metrics.
-            storeGroupIdFuture = storeGroupId(groupId, groupIdPath);
+                // Store group name to metadata store for current client, use to collect consumer metrics.
+                storeGroupIdFuture = storeGroupId(groupId, groupIdPath);
+            } else {
+                storeGroupIdFuture = CompletableFuture.completedFuture(null);
+            }
+
         } else {
             throw new NotImplementedException("FindCoordinatorRequest not support unknown type "
                 + request.coordinatorType());

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -470,6 +470,12 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
 
     @FieldContext(
             category = CATEGORY_KOP,
+            doc = "KOP Enable the group level consumer metrics. (Default: false)"
+    )
+    private boolean kopEnableGroupLevelConsumerMetrics = false;
+
+    @FieldContext(
+            category = CATEGORY_KOP,
             doc = "The allowed namespaces to list topics with a comma separator.\n"
                     + " For example, \"public/default,public/kafka\".\n"
                     + "If it's not set or empty, the allowed namespaces will be \"<kafkaTenant>/<kafkaNamespace>\"."

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -447,28 +447,40 @@ public final class MessageFetchContext {
         } else {
             magic = RecordBatch.CURRENT_MAGIC_VALUE;
         }
+        final CompletableFuture<String> groupNameFuture;
+        if (requestHandler.getKafkaConfig().isKopEnableGroupLevelConsumerMetrics()) {
+            groupNameFuture = requestHandler
+                    .getCurrentConnectedGroup()
+                    .computeIfAbsent(clientHost, clientHost -> {
+                        CompletableFuture<String> future = new CompletableFuture<>();
+                        String groupIdPath = GroupIdUtils.groupIdPathFormat(clientHost, header.clientId());
+                        requestHandler.getMetadataStore()
+                                .get(requestHandler.getGroupIdStoredPath() + groupIdPath)
+                                .thenAccept(getResultOpt -> {
+                                    String groupName;
+                                    if (getResultOpt.isPresent()) {
+                                        GetResult getResult = getResultOpt.get();
+                                        groupName = new String(getResult.getValue() == null
+                                                ? new byte[0] : getResult.getValue(), StandardCharsets.UTF_8);
 
-        CompletableFuture<String> groupNameFuture = requestHandler
-                .getCurrentConnectedGroup()
-                .computeIfAbsent(clientHost, clientHost -> {
-                    CompletableFuture<String> future = new CompletableFuture<>();
-                    String groupIdPath = GroupIdUtils.groupIdPathFormat(clientHost, header.clientId());
-                    requestHandler.getMetadataStore()
-                            .get(requestHandler.getGroupIdStoredPath() + groupIdPath)
-                            .thenAccept(getResultOpt -> {
-                                if (getResultOpt.isPresent()) {
-                                    GetResult getResult = getResultOpt.get();
-                                    future.complete(new String(getResult.getValue() == null
-                                            ? new byte[0] : getResult.getValue(), StandardCharsets.UTF_8));
-                                } else {
-                                    future.complete("");
-                                }
-                            }).exceptionally(ex -> {
-                                future.completeExceptionally(ex);
-                                return null;
-                            });
-                    return future;
-                });
+                                    } else {
+                                        groupName = "";
+                                    }
+                                    if (log.isDebugEnabled()) {
+                                        log.debug("Request {}: Path {} get current group ID is {}",
+                                                header, groupIdPath, groupName);
+                                    }
+                                    future.complete(groupName);
+                                }).exceptionally(ex -> {
+                                    future.completeExceptionally(ex);
+                                    return null;
+                                });
+                        return future;
+                    });
+        } else {
+            groupNameFuture = CompletableFuture.completedFuture(null);
+        }
+
 
         // this part is heavyweight, and we should not execute in the ManagedLedger Ordered executor thread
         groupNameFuture.whenCompleteAsync((groupName, ex) -> {
@@ -476,7 +488,6 @@ public final class MessageFetchContext {
                 log.error("Get groupId failed.", ex);
                 groupName = "";
             }
-
 
             final long startDecodingEntriesNanos = MathUtils.nowInNano();
             final DecodeResult decodeResult = requestHandler
@@ -496,6 +507,10 @@ public final class MessageFetchContext {
                 abortedTransactions = partitionLog.getAbortedIndexList(partitionData.fetchOffset);
             } else {
                 abortedTransactions = null;
+            }
+            if (log.isDebugEnabled()) {
+                log.debug("Request {}: Partition {} read entry completed in {} ns",
+                        header, topicPartition, MathUtils.nowInNano() - startDecodingEntriesNanos);
             }
             responseData.put(topicPartition, new PartitionData<>(
                     Errors.NONE,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/DecodeResult.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/DecodeResult.java
@@ -107,9 +107,12 @@ public class DecodeResult {
         statsLoggerForThisPartition.getCounter(CONSUME_MESSAGE_CONVERSIONS).add(conversionCount);
         statsLoggerForThisPartition.getOpStatsLogger(CONSUME_MESSAGE_CONVERSIONS_TIME_NANOS)
                 .registerSuccessfulEvent(conversionTimeNanos, TimeUnit.NANOSECONDS);
-
-        final StatsLogger statsLoggerForThisGroup = statsLoggerForThisPartition.scopeLabel(GROUP_SCOPE, groupId);
-
+        final StatsLogger statsLoggerForThisGroup;
+        if (groupId != null) {
+            statsLoggerForThisGroup = statsLoggerForThisPartition.scopeLabel(GROUP_SCOPE, groupId);
+        } else {
+            statsLoggerForThisGroup = statsLoggerForThisPartition;
+        }
         statsLoggerForThisGroup.getCounter(BYTES_OUT).add(records.sizeInBytes());
         statsLoggerForThisGroup.getCounter(MESSAGE_OUT).add(numMessages);
         statsLoggerForThisGroup.getCounter(ENTRIES_OUT).add(entrySize);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderWithDisableGroupLevelConsumerMetricsTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MetricsProviderWithDisableGroupLevelConsumerMetricsTest.java
@@ -1,0 +1,20 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+public class MetricsProviderWithDisableGroupLevelConsumerMetricsTest extends MetricsProviderTest {
+    public MetricsProviderWithDisableGroupLevelConsumerMetricsTest() {
+        super(false);
+    }
+}


### PR DESCRIPTION
### Motivation

The group-level consumer metrics are heavyweight metrics, 
they use the ZK node to store the group id, 
and read it when fetching one partition is completed,
we should add an option to disable the group-level consumer metrics.

### Modifications
* Add an option to disable the group-level consumer metrics.
* Add unit test to cover disable case.

### Documentation

Check the box below.

Need to update docs? 

- [x] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

