### PR TITLE
Fix NPE that occurs when getting topic fails

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
@@ -78,7 +78,7 @@ public class KafkaTopicManager {
             () -> {
                 final CompletableFuture<KafkaTopicConsumerManager> tcmFuture = new CompletableFuture<>();
                 getTopic(topicName).whenComplete((persistentTopic, throwable) -> {
-                    if (persistentTopic.isPresent() && throwable == null) {
+                    if (throwable == null && persistentTopic.isPresent()) {
                         if (log.isDebugEnabled()) {
                             log.debug("[{}] Call getTopicConsumerManager for {}, and create TCM for {}.",
                                     requestHandler.ctx.channel(), topicName, persistentTopic);


### PR DESCRIPTION
### Motivation

NPE issue [reported on Pulsar Slack](https://apache-pulsar.slack.com/archives/C5Z4T36F7/p1661759412459669).
NPE happens at https://github.com/streamnative/kop/blob/v2.10.1.4/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java#L81

### Modifications

- reorder conditions in if statement so that a possible throwable is checked first. This prevents NPE
  when a throwable is present and the persistentTopic is null

- [x] `no-need-doc`