### PR TITLE
[BUG#1500] Cannot submit offset correctly

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadata.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadata.java
@@ -52,7 +52,6 @@ import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.pulsar.common.schema.KeyValue;
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadata.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadata.java
@@ -51,6 +51,7 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.pulsar.common.schema.KeyValue;
 
@@ -166,11 +167,22 @@ public class GroupMetadata {
      */
     @Data
     static class CommitRecordMetadataAndOffset {
-        private final Optional<Long> appendedBatchOffset;
+        private final Optional<String> appendedBatchOffset;
         private final OffsetAndMetadata offsetAndMetadata;
 
         public boolean olderThan(CommitRecordMetadataAndOffset that) {
-            return appendedBatchOffset.get() < that.appendedBatchOffset.get();
+            String[] thisLedgerIdAndEntryId = StringUtils.split(appendedBatchOffset.get(), "-");
+            String[] thatLedgerIdAndEntryId = StringUtils.split(that.appendedBatchOffset.get(), "-");
+
+            long thisLedgerId = NumberUtils.toLong(thisLedgerIdAndEntryId[0]);
+            long thatLedgerId = NumberUtils.toLong(thatLedgerIdAndEntryId[0]);
+            if (thisLedgerId != thatLedgerId) {
+                return thisLedgerId < thatLedgerId;
+            }
+
+            long thisEntryId = NumberUtils.toLong(thisLedgerIdAndEntryId.length == 2 ? thisLedgerIdAndEntryId[1] : "0");
+            long thatEntryId = NumberUtils.toLong(thatLedgerIdAndEntryId.length == 2 ? thatLedgerIdAndEntryId[1] : "0");
+            return thisEntryId < thatEntryId;
         }
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadata.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadata.java
@@ -167,11 +167,11 @@ public class GroupMetadata {
      */
     @Data
     static class CommitRecordMetadataAndOffset {
-        private final Optional<PositionImpl> appendedBatchOffset;
+        private final Optional<PositionImpl> appendedPosition;
         private final OffsetAndMetadata offsetAndMetadata;
 
         public boolean olderThan(CommitRecordMetadataAndOffset that) {
-            return appendedBatchOffset.get().compareTo(that.appendedBatchOffset.get()) < 0;
+            return appendedPosition.get().compareTo(that.appendedPosition.get()) < 0;
         }
     }
 
@@ -432,7 +432,7 @@ public class GroupMetadata {
     public void onOffsetCommitAppend(TopicPartition topicPartition,
                                      CommitRecordMetadataAndOffset offsetWithCommitRecordMetadata) {
         if (pendingOffsetCommits.containsKey(topicPartition)) {
-            if (!offsetWithCommitRecordMetadata.appendedBatchOffset.isPresent()) {
+            if (!offsetWithCommitRecordMetadata.appendedPosition.isPresent()) {
                 throw new IllegalStateException("Cannot complete offset commit write without providing the metadata"
                     + " of the record in the log.");
             }
@@ -533,7 +533,7 @@ public class GroupMetadata {
         if (isCommit) {
             if (null != pendingOffsets) {
                 pendingOffsets.forEach((topicPartition, commitRecordMetadataAndOffset) -> {
-                    if (!commitRecordMetadataAndOffset.appendedBatchOffset.isPresent()) {
+                    if (!commitRecordMetadataAndOffset.appendedPosition.isPresent()) {
                         throw new IllegalStateException(String.format("Trying to complete a transactional offset"
                                 + " commit for producerId %s and groupId %s even though the offset commit record"
                                 + " itself hasn't been appended to the log.", producerId, groupId));

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadata.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadata.java
@@ -50,6 +50,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.kafka.common.TopicPartition;
@@ -167,22 +168,11 @@ public class GroupMetadata {
      */
     @Data
     static class CommitRecordMetadataAndOffset {
-        private final Optional<String> appendedBatchOffset;
+        private final Optional<PositionImpl> appendedBatchOffset;
         private final OffsetAndMetadata offsetAndMetadata;
 
         public boolean olderThan(CommitRecordMetadataAndOffset that) {
-            String[] thisLedgerIdAndEntryId = StringUtils.split(appendedBatchOffset.get(), "-");
-            String[] thatLedgerIdAndEntryId = StringUtils.split(that.appendedBatchOffset.get(), "-");
-
-            long thisLedgerId = NumberUtils.toLong(thisLedgerIdAndEntryId[0]);
-            long thatLedgerId = NumberUtils.toLong(thatLedgerIdAndEntryId[0]);
-            if (thisLedgerId != thatLedgerId) {
-                return thisLedgerId < thatLedgerId;
-            }
-
-            long thisEntryId = NumberUtils.toLong(thisLedgerIdAndEntryId.length == 2 ? thisLedgerIdAndEntryId[1] : "0");
-            long thatEntryId = NumberUtils.toLong(thatLedgerIdAndEntryId.length == 2 ? thatLedgerIdAndEntryId[1] : "0");
-            return thisEntryId < thatEntryId;
+            return appendedBatchOffset.get().compareTo(that.appendedBatchOffset.get()) < 0;
         }
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
@@ -63,6 +63,7 @@ import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
 import org.apache.bookkeeper.common.util.MathUtils;
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.protocol.Errors;
@@ -533,14 +534,10 @@ public class GroupMetadataManager {
             .thenApplyAsync(messageId -> {
                 if (!group.is(GroupState.Dead)) {
                     MessageIdImpl lastMessageId = (MessageIdImpl) messageId;
-                    String baseOffset = MessageMetadataUtils.getMockOffset(
-                        lastMessageId.getLedgerId(),
-                        lastMessageId.getEntryId()
-                    );
                     filteredOffsetMetadata.forEach((tp, offsetAndMetadata) -> {
                         CommitRecordMetadataAndOffset commitRecordMetadataAndOffset =
                             new CommitRecordMetadataAndOffset(
-                                Optional.of(baseOffset),
+                                Optional.of(new PositionImpl(lastMessageId.getLedgerId(), lastMessageId.getEntryId())),
                                 offsetAndMetadata
                             );
                         if (isTxnOffsetCommit) {
@@ -872,11 +869,11 @@ public class GroupMetadataManager {
                         pendingOffsets.remove(batch.producerId());
                     }
                 } else {
-                    Optional<String> batchBaseOffset = Optional.empty();
+                    Optional<PositionImpl> batchBaseOffset = Optional.empty();
                     for (Record record : batch) {
                         checkArgument(record.hasKey(), "Group metadata/offset entry key should not be null");
                         if (!batchBaseOffset.isPresent()) {
-                            batchBaseOffset = Optional.of(MessageMetadataUtils.getMockOffset(0, record.offset()));
+                            batchBaseOffset = Optional.of(new PositionImpl(0, record.offset()));
                         }
                         BaseKey bk = readMessageKey(record.key());
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
@@ -1097,7 +1097,7 @@ public class GroupMetadataManager {
                     updatedOffsetAndMetadata = offsetAndMetadata;
                 }
                 return new CommitRecordMetadataAndOffset(
-                    commitRecordMetadataAndOffset.appendedBatchOffset(),
+                    commitRecordMetadataAndOffset.appendedPosition(),
                     updatedOffsetAndMetadata
                 );
             }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
@@ -33,7 +33,6 @@ import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupMetadata.Commi
 import io.streamnative.pulsar.handlers.kop.offset.OffsetAndMetadata;
 import io.streamnative.pulsar.handlers.kop.utils.CoreUtils;
 import io.streamnative.pulsar.handlers.kop.utils.KafkaResponseUtils;
-import io.streamnative.pulsar.handlers.kop.utils.MessageMetadataUtils;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManager.java
@@ -533,7 +533,7 @@ public class GroupMetadataManager {
             .thenApplyAsync(messageId -> {
                 if (!group.is(GroupState.Dead)) {
                     MessageIdImpl lastMessageId = (MessageIdImpl) messageId;
-                    long baseOffset = MessageMetadataUtils.getMockOffset(
+                    String baseOffset = MessageMetadataUtils.getMockOffset(
                         lastMessageId.getLedgerId(),
                         lastMessageId.getEntryId()
                     );
@@ -872,11 +872,11 @@ public class GroupMetadataManager {
                         pendingOffsets.remove(batch.producerId());
                     }
                 } else {
-                    Optional<Long> batchBaseOffset = Optional.empty();
+                    Optional<String> batchBaseOffset = Optional.empty();
                     for (Record record : batch) {
                         checkArgument(record.hasKey(), "Group metadata/offset entry key should not be null");
                         if (!batchBaseOffset.isPresent()) {
-                            batchBaseOffset = Optional.of(record.offset());
+                            batchBaseOffset = Optional.of(MessageMetadataUtils.getMockOffset(0, record.offset()));
                         }
                         BaseKey bk = readMessageKey(record.key());
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MessageMetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MessageMetadataUtils.java
@@ -166,8 +166,8 @@ public class MessageMetadataUtils {
         }
     }
 
-    public static long getMockOffset(long ledgerId, long entryId) {
-        return ledgerId + entryId;
+    public static String getMockOffset(long ledgerId, long entryId) {
+        return Long.toString(ledgerId) + "-" + Long.toString(entryId);
     }
 
     public static CompletableFuture<Position> asyncFindPosition(final ManagedLedger managedLedger,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MessageMetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MessageMetadataUtils.java
@@ -166,10 +166,6 @@ public class MessageMetadataUtils {
         }
     }
 
-    public static String getMockOffset(long ledgerId, long entryId) {
-        return Long.toString(ledgerId) + "-" + Long.toString(entryId);
-    }
-
     public static CompletableFuture<Position> asyncFindPosition(final ManagedLedger managedLedger,
                                                                 final long offset,
                                                                 final boolean skipMessagesWithoutIndex) {

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataTest.java
@@ -34,8 +34,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
-import io.streamnative.pulsar.handlers.kop.utils.MessageMetadataUtils;
 import lombok.val;
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.kafka.common.TopicPartition;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -399,7 +399,7 @@ public class GroupMetadataTest {
 
         group.onOffsetCommitAppend(
             partition,
-            new CommitRecordMetadataAndOffset(Optional.of(MessageMetadataUtils.getMockOffset(0, commitRecordOffset)), OffsetAndMetadata.apply(37)));
+            new CommitRecordMetadataAndOffset(Optional.of(new PositionImpl(1000, commitRecordOffset)), OffsetAndMetadata.apply(37)));
         assertEquals(group.numPendingOffsetCommits(), 0);
         assertEquals(group.numOffsets(), 1);
         assertEquals(Optional.of(offset), group.offset(partition, NAMESPACE_PREFIX));
@@ -442,7 +442,7 @@ public class GroupMetadataTest {
         assertTrue(group.hasOffsets());
         assertEquals(Optional.empty(), group.offset(partition, NAMESPACE_PREFIX));
 
-        group.onOffsetCommitAppend(partition, new CommitRecordMetadataAndOffset(Optional.of(MessageMetadataUtils.getMockOffset(0, 3L)), secondOffset));
+        group.onOffsetCommitAppend(partition, new CommitRecordMetadataAndOffset(Optional.of(new PositionImpl(1000, 3L)), secondOffset));
         assertTrue(group.hasOffsets());
         assertEquals(Optional.of(secondOffset), group.offset(partition, NAMESPACE_PREFIX));
     }
@@ -464,11 +464,11 @@ public class GroupMetadataTest {
         group.prepareOffsetCommit(offsets);
         assertTrue(group.hasOffsets());
 
-        group.onOffsetCommitAppend(partition, new CommitRecordMetadataAndOffset(Optional.of(MessageMetadataUtils.getMockOffset(0, 4L)), firstOffset));
+        group.onOffsetCommitAppend(partition, new CommitRecordMetadataAndOffset(Optional.of(new PositionImpl(1000, 4L)), firstOffset));
         assertTrue(group.hasOffsets());
         assertEquals(Optional.of(firstOffset), group.offset(partition, NAMESPACE_PREFIX));
 
-        group.onOffsetCommitAppend(partition, new CommitRecordMetadataAndOffset(Optional.of(MessageMetadataUtils.getMockOffset(0, 5L)), secondOffset));
+        group.onOffsetCommitAppend(partition, new CommitRecordMetadataAndOffset(Optional.of(new PositionImpl(1000, 5L)), secondOffset));
         assertTrue(group.hasOffsets());
         assertEquals(Optional.of(secondOffset), group.offset(partition, NAMESPACE_PREFIX));
     }
@@ -492,9 +492,9 @@ public class GroupMetadataTest {
         assertTrue(group.hasOffsets());
 
         group.onTxnOffsetCommitAppend(producerId, partition,
-            new CommitRecordMetadataAndOffset(Optional.of(MessageMetadataUtils.getMockOffset(0, 3L)), OffsetAndMetadata.apply(37)));
+            new CommitRecordMetadataAndOffset(Optional.of(new PositionImpl(1000, 3L)), OffsetAndMetadata.apply(37)));
         group.onOffsetCommitAppend(partition,
-            new CommitRecordMetadataAndOffset(Optional.of(MessageMetadataUtils.getMockOffset(0, 4L)), consumerOffsetCommit));
+            new CommitRecordMetadataAndOffset(Optional.of(new PositionImpl(1000, 4L)), consumerOffsetCommit));
         assertTrue(group.hasOffsets());
         assertEquals(Optional.of(consumerOffsetCommit), group.offset(partition, NAMESPACE_PREFIX));
 
@@ -526,9 +526,9 @@ public class GroupMetadataTest {
         assertTrue(group.hasOffsets());
 
         group.onOffsetCommitAppend(
-            partition, new CommitRecordMetadataAndOffset(Optional.of(MessageMetadataUtils.getMockOffset(0, 3L)), consumerOffsetCommit));
+            partition, new CommitRecordMetadataAndOffset(Optional.of(new PositionImpl(1000, 3L)), consumerOffsetCommit));
         group.onTxnOffsetCommitAppend(producerId, partition,
-            new CommitRecordMetadataAndOffset(Optional.of(MessageMetadataUtils.getMockOffset(0, 4L)), txnOffsetCommit));
+            new CommitRecordMetadataAndOffset(Optional.of(new PositionImpl(1000, 4L)), txnOffsetCommit));
         assertTrue(group.hasOffsets());
         // The transactional offset commit hasn't been committed yet, so we should materialize
         // the consumer offset commit.
@@ -560,9 +560,9 @@ public class GroupMetadataTest {
         assertTrue(group.hasOffsets());
 
         group.onOffsetCommitAppend(partition,
-            new CommitRecordMetadataAndOffset(Optional.of(MessageMetadataUtils.getMockOffset(0, 3L)), consumerOffsetCommit));
+            new CommitRecordMetadataAndOffset(Optional.of(new PositionImpl(1000, 3L)), consumerOffsetCommit));
         group.onTxnOffsetCommitAppend(producerId, partition,
-            new CommitRecordMetadataAndOffset(Optional.of(MessageMetadataUtils.getMockOffset(0, 4L)), txnOffsetCommit));
+            new CommitRecordMetadataAndOffset(Optional.of(new PositionImpl(1000, 4L)), txnOffsetCommit));
         assertTrue(group.hasOffsets());
         // The transactional offset commit hasn't been committed yet, so we should materialize the consumer
         // offset commit.

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataTest.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
+import io.streamnative.pulsar.handlers.kop.utils.MessageMetadataUtils;
 import lombok.val;
 import org.apache.kafka.common.TopicPartition;
 import org.testng.annotations.BeforeMethod;
@@ -398,7 +399,7 @@ public class GroupMetadataTest {
 
         group.onOffsetCommitAppend(
             partition,
-            new CommitRecordMetadataAndOffset(Optional.of(commitRecordOffset), OffsetAndMetadata.apply(37)));
+            new CommitRecordMetadataAndOffset(Optional.of(MessageMetadataUtils.getMockOffset(0, commitRecordOffset)), OffsetAndMetadata.apply(37)));
         assertEquals(group.numPendingOffsetCommits(), 0);
         assertEquals(group.numOffsets(), 1);
         assertEquals(Optional.of(offset), group.offset(partition, NAMESPACE_PREFIX));
@@ -441,7 +442,7 @@ public class GroupMetadataTest {
         assertTrue(group.hasOffsets());
         assertEquals(Optional.empty(), group.offset(partition, NAMESPACE_PREFIX));
 
-        group.onOffsetCommitAppend(partition, new CommitRecordMetadataAndOffset(Optional.of(3L), secondOffset));
+        group.onOffsetCommitAppend(partition, new CommitRecordMetadataAndOffset(Optional.of(MessageMetadataUtils.getMockOffset(0, 3L)), secondOffset));
         assertTrue(group.hasOffsets());
         assertEquals(Optional.of(secondOffset), group.offset(partition, NAMESPACE_PREFIX));
     }
@@ -463,11 +464,11 @@ public class GroupMetadataTest {
         group.prepareOffsetCommit(offsets);
         assertTrue(group.hasOffsets());
 
-        group.onOffsetCommitAppend(partition, new CommitRecordMetadataAndOffset(Optional.of(4L), firstOffset));
+        group.onOffsetCommitAppend(partition, new CommitRecordMetadataAndOffset(Optional.of(MessageMetadataUtils.getMockOffset(0, 4L)), firstOffset));
         assertTrue(group.hasOffsets());
         assertEquals(Optional.of(firstOffset), group.offset(partition, NAMESPACE_PREFIX));
 
-        group.onOffsetCommitAppend(partition, new CommitRecordMetadataAndOffset(Optional.of(5L), secondOffset));
+        group.onOffsetCommitAppend(partition, new CommitRecordMetadataAndOffset(Optional.of(MessageMetadataUtils.getMockOffset(0, 5L)), secondOffset));
         assertTrue(group.hasOffsets());
         assertEquals(Optional.of(secondOffset), group.offset(partition, NAMESPACE_PREFIX));
     }
@@ -491,9 +492,9 @@ public class GroupMetadataTest {
         assertTrue(group.hasOffsets());
 
         group.onTxnOffsetCommitAppend(producerId, partition,
-            new CommitRecordMetadataAndOffset(Optional.of(3L), OffsetAndMetadata.apply(37)));
+            new CommitRecordMetadataAndOffset(Optional.of(MessageMetadataUtils.getMockOffset(0, 3L)), OffsetAndMetadata.apply(37)));
         group.onOffsetCommitAppend(partition,
-            new CommitRecordMetadataAndOffset(Optional.of(4L), consumerOffsetCommit));
+            new CommitRecordMetadataAndOffset(Optional.of(MessageMetadataUtils.getMockOffset(0, 4L)), consumerOffsetCommit));
         assertTrue(group.hasOffsets());
         assertEquals(Optional.of(consumerOffsetCommit), group.offset(partition, NAMESPACE_PREFIX));
 
@@ -525,9 +526,9 @@ public class GroupMetadataTest {
         assertTrue(group.hasOffsets());
 
         group.onOffsetCommitAppend(
-            partition, new CommitRecordMetadataAndOffset(Optional.of(3L), consumerOffsetCommit));
+            partition, new CommitRecordMetadataAndOffset(Optional.of(MessageMetadataUtils.getMockOffset(0, 3L)), consumerOffsetCommit));
         group.onTxnOffsetCommitAppend(producerId, partition,
-            new CommitRecordMetadataAndOffset(Optional.of(4L), txnOffsetCommit));
+            new CommitRecordMetadataAndOffset(Optional.of(MessageMetadataUtils.getMockOffset(0, 4L)), txnOffsetCommit));
         assertTrue(group.hasOffsets());
         // The transactional offset commit hasn't been committed yet, so we should materialize
         // the consumer offset commit.
@@ -559,9 +560,9 @@ public class GroupMetadataTest {
         assertTrue(group.hasOffsets());
 
         group.onOffsetCommitAppend(partition,
-            new CommitRecordMetadataAndOffset(Optional.of(3L), consumerOffsetCommit));
+            new CommitRecordMetadataAndOffset(Optional.of(MessageMetadataUtils.getMockOffset(0, 3L)), consumerOffsetCommit));
         group.onTxnOffsetCommitAppend(producerId, partition,
-            new CommitRecordMetadataAndOffset(Optional.of(4L), txnOffsetCommit));
+            new CommitRecordMetadataAndOffset(Optional.of(MessageMetadataUtils.getMockOffset(0, 4L)), txnOffsetCommit));
         assertTrue(group.hasOffsets());
         // The transactional offset commit hasn't been committed yet, so we should materialize the consumer
         // offset commit.

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataTest.java
@@ -399,7 +399,8 @@ public class GroupMetadataTest {
 
         group.onOffsetCommitAppend(
             partition,
-            new CommitRecordMetadataAndOffset(Optional.of(new PositionImpl(1000, commitRecordOffset)), OffsetAndMetadata.apply(37)));
+            new CommitRecordMetadataAndOffset(Optional.of(new PositionImpl(1000, commitRecordOffset)),
+                    OffsetAndMetadata.apply(37)));
         assertEquals(group.numPendingOffsetCommits(), 0);
         assertEquals(group.numOffsets(), 1);
         assertEquals(Optional.of(offset), group.offset(partition, NAMESPACE_PREFIX));
@@ -442,7 +443,8 @@ public class GroupMetadataTest {
         assertTrue(group.hasOffsets());
         assertEquals(Optional.empty(), group.offset(partition, NAMESPACE_PREFIX));
 
-        group.onOffsetCommitAppend(partition, new CommitRecordMetadataAndOffset(Optional.of(new PositionImpl(1000, 3L)), secondOffset));
+        group.onOffsetCommitAppend(partition,
+                new CommitRecordMetadataAndOffset(Optional.of(new PositionImpl(1000, 3L)), secondOffset));
         assertTrue(group.hasOffsets());
         assertEquals(Optional.of(secondOffset), group.offset(partition, NAMESPACE_PREFIX));
     }
@@ -464,11 +466,13 @@ public class GroupMetadataTest {
         group.prepareOffsetCommit(offsets);
         assertTrue(group.hasOffsets());
 
-        group.onOffsetCommitAppend(partition, new CommitRecordMetadataAndOffset(Optional.of(new PositionImpl(1000, 4L)), firstOffset));
+        group.onOffsetCommitAppend(partition,
+                new CommitRecordMetadataAndOffset(Optional.of(new PositionImpl(1000, 4L)), firstOffset));
         assertTrue(group.hasOffsets());
         assertEquals(Optional.of(firstOffset), group.offset(partition, NAMESPACE_PREFIX));
 
-        group.onOffsetCommitAppend(partition, new CommitRecordMetadataAndOffset(Optional.of(new PositionImpl(1000, 5L)), secondOffset));
+        group.onOffsetCommitAppend(partition,
+                new CommitRecordMetadataAndOffset(Optional.of(new PositionImpl(1000, 5L)), secondOffset));
         assertTrue(group.hasOffsets());
         assertEquals(Optional.of(secondOffset), group.offset(partition, NAMESPACE_PREFIX));
     }
@@ -492,7 +496,8 @@ public class GroupMetadataTest {
         assertTrue(group.hasOffsets());
 
         group.onTxnOffsetCommitAppend(producerId, partition,
-            new CommitRecordMetadataAndOffset(Optional.of(new PositionImpl(1000, 3L)), OffsetAndMetadata.apply(37)));
+            new CommitRecordMetadataAndOffset(Optional.of(new PositionImpl(1000, 3L)),
+                    OffsetAndMetadata.apply(37)));
         group.onOffsetCommitAppend(partition,
             new CommitRecordMetadataAndOffset(Optional.of(new PositionImpl(1000, 4L)), consumerOffsetCommit));
         assertTrue(group.hasOffsets());
@@ -526,7 +531,8 @@ public class GroupMetadataTest {
         assertTrue(group.hasOffsets());
 
         group.onOffsetCommitAppend(
-            partition, new CommitRecordMetadataAndOffset(Optional.of(new PositionImpl(1000, 3L)), consumerOffsetCommit));
+            partition, new CommitRecordMetadataAndOffset(Optional.of(new PositionImpl(1000, 3L)),
+                        consumerOffsetCommit));
         group.onTxnOffsetCommitAppend(producerId, partition,
             new CommitRecordMetadataAndOffset(Optional.of(new PositionImpl(1000, 4L)), txnOffsetCommit));
         assertTrue(group.hasOffsets());

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
@@ -44,7 +44,6 @@ import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupMetadataManage
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupMetadataManager.OffsetKey;
 import io.streamnative.pulsar.handlers.kop.offset.OffsetAndMetadata;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
-import io.streamnative.pulsar.handlers.kop.utils.MessageMetadataUtils;
 import io.streamnative.pulsar.handlers.kop.utils.timer.MockTime;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -62,6 +61,7 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.util.MathUtils;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.AbstractRecords;
@@ -806,13 +806,13 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         committedOffsetsFirstProducer.forEach((tp, offset) -> {
             assertEquals(Optional.of(offset), group.offset(tp, NAMESPACE_PREFIX).map(OffsetAndMetadata::offset));
             assertEquals(
-                Optional.of(MessageMetadataUtils.getMockOffset(0, firstProduceRecordOffset)),
+                Optional.of(new PositionImpl(1000, firstProduceRecordOffset)),
                 group.offsetWithRecordMetadata(tp).flatMap(CommitRecordMetadataAndOffset::appendedBatchOffset));
         });
         committedOffsetsSecondProducer.forEach((tp, offset) -> {
             assertEquals(Optional.of(offset), group.offset(tp, NAMESPACE_PREFIX).map(OffsetAndMetadata::offset));
             assertEquals(
-                Optional.of(MessageMetadataUtils.getMockOffset(0, secondProduceRecordOffset)),
+                Optional.of(new PositionImpl(1000, secondProduceRecordOffset)),
                 group.offsetWithRecordMetadata(tp).flatMap(CommitRecordMetadataAndOffset::appendedBatchOffset));
         });
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
@@ -44,6 +44,7 @@ import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupMetadataManage
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupMetadataManager.OffsetKey;
 import io.streamnative.pulsar.handlers.kop.offset.OffsetAndMetadata;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
+import io.streamnative.pulsar.handlers.kop.utils.MessageMetadataUtils;
 import io.streamnative.pulsar.handlers.kop.utils.timer.MockTime;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -805,13 +806,13 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         committedOffsetsFirstProducer.forEach((tp, offset) -> {
             assertEquals(Optional.of(offset), group.offset(tp, NAMESPACE_PREFIX).map(OffsetAndMetadata::offset));
             assertEquals(
-                Optional.of((long) firstProduceRecordOffset),
+                Optional.of(MessageMetadataUtils.getMockOffset(0, firstProduceRecordOffset)),
                 group.offsetWithRecordMetadata(tp).flatMap(CommitRecordMetadataAndOffset::appendedBatchOffset));
         });
         committedOffsetsSecondProducer.forEach((tp, offset) -> {
             assertEquals(Optional.of(offset), group.offset(tp, NAMESPACE_PREFIX).map(OffsetAndMetadata::offset));
             assertEquals(
-                Optional.of((long) secondProduceRecordOffset),
+                Optional.of(MessageMetadataUtils.getMockOffset(0, secondProduceRecordOffset)),
                 group.offsetWithRecordMetadata(tp).flatMap(CommitRecordMetadataAndOffset::appendedBatchOffset));
         });
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
@@ -807,13 +807,13 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
             assertEquals(Optional.of(offset), group.offset(tp, NAMESPACE_PREFIX).map(OffsetAndMetadata::offset));
             assertEquals(
                 Optional.of(new PositionImpl(0, firstProduceRecordOffset)),
-                group.offsetWithRecordMetadata(tp).flatMap(CommitRecordMetadataAndOffset::appendedBatchOffset));
+                group.offsetWithRecordMetadata(tp).flatMap(CommitRecordMetadataAndOffset::appendedPosition));
         });
         committedOffsetsSecondProducer.forEach((tp, offset) -> {
             assertEquals(Optional.of(offset), group.offset(tp, NAMESPACE_PREFIX).map(OffsetAndMetadata::offset));
             assertEquals(
                 Optional.of(new PositionImpl(0, secondProduceRecordOffset)),
-                group.offsetWithRecordMetadata(tp).flatMap(CommitRecordMetadataAndOffset::appendedBatchOffset));
+                group.offsetWithRecordMetadata(tp).flatMap(CommitRecordMetadataAndOffset::appendedPosition));
         });
 
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
@@ -806,13 +806,13 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         committedOffsetsFirstProducer.forEach((tp, offset) -> {
             assertEquals(Optional.of(offset), group.offset(tp, NAMESPACE_PREFIX).map(OffsetAndMetadata::offset));
             assertEquals(
-                Optional.of(new PositionImpl(1000, firstProduceRecordOffset)),
+                Optional.of(new PositionImpl(0, firstProduceRecordOffset)),
                 group.offsetWithRecordMetadata(tp).flatMap(CommitRecordMetadataAndOffset::appendedBatchOffset));
         });
         committedOffsetsSecondProducer.forEach((tp, offset) -> {
             assertEquals(Optional.of(offset), group.offset(tp, NAMESPACE_PREFIX).map(OffsetAndMetadata::offset));
             assertEquals(
-                Optional.of(new PositionImpl(1000, secondProduceRecordOffset)),
+                Optional.of(new PositionImpl(0, secondProduceRecordOffset)),
                 group.offsetWithRecordMetadata(tp).flatMap(CommitRecordMetadataAndOffset::appendedBatchOffset));
         });
 


### PR DESCRIPTION

Fixes #1500 


### Motivation

The baseOffset is not monotonically increasing, consumer cannot submit offset correctly.

### Modifications

When the offset is submitted, the increasing judgment mode of baseOffset is changed


### Verifying this change

This change is already covered by existing tests.

1.passed GroupMetadataManagerTest
2.passed GroupMetadataTest


