### PR TITLE
Add migration handler and various code style fixes

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AbstractPulsarClient.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AbstractPulsarClient.java
@@ -59,7 +59,14 @@ public abstract class AbstractPulsarClient implements Closeable {
         }
     }
 
-    protected static PulsarClientImpl createPulsarClient(final PulsarService pulsarService,
+    /**
+     * Create a Pulsar client.
+     * @param pulsarService the PulsarService for the client
+     * @param kafkaConfig the Kafka config object
+     * @param customConfig a custom Consumer for setting values in kafkaConfig
+     * @return the created Pulsar client
+     */
+    public static PulsarClientImpl createPulsarClient(final PulsarService pulsarService,
                                                          final KafkaServiceConfiguration kafkaConfig,
                                                          final Consumer<ClientConfigurationData> customConfig) {
         // It's migrated from PulsarService#getClient()

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -18,7 +18,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration.TENANT_ALLNAMESPACES_PLACEHOLDER;
 import static io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration.TENANT_PLACEHOLDER;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.kafka.common.protocol.CommonFields.THROTTLE_TIME_MS;
 import static org.apache.kafka.common.requests.CreateTopicsRequest.TopicDetails;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -1551,10 +1550,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             log.debug("[{}] Request {} Fetch request. Size: {}. Each item: ",
                 ctx.channel(), fetch.getHeader(), request.fetchData().size());
 
-            request.fetchData().forEach((topic, data) -> {
-                log.debug("  Fetch request topic:{} data:{}.",
-                    topic, data.toString());
-            });
+            request.fetchData().forEach((topic, data) -> log.debug("  Fetch request topic:{} data:{}.",
+                topic, data.toString()));
         }
         TransactionCoordinator transactionCoordinator = null;
         if (request.isolationLevel().equals(IsolationLevel.READ_COMMITTED)
@@ -1577,7 +1574,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
 
         Map<String, byte[]> protocols = new HashMap<>();
         request.groupProtocols()
-            .stream()
             .forEach(protocol -> protocols.put(protocol.name(), Utils.toArray(protocol.metadata())));
         getGroupCoordinator().handleJoinGroup(
             request.groupId(),
@@ -1669,9 +1665,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         getGroupCoordinator().handleLeaveGroup(
             request.groupId(),
             request.memberId()
-        ).thenAccept(errors -> {
-            resultFuture.complete(KafkaResponseUtils.newLeaveGroup(errors));
-        });
+        ).thenAccept(errors -> resultFuture.complete(KafkaResponseUtils.newLeaveGroup(errors)));
     }
 
     @Override
@@ -1816,9 +1810,9 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
 
         Map<ConfigResource, ApiError> results = new HashMap<>();
         request.configs().forEach((ConfigResource configResource, AlterConfigsRequest.Config newConfig) -> {
-            newConfig.entries().forEach(entry -> {
-                log.info("Ignoring ALTER_CONFIG for {} {} = {}", configResource, entry.name(), entry.value());
-            });
+            newConfig.entries().forEach(
+                    entry -> log.info("Ignoring ALTER_CONFIG for {} {} = {}", configResource, entry.name(),
+                            entry.value()));
             results.put(configResource, ApiError.NONE);
         });
         resultFuture.complete(new AlterConfigsResponse(0, results));
@@ -1917,11 +1911,10 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         InitProducerIdRequest request = (InitProducerIdRequest) kafkaHeaderAndRequest.getRequest();
         TransactionCoordinator transactionCoordinator = getTransactionCoordinator();
         transactionCoordinator.handleInitProducerId(
-                request.transactionalId(), request.transactionTimeoutMs(), Optional.empty(), (resp) -> {
-                    response.complete(
-                            new InitProducerIdResponse(0, resp.getError(), resp.getProducerId(),
-                                    resp.getProducerEpoch()));
-                });
+                request.transactionalId(), request.transactionTimeoutMs(), Optional.empty(),
+                (resp) -> response.complete(
+                        new InitProducerIdResponse(0, resp.getError(), resp.getProducerId(),
+                                resp.getProducerEpoch())));
     }
 
     @Override
@@ -2039,7 +2032,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                     StringBuffer traceInfo = new StringBuffer();
                     replacingIndex.forEach((inner, outer) ->
                             traceInfo.append(String.format("\tinnerName:%s, outerName:%s%n", inner, outer)));
