### PR TITLE
[fix] Handle replicated subscription marker correct in pulsar entry formatter

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -521,7 +521,11 @@ public final class MessageFetchContext {
                     kafkaRecords));
             bytesReadable.getAndAdd(kafkaRecords.sizeInBytes());
             tryComplete();
-        }, requestHandler.getDecodeExecutor());
+        }, requestHandler.getDecodeExecutor()).exceptionally(ex -> {
+            log.error("Request {}: Partition {} read entry exceptionally. ", header, topicPartition, ex);
+            addErrorPartitionResponse(topicPartition, Errors.KAFKA_STORAGE_ERROR);
+            return null;
+        });
     }
 
     private List<Entry> getCommittedEntries(List<Entry> entries, long lso) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ByteBufUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ByteBufUtils.java
@@ -117,9 +117,10 @@ public class ByteBufUtils {
                     baseOffset,
                     metadata.getPublishTime(),
                     0,
-                    metadata.getTxnidMostBits(),
-                    (short) metadata.getTxnidLeastBits(),
-                    new EndTransactionMarker(controlRecordType, 0)
+                    metadata.hasTxnidMostBits() ? metadata.getTxnidMostBits() : Long.MAX_VALUE,
+                    metadata.hasTxnidLeastBits() ? (short) metadata.getTxnidLeastBits() : 0,
+                    new EndTransactionMarker(controlRecordType == ControlRecordType.UNKNOWN
+                            ? ControlRecordType.ABORT : controlRecordType, 0)
                     ));
         }
         long startConversionNanos = MathUtils.nowInNano();


### PR DESCRIPTION
Fixes #1458

### Motivation

When we use the pulsar entry formatter and enable replicated subscription, 
the pulsar broker will write the replicated subscription marker,
but when we handle this marker, we will treat this marker as a transaction marker.

However the replicated subscription marker doesn't have `txnid_most_bits`,
so we will get the following exception, and the consumer will never receive the message.

```
2022-08-31T14:47:09,567+0800 [pulsar-2-5] ERROR io.streamnative.pulsar.handlers.kop.MessageFetchContext - Request RequestHeader(apiKey=FETCH, apiVersion=2, clientId=consumer-5, correlationId=246712): Partition test-topic read entry exceptionally. 
java.util.concurrent.CompletionException: java.lang.IllegalStateException: Field 'txnid_most_bits' is not set
	at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:292) ~[?:1.8.0_181]
	at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:308) [?:1.8.0_181]
	at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:769) [?:1.8.0_181]
	at java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:736) [?:1.8.0_181]
	at java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:442) [?:1.8.0_181]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_181]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_181]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180) [?:1.8.0_181]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293) [?:1.8.0_181]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_181]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_181]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [io.netty-netty-common-4.1.77.Final.jar:4.1.77.Final]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_181]
Caused by: java.lang.IllegalStateException: Field 'txnid_most_bits' is not set
	at org.apache.pulsar.common.api.proto.MessageMetadata.getTxnidMostBits(MessageMetadata.java:737) ~[org.apache.pulsar-pulsar-common-2.10.1.jar:2.10.1]
	at io.streamnative.pulsar.handlers.kop.utils.ByteBufUtils.decodePulsarEntryToKafkaRecords(ByteBufUtils.java:120) ~[?:?]
	at io.streamnative.pulsar.handlers.kop.format.AbstractEntryFormatter.decode(AbstractEntryFormatter.java:90) ~[?:?]
	at io.streamnative.pulsar.handlers.kop.format.PulsarEntryFormatter.decode(PulsarEntryFormatter.java:118) ~[?:?]
	at io.streamnative.pulsar.handlers.kop.MessageFetchContext.lambda$handleEntries$10(MessageFetchContext.java:494) ~[?:?]
	at java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:760) ~[?:1.8.0_181]
	... 10 more
```

### Modifications

* Treat the replicated subscription as an `ABORT ` marker.
* Add unit test to cover this case.


### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

