### PR TITLE
[fix][sec] Upgrade JacksonXML to 2.13.4.1 to get rid of CVE-2022-42003

### DIFF
--- a/oauth-client/pom.xml
+++ b/oauth-client/pom.xml
@@ -30,7 +30,7 @@
   <description>OAuth 2.0 login callback handler for Kafka client</description>
 
   <properties>
-    <jackson.version>2.13.4</jackson.version>
+    <jackson.version>2.13.4.1</jackson.version>
     <async-http-client.version>2.12.1</async-http-client.version>
     <guava.version>31.1-jre</guava.version>
   </properties>

--- a/oauth-client/pom.xml
+++ b/oauth-client/pom.xml
@@ -30,7 +30,6 @@
   <description>OAuth 2.0 login callback handler for Kafka client</description>
 
   <properties>
-    <jackson.version>2.13.4.1</jackson.version>
     <async-http-client.version>2.12.1</async-http-client.version>
     <guava.version>31.1-jre</guava.version>
   </properties>
@@ -51,13 +50,11 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${jackson.version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     </test.additional.args>
     <!-- dependencies -->
     <jackson.version>2.14.0</jackson.version>
-    <jackson-databind.version>2.13.4</jackson-databind.version>
+    <jackson-databind.version>2.13.4.1</jackson-databind.version>
     <kafka.version>2.1.1</kafka.version>
     <lombok.version>1.18.24</lombok.version>
     <mockito.version>2.22.0</mockito.version>


### PR DESCRIPTION
### Motivation

`jackson-databind`  2.13.4 is vulnerable to [CVE-2022-42003](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-42003)

### Modifications

* Upgrade to 2.13.4.1

- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->