### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*                       @jiazhai @BewareMyPower @streamnative/platform
+*                       @BewareMyPower Demogorgon314

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*                       @BewareMyPower Demogorgon314
+*                       @BewareMyPower @Demogorgon314


### PR DESCRIPTION
Remove @streamnative/platform from CODEOWNERS  since the new PR will invite the CODEOWNERS as the reviewers. But the @streamnative/platform has a lot of engineers. Everyone under the @streamnative/platform will receive the Github notifications.