-                    log.trace("TXN_OFFSET_COMMIT TopicPartition relations: \n{}", traceInfo.toString());
+                    log.trace("TXN_OFFSET_COMMIT TopicPartition relations: \n{}", traceInfo);
                 }
 
                 getGroupCoordinator().handleTxnCommitOffsets(
@@ -2164,9 +2157,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 if (ex != null) {
                     log.error("[{}] Append txn marker ({}) failed.", ctx.channel(), marker, ex);
                     Map<TopicPartition, Errors> currentErrors = new HashMap<>();
-                    controlRecords.forEach(((topicPartition, partitionResponse) -> {
-                        currentErrors.put(topicPartition, Errors.KAFKA_STORAGE_ERROR);
-                    }));
+                    controlRecords.forEach(((topicPartition, partitionResponse) -> currentErrors.put(topicPartition,
+                            Errors.KAFKA_STORAGE_ERROR)));
                     updateErrors.accept(producerId, currentErrors);
                     completeOne.run();
                     return;
@@ -2323,16 +2315,13 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                             return;
                         }
                         topicManager
-                            .getTopicConsumerManager(fullTopicName)
-                                .thenAccept(topicManager -> {
-                                    topicManager.findPositionForIndex(offset)
-                                            .thenAccept(position -> {
-                                                adminManager.truncateTopic(fullTopicName, offset, position,
+                                .getTopicConsumerManager(fullTopicName)
+                                .thenAccept(topicManager -> topicManager.findPositionForIndex(offset)
+                                        .thenAccept(
+                                                position -> adminManager.truncateTopic(fullTopicName, offset, position,
                                                         __ -> completeOne.accept(topicPartition, Errors.NONE),
                                                         __ -> completeOne.accept(topicPartition,
-                                                                Errors.UNKNOWN_TOPIC_OR_PARTITION));
-                                            });
-                                });
+                                                                Errors.UNKNOWN_TOPIC_OR_PARTITION))));
 
                     });
         });
@@ -2475,13 +2464,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         // most of this error happens when topic is in loading/unloading status,
         return KafkaResponseUtils.newMetadataPartition(
                 Errors.NOT_LEADER_FOR_PARTITION, kafkaPartitionIndex);
