### PR TITLE
Add MigrationMetadataManager

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
@@ -56,10 +56,10 @@ import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 
 @Slf4j
-class AdminManager {
+public class AdminManager {
 
     private final DelayedOperationPurgatory<DelayedOperation> topicPurgatory =
-            DelayedOperationPurgatory.<DelayedOperation>builder()
+            DelayedOperationPurgatory.builder()
                     .purgatoryName("topic")
                     .timeoutTimer(SystemTimer.builder().executorName("topic").build())
                     .build();
@@ -83,9 +83,9 @@ class AdminManager {
         topicPurgatory.shutdown();
     }
 
-    CompletableFuture<Map<String, ApiError>> createTopicsAsync(Map<String, TopicDetails> createInfo,
-                                                               int timeoutMs,
-                                                               String namespacePrefix) {
+    public CompletableFuture<Map<String, ApiError>> createTopicsAsync(Map<String, TopicDetails> createInfo,
+                                                                      int timeoutMs,
+                                                                      String namespacePrefix) {
         final Map<String, CompletableFuture<ApiError>> futureMap = new ConcurrentHashMap<>();
         final AtomicInteger numTopics = new AtomicInteger(createInfo.size());
         final CompletableFuture<Map<String, ApiError>> resultFuture = new CompletableFuture<>();
@@ -245,11 +245,10 @@ class AdminManager {
     }
 
     private DescribeConfigsResponse.ConfigEntry buildDummyEntryConfig(String configName, String configValue) {
-        DescribeConfigsResponse.ConfigEntry configEntry = new DescribeConfigsResponse.ConfigEntry(
+        return new DescribeConfigsResponse.ConfigEntry(
                 configName, configValue,
                 DescribeConfigsResponse.ConfigSource.DEFAULT_CONFIG, true, true,
                 Collections.emptyList());
-        return configEntry;
     }
 
     public void deleteTopic(String topicToDelete,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicLookupService.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicLookupService.java
@@ -32,7 +32,7 @@ import org.apache.pulsar.common.naming.TopicName;
 public class KafkaTopicLookupService {
     private final BrokerService brokerService;
 
-    KafkaTopicLookupService(BrokerService brokerService) {
+    public KafkaTopicLookupService(BrokerService brokerService) {
         this.brokerService = brokerService;
      }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/migration/metadata/ManagedLedgerPropertiesMigrationMetadataManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/migration/metadata/ManagedLedgerPropertiesMigrationMetadataManager.java
@@ -28,7 +28,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
-import java.util.concurrent.Future;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/migration/metadata/ManagedLedgerPropertiesMigrationMetadataManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/migration/metadata/ManagedLedgerPropertiesMigrationMetadataManager.java
@@ -1,0 +1,262 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.migration.metadata;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import io.netty.channel.Channel;
+import io.streamnative.pulsar.handlers.kop.AdminManager;
+import io.streamnative.pulsar.handlers.kop.KafkaTopicLookupService;
+import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.Future;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.requests.ApiError;
+import org.apache.kafka.common.requests.CreateTopicsRequest;
+import org.apache.kafka.common.serialization.ByteBufferDeserializer;
+import org.apache.kafka.common.serialization.ByteBufferSerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+
+/**
+ * A MigrationMetadata Manager that uses Managed Ledger properties for metadata storage.
+ */
+@Slf4j
+public class ManagedLedgerPropertiesMigrationMetadataManager implements MigrationMetadataManager {
+    @VisibleForTesting
+    static final String KAFKA_CLUSTER_ADDRESS = "migrationKafkaClusterAddress";
+    @VisibleForTesting
+    static final String TOPIC_MIGRATION_STATUS = "migrationTopicMigrationStatus";
+
+    @VisibleForTesting
+    final Map<String, Integer> numOutstandingRequests = new ConcurrentHashMap<>();
+    @VisibleForTesting
+    final Map<String, KafkaProducer<String, ByteBuffer>> kafkaProducers = new ConcurrentHashMap<>();
+    @VisibleForTesting
+    final Map<String, KafkaConsumer<String, ByteBuffer>> kafkaConsumers = new ConcurrentHashMap<>();
+    @VisibleForTesting
+    final Map<String, AdminClient> adminClients = new ConcurrentHashMap<>();
+
+    // Cache topics that are not configured with migration so save lookup costs
+    private final Set<String> nonMigratoryTopics = new ConcurrentSkipListSet<>();
+
+    private final AdminManager adminManager;
+    private final KafkaTopicLookupService topicLookupService;
+
+    public ManagedLedgerPropertiesMigrationMetadataManager(KafkaTopicLookupService topicLookupService,
+                                                           AdminManager adminManager) {
+        this.adminManager = adminManager;
+        this.topicLookupService = topicLookupService;
+    }
+
+    @Override
+    public KafkaProducer<String, ByteBuffer> getKafkaProducerForTopic(String topic, String namespacePrefix,
+                                                                      String kafkaClusterAddress) {
+        String fullTopicName = new KopTopic(topic, namespacePrefix).getFullName();
+        return kafkaProducers.computeIfAbsent(fullTopicName, key -> {
+            Properties props = new Properties();
+            props.put("bootstrap.servers", kafkaClusterAddress);
+            props.put("key.serializer", StringSerializer.class);
+            props.put("value.serializer", ByteBufferSerializer.class);
+            return new KafkaProducer<>(props);
+        });
+    }
+
+    @Override
+    public KafkaConsumer<String, ByteBuffer> getKafkaConsumerForTopic(String topic, String namespacePrefix,
+                                                                      String kafkaClusterAddress) {
+        String fullTopicName = new KopTopic(topic, namespacePrefix).getFullName();
+        return kafkaConsumers.computeIfAbsent(fullTopicName, key -> {
+            Properties props = new Properties();
+            props.put("bootstrap.servers", kafkaClusterAddress);
+            props.put("key.deserializer", StringDeserializer.class);
+            props.put("value.deserializer", ByteBufferDeserializer.class);
+            return new KafkaConsumer<>(props);
+        });
+    }
+
+    @Override
+    public AdminClient getAdminClientForKafka(String kafkaClusterAddress) {
+        return adminClients.computeIfAbsent(kafkaClusterAddress, key -> {
+            Properties props = new Properties();
+            props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaClusterAddress);
+            return AdminClient.create(props);
+        });
+    }
+
+    private CompletableFuture<Map<String, String>> getManagedLedgerProperties(String topic, String namespacePrefix,
+                                                                              Channel channel) {
+        String fullPartitionName = KopTopic.toString(topic, 0, namespacePrefix);
+        return topicLookupService.getTopic(fullPartitionName, channel).thenApply(persistentTopic -> {
+            if (!persistentTopic.isPresent()) {
+                throw new IllegalArgumentException("Cannot get topic " + fullPartitionName);
+            }
+            return persistentTopic.get().getManagedLedger().getProperties();
+        });
+    }
+
+    @Override
+    public CompletableFuture<MigrationMetadata> getMigrationMetadata(String topic, String namespacePrefix,
+                                                                     Channel channel) {
+        if (nonMigratoryTopics.contains(topic)) {
+            return null;
+        }
+        return getManagedLedgerProperties(topic, namespacePrefix, channel).thenApply(properties -> {
+            String status = properties.get(TOPIC_MIGRATION_STATUS);
+            if (status == null) {
+                nonMigratoryTopics.add(topic);
+                return null;
+            }
+
+            String kafkaClusterAddress = properties.get(KAFKA_CLUSTER_ADDRESS);
+            if (kafkaClusterAddress == null) {
+                log.error("Topic {} migration misconfigured", topic);
+                nonMigratoryTopics.add(topic);
+                return null;
+            }
+
+            return new MigrationMetadata(kafkaClusterAddress, MigrationStatus.valueOf(status));
+        });
+    }
+
+    @Override
+    public CompletableFuture<String> getKafkaClusterAddress(String topic, String namespacePrefix, Channel channel) {
+        return getMigrationMetadata(topic, namespacePrefix, channel).thenApply(migrationMetadata -> {
+            if (migrationMetadata == null) {
+                return null;
+            }
+            return migrationMetadata.getKafkaClusterAddress();
+        });
+    }
+
+    @Override
+    public CompletableFuture<MigrationStatus> getMigrationStatus(String topic, String namespacePrefix,
+                                                                 Channel channel) {
+        return getMigrationMetadata(topic, namespacePrefix, channel).thenApply(migrationMetadata -> {
+            if (migrationMetadata == null) {
+                return null;
+            }
+            return migrationMetadata.getMigrationStatus();
+        });
+    }
+
+    @Override
+    public void startProxyRequest(String topic, String namespacePrefix) {
+        String fullTopicName = new KopTopic(topic, namespacePrefix).getFullName();
+        numOutstandingRequests.put(fullTopicName, numOutstandingRequests.getOrDefault(topic, 0) + 1);
+    }
+
+    @Override
+    public void finishProxyRequest(String topic, String namespacePrefix) {
+        String fullTopicName = new KopTopic(topic, namespacePrefix).getFullName();
+        numOutstandingRequests.compute(fullTopicName, (key, value) -> {
+            if (value == null) {
+                log.error("Cannot finish request for topic {}; no request has been proxied", topic);
+                return null;
+            }
+            if (value == 0) {
+                log.error("Cannot finish more requests than started for topic {}", topic);
+                return 0;
+            }
+            return value - 1;
+        });
+    }
+
+    private CompletableFuture<Void> setMigrationMetadata(String topic, String namespacePrefix, String key, String value,
+                                                         Channel channel) {
+        return getManagedLedgerProperties(topic, namespacePrefix, channel).thenAccept(
+                properties -> properties.put(key, value));
+    }
+
+    private CompletableFuture<Void> setMigrationStatus(String topic, String namespacePrefix, MigrationStatus status,
+                                                       Channel channel) {
+        return setMigrationMetadata(topic, namespacePrefix, TOPIC_MIGRATION_STATUS, status.name(), channel);
+    }
+
+    @Override
+    public CompletableFuture<Void> createWithMigration(String topic, String namespacePrefix, String kafkaClusterAddress,
+                                                       Channel channel) {
+        // TODO: Check authorization
+
+        AdminClient adminClient = getAdminClientForKafka(kafkaClusterAddress);
+        KafkaFuture<TopicDescription> future =
+                new ArrayList<>(adminClient.describeTopics(Collections.singleton(topic)).values().values()).get(0);
+
+        // https://gist.github.com/bmaggi/8e42a16a02f18d3bff9b0b742a75bfe7
+        CompletableFuture<Void> wrappingFuture = new CompletableFuture<>();
+
+        future.thenApply(topicDescription -> {
+            log.error(topicDescription.toString());
+            int numPartitions = topicDescription.partitions().size();
+            int replicationFactor = topicDescription.partitions().get(0).replicas().size();
+            adminManager.createTopicsAsync(ImmutableMap.of(topic,
+                                    new CreateTopicsRequest.TopicDetails(numPartitions, (short) replicationFactor)),
+                            1000,
+                            namespacePrefix)
+                    .thenCompose(validResult -> CompletableFuture.allOf(validResult.entrySet().stream().map(entry -> {
+                        String key = entry.getKey();
+                        ApiError value = entry.getValue();
+                        if (!value.equals(ApiError.NONE)) {
+                            throw value.exception();
+                        }
+                        log.info("Created topic partition: " + key + " with result " + value);
+                        return setMigrationMetadata(topic, namespacePrefix, KAFKA_CLUSTER_ADDRESS, kafkaClusterAddress,
+                                channel).thenCompose(
+                                ignored -> setMigrationStatus(
+                                        topic,
+                                        namespacePrefix,
+                                        MigrationStatus.NOT_STARTED,
+                                        channel));
+                    }).toArray(CompletableFuture[]::new))).join();
+            return null;
+        }).whenComplete((value, throwable) -> {
+            if (throwable != null) {
+                wrappingFuture.completeExceptionally(throwable);
+            } else {
+                wrappingFuture.complete(null);
+            }
+        });
+        return wrappingFuture;
+    }
+
+    @Override
+    public CompletableFuture<Void> migrate(String topic, String namespacePrefix, Channel channel) {
+        // TODO: actually start the migration
+        setMigrationStatus(topic, namespacePrefix, MigrationStatus.STARTED, channel);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public void close() {
+        kafkaProducers.values().forEach(Producer::close);
+        kafkaConsumers.values().forEach(Consumer::close);
+        adminClients.values().forEach(AdminClient::close);
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/migration/metadata/MigrationMetadata.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/migration/metadata/MigrationMetadata.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.migration.metadata;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * Metadata about Kafka migration for a topic.
+ */
+@AllArgsConstructor
+@Data
+public class MigrationMetadata {
+    /**
+     * Address of the Kafka cluster backing this topic.
+     */
+    private String kafkaClusterAddress;
+
+    /**
+     * Migration status of the topic.
+     */
+    private MigrationStatus migrationStatus;
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/migration/metadata/MigrationMetadataManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/migration/metadata/MigrationMetadataManager.java
@@ -1,0 +1,129 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.migration.metadata;
+
+import io.netty.channel.Channel;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.producer.Producer;
+
+/**
+ * The interface for managing metadata and state related to topic migrations from Kafka.
+ *
+ * TODO: Find a way to cleanup all the channel arguments since they are only for logging.
+ */
+public interface MigrationMetadataManager {
+    /**
+     * Get a Kafka producer for the given topic.
+     *
+     * @param topic               the topic
+     * @param kafkaClusterAddress address of the Kafka cluster for the topic
+     * @param namespacePrefix     namespace prefix of the topic
+     * @return a Kafka producer
+     */
+    Producer<String, ByteBuffer> getKafkaProducerForTopic(String topic, String namespacePrefix,
+                                                          String kafkaClusterAddress);
+
+    /**
+     * Get a Kafka consumer for the given topic.
+     *
+     * @param topic               the topic
+     * @param kafkaClusterAddress address of the Kafka cluster for the topic
+     * @param namespacePrefix     namespace prefix of the topic
+     * @return a Kafka consumer
+     */
+    Consumer<String, ByteBuffer> getKafkaConsumerForTopic(String topic, String namespacePrefix,
+                                                          String kafkaClusterAddress);
+
+    /**
+     * Get an AdminClient for a Kafka instance.
+     *
+     * @param kafkaClusterAddress address of the kafka instance
+     * @return the admin client
+     */
+    AdminClient getAdminClientForKafka(String kafkaClusterAddress);
+
+    /**
+     * Gets the migration metadata for a topic.
+     *
+     * @param topic           the topic
+     * @param channel         the channel where the original request came from
+     * @param namespacePrefix namespace prefix of the topic
+     * @return the migration metadata of the topic, null if the topic isn't configured for migration
+     */
+    CompletableFuture<MigrationMetadata> getMigrationMetadata(String topic, String namespacePrefix, Channel channel);
+
+    /**
+     * Gets the Kafka cluster address for a topic.
+     *
+     * @param topic           the topic
+     * @param channel         the channel where the original request came from
+     * @param namespacePrefix namespace prefix of the topic
+     * @return the address of the Kafka cluster containing the topic, null if the topic isn't configured for migration
+     */
+    CompletableFuture<String> getKafkaClusterAddress(String topic, String namespacePrefix, Channel channel);
+
+    /**
+     * Returns the migration status of the topic.
+     *
+     * @param topic           the topic
+     * @param channel         the channel where the original request came from
+     * @param namespacePrefix namespace prefix of the topic
+     * @return the migration status, null if the topic isn't configured for migration
+     */
+    CompletableFuture<MigrationStatus> getMigrationStatus(String topic, String namespacePrefix, Channel channel);
+
+    /**
+     * This marks the start of a request proxied through to Kafka for a topic before the migration.
+     *
+     * @param topic           the topic
+     * @param namespacePrefix namespace prefix of the topic
+     */
+    void startProxyRequest(String topic, String namespacePrefix);
+
+    /**
+     * This marks the end of a request proxied through to Kafka for a topic before the migration.
+     *
+     * @param topic           the topic
+     * @param namespacePrefix namespace prefix of the topic
+     */
+    void finishProxyRequest(String topic, String namespacePrefix);
+
+    /**
+     * Create a KoP topic with Kafka migration configuration.
+     *
+     * @param topic               the topic
+     * @param namespacePrefix     namespace prefix of the topic
+     * @param kafkaClusterAddress the address of the Kafka cluster containing the topic
+     * @param channel             the channel where the original request came from
+     */
+    CompletableFuture<Void> createWithMigration(String topic, String namespacePrefix, String kafkaClusterAddress,
+                                                Channel channel);
+
+    /**
+     * Migrate a topic from Kafka.
+     *
+     * @param topic           the topic
+     * @param namespacePrefix namespace prefix of the topic
+     * @param channel         the channel where the original request came from
+     */
+    CompletableFuture<Void> migrate(String topic, String namespacePrefix, Channel channel);
+
+    /**
+     * Close this and clean up all resource usages.
+     */
+    void close();
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/migration/metadata/MigrationStatus.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/migration/metadata/MigrationStatus.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.migration.metadata;
+
+/**
+ * Possible migration statues for a topic.
+ */
+public enum MigrationStatus {
+    /**
+     * The topic has been created in KoP, but migration hasn't started.
+     */
+    NOT_STARTED,
+
+    /**
+     * Migration has started, but hasn't finished. KoP will not handle any requests for this topic.
+     */
+    STARTED,
+
+    /**
+     * Migration has finished.
+     */
+    DONE
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/migration/metadata/package-info.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/migration/metadata/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.migration.metadata;

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/migration/metadata/ManagedLedgerPropertiesMetadataManagerTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/migration/metadata/ManagedLedgerPropertiesMetadataManagerTest.java
@@ -36,6 +36,14 @@ import org.testng.annotations.Test;
 public class ManagedLedgerPropertiesMetadataManagerTest {
     private static final String NAMESPACE_PREFIX = "public/default";
 
+    private String fullPartitionName(String topic, int partition) {
+        return String.format("%s-partition-%d", fullTopicName(topic), partition);
+    }
+
+    private String fullTopicName(String topic) {
+        return String.format("persistent://%s/%s", NAMESPACE_PREFIX, topic);
+    }
+
     @Test
     public void testGetKafkaProducerForTopic() {
         ManagedLedgerPropertiesMigrationMetadataManager metadataManager =
@@ -78,7 +86,7 @@ public class ManagedLedgerPropertiesMetadataManagerTest {
         PersistentTopic persistentTopic = mock(PersistentTopic.class);
         ManagedLedger managedLedger = mock(ManagedLedger.class);
 
-        when(topicLookupService.getTopic(eq(topic), nullable(Channel.class))).thenReturn(
+        when(topicLookupService.getTopic(eq(fullPartitionName(topic, 0)), nullable(Channel.class))).thenReturn(
                 CompletableFuture.completedFuture(Optional.of(persistentTopic)));
         when(persistentTopic.getManagedLedger()).thenReturn(managedLedger);
         when(managedLedger.getProperties()).thenReturn(
@@ -135,10 +143,10 @@ public class ManagedLedgerPropertiesMetadataManagerTest {
                         mock(AdminManager.class));
         String topic = "topic";
         metadataManager.startProxyRequest(topic, NAMESPACE_PREFIX);
-        assertEquals(metadataManager.numOutstandingRequests.get(topic).intValue(), 1);
 
+        assertEquals(metadataManager.numOutstandingRequests.get(fullTopicName(topic)).intValue(), 1);
         metadataManager.finishProxyRequest(topic, NAMESPACE_PREFIX);
-        assertEquals(metadataManager.numOutstandingRequests.get(topic).intValue(), 0);
+        assertEquals(metadataManager.numOutstandingRequests.get(fullTopicName(topic)).intValue(), 0);
     }
 
     @Test

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/migration/metadata/ManagedLedgerPropertiesMetadataManagerTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/migration/metadata/ManagedLedgerPropertiesMetadataManagerTest.java
@@ -1,0 +1,148 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.migration.metadata;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+
+import com.google.common.collect.ImmutableMap;
+import io.netty.channel.Channel;
+import io.streamnative.pulsar.handlers.kop.AdminManager;
+import io.streamnative.pulsar.handlers.kop.KafkaTopicLookupService;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.testng.annotations.Test;
+
+public class ManagedLedgerPropertiesMetadataManagerTest {
+    private static final String NAMESPACE_PREFIX = "public/default";
+
+    @Test
+    public void testGetKafkaProducerForTopic() {
+        ManagedLedgerPropertiesMigrationMetadataManager metadataManager =
+                new ManagedLedgerPropertiesMigrationMetadataManager(mock(KafkaTopicLookupService.class),
+                        mock(AdminManager.class));
+        String topic = "topic";
+        String address = "127.0.01:9091";
+        KafkaProducer<String, ByteBuffer> producer =
+                metadataManager.getKafkaProducerForTopic(topic, NAMESPACE_PREFIX, address);
+        assertEquals(metadataManager.kafkaProducers.size(), 1);
+
+        // Make sure the producer is cached
+        assertSame(producer, metadataManager.getKafkaProducerForTopic(topic, NAMESPACE_PREFIX, address));
+        assertEquals(metadataManager.kafkaProducers.size(), 1);
+
+        metadataManager.close();
+    }
+
+    @Test
+    public void testGetKafkaConsumerForTopic() {
+        ManagedLedgerPropertiesMigrationMetadataManager metadataManager =
+                new ManagedLedgerPropertiesMigrationMetadataManager(mock(KafkaTopicLookupService.class),
+                        mock(AdminManager.class));
+        String topic = "topic";
+        String address = "127.0.01:9091";
+        KafkaConsumer<String, ByteBuffer> consumer =
+                metadataManager.getKafkaConsumerForTopic(topic, NAMESPACE_PREFIX, address);
+        assertEquals(metadataManager.kafkaConsumers.size(), 1);
+
+        // Make sure the consumer is cached
+        assertSame(consumer, metadataManager.getKafkaConsumerForTopic(topic, NAMESPACE_PREFIX, address));
+        assertEquals(metadataManager.kafkaConsumers.size(), 1);
+
+        metadataManager.close();
+    }
+
+    private ManagedLedgerPropertiesMigrationMetadataManager setUpMetadata(String topic, String address,
+                                                                          MigrationStatus migrationStatus) {
+        KafkaTopicLookupService topicLookupService = mock(KafkaTopicLookupService.class);
+        PersistentTopic persistentTopic = mock(PersistentTopic.class);
+        ManagedLedger managedLedger = mock(ManagedLedger.class);
+
+        when(topicLookupService.getTopic(eq(topic), nullable(Channel.class))).thenReturn(
+                CompletableFuture.completedFuture(Optional.of(persistentTopic)));
+        when(persistentTopic.getManagedLedger()).thenReturn(managedLedger);
+        when(managedLedger.getProperties()).thenReturn(
+                ImmutableMap.of(ManagedLedgerPropertiesMigrationMetadataManager.KAFKA_CLUSTER_ADDRESS, address,
+                        ManagedLedgerPropertiesMigrationMetadataManager.TOPIC_MIGRATION_STATUS,
+                        migrationStatus.name()));
+
+        return new ManagedLedgerPropertiesMigrationMetadataManager(topicLookupService, mock(AdminManager.class));
+    }
+
+    @Test
+    public void testGetMigrationMetadata() {
+        String address = "127.0.0.1:9091";
+        String topic = "topic";
+        MigrationStatus migrationStatus = MigrationStatus.NOT_STARTED;
+        ManagedLedgerPropertiesMigrationMetadataManager metadataManager =
+                setUpMetadata(topic, address, migrationStatus);
+        assertEquals(metadataManager.getMigrationMetadata(topic, NAMESPACE_PREFIX, mock(Channel.class)).join(),
+                new MigrationMetadata(address, migrationStatus));
+
+        metadataManager.close();
+    }
+
+    @Test
+    public void testGetKafkaClusterAddress() {
+        String address = "127.0.0.1:9091";
+        String topic = "topic";
+        MigrationStatus migrationStatus = MigrationStatus.NOT_STARTED;
+        ManagedLedgerPropertiesMigrationMetadataManager metadataManager =
+                setUpMetadata(topic, address, migrationStatus);
+        assertEquals(metadataManager.getKafkaClusterAddress(topic, NAMESPACE_PREFIX, mock(Channel.class)).join(),
+                address);
+
+        metadataManager.close();
+    }
+
+    @Test
+    public void testGetMigrationStatus() {
+        String address = "127.0.0.1:9091";
+        String topic = "topic";
+        MigrationStatus migrationStatus = MigrationStatus.STARTED;
+        ManagedLedgerPropertiesMigrationMetadataManager metadataManager =
+                setUpMetadata(topic, address, migrationStatus);
+        assertEquals(metadataManager.getMigrationStatus(topic, NAMESPACE_PREFIX, mock(Channel.class)).join(),
+                migrationStatus);
+
+        metadataManager.close();
+    }
+
+    @Test
+    public void testStartFinishProxyRequest() {
+        ManagedLedgerPropertiesMigrationMetadataManager metadataManager =
+                new ManagedLedgerPropertiesMigrationMetadataManager(mock(KafkaTopicLookupService.class),
+                        mock(AdminManager.class));
+        String topic = "topic";
+        metadataManager.startProxyRequest(topic, NAMESPACE_PREFIX);
+        assertEquals(metadataManager.numOutstandingRequests.get(topic).intValue(), 1);
+
+        metadataManager.finishProxyRequest(topic, NAMESPACE_PREFIX);
+        assertEquals(metadataManager.numOutstandingRequests.get(topic).intValue(), 0);
+    }
+
+    @Test
+    public void testCreateWithMigration() {
+        // TODO
+    }
+}


### PR DESCRIPTION
Master Issue: #1475 

### Motivation

The migration workflow and metadata management is somewhat complicated, so it's probably cleaner to group the corresponding logic together. This will be used by later PRs.

### Modifications

This add a MigrationMetadataManager interface and a concrete implementation using managed ledger properties. It's not 100% complete yet and will be filled out in subsequent PRs.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

WIP

### Documentation

Check the box below.

Need to update docs? 

- [x] `no-need-doc` 
  
  Only contains internal business logic