### PR TITLE
[fix][sec] Upgrade protobuf-java to 3.19.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
     <testng.version>6.14.3</testng.version>
     <awaitility.version>4.0.3</awaitility.version>
     <grpc.version>1.45.1</grpc.version>
+    <protobuf3.version>3.19.6</protobuf3.version>
     <junit.version>4.13.1</junit.version>
     <fusionauth-jwt.version>5.2.1</fusionauth-jwt.version>
     <snakeyaml.version>1.32</snakeyaml.version>
@@ -142,6 +143,15 @@
         <version>${grpc.version}</version>
         <scope>provided</scope>
       </dependency>
+
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-bom</artifactId>
+        <version>${protobuf3.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
 
       <dependency>
         <groupId>junit</groupId>


### PR DESCRIPTION
### Motivation

Current protobuf version imported by the broker is vulnerable, see related Pulsar patch: https://github.com/apache/pulsar/pull/18086

### Modifications

* Add bom import to 3.19.6
  
- [x] `no-need-doc` 