### PR TITLE
[branch-2.10.2] Add commons-validator dependency

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -16,13 +16,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: s4u/maven-settings-action@v2.6.0
-      with:
-        servers: '[{"id": "ossrh", "username": "${{ secrets.SONATYPE_USERNAME }}",
-          "password": "${{ secrets.SONATYPE_PASSWORD }}"}]'
-    - name: Login to cloudsmith
-      run: docker login -u="${{ secrets.CLOUDSMITH_USERNAME }}" -p="${{ secrets.CLOUDSMITH_API_KEY
-        }}" docker.cloudsmith.io
     - uses: actions/checkout@v1
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
@@ -58,8 +51,7 @@ jobs:
       run: mvn test -ntp -B -DfailIfNoTests=false -pl oauth-client
 
     - name: tests module
-      run: mvn test -ntp -B -DfailIfNoTests=false '-Dtest=!KafkaIntegration*Test'
-        -pl tests
+      run: mvn test -ntp -B -DfailIfNoTests=false '-Dtest=!KafkaIntegration*Test' -pl tests
       timeout-minutes: 60
 
     - name: package surefire artifacts

--- a/kafka-impl/pom.xml
+++ b/kafka-impl/pom.xml
@@ -88,6 +88,11 @@
     </dependency>
 
     <dependency>
+      <groupId>commons-validator</groupId>
+      <artifactId>commons-validator</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     <fusionauth-jwt.version>5.2.1</fusionauth-jwt.version>
     <jsr305.version>3.0.2</jsr305.version>
     <snakeyaml.version>1.31</snakeyaml.version>
+    <commons-validator.version>1.7</commons-validator.version>
     <!-- plugin dependencies -->
     <license-maven-plugin.version>3.0.rc1</license-maven-plugin.version>
     <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
@@ -237,6 +238,11 @@
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
         <version>${snakeyaml.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-validator</groupId>
+        <artifactId>commons-validator</artifactId>
+        <version>${commons-validator.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
### Motivation
```
Error:  Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project pulsar-protocol-handler-kafka: Compilation failure
Error:  /home/runner/work/kop/kop/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdvertisedListener.java:[23,45] package org.apache.commons.validator.routines does not exist
Error:  -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
Error:  
Error:  After correcting the problems, you can resume the build with the command
Error:    mvn <args> -rf :pulsar-protocol-handler-kafka
Error: Process completed with exit code 1.
```