### PR TITLE
Fix list offsets response wrong result

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -1125,23 +1125,15 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                     partitionData.complete(Pair.of(Errors.UNKNOWN_SERVER_ERROR, -1L));
                     return;
                 }
-
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] Get earliest position for topic {}: {}, lac: {}",
                             ctx, perTopic.getName(), position, lac);
                 }
-                final long latestOffset = MessageMetadataUtils.getCurrentOffset(managedLedger);
-                if (latestOffset < 0) {
-                    log.warn("[{}] Unexpected latest offset {} (< 0) for topic {}",
-                            ctx, latestOffset, perTopic.getName());
-                    partitionData.complete(Pair.of(Errors.NONE, 0L));
-                    return;
-                }
                 if (position.compareTo(lac) > 0) {
-                    partitionData.complete(Pair.of(Errors.NONE, latestOffset));
+                    partitionData.complete(Pair.of(Errors.NONE, 0L));
                 } else {
                     MessageMetadataUtils.getOffsetOfPosition(managedLedger, position, false,
-                            timestamp, skipMessagesWithoutIndex)
+                                    timestamp, skipMessagesWithoutIndex)
                             .whenComplete((offset, throwable) -> {
                                 if (throwable != null) {
                                     log.error("[{}] Failed to get offset for position {}",
@@ -1149,10 +1141,13 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                     partitionData.complete(Pair.of(Errors.UNKNOWN_SERVER_ERROR, null));
                                     return;
                                 }
+                                if (log.isDebugEnabled()) {
+                                    log.debug("[{}] Get offset of position for topic {}: {}, lac: {}, offset: {}",
+                                            ctx, perTopic.getName(), position, lac, offset);
+                                }
                                 partitionData.complete(Pair.of(Errors.NONE, offset));
-                    });
+                            });
                 }
-
             } else {
                 fetchOffsetByTimestamp(partitionData, managedLedger, lac, timestamp, perTopic.getName());
             }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaMessageOrderTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaMessageOrderTestBase.java
@@ -164,7 +164,10 @@ public abstract class KafkaMessageOrderTestBase extends KopProtocolHandlerTestBa
             kConsumer.getConsumer().subscribe(Collections.singleton(topicName));
             int[] receivedKeys = new int[totalMsgs];
             for (int i = 0; i < totalMsgs; ) {
-                ConsumerRecords<Integer, String> records = kConsumer.getConsumer().poll(Duration.ofSeconds(1));
+                ConsumerRecords<Integer, String> records = kConsumer.getConsumer().poll(Duration.ofSeconds(5));
+                if (records.isEmpty()) {
+                    break;
+                }
                 for (ConsumerRecord<Integer, String> record : records) {
                     if (log.isDebugEnabled()) {
                         log.debug("Kafka consumer get i: {} offset: {}, message: {}, key: {}",


### PR DESCRIPTION
Fixes #1444 #1168

### Motivation

Currently, the list offset operation might return the wrong offset.
Because when `position > lac`, we will try to get the latest offset from `AppendIndexMetadataInterceptor`,
However, if we have a producer produce messages to the current `ManagedLedger`,
the latest offset might be wrong since the `AppendIndexMetadataInterceptor#index` is increased before the ledger persistence.

When this case happens, we might lose the first few pieces of messages, since the Kafka client will reset offset in the beginning.

### Modifications

Make the `position > lac` condition return offset 0.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

