### PR TITLE
[Transaction] Fix concurrent modification exception when broker close

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
@@ -27,7 +27,6 @@ import io.streamnative.pulsar.handlers.kop.utils.ssl.SSLUtils;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -77,7 +76,8 @@ public class TransactionMarkerChannelManager {
 
     private final Bootstrap bootstrap;
 
-    private Map<InetSocketAddress, CompletableFuture<TransactionMarkerChannelHandler>> handlerMap = new HashMap<>();
+    private final Map<InetSocketAddress, CompletableFuture<TransactionMarkerChannelHandler>> handlerMap =
+            new ConcurrentHashMap<>();
 
     private TransactionStateManager txnStateManager;
 


### PR DESCRIPTION
### Motivation

There is some flaky test when we stop the brokers.
```
Error:  Failures: 
Error:    CacheInvalidatorTest.cleanup:111->KopProtocolHandlerTestBase.internalCleanup:319->KopProtocolHandlerTestBase.stopBroker:355->KopProtocolHandlerTestBase.stopBroker:351 » PulsarServer
Error:    TransactionWithOAuthBearerAuthTest.cleanup:72->TransactionTest.cleanup:77->KopProtocolHandlerTestBase.internalCleanup:319->KopProtocolHandlerTestBase.stopBroker:355->KopProtocolHandlerTestBase.stopBroker:351 » PulsarServer
```

The root cause is when we close the `TransactionMarkerChannelManager`, 
we will traverse all entries of `handlerMap`, 
but some of the entry already been removed, 
we can use `ConcurrentHashMap` to avoid it.

### Modifications

Use `ConcurrentHashMap` instead of `HashMap`.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

