### PR TITLE
Update the description of kopAllowedNamespaces

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,7 +53,7 @@ Pulsar is a multi-tenant system that requires users to specify the [tenant and n
 | kafkaMetadataTenant    | The tenant used for storing Kafka metadata topics    | public  |
 | kafkaEnableMultiTenantMetadata    | Use the SASL username as `kafkaMetadataTenant`  | true  |
 | kafkaMetadataNamespace | The namespace used for storing Kafka metadata topics | __kafka |
-| kopAllowedNamespaces   | The allowed namespace to list topics with a comma separator.<br>For example, "public/default,public/kafka".<br>If it's not set or empty, the allowed namespaces will be "<kafkaTenant>/<kafkaNamespace>". | |
+| kopAllowedNamespaces   | The allowed namespace to list topics with a comma separator.<br>For example, `kopAllowedNamespaces=public/default,public/kafka`.<br>If not configured or empty, the allowed namespaces will take values from `kafkaTenant` and `kafkaNamespace`, which will be, `<kafkaTenant>/<kafkaNamespace>`. | |
 
 When you enable `kafkaEnableMultiTenantMetadata`, KoP uses separate tenants for handling the system metadata.
 This enables you to fully isolate your tenants in your Pulsar cluster.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,7 +53,7 @@ Pulsar is a multi-tenant system that requires users to specify the [tenant and n
 | kafkaMetadataTenant    | The tenant used for storing Kafka metadata topics    | public  |
 | kafkaEnableMultiTenantMetadata    | Use the SASL username as `kafkaMetadataTenant`  | true  |
 | kafkaMetadataNamespace | The namespace used for storing Kafka metadata topics | __kafka |
-| kopAllowedNamespaces   | The allowed namespace to list topics with a comma separator.<br>For example, `kopAllowedNamespaces=public/default,public/kafka`.<br>If not configured or empty, the allowed namespaces will take values from `kafkaTenant` and `kafkaNamespace`, which will be, `<kafkaTenant>/<kafkaNamespace>`. | |
+| kopAllowedNamespaces   | The allowed namespace to list topics with a comma separator.<br>For example, `kopAllowedNamespaces=public/default,public/kafka`.<br>If it is not configured or is empty, the allowed namespaces will get values from `kafkaTenant` and `kafkaNamespace`, which is `<kafkaTenant>/<kafkaNamespace>`. | |
 
 When you enable `kafkaEnableMultiTenantMetadata`, KoP uses separate tenants for handling the system metadata.
 This enables you to fully isolate your tenants in your Pulsar cluster.


### PR DESCRIPTION
1. The current example uses double quotes, which can mislead users into imitating the configuration. But you can't use quotation marks. The update uses backquote and configures the complete example, which may be expressed more clearly.
2. The last less than sign will have a markdown syntax exception, now adjust.