-    }
-
-    static AbstractResponse failedResponse(KafkaHeaderAndRequest requestHar, Throwable e) {
-        if (log.isDebugEnabled()) {
-            log.debug("Request {} get failed response ", requestHar.getHeader().apiKey(), e);
-        }
-        return requestHar.getRequest().getErrorResponse(((Integer) THROTTLE_TIME_MS.defaultValue), e);
     }
 
     private void throwIfTransactionCoordinatorDisabled() {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -502,6 +502,18 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
 
     @FieldContext(
             category = CATEGORY_KOP,
+            doc = "Start the Migration service."
+    )
+    private boolean kopMigrationEnable = false;
+
+    @FieldContext(
+            category = CATEGORY_KOP,
+            doc = "Migration service port."
+    )
+    private int kopMigrationServicePort = 8002;
+
+    @FieldContext(
+            category = CATEGORY_KOP,
             doc = "KOP server compression type. Only used for entryFormat=mixed_kafka. If it's not set to none, "
                     + "the client messages will be used compression type which configured in here.\n"
                     + "The supported compression types are: [\"none\", \"gzip\", \"snappy\", \"lz4\"]"

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/http/HttpChannelInitializer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/http/HttpChannelInitializer.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.http;
+
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpServerCodec;
+import java.util.function.Consumer;
+import lombok.AllArgsConstructor;
+
+/**
+ * A channel initializer that initialize channels for an HTTP service.
+ */
+@AllArgsConstructor
+public class HttpChannelInitializer extends ChannelInitializer<SocketChannel> {
+
+    public static final int MAX_FRAME_LENGTH = 5 * 1024 * 1024; // 5MB
+
+    private final HttpHandler httpHandler;
+    private final Consumer<ChannelPipeline> pipelineCustomizer;
+
+    public HttpChannelInitializer(HttpHandler httpHandler) {
+        this.httpHandler = httpHandler;
+        this.pipelineCustomizer = null;
+    }
+
+    @Override
+    protected void initChannel(SocketChannel ch) {
+        ChannelPipeline p = ch.pipeline();
+        if (pipelineCustomizer != null) {
+            pipelineCustomizer.accept(p);
+        }
+        p.addLast(new HttpServerCodec());
+        p.addLast(new HttpObjectAggregator(MAX_FRAME_LENGTH));
+        p.addLast(httpHandler);
+    }
+
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/http/HttpHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/http/HttpHandler.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.http;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Abstract handler for HTTP requests.
+ */
+@Slf4j
+@ChannelHandler.Sharable
+public abstract class HttpHandler extends SimpleChannelInboundHandler<FullHttpRequest> {
+    private final List<HttpRequestProcessor> processors = new ArrayList<>();
+
+    /**
+     * Add a processor to this handler.
+     * @param processor the processor to add
+     * @return this handler
+     */
+    public HttpHandler addProcessor(HttpRequestProcessor processor) {
+        this.processors.add(processor);
+        return this;
+    }
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) {
+        ctx.flush();
+    }
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest request) {
+        if (log.isDebugEnabled()) {
+            log.debug("{} at {} request {}", getName(), ctx.channel().localAddress(), request);
+        }
+        log.info("{} {} {} from {}", getName(), request.method(), request.uri(), ctx.channel().localAddress());
+
+        Optional<HttpRequestProcessor> processorOr =
+                processors.stream().filter(p -> p.acceptRequest(request)).findAny();
+        if (!processorOr.isPresent()) {
+            FullHttpResponse notFoundResponse = getNotFoundResponse(request, ctx);
+            ctx.writeAndFlush(notFoundResponse);
+            return;
+        }
+
+        HttpRequestProcessor processor = processorOr.get();
+
+        CompletableFuture<FullHttpResponse> fullHttpResponse = processor.processRequest(request);
+        fullHttpResponse.thenAccept(resp -> {
+            if (log.isDebugEnabled()) {
+                log.debug("{} at {} request {} response {}", getName(), ctx.channel().localAddress(), request,
+                        resp);
+            }
+            log.info("{} {} {} from {} response {} {}", getName(), request.method(), request.uri(),
+                    ctx.channel().localAddress(),
+                    resp.status().code(), resp.status().reasonPhrase());
+            ctx.writeAndFlush(resp);
+        }).exceptionally(err -> {
+            FullHttpResponse resp = processor.buildJsonErrorResponse(err);
+            if (log.isDebugEnabled()) {
+                log.debug("{} at {} request {} response {}", getName(), ctx.channel().localAddress(), request,
+                        resp);
+            }
+            log.info("{} {} {} from {} response {} {}", getName(), request.method(), request.uri(),
+                    ctx.channel().localAddress(),
+                    resp.status().code(), resp.status().reasonPhrase());
+            ctx.writeAndFlush(resp);
+            return null;
+        });
+    }
+
+    protected abstract FullHttpResponse getNotFoundResponse(FullHttpRequest request,
+                                                            ChannelHandlerContext ctx);
+
+    protected abstract String getName();
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        log.error("Unhandled error, closing connection to {}", ctx.channel(), cause);
+        ctx.close();
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/http/HttpRequestProcessor.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/http/HttpRequestProcessor.java
@@ -1,0 +1,172 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.http;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.netty.handler.codec.http.HttpResponseStatus.NO_CONTENT;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.google.common.annotations.VisibleForTesting;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.CharsetUtil;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import lombok.AllArgsConstructor;
+
+/**
+ * Abstract request processor for HTTP requests.
+ */
+public abstract class HttpRequestProcessor implements AutoCloseable {
+
+    protected static final ObjectMapper MAPPER = new ObjectMapper().configure(SerializationFeature.INDENT_OUTPUT, true);
+
+    /**
+     * Build a FullHttpResponse using the given parameters.
+     *
+     * @param body        the response body
+     * @param contentType the CONTENT_TYPE header
+     * @return the response built
+     */
+    public static FullHttpResponse buildStringResponse(String body, String contentType) {
+        FullHttpResponse httpResponse =
+                new DefaultFullHttpResponse(HTTP_1_1, OK, Unpooled.copiedBuffer(body, CharsetUtil.UTF_8));
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, contentType);
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, body.length());
+        addCORSHeaders(httpResponse);
+        return httpResponse;
+    }
+
+    /**
+     * Build an empty FullHttpResponse.
+     *
+     * @return the response built
+     */
+    public static FullHttpResponse buildEmptyResponseNoContentResponse() {
+        FullHttpResponse httpResponse = new DefaultFullHttpResponse(HTTP_1_1, NO_CONTENT, Unpooled.EMPTY_BUFFER);
+        httpResponse.headers().set(HttpHeaderNames.ALLOW, "GET, POST, PUT, DELETE");
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, 0);
+        addCORSHeaders(httpResponse);
+        return httpResponse;
+    }
+
+    /**
+     * Build a FullHttpResponse with an error using the given parameters.
+     *
+     * @param error       the error
+     * @param body        the response body
+     * @param contentType the CONTENT_TYPE header
+     * @return the response built
+     */
+    public static FullHttpResponse buildErrorResponse(HttpResponseStatus error, String body, String contentType) {
+        FullHttpResponse httpResponse =
+                new DefaultFullHttpResponse(HTTP_1_1, error, Unpooled.copiedBuffer(body, CharsetUtil.UTF_8));
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, contentType);
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, body.length());
+        addCORSHeaders(httpResponse);
+        return httpResponse;
+    }
+
+    protected abstract int statusCodeFromThrowable(Throwable err);
+
+    protected abstract String getErrorResponseContentType();
+
+    /**
+     * Build a FullHttpResponse from an error. The response body is a serialized ErrorModel.
+     *
+     * @param throwable the error
+     * @return the response built
+     */
+    public FullHttpResponse buildJsonErrorResponse(Throwable throwable) {
+        Throwable err = throwable;
+        while (err instanceof CompletionException) {
+            err = err.getCause();
+        }
+        int httpStatusCode = statusCodeFromThrowable(err);
+        HttpResponseStatus error = HttpResponseStatus.valueOf(httpStatusCode);
+
+        FullHttpResponse httpResponse;
+        String body;
+        String contentType;
+        try {
+            body = MAPPER.writeValueAsString(new ErrorModel(httpStatusCode, err.getMessage()));
+            contentType = getErrorResponseContentType();
+        } catch (JsonProcessingException impossible) {
+            body = "Error " + err;
+            contentType = "text/plain";
+        }
+        httpResponse = new DefaultFullHttpResponse(HTTP_1_1, error, Unpooled.copiedBuffer(body, CharsetUtil.UTF_8));
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, contentType);
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, body.length());
+        addCORSHeaders(httpResponse);
+        return httpResponse;
+    }
+
+    /**
+     * Add CORS headers to a given FullHttpResponse.
+     *
+     * @param httpResponse the FullHttpResponse
+     */
+    public static void addCORSHeaders(FullHttpResponse httpResponse) {
+        httpResponse.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS, true);
+        httpResponse.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN, "*");
+        httpResponse.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS, "PUT, POST, GET, DELETE");
+        httpResponse.headers().set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS, "content-type");
+    }
+
+    protected abstract boolean acceptRequest(FullHttpRequest request);
+
+    protected abstract CompletableFuture<FullHttpResponse> processRequest(FullHttpRequest request);
+
+    @VisibleForTesting
+    static FullHttpResponse buildJsonResponse(Object content, String contentType) {
+        try {
+            String body = MAPPER.writeValueAsString(content);
+            return buildStringResponse(body, contentType);
+        } catch (JsonProcessingException err) {
+            return buildErrorResponse(INTERNAL_SERVER_ERROR, "Internal server error - JSON Processing", "text/plain");
+        }
+    }
+
+    @Override
+    public void close() {
+        // nothing
+    }
+
+    @AllArgsConstructor
+    private static final class ErrorModel {
+        // https://docs.confluent.io/platform/current/schema-registry/develop/api.html#schemas
+
+        final int errorCode;
+        final String message;
+
+        @JsonProperty("error_code")
+        public int getErrorCode() {
+            return errorCode;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/http/package-info.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/http/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Timer related classes.
+ *
+ * <p>The classes under this package are ported from Kafka.
+ */
+package io.streamnative.pulsar.handlers.kop.http;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/migration/MigrationHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/migration/MigrationHandler.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.migration;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.util.CharsetUtil;
+import io.streamnative.pulsar.handlers.kop.http.HttpHandler;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.HttpRequestProcessor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Handler for the KoP migration service.
+ */
+@Slf4j
+@ChannelHandler.Sharable
+public class MigrationHandler extends HttpHandler {
+
+    @Override
+    protected FullHttpResponse getNotFoundResponse(FullHttpRequest request, ChannelHandlerContext ctx) {
+        String body = "{\n" + "  \"message\" : \"Not found\",\n" + "  \"error_code\" : 404\n" + "}";
+        FullHttpResponse httpResponse =
+                new DefaultFullHttpResponse(HTTP_1_1, NOT_FOUND, Unpooled.copiedBuffer(body, CharsetUtil.UTF_8));
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/vnd.schemaregistry.v1+json");
+        httpResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, body.length());
+        HttpRequestProcessor.addCORSHeaders(httpResponse);
+        log.info("not found {} {} from {}", request.method(), request.uri(), ctx.channel().localAddress());
+        if (log.isDebugEnabled()) {
+            log.debug("SchemaRegistry at {} request {} response {}", ctx.channel().localAddress(), request,
+                    httpResponse);
+        }
+        return httpResponse;
+    }
+
+    @Override
+    protected String getName() {
+        return "MigrationHandler";
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        log.error("Unhandled error, closing connection to {}", ctx.channel(), cause);
+        ctx.close();
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/migration/MigrationManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/migration/MigrationManager.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.migration;
+
+import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
+import io.streamnative.pulsar.handlers.kop.SystemTopicClient;
+import io.streamnative.pulsar.handlers.kop.http.HttpChannelInitializer;
+import io.streamnative.pulsar.handlers.kop.http.HttpHandler;
+import java.net.InetSocketAddress;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+
+/**
+ * The MigrationManager class manages Kafka to KoP topic migrations.
+ */
+@Slf4j
+public class MigrationManager {
+    private final KafkaServiceConfiguration kafkaConfig;
+    private final PulsarClient pulsarClient;
+
+    /**
+     * Creates a MigrationManager.
+     * @param kafkaConfig the KafkaConfig used by the underlying PulsarClient
+     * @param pulsar the PulsarService
+     */
+    public MigrationManager(KafkaServiceConfiguration kafkaConfig,
+                            PulsarService pulsar) {
+        this.kafkaConfig = kafkaConfig;
+        this.pulsarClient = SystemTopicClient.createPulsarClient(pulsar, kafkaConfig, (___) -> {});
+    }
+
+    /**
+     * Get the address of the KoP migration service.
+     * @return the address of the KoP migration service
+     */
+    public InetSocketAddress getAddress() {
+        return new InetSocketAddress(kafkaConfig.getKopMigrationServicePort());
+    }
+
+    /**
+     * Build an HttpChannelInitializer for KoP migration service.
+     * @return the HttpChannelInitializer for KoP migration service
+     */
+    public Optional<HttpChannelInitializer> build() {
+        if (!kafkaConfig.isKopMigrationEnable()) {
+            return Optional.empty();
+        }
+        HttpHandler handler = new MigrationHandler();
+
+        return Optional.of(new HttpChannelInitializer(handler));
+    }
+
+    /**
+     * Close and clean up resource usage.
+     */
+    public void close() {
+        try {
+            pulsarClient.close();
+        } catch (PulsarClientException err) {
+            log.error("Error while shutting down", err);
+        }
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/migration/package-info.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/migration/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Timer related classes.
+ *
+ * <p>The classes under this package are ported from Kafka.
+ */
+package io.streamnative.pulsar.handlers.kop.migration;

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
@@ -88,7 +88,7 @@ public class KafkaServiceConfigurationTest {
     }
 
     @Test
-    public void testKafkaListenersWithAdvertisedListener() throws UnknownHostException {
+    public void testKafkaListenersWithAdvertisedListener() {
         KafkaServiceConfiguration configuration = new KafkaServiceConfiguration();
         configuration.setAdvertisedAddress("advertise-me");
         configuration.setKafkaListeners("PLAINTEXT://0.0.0.0:9092");
@@ -153,7 +153,7 @@ public class KafkaServiceConfigurationTest {
 
         assertNotNull(kafkaServiceConfig);
         assertEquals(kafkaServiceConfig.getMetadataStoreUrl(), "zk:" + zkServer);
-        assertEquals(kafkaServiceConfig.isBrokerDeleteInactiveTopicsEnabled(), true);
+        assertTrue(kafkaServiceConfig.isBrokerDeleteInactiveTopicsEnabled());
         assertEquals(kafkaServiceConfig.getBacklogQuotaDefaultLimitGB(), 18.0);
         assertEquals(kafkaServiceConfig.getClusterName(), "usc");
         assertEquals(kafkaServiceConfig.getBrokerClientAuthenticationParameters(), "role:my-role");
@@ -257,5 +257,15 @@ public class KafkaServiceConfigurationTest {
                         "logged", pulsarService).get(),
                 Arrays.asList("logged/one", "logged/two"));
 
+    }
+
+    @Test
+    public void testKopMigrationServiceConfiguration() {
+        int port = 8005;
+        KafkaServiceConfiguration configuration = new KafkaServiceConfiguration();
+        configuration.setKopMigrationEnable(true);
+        configuration.setKopMigrationServicePort(port);
+        assertTrue(configuration.isKopMigrationEnable());
+        assertEquals(port, configuration.getKopMigrationServicePort());
     }
 }

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/http/HttpRequestProcessorTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/http/HttpRequestProcessorTest.java
@@ -1,0 +1,120 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.http;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.NO_CONTENT;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static org.testng.Assert.assertEquals;
+
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.testng.annotations.Test;
+
+public class HttpRequestProcessorTest {
+    private static class DummyHttpRequestProcessor extends HttpRequestProcessor {
+        @Override
+        protected int statusCodeFromThrowable(Throwable err) {
+            return 404;
+        }
+
+        @Override
+        protected String getErrorResponseContentType() {
+            return "error";
+        }
+
+        @Override
+        protected boolean acceptRequest(FullHttpRequest request) {
+            return true;
+        }
+
+        @Override
+        protected CompletableFuture<FullHttpResponse> processRequest(FullHttpRequest request) {
+            return CompletableFuture.completedFuture(
+                    new DefaultFullHttpResponse(HTTP_1_1, NO_CONTENT, Unpooled.EMPTY_BUFFER));
+        }
+    }
+
+    @Test
+    public void testBuildStringResponse() {
+        String body = "body";
+        String contentType = "type";
+        FullHttpResponse response = HttpRequestProcessor.buildStringResponse(body, contentType);
+        assertEquals(response.headers().get(HttpHeaderNames.CONTENT_TYPE), contentType);
+        assertEquals(response.headers().get(HttpHeaderNames.CONTENT_LENGTH), String.valueOf(contentType.length()));
+        assertEquals(response.content().toString(StandardCharsets.UTF_8), body);
+    }
+
+    @Test
+    public void testBuildEmptyResponseNoContentResponse() {
+        FullHttpResponse response = HttpRequestProcessor.buildEmptyResponseNoContentResponse();
+        assertEquals(response.headers().get(HttpHeaderNames.CONTENT_LENGTH), "0");
+        assertEquals(response.content().array().length, 0);
+    }
+
+    @Test
+    public void testBuildErrorResponse() {
+        HttpResponseStatus error = HttpResponseStatus.BAD_REQUEST;
+        String body = "body";
+        String contentType = "type";
+        FullHttpResponse response = HttpRequestProcessor.buildErrorResponse(error, body, contentType);
+        assertEquals(response.status(), error);
+        assertEquals(response.headers().get(HttpHeaderNames.CONTENT_TYPE), contentType);
+        assertEquals(response.headers().get(HttpHeaderNames.CONTENT_LENGTH), String.valueOf(contentType.length()));
+        assertEquals(response.content().toString(StandardCharsets.UTF_8), body);
+    }
+
+    @Test
+    public void testBuildJsonErrorResponse() {
+        Throwable error = new RuntimeException("error");
+        DummyHttpRequestProcessor processor = new DummyHttpRequestProcessor();
+        FullHttpResponse response = processor.buildJsonErrorResponse(error);
+        assertEquals(response.headers().get(HttpHeaderNames.CONTENT_TYPE), "error");
+        assertEquals(response.content().toString(StandardCharsets.UTF_8), String.join("\n", """
+                {
+                  "message" : "error",
+                  "error_code" : 404
+                }"""));
+    }
+
+    @Test
+    public void testAddCORSHeaders() {
+        FullHttpResponse response = new DefaultFullHttpResponse(HTTP_1_1, NO_CONTENT, Unpooled.EMPTY_BUFFER);
+        HttpRequestProcessor.addCORSHeaders(response);
+        assertEquals(response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS), "true");
+        assertEquals(response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN), "*");
+        assertEquals(response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS), "PUT, POST, GET, DELETE");
+        assertEquals(response.headers().get(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS), "content-type");
+    }
+
+    @Test
+    public void testBuildJsonResponse() {
+        Pair<Integer, String> pair = new ImmutablePair<>(1, "a");
+        String contentType = "application/json";
+        FullHttpResponse response = HttpRequestProcessor.buildJsonResponse(pair, contentType);
+        assertEquals(response.content().toString(StandardCharsets.UTF_8),
+                String.join("\n", """
+                        {
+                          "1" : "a"
+                        }"""));
+        assertEquals(response.headers().get(HttpHeaderNames.CONTENT_TYPE), contentType);
+    }
+}

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/migration/MigrationManagerTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/migration/MigrationManagerTest.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.migration;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
+import java.net.InetSocketAddress;
+import java.util.Optional;
+import org.apache.pulsar.broker.PulsarService;
+import org.testng.annotations.Test;
+
+public class MigrationManagerTest {
+
+    @Test
+    public void testGetAddress() {
+        PulsarService pulsarService = mock(PulsarService.class);
+        when(pulsarService.getBrokerServiceUrl()).thenReturn("http://localhost");
+        KafkaServiceConfiguration kafkaServiceConfiguration = new KafkaServiceConfiguration();
+        int port = 8005;
+        kafkaServiceConfiguration.setKopMigrationServicePort(port);
+        MigrationManager migrationManager = new MigrationManager(kafkaServiceConfiguration, pulsarService);
+        assertEquals(migrationManager.getAddress(), new InetSocketAddress(port));
+    }
+
+    @Test
+    public void testBuild() {
+        PulsarService pulsarService = mock(PulsarService.class);
+        when(pulsarService.getBrokerServiceUrl()).thenReturn("http://localhost");
+        KafkaServiceConfiguration kafkaServiceConfiguration = new KafkaServiceConfiguration();
+        kafkaServiceConfiguration.setKopMigrationEnable(true);
+        MigrationManager migrationManager = new MigrationManager(kafkaServiceConfiguration, pulsarService);
+        assertTrue(migrationManager.build().isPresent());
+    }
+
+    @Test
+    public void testBuildReturnsEmptyWhenMigrationIsDisabled() {
+        PulsarService pulsarService = mock(PulsarService.class);
+        when(pulsarService.getBrokerServiceUrl()).thenReturn("http://localhost");
+        KafkaServiceConfiguration kafkaServiceConfiguration = new KafkaServiceConfiguration();
+        kafkaServiceConfiguration.setKopMigrationEnable(false);
+        MigrationManager migrationManager = new MigrationManager(kafkaServiceConfiguration, pulsarService);
+        assertEquals(migrationManager.build(), Optional.empty());
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -42,7 +42,6 @@ import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -198,7 +197,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
 
 
     @Test
-    public void testResponseToByteBuf() throws Exception {
+    public void testResponseToByteBuf() {
         int correlationId = 7777;
         String clientId = "KopClientId";
 
@@ -220,7 +219,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
             kopRequest, apiVersionsResponse);
 
         // 1. serialize response into ByteBuf
-        ByteBuf serializedResponse = handler.responseToByteBuf(kopResponse.getResponse(), kopRequest);
+        ByteBuf serializedResponse = KafkaCommandDecoder.responseToByteBuf(kopResponse.getResponse(), kopRequest);
 
         // 2. verify responseToByteBuf works well.
         ByteBuffer byteBuffer = serializedResponse.nioBuffer();
@@ -302,7 +301,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
             throws ExecutionException, InterruptedException {
         Map<TopicPartition, RecordsToDelete> toDelete = new HashMap<>();
         topicToNumPartitions.forEach((topic, numPartitions) -> {
-             try (KConsumer consumer = new KConsumer(topic, getKafkaBrokerPort());) {
+             try (KConsumer consumer = new KConsumer(topic, getKafkaBrokerPort())) {
                     Collection<TopicPartition> topicPartitions = new ArrayList<>();
                     for (int i = 0; i < numPartitions; i++) {
                         topicPartitions.add(new TopicPartition(topic, i));
@@ -352,7 +351,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
 
         @Cleanup
         AdminClient kafkaAdmin = AdminClient.create(props);
-        Map<String, Integer> topicToNumPartitions = new HashMap<String, Integer>(){{
+        Map<String, Integer> topicToNumPartitions = new HashMap<>() {{
             put("testCreateTopics-0", 1);
             put("testCreateTopics-1", 3);
             put("my-tenant/my-ns/testCreateTopics-2", 1);
@@ -373,7 +372,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
 
         @Cleanup
         AdminClient kafkaAdmin = AdminClient.create(props);
-        Map<String, Integer> topicToNumPartitions = new HashMap<String, Integer>(){{
+        Map<String, Integer> topicToNumPartitions = new HashMap<>() {{
             put("testDeleteRecords-0", 1);
             put("testDeleteRecords-1", 3);
             put("my-tenant/my-ns/testDeleteRecords-2", 1);
@@ -500,7 +499,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
             assertTrue(e.getCause() instanceof UnknownTopicOrPartitionException);
         }
 
-        final Map<String, Integer> expectedTopicPartitions = new HashMap<String, Integer>() {{
+        final Map<String, Integer> expectedTopicPartitions = new HashMap<>() {{
             put("testDescribeTopics-topic-1", 1);
             put("testDescribeTopics-topic-2", 3);
         }};
@@ -617,7 +616,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
     }
 
     @Test(timeOut = 10000)
-    public void testConvertOffsetCommitRetentionMsIfSetDefaultValue() throws Exception {
+    public void testConvertOffsetCommitRetentionMsIfSetDefaultValue() {
 
         String memberId = "test_member_id";
         int generationId = 0;
@@ -651,7 +650,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
     }
 
     @Test(timeOut = 10000)
-    public void testConvertOffsetCommitRetentionMsIfRetentionMsSet() throws Exception {
+    public void testConvertOffsetCommitRetentionMsIfRetentionMsSet() {
 
         long currentTime = 100;
         int offsetsConfigRetentionMs = 1000;
@@ -774,7 +773,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
 
         @Cleanup
         AdminClient kafkaAdmin = AdminClient.create(props);
-        Map<String, Integer> topicToNumPartitions = new HashMap<String, Integer>(){{
+        Map<String, Integer> topicToNumPartitions = new HashMap<>() {{
             put("testCreateTopics-0", 1);
             put("testCreateTopics-1", 3);
             put("my-tenant/my-ns/testCreateTopics-2", 1);
@@ -824,9 +823,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
         assertEquals(1, replacedMap.size());
 
         // 5. after replace, replacedMap has a short topic name
-        replacedMap.forEach(((topicPartition, s) -> {
-            assertEquals(tp0, topicPartition);
-        }));
+        replacedMap.forEach(((topicPartition, s) -> assertEquals(tp0, topicPartition)));
     }
 
     @Test
@@ -854,9 +851,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
         assertEquals(1, replacedMap.size());
 
         // 5. after replace, replacedMap has a short topic name
-        replacedMap.forEach(((topicPartition, s) -> {
-            assertEquals(tp0, topicPartition);
-        }));
+        replacedMap.forEach(((topicPartition, s) -> assertEquals(tp0, topicPartition)));
     }
 
     @Test(timeOut = 20000)
@@ -898,20 +893,15 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
         assertEquals(1, groupDescription.members().size());
 
         // member assignment topic name must be short topic name
-        groupDescription.members().forEach(memberDescription -> {
-            memberDescription.assignment().topicPartitions().forEach(topicPartition -> {
-                assertEquals(topic, topicPartition.topic());
-            });
-        });
+        groupDescription.members().forEach(memberDescription -> memberDescription.assignment().topicPartitions()
+                .forEach(topicPartition -> assertEquals(topic, topicPartition.topic())));
 
         Map<TopicPartition, org.apache.kafka.clients.consumer.OffsetAndMetadata> offsetAndMetadataMap =
                 kafkaAdmin.listConsumerGroupOffsets(group).partitionsToOffsetAndMetadata().get();
         assertEquals(1, offsetAndMetadataMap.size());
 
         //  topic name from offset fetch response must be short topic name
-        offsetAndMetadataMap.keySet().forEach(topicPartition -> {
-            assertEquals(topic, topicPartition.topic());
-        });
+        offsetAndMetadataMap.keySet().forEach(topicPartition -> assertEquals(topic, topicPartition.topic()));
 
         consumer.close();
         kafkaAdmin.close();
@@ -1165,7 +1155,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
             String topicName = "kopBrokerHandleTopicMetadataRequest-" + brokerAllowAutoTopicCreation + "-"
                     + overrideNameSpaceAutoTopicCreation + "-"
                     + allowAutoTopicCreationInRequest;
-            List<String> kafkaTopics = Arrays.asList(topicName);
+            List<String> kafkaTopics = Collections.singletonList(topicName);
             KafkaHeaderAndRequest metadataRequest =
                     createTopicMetadataRequest(kafkaTopics, allowAutoTopicCreationInRequest);
             CompletableFuture<AbstractResponse> responseFuture = new CompletableFuture<>();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerWithAuthorizationTest.java
@@ -261,9 +261,7 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
         String localName = TopicName.get(topic).getLocalName();
 
         HashMap<String, MetadataResponse.TopicMetadata> topicMap = new HashMap<>();
-        response.topicMetadata().forEach(metadata -> {
-            topicMap.put(metadata.topic(), metadata);
-        });
+        response.topicMetadata().forEach(metadata -> topicMap.put(metadata.topic(), metadata));
         assertTrue(topicMap.containsKey(localName));
         assertEquals(topicMap.get(localName).partitionMetadata().size(), DEFAULT_PARTITION_NUM);
         assertNull(response.errors().get(localName));
@@ -401,9 +399,8 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
         OffsetFetchResponse offsetFetchResponse = (OffsetFetchResponse) response;
         assertEquals(offsetFetchResponse.responseData().size(), 1);
         assertEquals(offsetFetchResponse.error(), Errors.NONE);
-        offsetFetchResponse.responseData().forEach((topicPartition, partitionData) -> {
-            assertEquals(partitionData.error, Errors.NONE);
-        });
+        offsetFetchResponse.responseData()
+                .forEach((topicPartition, partitionData) -> assertEquals(partitionData.error, Errors.NONE));
     }
 
     @Test(timeOut = 20000)
@@ -432,9 +429,8 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
         OffsetFetchResponse offsetFetchResponse = (OffsetFetchResponse) response;
         assertEquals(offsetFetchResponse.responseData().size(), 1);
         assertEquals(offsetFetchResponse.error(), Errors.NONE);
-        offsetFetchResponse.responseData().forEach((topicPartition, partitionData) -> {
-            assertEquals(partitionData.error, Errors.TOPIC_AUTHORIZATION_FAILED);
-        });
+        offsetFetchResponse.responseData().forEach((topicPartition, partitionData) -> assertEquals(partitionData.error,
+                Errors.TOPIC_AUTHORIZATION_FAILED));
     }
 
     @Test(timeOut = 20000)
@@ -459,9 +455,8 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
         OffsetCommitResponse offsetCommitResponse = (OffsetCommitResponse) response;
         assertEquals(offsetCommitResponse.responseData().size(), 1);
         assertFalse(offsetCommitResponse.errorCounts().isEmpty());
-        offsetCommitResponse.responseData().forEach((__, error) -> {
-            assertEquals(error, Errors.TOPIC_AUTHORIZATION_FAILED);
-        });
+        offsetCommitResponse.responseData()
+                .forEach((__, error) -> assertEquals(error, Errors.TOPIC_AUTHORIZATION_FAILED));
     }
 
     @Test(timeOut = 20000)
@@ -527,9 +522,8 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
         TxnOffsetCommitResponse txnOffsetCommitResponse = (TxnOffsetCommitResponse) response;
 
         assertEquals(txnOffsetCommitResponse.errorCounts().size(), 1);
-        txnOffsetCommitResponse.errors().values().forEach(errors -> {
-            assertEquals(errors, Errors.TOPIC_AUTHORIZATION_FAILED);
-        });
+        txnOffsetCommitResponse.errors().values()
+                .forEach(errors -> assertEquals(errors, Errors.TOPIC_AUTHORIZATION_FAILED));
     }
 
     @Test(timeOut = 20000)
@@ -626,9 +620,8 @@ public class KafkaRequestHandlerWithAuthorizationTest extends KopProtocolHandler
         AddPartitionsToTxnResponse addPartitionsToTxnResponse = (AddPartitionsToTxnResponse) response;
 
         assertEquals(addPartitionsToTxnResponse.errorCounts().size(), 1);
-        addPartitionsToTxnResponse.errors().values().forEach(errors -> {
-            assertEquals(errors, Errors.TOPIC_AUTHORIZATION_FAILED);
-        });
+        addPartitionsToTxnResponse.errors().values()
+                .forEach(errors -> assertEquals(errors, Errors.TOPIC_AUTHORIZATION_FAILED));
     }
 
     @Test(timeOut = 20000)


### PR DESCRIPTION
Master Issue: #1475 

### Motivation

The migration service needs a set of API for the clients to talk to.

Also, there are a lot of code style warnings for these files in IntelliJ which makes it harder to find real issues.

### Modifications

This adds the HTTP request handling boilerplate for the new live migration service. Note this is largely based on the Schema Registry HTTP handling code and listens to a separate port from the main Kafka listener, and in the future we should probably refactor the Schema Registry code to using this common boilerplate. Also contains some IntelliJ auto code style fixes.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

Check the box below.

Need to update docs? 
  
- [x] `no-need-doc` 
  
  Doesn't need docs at this moment, will add doc after the live migration service is done.