### PR TITLE
[security] Upgrade snakeyaml to 1.31

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
     <grpc.version>1.45.1</grpc.version>
     <junit.version>4.13.1</junit.version>
     <fusionauth-jwt.version>5.2.0</fusionauth-jwt.version>
+    <snakeyaml.version>1.31</snakeyaml.version>
 
     <!-- plugin dependencies -->
     <license-maven-plugin.version>3.0.rc1</license-maven-plugin.version>
@@ -249,6 +250,12 @@
         <groupId>io.streamnative.pulsar.handlers</groupId>
         <artifactId>test-listener</artifactId>
         <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>${snakeyaml.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
### Motivation

snakeyaml < 1.31 is subject to CVE-2022-25857

### Modifications

Upgrade to 1.31
