### PR TITLE
[Improvement] Adopt unified style for whenComplete to avoid NPE

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManager.java
@@ -135,6 +135,7 @@ public class KafkaTopicConsumerManager implements Closeable {
     // get one cursor offset pair.
     // remove from cache, so another same offset read could happen.
     // each success remove should have a following add.
+    // The returned future completes exceptionally or a nullable value
     public CompletableFuture<Pair<ManagedCursor, Long>> removeCursorFuture(long offset) {
         if (closed.get()) {
             return null;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
@@ -116,6 +116,7 @@ public class KafkaTopicManager {
     }
 
     // A wrapper of `BrokerService#getTopic` that is to find the topic's associated `PersistentTopic` instance
+    // The returned future completes exceptionally or with a non-null value
     public CompletableFuture<Optional<PersistentTopic>> getTopic(String topicName) {
         if (closed.get()) {
             if (log.isDebugEnabled()) {
@@ -137,7 +138,7 @@ public class KafkaTopicManager {
                     return;
                 }
             }
-            if (t2 != null && t2.isPresent()) {
+            if (t2.isPresent()) {
                 topicCompletableFuture.complete(Optional.of((PersistentTopic) t2.get()));
                 return;
             }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
@@ -57,6 +57,7 @@ public class KopBrokerLookupManager {
         this.selfAdvertisedListeners = conf.getKafkaAdvertisedListeners();
     }
 
+    // The returned future completes exceptionally or with a non-null value
     public CompletableFuture<Optional<InetSocketAddress>> findBroker(String topic,
                                                                      @Nullable EndPoint advertisedEndPoint) {
         return getTopicBroker(topic)
@@ -118,6 +119,7 @@ public class KopBrokerLookupManager {
         return lookupClient.getBrokerAddress(TopicName.get(topic));
     }
 
+    // The returned future always completes with a non-null value
     public CompletableFuture<Boolean> isTopicExists(final String topic) {
         CompletableFuture<Boolean> future = new CompletableFuture<>();
         TopicName topicName = TopicName.get(topic);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -57,7 +57,6 @@ import org.apache.bookkeeper.stats.OpStatsLogger;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.acl.AclOperation;
-import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.RecordBatch;
@@ -269,7 +268,7 @@ public final class MessageFetchContext {
                             addErrorPartitionResponse(topicPartition, Errors.TOPIC_AUTHORIZATION_FAILED);
                             return;
                         }
-                        if (!isAuthorized) {
+                        if (isAuthorized == null || !isAuthorized) {
                             addErrorPartitionResponse(topicPartition, Errors.TOPIC_AUTHORIZATION_FAILED);
                             return;
                         }
@@ -383,9 +382,6 @@ public final class MessageFetchContext {
                                                 addErrorPartitionResponse(topicPartition,
                                                         Errors.forException(throwable));
                                             }
-                                        } else if (entries == null) {
-                                            addErrorPartitionResponse(topicPartition,
-                                                    Errors.forException(new ApiException("Cursor is null")));
                                         } else {
                                             long readSize = entries.stream().mapToLong(Entry::getLength).sum();
                                             limitBytes.addAndGet(-1 * readSize);
@@ -474,7 +470,7 @@ public final class MessageFetchContext {
         groupNameFuture.whenCompleteAsync((groupName, ex) -> {
             if (ex != null) {
                 log.error("Get groupId failed.", ex);
-                groupName = "";
+                groupName = null;
             }
 
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/NamespaceBundleOwnershipListenerImpl.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/NamespaceBundleOwnershipListenerImpl.java
@@ -95,6 +95,7 @@ public class NamespaceBundleOwnershipListenerImpl implements NamespaceBundleOwne
     // Kafka topics are always persistent so there is no need to get owned non-persistent topics.
     // However, `NamespaceService#getOwnedTopicListForNamespaceBundle` calls `getFullListTopics`, which always calls
     // `getListOfNonPersistentTopics`. So this method is a supplement to the existing NamespaceService API.
+    // The returned value completes exceptionally or with a non-null value
     private CompletableFuture<List<String>> getOwnedPersistentTopicList(final NamespaceBundle bundle) {
         final NamespaceName namespaceName = bundle.getNamespaceObject();
         final CompletableFuture<List<String>> topicsFuture = namespaceService.getListOfPersistentTopics(namespaceName)

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinator.java
@@ -703,6 +703,7 @@ public class GroupCoordinator {
         ));
     }
 
+    // The returned future always completes with a non-null value
     public CompletableFuture<Map<TopicPartition, Errors>> handleTxnCommitOffsets(
         String groupId,
         long producerId,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
@@ -1307,14 +1307,7 @@ public class GroupMetadataManager {
                 return null;
             });
         });
-        FutureUtil.waitForAll(groupFutureList).whenComplete((ignored, throwable) -> {
-            if (throwable != null) {
-                log.error("Failed to handle txn completion.");
-                completableFuture.completeExceptionally(throwable);
-            } else {
-                completableFuture.complete(null);
-            }
-        });
+        FutureUtil.waitForAll(groupFutureList).thenAccept(__ -> completableFuture.complete(null));
     }
 
     /**

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/ProducerIdManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/ProducerIdManager.java
@@ -18,6 +18,11 @@ import java.util.concurrent.CompletableFuture;
 public interface ProducerIdManager {
     CompletableFuture<Void> initialize();
 
+    /**
+     * Generate a producer id.
+     *
+     * @return a future that completes exceptionally or with a non-null value
+     */
     CompletableFuture<Long> generateProducerId();
 
     void shutdown();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/PulsarStorageProducerIdManagerImpl.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/PulsarStorageProducerIdManagerImpl.java
@@ -195,13 +195,15 @@ public class PulsarStorageProducerIdManagerImpl implements ProducerIdManager {
     public synchronized void shutdown() {
         if (reader != null) {
             reader.whenComplete((r, e) -> {
-                if (r != null) {
-                    r.closeAsync().whenComplete((___, err) -> {
-                       if (err != null) {
-                           log.error("Error closing reader for {}", topic, err);
-                       }
-                    });
+                if (e != null) {
+                    log.error("Failed to create reader", e);
+                    return;
                 }
+                r.closeAsync().whenComplete((___, err) -> {
+                    if (err != null) {
+                        log.error("Error closing reader for {}", topic, err);
+                    }
+                });
             });
         }
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -381,6 +381,7 @@ public class TransactionCoordinator {
                 && txnMetadata.isEpochExhausted(producerIdAndEpoch.epoch));
     }
 
+    // The returned future completes exceptionally or with a non-null value
     private CompletableFuture<Either<Errors, EpochAndTxnTransitMetadata>> prepareInitProducerIdTransit(
             String transactionalId,
             Integer transactionTimeoutMs,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelHandler.java
@@ -149,7 +149,9 @@ public class TransactionMarkerChannelHandler extends ChannelInboundHandlerAdapte
     public void close() {
         log.info("[TransactionMarkerChannelHandler] closing");
         this.cnxFuture.whenComplete((ctx, err) -> {
-            if (ctx != null) {
+            if (err != null) {
+                log.error("Failed to establish connection", err);
+            } else {
                 ctx.close();
             }
         });

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManager.java
@@ -670,6 +670,7 @@ public class TransactionStateManager {
             if (throwable != null) {
                 log.error("Failed to load transaction log.", throwable);
                 loadFuture.completeExceptionally(throwable);
+                return;
             }
             if (message.getMessageId().compareTo(lastMessageId) >= 0) {
                 // reach the end of partition

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/DecodeResult.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/DecodeResult.java
@@ -28,6 +28,7 @@ import io.netty.util.Recycler;
 import io.streamnative.pulsar.handlers.kop.RequestStats;
 import io.streamnative.pulsar.handlers.kop.stats.StatsLogger;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.NonNull;
 import org.apache.kafka.common.TopicPartition;
@@ -96,7 +97,7 @@ public class DecodeResult {
 
     public void updateConsumerStats(final TopicPartition topicPartition,
                                     int entrySize,
-                                    final String groupId,
+                                    @Nullable final String groupId,
                                     RequestStats statsLogger) {
         final int numMessages = EntryFormatter.parseNumMessages(records);
 
@@ -107,6 +108,10 @@ public class DecodeResult {
         statsLoggerForThisPartition.getCounter(CONSUME_MESSAGE_CONVERSIONS).add(conversionCount);
         statsLoggerForThisPartition.getOpStatsLogger(CONSUME_MESSAGE_CONVERSIONS_TIME_NANOS)
                 .registerSuccessfulEvent(conversionTimeNanos, TimeUnit.NANOSECONDS);
+
+        if (groupId == null) {
+            return;
+        }
 
         final StatsLogger statsLoggerForThisGroup = statsLoggerForThisPartition.scopeLabel(GROUP_SCOPE, groupId);
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/Authorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/Authorizer.java
@@ -28,7 +28,8 @@ public interface Authorizer {
      *
      * @param principal login info
      * @param resource resources to be authorized
-     * @return a boolean to determine whether authorized or not
+     * @return a boolean to determine whether authorized or not. It's possible to be null if the authorization provider
+     * was customized.
      */
     CompletableFuture<Boolean> canLookupAsync(KafkaPrincipal principal, Resource resource);
 
@@ -39,7 +40,8 @@ public interface Authorizer {
      *
      * @param principal login info
      * @param resource resources to be authorized
-     * @return a boolean to determine whether authorized or not
+     * @return a boolean to determine whether authorized or not. It's possible to be null if the authorization provider
+     * was customized.
      */
     CompletableFuture<Boolean> canGetTopicList(KafkaPrincipal principal, Resource resource);
 
@@ -48,7 +50,8 @@ public interface Authorizer {
      *
      * @param principal login info
      * @param resource resources to be authorized
-     * @return a boolean to determine whether authorized or not
+     * @return a boolean to determine whether authorized or not. It's possible to be null if the authorization provider
+     * was customized.
      */
     CompletableFuture<Boolean> canAccessTenantAsync(KafkaPrincipal principal, Resource resource);
 
@@ -58,7 +61,8 @@ public interface Authorizer {
      *
      * @param principal login info
      * @param resource resources to be authorized
-     * @return a boolean to determine whether authorized or not
+     * @return a boolean to determine whether authorized or not. It's possible to be null if the authorization provider
+     * was customized.
      */
     CompletableFuture<Boolean> canCreateTopicAsync(KafkaPrincipal principal, Resource resource);
 
@@ -68,7 +72,8 @@ public interface Authorizer {
      *
      * @param principal login info
      * @param resource resources to be authorized
-     * @return a boolean to determine whether authorized or not
+     * @return a boolean to determine whether authorized or not. It's possible to be null if the authorization provider
+     * was customized.
      */
     CompletableFuture<Boolean> canDeleteTopicAsync(KafkaPrincipal principal, Resource resource);
 
@@ -78,7 +83,8 @@ public interface Authorizer {
      *
      * @param principal login info
      * @param resource resources to be authorized
-     * @return a boolean to determine whether authorized or not
+     * @return a boolean to determine whether authorized or not. It's possible to be null if the authorization provider
+     * was customized.
      */
     CompletableFuture<Boolean> canAlterTopicAsync(KafkaPrincipal principal, Resource resource);
 
@@ -88,7 +94,8 @@ public interface Authorizer {
      *
      * @param principal login info
      * @param resource resources to be authorized
-     * @return a boolean to determine whether authorized or not
+     * @return a boolean to determine whether authorized or not. It's possible to be null if the authorization provider
+     * was customized.
      */
     CompletableFuture<Boolean> canManageTenantAsync(KafkaPrincipal principal, Resource resource);
 
@@ -99,7 +106,8 @@ public interface Authorizer {
      *
      * @param principal login info
      * @param resource resources to be authorized
-     * @return a boolean to determine whether authorized or not
+     * @return a boolean to determine whether authorized or not. It's possible to be null if the authorization provider
+     * was customized.
      */
     CompletableFuture<Boolean> canProduceAsync(KafkaPrincipal principal, Resource resource);
 
@@ -110,7 +118,8 @@ public interface Authorizer {
      *
      * @param principal login info
      * @param resource resources to be authorized
-     * @return a boolean to determine whether authorized or not
+     * @return a boolean to determine whether authorized or not. It's possible to be null if the authorization provider
+     * was customized.
      */
     CompletableFuture<Boolean> canConsumeAsync(KafkaPrincipal principal, Resource resource);
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -307,7 +307,7 @@ public class PartitionLog {
      * @param persistentTopic The persistentTopic, use to publish message and check message deduplication.
      * @param byteBuf Message byteBuf
      * @param appendInfo Pre-analyzed recode info, we can get sequence, message num ...
-     * @return offset
+     * @return a future that completes exceptionally or with a non-null offset
      */
     private CompletableFuture<Long> publishMessage(final PersistentTopic persistentTopic,
                                                    final ByteBuf byteBuf,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
@@ -57,6 +57,7 @@ public class ReplicaManager {
         return logManager.getLog(topicPartition, namespacePrefix);
     }
 
+    // The returned future always completes with a non-null value
     public CompletableFuture<Map<TopicPartition, ProduceResponse.PartitionResponse>> appendRecords(
             final long timeout,
             final boolean internalTopicsAllowed,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MessageMetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MessageMetadataUtils.java
@@ -134,6 +134,14 @@ public class MessageMetadataUtils {
         }
     }
 
+    /**
+     * Peek the base offset from an Entry.
+     *
+     * @param entry the BookKeeper Entry
+     * @return the offset stored in the broker entry metadata
+     * @throws MetadataCorruptedException if the broker entry metadata doesn't contain the index field from
+     * {@link org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor}
+     */
     public static long peekBaseOffsetFromEntry(Entry entry) throws MetadataCorruptedException {
         return peekBaseOffset(entry.getDataBuffer(), entry.getPosition());
     }

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/SchemaStorage.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/SchemaStorage.java
@@ -31,7 +31,7 @@ public interface SchemaStorage {
     /**
      * Find a schema by unique id.
      * @param id the id
-     * @return the Schema or null
+     * @return the Schema or null if it has been deleted
      */
     CompletableFuture<Schema> findSchemaById(int id);
 
@@ -115,7 +115,9 @@ public interface SchemaStorage {
                 if (err != null) {
                     res.completeExceptionally(err);
                 } else {
-                    schemas.add(downloadedSchema);
+                    if (downloadedSchema != null) {
+                        schemas.add(downloadedSchema);
+                    }
                     if (index == ids.size() - 1) {
                         res.complete(schemas);
                         return;

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorage.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorage.java
@@ -179,6 +179,7 @@ public class PulsarSchemaStorage implements SchemaStorage, Closeable {
                 .orElse(null)));
     }
 
+    // The future could complete with null when the schema is deleted
     private CompletableFuture<SchemaEntry> fetchSchemaEntry(Supplier<SchemaEntry> procedure) {
         return fetch(procedure,
                 (schemaEntry) -> schemaEntry != null && schemaEntry.status == SchemaStatus.DELETED,


### PR DESCRIPTION
### Motivation

There was a NPE caused by incorrect use of
`CompletableFuture#whenComplete`. In this method, if the future
completed exceptionally, the value would be `null`.

Then I found the `whenComplete` method was not used correctly in many
places. This PR intends to unify the code style of it.

### Modifications

Given the following code:

```java
future.whenComplete((value, e) -> {/* ... */});
```

If the future was returned by an API from Pulsar, we would assume
`value` is always non-null when `e` is `null` to avoid unnecessary null
checks. If NPE happened, we should correct the implementation at Pulsar
side and add a null check at KoP side as a workaround.

If the future was returned by the KoP internal API, the API must be
documented to show whether it could be completed exceptionally and
whether it could be completed with a `null` value.

Based on the documentation, remove unnecessary null checks or use
`thenAccept` for all `whenComplete` or `whenCompleteAsync` usages.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

