### PR TITLE
Log name of topic when topic not found

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -522,8 +522,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                 allowed = policies.autoTopicCreationOverride.isAllowAutoTopicCreation();
                             }
                             if (!allowed) {
-                                log.error("[{}] Automatic topic creation is not allowed on namespace {}",
-                                        ctx.channel(), namespace);
+                                log.error("[{}] Topic {} doesn't exist and it's not allowed" +
+                                                "to auto create partitioned topic", ctx.channel(), topicName);
                                 future.complete(TopicAndMetadata.INVALID_PARTITIONS);
                             } else {
                                 log.info("[{}] Topic {} doesn't exist, auto create it with {} partitions",

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -522,8 +522,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                 allowed = policies.autoTopicCreationOverride.isAllowAutoTopicCreation();
                             }
                             if (!allowed) {
-                                log.error("[{}] Topic {} doesn't exist and it's not allowed" +
-                                                "to auto create partitioned topic", ctx.channel(), topicName);
+                                log.error("[{}] Topic {} doesn't exist and it's not allowed "
+                                                 + "to auto create partitioned topic", ctx.channel(), topicName);
                                 future.complete(TopicAndMetadata.INVALID_PARTITIONS);
                             } else {
                                 log.info("[{}] Topic {} doesn't exist, auto create it with {} partitions",


### PR DESCRIPTION


### Motivation
We don't get the topic name when topic failed to found
```
2-09-16 14:12:30.043 [AsyncHttpClient-62-1] ERROR io.streamnative.pulsar.handlers.kop.KafkaRequestHandler - [[id: 0xb930401b, L:/x:9093 - R:/x:46344]] Automatic topic creation is not allowed on namespace public/data-channel
```

### Modifications

Log name of topic when topic not found



### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

