### PR TITLE
Fix lookup error when use simplified IPv6 address

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdvertisedListener.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdvertisedListener.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.Getter;
+import org.apache.commons.validator.routines.InetAddressValidator;
+
+@Getter
+public class AdvertisedListener {
+
+    private static final String REGEX = "^(.*)://\\[?([0-9a-zA-Z\\-%._:]*)\\]?:(-?[0-9]+)";
+    private static final Pattern PATTERN = Pattern.compile(REGEX);
+
+    // the original listener string, like "PLAINTEXT://localhost:9092"
+    private final String originalListener;
+
+    private final String listenerName;
+
+    private final String hostname;
+
+    private final int port;
+
+    public static AdvertisedListener create(String listener) {
+        return new AdvertisedListener(listener);
+    }
+
+    public AdvertisedListener(String listener) {
+        this.originalListener = listener;
+        final String errorMessage = "Listener '" + listener + "' is invalid";
+
+        Matcher matcher = AdvertisedListener.matcherListener(listener, errorMessage);
+
+        this.listenerName = matcher.group(1);
+        this.port = Integer.parseInt(matcher.group(3), 10);
+
+        checkState(port >= 0 && port <= 65535, errorMessage + ": port '" + port + "' is invalid.");
+
+        String hostname = matcher.group(2);
+
+        if (hostname.isEmpty()) {
+            try {
+                this.hostname = InetAddress.getLocalHost().getCanonicalHostName();
+            } catch (UnknownHostException e) {
+                throw new IllegalStateException("Hostname is empty and localhost is unknown: " + e.getMessage());
+            }
+        } else if (InetAddressValidator.getInstance().isValidInet6Address(hostname)) {
+            try {
+                // Get full IPv6 address
+                this.hostname = InetAddress.getByName(hostname).getHostAddress();
+            } catch (UnknownHostException e) {
+                throw new IllegalStateException("Hostname is invalid: " + e.getMessage());
+            }
+        } else {
+            this.hostname = hostname;
+        }
+    }
+
+    public static Matcher matcherListener(String listener, String errorMessage) {
+        final Matcher matcher = PATTERN.matcher(listener);
+        checkState(matcher.find(), errorMessage);
+        checkState(matcher.groupCount() == 3, errorMessage);
+        return matcher;
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -19,8 +19,6 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Properties;
@@ -540,16 +538,11 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
                         .append(":")
                         .append(advertisedListener.getPort());
             } else {
-                try {
-                    hostname = InetAddress.getLocalHost().getCanonicalHostName();
-                    listenersReBuilder.append(advertisedListener.getListenerName())
-                            .append("://")
-                            .append(hostname)
-                            .append(":")
-                            .append(advertisedListener.getPort());
-                } catch (UnknownHostException e) {
-                    throw new IllegalStateException("hostname is empty and localhost is unknown: " + e.getMessage());
-                }
+                listenersReBuilder.append(advertisedListener.getListenerName())
+                        .append("://")
+                        .append(advertisedListener.getHostname())
+                        .append(":")
+                        .append(advertisedListener.getPort());
             }
             listenersReBuilder.append(EndPoint.END_POINT_SEPARATOR);
         }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -26,7 +26,6 @@ import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
