### PR TITLE
Bump Pulsar to 2.11.0.0-rc3 and use JDK17 for KoP

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 17
 
     - name: License check
       run: mvn -ntp -B license:check

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -589,6 +589,11 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         final Map<String, List<Integer>> topicToPartitionIndexes = new HashMap<>();
         fullTopicNames.forEach(fullTopicName -> {
             final TopicName topicName = TopicName.get(fullTopicName);
+            // Skip Pulsar's system topic
+            if (topicName.getLocalName().startsWith("__change_events")
+                    && topicName.getPartitionedTopicName().endsWith("__change_events")) {
+                return;
+            }
             topicToPartitionIndexes.computeIfAbsent(
                     topicName.getPartitionedTopicName(),
                     ignored -> new ArrayList<>()

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
@@ -152,7 +152,7 @@ public class KafkaServiceConfigurationTest {
             ConfigurationUtils.create(stream, KafkaServiceConfiguration.class);
 
         assertNotNull(kafkaServiceConfig);
-        assertEquals(kafkaServiceConfig.getMetadataStoreUrl(), zkServer);
+        assertEquals(kafkaServiceConfig.getMetadataStoreUrl(), "zk:" + zkServer);
         assertEquals(kafkaServiceConfig.isBrokerDeleteInactiveTopicsEnabled(), true);
         assertEquals(kafkaServiceConfig.getBacklogQuotaDefaultLimitGB(), 18.0);
         assertEquals(kafkaServiceConfig.getClusterName(), "usc");

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   <description>Parent for Kafka on Pulsar implemented using Pulsar Protocol Handler.</description>
 
   <properties>
-    <javac.target>1.8</javac.target>
+    <javac.target>17</javac.target>
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
     <!-- required for running tests on JDK11+ -->
     <test.additional.args>
@@ -52,7 +52,7 @@
     <lombok.version>1.18.24</lombok.version>
     <mockito.version>2.22.0</mockito.version>
     <pulsar.group.id>io.streamnative</pulsar.group.id>
-    <pulsar.version>2.10.0.1</pulsar.version>
+    <pulsar.version>2.11.0.0-rc3</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <apicurio.version>2.1.1.Final</apicurio.version>
@@ -68,7 +68,7 @@
     <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
-    <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
+    <maven-shade-plugin.version>3.4.0</maven-shade-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
     <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>
     <spotbugs-maven-plugin.version>4.2.2</spotbugs-maven-plugin.version>

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -372,10 +372,10 @@ public abstract class KopProtocolHandlerTestBase {
 
     protected void setupBrokerMocks(PulsarService pulsar) throws Exception {
         // Override default providers with mocked ones
-        doReturn(createLocalMetadataStore()).when(pulsar).createLocalMetadataStore();
+        doReturn(createLocalMetadataStore()).when(pulsar).createLocalMetadataStore(null);
         doReturn(mockBookKeeperClientFactory).when(pulsar).newBookKeeperClientFactory();
-        doReturn(new ZKMetadataStore(mockZooKeeper)).when(pulsar).createLocalMetadataStore();
-        doReturn(new ZKMetadataStore(mockZooKeeper)).when(pulsar).createConfigurationMetadataStore();
+        doReturn(new ZKMetadataStore(mockZooKeeper)).when(pulsar).createLocalMetadataStore(null);
+        doReturn(new ZKMetadataStore(mockZooKeeper)).when(pulsar).createConfigurationMetadataStore(null);
 
         Supplier<NamespaceService> namespaceServiceSupplier = () -> spy(new NamespaceService(pulsar));
         doReturn(namespaceServiceSupplier).when(pulsar).getNamespaceServiceProvider();


### PR DESCRIPTION
### Modifications

Upgrade `maven-shaded-plugin` to 3.4.0 because 3.2.4 seems not work with JDK 17.

> entry io/streamnative/kafka/client/zero/nine/Consumer009Impl.class: java.lang.IllegalArgumentException: Unsupported

Skip `__change_event` system topic when processing list topics request.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

