### PR TITLE
Refactor MigrationWorkflowManager to use MigrationMetadata more consistently and write properties properly

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/migration/metadata/MigrationMetadata.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/migration/metadata/MigrationMetadata.java
@@ -13,15 +13,24 @@
  */
 package io.streamnative.pulsar.handlers.kop.migration.metadata;
 
+import com.google.common.annotations.VisibleForTesting;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 
 /**
  * Metadata about Kafka migration for a topic.
  */
 @AllArgsConstructor
+@Builder
 @Data
 public class MigrationMetadata {
+    @VisibleForTesting
+    static final String KAFKA_CLUSTER_ADDRESS = "migrationKafkaClusterAddress";
+    @VisibleForTesting
+    static final String TOPIC_MIGRATION_STATUS = "migrationTopicMigrationStatus";
     /**
      * Address of the Kafka cluster backing this topic.
      */
@@ -31,4 +40,29 @@ public class MigrationMetadata {
      * Migration status of the topic.
      */
     private MigrationStatus migrationStatus;
+
+    public Map<String, String> asProperties() {
+        Map<String, String> props = new HashMap<>();
+        if (kafkaClusterAddress != null) {
+            props.put(KAFKA_CLUSTER_ADDRESS, kafkaClusterAddress);
+        }
+        if (migrationStatus != null) {
+            props.put(TOPIC_MIGRATION_STATUS, migrationStatus.name());
+        }
+        return props;
+    }
+
+    public static MigrationMetadata fromProperties(Map<String, String> props) {
+        String status = props.get(TOPIC_MIGRATION_STATUS);
+        if (status == null) {
+            return null;
+        }
+
+        String kafkaClusterAddress = props.get(KAFKA_CLUSTER_ADDRESS);
+        if (kafkaClusterAddress == null) {
+            return null;
+        }
+
+        return new MigrationMetadata(kafkaClusterAddress, MigrationStatus.valueOf(status));
+    }
 }

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/migration/metadata/ManagedLedgerPropertiesMetadataManagerTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/migration/metadata/ManagedLedgerPropertiesMetadataManagerTest.java
@@ -13,6 +13,8 @@
  */
 package io.streamnative.pulsar.handlers.kop.migration.metadata;
 
+import static io.streamnative.pulsar.handlers.kop.migration.metadata.MigrationMetadata.KAFKA_CLUSTER_ADDRESS;
+import static io.streamnative.pulsar.handlers.kop.migration.metadata.MigrationMetadata.TOPIC_MIGRATION_STATUS;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
@@ -90,9 +92,7 @@ public class ManagedLedgerPropertiesMetadataManagerTest {
                 CompletableFuture.completedFuture(Optional.of(persistentTopic)));
         when(persistentTopic.getManagedLedger()).thenReturn(managedLedger);
         when(managedLedger.getProperties()).thenReturn(
-                ImmutableMap.of(ManagedLedgerPropertiesMigrationMetadataManager.KAFKA_CLUSTER_ADDRESS, address,
-                        ManagedLedgerPropertiesMigrationMetadataManager.TOPIC_MIGRATION_STATUS,
-                        migrationStatus.name()));
+                ImmutableMap.of(KAFKA_CLUSTER_ADDRESS, address, TOPIC_MIGRATION_STATUS, migrationStatus.name()));
 
         return new ManagedLedgerPropertiesMigrationMetadataManager(topicLookupService, mock(AdminManager.class));
     }

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/migration/metadata/MigrationMetadataTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/migration/metadata/MigrationMetadataTest.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.migration.metadata;
+
+import static io.streamnative.pulsar.handlers.kop.migration.metadata.MigrationMetadata.KAFKA_CLUSTER_ADDRESS;
+import static io.streamnative.pulsar.handlers.kop.migration.metadata.MigrationMetadata.TOPIC_MIGRATION_STATUS;
+import static org.testng.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+public class MigrationMetadataTest {
+
+    @Test
+    public void testAsProperties() {
+        MigrationMetadata migrationMetadata =
+                MigrationMetadata.builder().migrationStatus(MigrationStatus.DONE).kafkaClusterAddress("localhost")
+                        .build();
+        Map<String, String> properties =
+                ImmutableMap.of(TOPIC_MIGRATION_STATUS, MigrationStatus.DONE.name(), KAFKA_CLUSTER_ADDRESS,
+                        "localhost");
+        assertEquals(properties, migrationMetadata.asProperties());
+    }
+
+    @Test
+    public void testFromProperties() {
+        Map<String, String> properties =
+                ImmutableMap.of(TOPIC_MIGRATION_STATUS, MigrationStatus.DONE.name(), KAFKA_CLUSTER_ADDRESS,
+                        "localhost");
+        assertEquals(MigrationMetadata.fromProperties(properties),
+                MigrationMetadata.builder().migrationStatus(MigrationStatus.DONE).kafkaClusterAddress("localhost")
+                        .build());
+    }
+}


### PR DESCRIPTION
Master Issue: #1475 

### Motivation

MigrationWorkflowManager internally sometimes use a map instead of MigrationMetadata. Also it is only writing managed ledger properties to the in memory properties map.

### Modifications

Refactor to use MigrationMetadata more, and fix the bug.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as ManagedLedgerPropertiesMetadataManagerTest.

### Documentation

Check the box below.

Need to update docs? 
  
- [x] `no-need-doc` 
  
  Internal only change