### PR TITLE
Add migration handler

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AbstractPulsarClient.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AbstractPulsarClient.java
@@ -59,7 +59,14 @@ public abstract class AbstractPulsarClient implements Closeable {
         }
     }
 
-    protected static PulsarClientImpl createPulsarClient(final PulsarService pulsarService,
+    /**
+     * Create a Pulsar client.
+     * @param pulsarService the PulsarService for the client
+     * @param kafkaConfig the Kafka config object
+     * @param customConfig a custom Consumer for setting values in kafkaConfig
+     * @return the created Pulsar client
+     */
+    public static PulsarClientImpl createPulsarClient(final PulsarService pulsarService,
                                                          final KafkaServiceConfiguration kafkaConfig,
                                                          final Consumer<ClientConfigurationData> customConfig) {
         // It's migrated from PulsarService#getClient()

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -27,6 +27,8 @@ import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCo
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
 import io.streamnative.pulsar.handlers.kop.format.EntryFormatter;
 import io.streamnative.pulsar.handlers.kop.format.EntryFormatterFactory;
+import io.streamnative.pulsar.handlers.kop.http.HttpChannelInitializer;
+import io.streamnative.pulsar.handlers.kop.migration.MigrationManager;
 import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryChannelInitializer;
 import io.streamnative.pulsar.handlers.kop.stats.PrometheusMetricsProvider;
 import io.streamnative.pulsar.handlers.kop.stats.StatsLogger;
@@ -102,6 +104,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     private OrderedScheduler sendResponseScheduler;
     private NamespaceBundleOwnershipListenerImpl bundleListener;
     private SchemaRegistryManager schemaRegistryManager;
+    private MigrationManager migrationManager;
 
     private final Map<String, GroupCoordinator> groupCoordinatorsByTenant = new ConcurrentHashMap<>();
     private final Map<String, TransactionCoordinator> transactionCoordinatorByTenant = new ConcurrentHashMap<>();
@@ -280,6 +283,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
         brokerService.pulsar().addPrometheusRawMetricsProvider(statsProvider);
         schemaRegistryManager = new SchemaRegistryManager(kafkaConfig, brokerService.getPulsar(),
                 brokerService.getAuthenticationService());
+        migrationManager = new MigrationManager(kafkaConfig, brokerService.getPulsar());
     }
 
     private TransactionCoordinator createAndBootTransactionCoordinator(String tenant) {
@@ -430,6 +434,12 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                     forEach((listener, endPoint) ->
                             builder.put(endPoint.getInetAddress(), newKafkaChannelInitializer(endPoint))
                     );
+
+            Optional<HttpChannelInitializer> migrationChannelInitializer = migrationManager.build();
+            migrationChannelInitializer.ifPresent(
+                    initializer -> builder.put(migrationManager.getAddress(),
+                            initializer));
+
             Optional<SchemaRegistryChannelInitializer> schemaRegistryChannelInitializer = schemaRegistryManager.build();
             schemaRegistryChannelInitializer.ifPresent(
                     registryChannelInitializer -> builder.put(schemaRegistryManager.getAddress(),

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -502,6 +502,18 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
 
     @FieldContext(
             category = CATEGORY_KOP,
+            doc = "Start the Migration service."
+    )
+    private boolean kopMigrationEnable = false;
+
+    @FieldContext(
+            category = CATEGORY_KOP,
+            doc = "Migration service port."
+    )
+    private int kopMigrationServicePort = 8002;
+
+    @FieldContext(
+            category = CATEGORY_KOP,
             doc = "KOP server compression type. Only used for entryFormat=mixed_kafka. If it's not set to none, "
                     + "the client messages will be used compression type which configured in here.\n"
                     + "The supported compression types are: [\"none\", \"gzip\", \"snappy\", \"lz4\"]"

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/http/HttpChannelInitializer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/http/HttpChannelInitializer.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.http;
+
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpServerCodec;
+import java.util.function.Consumer;
+import lombok.AllArgsConstructor;
+
+/**
+ * A channel initializer that initialize channels for an HTTP service.
+ */
+@AllArgsConstructor
+public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
+
+    public static final int MAX_FRAME_LENGTH = 5 * 1024 * 1024; // 5MB
+
+    private final HttpHandler httpHandler;
+    private final Consumer<ChannelPipeline> pipelineCustomizer;
+
+    public HttpChannelInitializer(HttpHandler httpHandler) {
+        this.httpHandler = httpHandler;
+        this.pipelineCustomizer = null;
+    }
+
+    @Override
+    protected void initChannel(SocketChannel ch) {
+        ChannelPipeline p = ch.pipeline();
+        if (pipelineCustomizer != null) {
+            pipelineCustomizer.accept(p);
+        }
+        p.addLast(new HttpServerCodec());
+        p.addLast(new HttpObjectAggregator(MAX_FRAME_LENGTH));
+        p.addLast(httpHandler);
+    }
+
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/http/HttpHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/http/HttpHandler.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.http;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Abstract handler for HTTP requests.
+ */
+@Slf4j
+@ChannelHandler.Sharable
+public abstract class HttpHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
+    private final List<HttpRequestProcessor> processors = new ArrayList<>();
+
+    /**
+     * Add a processor to this handler.
+     * @param processor the processor to add
+     * @return this handler
+     */
+    public HttpHandler addProcessor(HttpRequestProcessor processor) {
+        this.processors.add(processor);
+        return this;
+    }
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) {
+        ctx.flush();
+    }
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest request) {
+        if (log.isDebugEnabled()) {
+            log.debug("{} at {} request {}", getName(), ctx.channel().localAddress(), request);
+        }
+        log.info("{} {} {} from {}", getName(), request.method(), request.uri(), ctx.channel().localAddress());
+
+        Optional<HttpRequestProcessor> processorOr = processors.stream().filter(p -> p.acceptRequest(request)).findAny();
+        if (!processorOr.isPresent()) {
+            FullHttpResponse notFoundResponse = getNotFoundResponse(request, ctx);
+            ctx.writeAndFlush(notFoundResponse);
+            return;
+        }
+
+        HttpRequestProcessor processor = processorOr.get();
+
+        CompletableFuture<FullHttpResponse> fullHttpResponse = processor.processRequest(request);
+        fullHttpResponse.thenAccept(resp -> {
+            if (log.isDebugEnabled()) {
+                log.debug("{} at {} request {} response {}", getName(), ctx.channel().localAddress(), request,
+                        resp);
+            }
+            log.info("{} {} {} from {} response {} {}", getName(), request.method(), request.uri(),
+                    ctx.channel().localAddress(),
+                    resp.status().code(), resp.status().reasonPhrase());
+            ctx.writeAndFlush(resp);
+        }).exceptionally(err -> {
+            FullHttpResponse resp = processor.buildJsonErrorResponse(err);
+            if (log.isDebugEnabled()) {
+                log.debug("{} at {} request {} response {}", getName(), ctx.channel().localAddress(), request,
+                        resp);
+            }
+            log.info("{} {} {} from {} response {} {}", getName(), request.method(), request.uri(),
+                    ctx.channel().localAddress(),
+                    resp.status().code(), resp.status().reasonPhrase());
+            ctx.writeAndFlush(resp);
+            return null;
+        });
+    }
+
+    protected abstract FullHttpResponse getNotFoundResponse(FullHttpRequest request,
+                                                            ChannelHandlerContext ctx);
+
+    protected abstract String getName();
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        log.error("Unhandled error, closing connection to {}", ctx.channel(), cause);
+        ctx.close();
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/http/HttpRequestProcessor.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/http/HttpRequestProcessor.java
@@ -1,0 +1,174 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.http;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.netty.handler.codec.http.HttpResponseStatus.NO_CONTENT;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.google.common.annotations.VisibleForTesting;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.CharsetUtil;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl.SchemaStorageException;
+import lombok.AllArgsConstructor;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+/**
+ * Abstract request processor for HTTP requests.
+ */
+public abstract class HttpRequestProcessor implements AutoCloseable {
+
+    protected static final ObjectMapper MAPPER = new ObjectMapper().configure(SerializationFeature.INDENT_OUTPUT, true);
+
+    /**
+     * Build a FullHttpResponse using the given parameters.
+     *
+     * @param body        the response body
+     * @param contentType the CONTENT_TYPE header
+     * @return the response built
+     */
+    public static FullHttpResponse buildStringResponse(String body, String contentType) {
+        FullHttpResponse httpResponse =
+                new DefaultFullHttpResponse(HTTP_1_1, OK, Unpooled.copiedBuffer(body, CharsetUtil.UTF_8));
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, contentType);
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, body.length());
+        addCORSHeaders(httpResponse);
+        return httpResponse;
+    }
+
+    /**
+     * Build an empty FullHttpResponse.
+     *
+     * @return the response built
+     */
+    public static FullHttpResponse buildEmptyResponseNoContentResponse() {
+        FullHttpResponse httpResponse = new DefaultFullHttpResponse(HTTP_1_1, NO_CONTENT, Unpooled.EMPTY_BUFFER);
+        httpResponse.headers().set(HttpHeaderNames.ALLOW, "GET, POST, PUT, DELETE");
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, 0);
+        addCORSHeaders(httpResponse);
+        return httpResponse;
+    }
+
+    /**
+     * Build a FullHttpResponse with an error using the given parameters.
+     *
+     * @param error       the error
+     * @param body        the response body
+     * @param contentType the CONTENT_TYPE header
+     * @return the response built
+     */
+    public static FullHttpResponse buildErrorResponse(HttpResponseStatus error, String body, String contentType) {
+        FullHttpResponse httpResponse =
+                new DefaultFullHttpResponse(HTTP_1_1, error, Unpooled.copiedBuffer(body, CharsetUtil.UTF_8));
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, contentType);
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, body.length());
+        addCORSHeaders(httpResponse);
+        return httpResponse;
+    }
+
+    abstract protected int statusCodeFromThrowable(Throwable err);
+
+    abstract protected String getErrorResponseContentType();
+
+    /**
+     * Build a FullHttpResponse from an error. The response body is a serialized ErrorModel.
+     *
+     * @param throwable the error
+     * @return the response built
+     */
+    public FullHttpResponse buildJsonErrorResponse(Throwable throwable) {
+        Throwable err = throwable;
+        while (err instanceof CompletionException) {
+            err = err.getCause();
+        }
+        int httpStatusCode = statusCodeFromThrowable(err);
+        HttpResponseStatus error = HttpResponseStatus.valueOf(httpStatusCode);
+
+        FullHttpResponse httpResponse;
+        String body;
+        String contentType;
+        try {
+            body = MAPPER.writeValueAsString(new ErrorModel(httpStatusCode, err.getMessage()));
+            contentType = getErrorResponseContentType();
+        } catch (JsonProcessingException impossible) {
+            body = "Error " + err;
+            contentType = "text/plain";
+        }
+        httpResponse = new DefaultFullHttpResponse(HTTP_1_1, error, Unpooled.copiedBuffer(body, CharsetUtil.UTF_8));
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, contentType);
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, body.length());
+        addCORSHeaders(httpResponse);
+        return httpResponse;
+    }
+
+    /**
+     * Add CORS headers to a given FullHttpResponse.
+     *
+     * @param httpResponse the FullHttpResponse
+     */
+    public static void addCORSHeaders(FullHttpResponse httpResponse) {
+        httpResponse.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS, true);
+        httpResponse.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN, "*");
+        httpResponse.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS, "PUT, POST, GET, DELETE");
+        httpResponse.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS, "content-type");
+    }
+
+    protected abstract boolean acceptRequest(FullHttpRequest request);
+
+    protected abstract CompletableFuture<FullHttpResponse> processRequest(FullHttpRequest request);
+
+    @VisibleForTesting
+    static FullHttpResponse buildJsonResponse(Object content, String contentType) {
+        try {
+            String body = MAPPER.writeValueAsString(content);
+            return buildStringResponse(body, contentType);
+        } catch (JsonProcessingException err) {
+            return buildErrorResponse(INTERNAL_SERVER_ERROR, "Internal server error - JSON Processing", "text/plain");
+        }
+    }
+
+    @Override
+    public void close() {
+        // nothing
+    }
+
+    @AllArgsConstructor
+    private static final class ErrorModel {
+        // https://docs.confluent.io/platform/current/schema-registry/develop/api.html#schemas
+
+        final int errorCode;
+        final String message;
+
+        @JsonProperty("error_code")
+        public int getErrorCode() {
+            return errorCode;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/http/package-info.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/http/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Timer related classes.
+ *
+ * <p>The classes under this package are ported from Kafka.
+ */
+package io.streamnative.pulsar.handlers.kop.http;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/migration/MigrationHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/migration/MigrationHandler.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.migration;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.util.CharsetUtil;
+import io.streamnative.pulsar.handlers.kop.http.HttpHandler;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.HttpRequestProcessor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Handler for the KoP migration service.
+ */
+@Slf4j
+@ChannelHandler.Sharable
+public class MigrationHandler extends HttpHandler {
+
+    @Override
+    protected FullHttpResponse getNotFoundResponse(FullHttpRequest request, ChannelHandlerContext ctx) {
+        String body = "{\n" + "  \"message\" : \"Not found\",\n" + "  \"error_code\" : 404\n" + "}";
+        FullHttpResponse httpResponse =
+                new DefaultFullHttpResponse(HTTP_1_1, NOT_FOUND, Unpooled.copiedBuffer(body, CharsetUtil.UTF_8));
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/vnd.schemaregistry.v1+json");
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, body.length());
+        HttpRequestProcessor.addCORSHeaders(httpResponse);
+        log.info("not found {} {} from {}", request.method(), request.uri(), ctx.channel().localAddress());
+        if (log.isDebugEnabled()) {
+            log.debug("SchemaRegistry at {} request {} response {}", ctx.channel().localAddress(), request,
+                    httpResponse);
+        }
+        return httpResponse;
+    }
+
+    @Override
+    protected String getName() {
+        return "MigrationHandler";
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        log.error("Unhandled error, closing connection to {}", ctx.channel(), cause);
+        ctx.close();
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/migration/MigrationManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/migration/MigrationManager.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.migration;
+
+import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
+import io.streamnative.pulsar.handlers.kop.SystemTopicClient;
+import io.streamnative.pulsar.handlers.kop.http.HttpChannelInitializer;
+import io.streamnative.pulsar.handlers.kop.http.HttpHandler;
+import java.net.InetSocketAddress;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+
+/**
+ * The MigrationManager class manages Kafka to KoP topic migrations.
+ */
+@Slf4j
+public class MigrationManager {
+    private final KafkaServiceConfiguration kafkaConfig;
+    private final PulsarClient pulsarClient;
+
+    /**
+     * Creates a MigrationManager.
+     * @param kafkaConfig the KafkaConfig used by the underlying PulsarClient
+     * @param pulsar the PulsarService
+     */
+    public MigrationManager(KafkaServiceConfiguration kafkaConfig,
+                            PulsarService pulsar) {
+        this.kafkaConfig = kafkaConfig;
+        this.pulsarClient = SystemTopicClient.createPulsarClient(pulsar, kafkaConfig, (___) -> {});
+    }
+
+    /**
+     * Get the address of the KoP migration service.
+     * @return the address of the KoP migration service
+     */
+    public InetSocketAddress getAddress() {
+        return new InetSocketAddress(kafkaConfig.getKopMigrationServicePort());
+    }
+
+    /**
+     * Build an HttpChannelInitializer for KoP migration service.
+     * @return the HttpChannelInitializer for KoP migration service
+     */
+    public Optional<HttpChannelInitializer> build() {
+        if (!kafkaConfig.isKopMigrationEnable()) {
+            return Optional.empty();
+        }
+        HttpHandler handler = new MigrationHandler();
+
+        return Optional.of(new HttpChannelInitializer(handler));
+    }
+
+    /**
+     * Close and clean up resource usage.
+     */
+    public void close() {
+        try {
+            pulsarClient.close();
+        } catch (PulsarClientException err) {
+            log.error("Error while shutting down", err);
+        }
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/migration/package-info.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/migration/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Timer related classes.
+ *
+ * <p>The classes under this package are ported from Kafka.
+ */
+package io.streamnative.pulsar.handlers.kop.migration;

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
@@ -88,7 +88,7 @@ public class KafkaServiceConfigurationTest {
     }
 
     @Test
-    public void testKafkaListenersWithAdvertisedListener() throws UnknownHostException {
+    public void testKafkaListenersWithAdvertisedListener() {
         KafkaServiceConfiguration configuration = new KafkaServiceConfiguration();
         configuration.setAdvertisedAddress("advertise-me");
         configuration.setKafkaListeners("PLAINTEXT://0.0.0.0:9092");
@@ -153,7 +153,7 @@ public class KafkaServiceConfigurationTest {
 
         assertNotNull(kafkaServiceConfig);
         assertEquals(kafkaServiceConfig.getMetadataStoreUrl(), "zk:" + zkServer);
-        assertEquals(kafkaServiceConfig.isBrokerDeleteInactiveTopicsEnabled(), true);
+        assertTrue(kafkaServiceConfig.isBrokerDeleteInactiveTopicsEnabled());
         assertEquals(kafkaServiceConfig.getBacklogQuotaDefaultLimitGB(), 18.0);
         assertEquals(kafkaServiceConfig.getClusterName(), "usc");
         assertEquals(kafkaServiceConfig.getBrokerClientAuthenticationParameters(), "role:my-role");
@@ -257,5 +257,15 @@ public class KafkaServiceConfigurationTest {
                         "logged", pulsarService).get(),
                 Arrays.asList("logged/one", "logged/two"));
 
+    }
+
+    @Test
+    public void testKopMigrationServiceConfiguration() {
+        int port = 8005;
+        KafkaServiceConfiguration configuration = new KafkaServiceConfiguration();
+        configuration.setKopMigrationEnable(true);
+        configuration.setKopMigrationServicePort(port);
+        assertTrue(configuration.isKopMigrationEnable());
+        assertEquals(port, configuration.getKopMigrationServicePort());
     }
 }

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/http/HttpRequestProcessorTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/http/HttpRequestProcessorTest.java
@@ -1,0 +1,120 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.http;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.NO_CONTENT;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static org.testng.Assert.assertEquals;
+
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.testng.annotations.Test;
+
+public class HttpRequestProcessorTest {
+    private static class DummyHttpRequestProcessor extends HttpRequestProcessor {
+        @Override
+        protected int statusCodeFromThrowable(Throwable err) {
+            return 404;
+        }
+
+        @Override
+        protected String getErrorResponseContentType() {
+            return "error";
+        }
+
+        @Override
+        protected boolean acceptRequest(FullHttpRequest request) {
+            return true;
+        }
+
+        @Override
+        protected CompletableFuture<FullHttpResponse> processRequest(FullHttpRequest request) {
+            return CompletableFuture.completedFuture(
+                    new DefaultFullHttpResponse(HTTP_1_1, NO_CONTENT, Unpooled.EMPTY_BUFFER));
+        }
+    }
+
+    @Test
+    public void testBuildStringResponse() {
+        String body = "body";
+        String contentType = "type";
+        FullHttpResponse response = HttpRequestProcessor.buildStringResponse(body, contentType);
+        assertEquals(response.headers().get(HttpHeaderNames.CONTENT_TYPE), contentType);
+        assertEquals(response.headers().get(HttpHeaderNames.CONTENT_LENGTH), String.valueOf(contentType.length()));
+        assertEquals(response.content().toString(StandardCharsets.UTF_8), body);
+    }
+
+    @Test
+    public void testBuildEmptyResponseNoContentResponse() {
+        FullHttpResponse response = HttpRequestProcessor.buildEmptyResponseNoContentResponse();
+        assertEquals(response.headers().get(HttpHeaderNames.CONTENT_LENGTH), "0");
+        assertEquals(response.content().array().length, 0);
+    }
+
+    @Test
+    public void testBuildErrorResponse() {
+        HttpResponseStatus error = HttpResponseStatus.BAD_REQUEST;
+        String body = "body";
+        String contentType = "type";
+        FullHttpResponse response = HttpRequestProcessor.buildErrorResponse(error, body, contentType);
+        assertEquals(response.status(), error);
+        assertEquals(response.headers().get(HttpHeaderNames.CONTENT_TYPE), contentType);
+        assertEquals(response.headers().get(HttpHeaderNames.CONTENT_LENGTH), String.valueOf(contentType.length()));
+        assertEquals(response.content().toString(StandardCharsets.UTF_8), body);
+    }
+
+    @Test
+    public void testBuildJsonErrorResponse() {
+        Throwable error = new RuntimeException("error");
+        DummyHttpRequestProcessor processor = new DummyHttpRequestProcessor();
+        FullHttpResponse response = processor.buildJsonErrorResponse(error);
+        assertEquals(response.headers().get(HttpHeaderNames.CONTENT_TYPE), "error");
+        assertEquals(response.content().toString(StandardCharsets.UTF_8), String.join("\n", """
+                {
+                  "message" : "error",
+                  "error_code" : 404
+                }"""));
+    }
+
+    @Test
+    public void testAddCORSHeaders() {
+        FullHttpResponse response = new DefaultFullHttpResponse(HTTP_1_1, NO_CONTENT, Unpooled.EMPTY_BUFFER);
+        HttpRequestProcessor.addCORSHeaders(response);
+        assertEquals(response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS), "true");
+        assertEquals(response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN), "*");
+        assertEquals(response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS), "PUT, POST, GET, DELETE");
+        assertEquals(response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS), "content-type");
+    }
+
+    @Test
+    public void testBuildJsonResponse() {
+        Pair<Integer, String> pair = new ImmutablePair<>(1, "a");
+        String contentType = "application/json";
+        FullHttpResponse response = HttpRequestProcessor.buildJsonResponse(pair, contentType);
+        assertEquals(response.content().toString(StandardCharsets.UTF_8),
+                String.join("\n", """
+                        {
+                          "1" : "a"
+                        }"""));
+        assertEquals(response.headers().get(HttpHeaderNames.CONTENT_TYPE), contentType);
+    }
+}

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/migration/MigrationManagerTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/migration/MigrationManagerTest.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.migration;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
+import java.net.InetSocketAddress;
+import java.util.Optional;
+import org.apache.pulsar.broker.PulsarService;
+import org.testng.annotations.Test;
+
+public class MigrationManagerTest {
+
+    @Test
+    public void testGetAddress() {
+        PulsarService pulsarService = mock(PulsarService.class);
+        when(pulsarService.getBrokerServiceUrl()).thenReturn("http://localhost");
+        KafkaServiceConfiguration kafkaServiceConfiguration = new KafkaServiceConfiguration();
+        int port = 8005;
+        kafkaServiceConfiguration.setKopMigrationServicePort(port);
+        MigrationManager migrationManager = new MigrationManager(kafkaServiceConfiguration, pulsarService);
+        assertEquals(migrationManager.getAddress(), new InetSocketAddress(port));
+    }
+
+    @Test
+    public void testBuild() {
+        PulsarService pulsarService = mock(PulsarService.class);
+        when(pulsarService.getBrokerServiceUrl()).thenReturn("http://localhost");
+        KafkaServiceConfiguration kafkaServiceConfiguration = new KafkaServiceConfiguration();
+        kafkaServiceConfiguration.setKopMigrationEnable(true);
+        MigrationManager migrationManager = new MigrationManager(kafkaServiceConfiguration, pulsarService);
+        assertTrue(migrationManager.build().isPresent());
+    }
+
+    @Test
+    public void testBuildReturnsEmptyWhenMigrationIsDisabled() {
+        PulsarService pulsarService = mock(PulsarService.class);
+        when(pulsarService.getBrokerServiceUrl()).thenReturn("http://localhost");
+        KafkaServiceConfiguration kafkaServiceConfiguration = new KafkaServiceConfiguration();
+        kafkaServiceConfiguration.setKopMigrationEnable(false);
+        MigrationManager migrationManager = new MigrationManager(kafkaServiceConfiguration, pulsarService);
+        assertEquals(migrationManager.build(), Optional.empty());
+    }
+}


### PR DESCRIPTION
Master Issue: #1475

### Motivation

The migration service needs a set of API for the clients to talk to.

### Modifications

This adds the HTTP request handling boilerplate for the new live migration service. Note this is largely based on the Schema Registry HTTP handling code and listens to a separate port from the main Kafka listener, and in the future we should probably refactor the Schema Registry code to using this common boilerplate.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

The migration service is WIP so no tests are written yet but we can make sure the endpoint works by visiting it.

### Documentation
  
- [x] `no-need-doc` 
  
  Doesn't need docs at this moment, will add doc after the live migration service is done.