@@ -531,27 +530,26 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
     private String checkAdvertisedListeners(String advertisedListeners) {
         StringBuilder listenersReBuilder = new StringBuilder();
         for (String listener : advertisedListeners.split(EndPoint.END_POINT_SEPARATOR)) {
-            final String errorMessage = "listener '" + listener + "' is invalid";
-            final Matcher matcher = EndPoint.matcherListener(listener, errorMessage);
-            String hostname = matcher.group(2);
+            AdvertisedListener advertisedListener = AdvertisedListener.create(listener);
+            String hostname = advertisedListener.getHostname();
             if (hostname.isEmpty()) {
                 try {
                     hostname = InetAddress.getLocalHost().getCanonicalHostName();
-                    listenersReBuilder.append(matcher.group(1))
+                    listenersReBuilder.append(advertisedListener.getListenerName())
                             .append("://")
                             .append(hostname)
                             .append(":")
-                            .append(matcher.group(3));
+                            .append(advertisedListener.getPort());
                 } catch (UnknownHostException e) {
                     throw new IllegalStateException("hostname is empty and localhost is unknown: " + e.getMessage());
                 }
             } else if (hostname.equals("advertisedAddress")) {
                 hostname = getAdvertisedAddress();
-                listenersReBuilder.append(matcher.group(1))
+                listenersReBuilder.append(advertisedListener.getListenerName())
                         .append("://")
                         .append(hostname)
                         .append(":")
-                        .append(matcher.group(3));
+                        .append(advertisedListener.getPort());
             } else {
                 listenersReBuilder.append(listener);
             }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -532,7 +532,14 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
         for (String listener : advertisedListeners.split(EndPoint.END_POINT_SEPARATOR)) {
             AdvertisedListener advertisedListener = AdvertisedListener.create(listener);
             String hostname = advertisedListener.getHostname();
-            if (hostname.isEmpty()) {
+            if (hostname.equals("advertisedAddress")) {
+                hostname = getAdvertisedAddress();
+                listenersReBuilder.append(advertisedListener.getListenerName())
+                        .append("://")
+                        .append(hostname)
+                        .append(":")
+                        .append(advertisedListener.getPort());
+            } else {
                 try {
                     hostname = InetAddress.getLocalHost().getCanonicalHostName();
                     listenersReBuilder.append(advertisedListener.getListenerName())
@@ -543,15 +550,6 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
                 } catch (UnknownHostException e) {
                     throw new IllegalStateException("hostname is empty and localhost is unknown: " + e.getMessage());
                 }
-            } else if (hostname.equals("advertisedAddress")) {
-                hostname = getAdvertisedAddress();
-                listenersReBuilder.append(advertisedListener.getListenerName())
-                        .append("://")
-                        .append(hostname)
-                        .append(":")
-                        .append(advertisedListener.getPort());
-            } else {
-                listenersReBuilder.append(listener);
             }
             listenersReBuilder.append(EndPoint.END_POINT_SEPARATOR);
         }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
@@ -21,7 +21,6 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.regex.Matcher;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -81,9 +80,11 @@ public class KopBrokerLookupManager {
                         if (log.isDebugEnabled()) {
                             log.debug("Found listener {} for topic {}", listener, topic);
                         }
-                        final Matcher matcher = EndPoint.matcherListener(listener,
-                                listener + " cannot be split into 3 parts");
-                        return Optional.of(new InetSocketAddress(matcher.group(2), Integer.parseInt(matcher.group(3))));
+                        final AdvertisedListener advertisedListener = AdvertisedListener.create(listener);
+
+                        return Optional.of(new InetSocketAddress(
+                                advertisedListener.getHostname(),
+                                advertisedListener.getPort()));
                     } catch (IllegalStateException | NumberFormatException e) {
                         log.error("Failed to find the advertised listener: {}", e.getMessage());
                         removeTopicManagerCache(topic);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManager.java
@@ -39,7 +39,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
-import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -240,16 +239,15 @@ public class KopEventManager {
         HashMap<String, Set<Node>> nodesMap = Maps.newHashMap();
         String[] kopBrokerArr = kopBrokerStrs.split(EndPoint.END_POINT_SEPARATOR);
         for (String kopBrokerStr : kopBrokerArr) {
-            final String errorMessage = "kopBrokerStr " + kopBrokerStr + " is invalid";
-            final Matcher matcher = EndPoint.matcherListener(kopBrokerStr, errorMessage);
-            String listenerName = matcher.group(1);
-            String host = matcher.group(2);
-            String port = matcher.group(3);
+            final AdvertisedListener advertisedListener = AdvertisedListener.create(kopBrokerStr);
+            String listenerName = advertisedListener.getListenerName();
+            String host = advertisedListener.getHostname();
+            int port = advertisedListener.getPort();
             Set<Node> nodeSet = nodesMap.computeIfAbsent(listenerName, s -> new HashSet<>());
             nodeSet.add(new Node(
                     Murmur3_32Hash.getInstance().makeHash((host + port).getBytes(StandardCharsets.UTF_8)),
                     host,
-                    Integer.parseInt(port)));
+                    port));
             nodesMap.put(listenerName, nodeSet);
         }
 

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/AdvertisedListenerTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/AdvertisedListenerTest.java
@@ -1,0 +1,111 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import lombok.extern.slf4j.Slf4j;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class AdvertisedListenerTest {
+
+    @Test
+    public void testNormalCase() {
+        AdvertisedListener al = AdvertisedListener.create("PLAINTEXT://192.168.0.1:9092");
+        Assert.assertEquals(al.getListenerName(), "PLAINTEXT");
+        Assert.assertEquals(al.getHostname(), "192.168.0.1");
+        Assert.assertEquals(al.getPort(), 9092);
+    }
+
+    @Test
+    public void testEmptyHostName() throws UnknownHostException {
+        AdvertisedListener al = AdvertisedListener.create("PLAINTEXT://:9092");
+        Assert.assertEquals(al.getListenerName(), "PLAINTEXT");
+        Assert.assertEquals(al.getHostname(), InetAddress.getLocalHost().getCanonicalHostName());
+        Assert.assertEquals(al.getPort(), 9092);
+    }
+
+    @Test
+    public void testWrongFormat() {
+        try {
+            AdvertisedListener.create("PLAINTEXT:/:9092");
+            Assert.fail();
+        } catch (IllegalStateException ex) {
+            log.info("Exception message: {}", ex.getMessage());
+            Assert.assertTrue(ex.getMessage().contains("Listener 'PLAINTEXT:/:9092' is invalid"));
+        }
+        try {
+            AdvertisedListener.create("PLAINTEXT9092");
+            Assert.fail();
+        } catch (IllegalStateException ex) {
+            log.info("Exception message: {}", ex.getMessage());
+            Assert.assertTrue(ex.getMessage().contains("Listener 'PLAINTEXT9092' is invalid"));
+        }
+        try {
+            AdvertisedListener.create("PLAINTEXT:///192.168.0.1:9092");
+            Assert.fail();
+        } catch (IllegalStateException ex) {
+            log.info("Exception message: {}", ex.getMessage());
+            Assert.assertTrue(ex.getMessage().contains("Listener 'PLAINTEXT:///192.168.0.1:9092' is invalid"));
+        }
+    }
+
+    @Test
+    public void testWrongPort() {
+        AdvertisedListener.create("PLAINTEXT://192.168.0.1:0");
+        AdvertisedListener.create("PLAINTEXT://192.168.0.1:65535");
+        try {
+            AdvertisedListener.create("PLAINTEXT://192.168.0.1:65536");
+            Assert.fail();
+        } catch (IllegalStateException ex) {
+            log.info("Exception message: {}", ex.getMessage());
+            Assert.assertTrue(ex.getMessage().contains("port '65536' is invalid"));
+        }
+        try {
+            AdvertisedListener.create("PLAINTEXT://192.168.0.1:-1");
+            Assert.fail();
+        } catch (IllegalStateException ex) {
+            log.info("Exception message: {}", ex.getMessage());
+            Assert.assertTrue(ex.getMessage()
+                    .contains("Listener 'PLAINTEXT://192.168.0.1:-1' is invalid: port '-1' is invalid."));
+        }
+        try {
+            AdvertisedListener.create("PLAINTEXT://192.168.0.1");
+            Assert.fail();
+        } catch (IllegalStateException ex) {
+            log.info("Exception message: {}", ex.getMessage());
+            Assert.assertTrue(ex.getMessage().contains("Listener 'PLAINTEXT://192.168.0.1' is invalid"));
+        }
+    }
+
+    @Test
+    public void testIpv6() {
+        AdvertisedListener advertisedListener = AdvertisedListener.create("PLAINTEXT://[2409:8c85:aa34:1d3::1e]:9092");
+        Assert.assertEquals(advertisedListener.getListenerName(), "PLAINTEXT");
+        Assert.assertEquals(advertisedListener.getHostname(), "2409:8c85:aa34:1d3:0:0:0:1e");
+        Assert.assertEquals(advertisedListener.getPort(), 9092);
+
+        advertisedListener = AdvertisedListener.create("PLAINTEXT://[::1]:9092");
+        Assert.assertEquals(advertisedListener.getListenerName(), "PLAINTEXT");
+        Assert.assertEquals(advertisedListener.getHostname(), "0:0:0:0:0:0:0:1");
+        Assert.assertEquals(advertisedListener.getPort(), 9092);
+
+        advertisedListener = AdvertisedListener.create("PLAINTEXT://::1:9092");
+        Assert.assertEquals(advertisedListener.getListenerName(), "PLAINTEXT");
+        Assert.assertEquals(advertisedListener.getHostname(), "0:0:0:0:0:0:0:1");
+        Assert.assertEquals(advertisedListener.getPort(), 9092);
+    }
+}

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/EndPointTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/EndPointTest.java
@@ -47,7 +47,7 @@ public class EndPointTest {
         try {
             new EndPoint("hello world", null);
         } catch (IllegalStateException e) {
-            assertTrue(e.getMessage().contains("listener 'hello world' is invalid"));
+            assertTrue(e.getMessage().contains("Listener 'hello world' is invalid"));
         }
         try {
             new EndPoint("pulsar://localhost:6650", null);
@@ -59,13 +59,13 @@ public class EndPointTest {
             new EndPoint("PLAINTEXT://localhost:65536", null);
             fail();
         } catch (IllegalStateException e) {
-            assertTrue(e.getMessage().contains("port 65536 is invalid"));
+            assertTrue(e.getMessage().contains("port '65536' is invalid"));
         }
         try {
             new EndPoint("PLAINTEXT://localhost:-1", null);
             fail();
         } catch (IllegalStateException e) {
-            assertTrue(e.getMessage().contains("port -1 is invalid"));
+            assertTrue(e.getMessage().contains("port '-1' is invalid"));
         }
     }
 


### PR DESCRIPTION
Fixes #1567

### Motivation
See: #1567


### Modifications
* Refactor the advertised listener parser to `AdvertisedListener` class.
* Return full IPv6 address when advertised listeners are using simplified IPv6 address.
* Add units test to cover the `AdvertisedListener` class.


### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

