### PR TITLE
[improve] Remove partition log when bundle unload

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
@@ -25,6 +25,7 @@ import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.streamnative.pulsar.handlers.kop.stats.PrometheusMetricsProvider;
 import io.streamnative.pulsar.handlers.kop.stats.StatsLogger;
+import io.streamnative.pulsar.handlers.kop.storage.ReplicaManager;
 import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperation;
 import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperationPurgatory;
 import io.streamnative.pulsar.handlers.kop.utils.ssl.SSLUtils;
@@ -47,6 +48,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
     private final KafkaServiceConfiguration kafkaConfig;
     @Getter
     private final TenantContextManager tenantContextManager;
+    private final ReplicaManager replicaManager;
     @Getter
     private final KopBrokerLookupManager kopBrokerLookupManager;
     @Getter
@@ -71,6 +73,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
     public KafkaChannelInitializer(PulsarService pulsarService,
                                    KafkaServiceConfiguration kafkaConfig,
                                    TenantContextManager tenantContextManager,
+                                   ReplicaManager replicaManager,
                                    KopBrokerLookupManager kopBrokerLookupManager,
                                    AdminManager adminManager,
                                    DelayedOperationPurgatory<DelayedOperation> producePurgatory,
@@ -85,6 +88,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
         this.pulsarService = pulsarService;
         this.kafkaConfig = kafkaConfig;
         this.tenantContextManager = tenantContextManager;
+        this.replicaManager = replicaManager;
         this.kopBrokerLookupManager = kopBrokerLookupManager;
         this.adminManager = adminManager;
         this.producePurgatory = producePurgatory;
@@ -123,7 +127,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
     @VisibleForTesting
     public KafkaRequestHandler newCnx() throws Exception {
         return new KafkaRequestHandler(pulsarService, kafkaConfig,
-                tenantContextManager, kopBrokerLookupManager, adminManager,
+                tenantContextManager, replicaManager, kopBrokerLookupManager, adminManager,
                 producePurgatory, fetchPurgatory,
                 enableTls, advertisedEndPoint, skipMessagesWithoutIndex, requestStats, sendResponseScheduler,
                 kafkaTopicManagerSharedState);
@@ -134,7 +138,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
         PrometheusMetricsProvider statsProvider = new PrometheusMetricsProvider();
         StatsLogger rootStatsLogger = statsProvider.getStatsLogger("");
         return new KafkaRequestHandler(pulsarService, kafkaConfig,
-                tenantContextManager, kopBrokerLookupManager, adminManager,
+                tenantContextManager, replicaManager, kopBrokerLookupManager, adminManager,
                 producePurgatory, fetchPurgatory,
                 enableTls, advertisedEndPoint, skipMessagesWithoutIndex,
                 new RequestStats(rootStatsLogger.scope(SERVER_SCOPE)),

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -103,10 +103,10 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     private NamespaceBundleOwnershipListenerImpl bundleListener;
     private SchemaRegistryManager schemaRegistryManager;
     private MigrationManager migrationManager;
+    private ReplicaManager replicaManager;
 
     private final Map<String, GroupCoordinator> groupCoordinatorsByTenant = new ConcurrentHashMap<>();
     private final Map<String, TransactionCoordinator> transactionCoordinatorByTenant = new ConcurrentHashMap<>();
-    private final Map<String, ReplicaManager> replicaManagerByTenant = new ConcurrentHashMap<>();
 
     @Override
     public GroupCoordinator getGroupCoordinator(String tenant) {
@@ -123,17 +123,8 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
         return transactionCoordinatorByTenant.computeIfAbsent(tenant, this::createAndBootTransactionCoordinator);
     }
 
-    @Override
-    public ReplicaManager getReplicaManager(String tenant) {
-        return replicaManagerByTenant.computeIfAbsent(tenant, s -> {
-            return new ReplicaManager(
-                    kafkaConfig,
-                    requestStats,
-                    Time.SYSTEM,
-                    brokerService.getEntryFilters(),
-                    producePurgatory,
-                    fetchPurgatory);
-        });
+    public ReplicaManager getReplicaManager() {
+        return replicaManager;
     }
 
     @Override
@@ -235,6 +226,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
             @Override
             public void whenUnload(TopicName topicName) {
                 invalidateBundleCache(topicName);
+                invalidatePartitionLog(topicName);
             }
 
             @Override
@@ -245,7 +237,15 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
             private void invalidateBundleCache(TopicName topicName) {
                 kafkaTopicManagerSharedState.deReference(topicName.toString());
                 if (!topicName.isPartitioned()) {
-                    kafkaTopicManagerSharedState.deReference(topicName.getPartition(0).toString());
+                    String nonPartitionedTopicName = topicName.getPartition(0).toString();
+                    kafkaTopicManagerSharedState.deReference(nonPartitionedTopicName);
+                }
+            }
+
+            private void invalidatePartitionLog(TopicName topicName) {
+                getReplicaManager().removePartitionLog(topicName.toString());
+                if (!topicName.isPartitioned()) {
+                    getReplicaManager().removePartitionLog(topicName.getPartition(0).toString());
                 }
             }
         });
@@ -392,6 +392,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 brokerService.getPulsar(),
                 kafkaConfig,
                 this,
+                replicaManager,
                 kopBrokerLookupManager,
                 adminManager,
                 producePurgatory,
@@ -418,6 +419,14 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 .purgatoryName("fetch")
                 .timeoutTimer(SystemTimer.builder().executorName("fetch").build())
                 .build();
+
+        replicaManager = new ReplicaManager(
+                kafkaConfig,
+                requestStats,
+                Time.SYSTEM,
+                brokerService.getEntryFilters(),
+                producePurgatory,
+                fetchPurgatory);
 
         try {
             ImmutableMap.Builder<InetSocketAddress, ChannelInitializer<SocketChannel>> builder =

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -189,6 +189,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     private final PulsarService pulsarService;
     private final KafkaTopicManager topicManager;
     private final TenantContextManager tenantContextManager;
+    private final ReplicaManager replicaManager;
     private final KopBrokerLookupManager kopBrokerLookupManager;
     @Getter
     private final KafkaTopicManagerSharedState kafkaTopicManagerSharedState;
@@ -276,13 +277,11 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         return tenantContextManager.getTransactionCoordinator(getCurrentTenant());
     }
 
-    public ReplicaManager getReplicaManager() {
-        return tenantContextManager.getReplicaManager(getCurrentTenant());
-    }
 
     public KafkaRequestHandler(PulsarService pulsarService,
                                KafkaServiceConfiguration kafkaConfig,
                                TenantContextManager tenantContextManager,
+                               ReplicaManager replicaManager,
                                KopBrokerLookupManager kopBrokerLookupManager,
                                AdminManager adminManager,
                                DelayedOperationPurgatory<DelayedOperation> producePurgatory,
@@ -296,6 +295,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         super(requestStats, kafkaConfig, sendResponseScheduler);
         this.pulsarService = pulsarService;
         this.tenantContextManager = tenantContextManager;
+        this.replicaManager = replicaManager;
         this.kopBrokerLookupManager = kopBrokerLookupManager;
         this.clusterName = kafkaConfig.getClusterName();
         this.executor = pulsarService.getExecutor();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/NamespaceBundleOwnershipListenerImpl.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/NamespaceBundleOwnershipListenerImpl.java
@@ -59,7 +59,11 @@ public class NamespaceBundleOwnershipListenerImpl implements NamespaceBundleOwne
                     if (log.isDebugEnabled()) {
                         log.debug("[{}][{}] Trigger load callback for {}", brokerUrl, listener.name(), topic);
                     }
-                    listener.whenLoad(TopicName.get(topic));
+                    try {
+                        listener.whenLoad(TopicName.get(topic));
+                    } catch (Exception ex) {
+                        log.error("[{}][{}] Failed to do load for {}", brokerUrl, listener.name(), topic, ex);
+                    }
                 });
             });
         });
@@ -81,7 +85,11 @@ public class NamespaceBundleOwnershipListenerImpl implements NamespaceBundleOwne
                     if (log.isDebugEnabled()) {
                         log.debug("[{}][{}] Trigger unload callback for {}", brokerUrl, listener.name(), topic);
                     }
-                    listener.whenUnload(TopicName.get(topic));
+                    try {
+                        listener.whenUnload(TopicName.get(topic));
+                    } catch (Exception ex) {
+                        log.error("[{}][{}] Failed to do unload for {}", brokerUrl, listener.name(), topic, ex);
+                    }
                 });
             });
         });

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/TenantContextManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/TenantContextManager.java
@@ -15,7 +15,6 @@ package io.streamnative.pulsar.handlers.kop;
 
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupCoordinator;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
-import io.streamnative.pulsar.handlers.kop.storage.ReplicaManager;
 
 /**
  * Access Tenant level coordinators.
@@ -38,11 +37,4 @@ public interface TenantContextManager {
      */
     TransactionCoordinator getTransactionCoordinator(String tenant);
 
-    /**
-     * Access the ReplicaManager for the current Tenant.
-     * This method bootstraps a new ReplicaManager if it is not started
-     * @param tenant
-     * @return the ReplicaManager
-     */
-    ReplicaManager getReplicaManager(String tenant);
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
@@ -55,5 +55,13 @@ public class PartitionLogManager {
                         new ProducerStateManager(kopTopic));
         });
     }
+
+    public PartitionLog removeLog(String topicName) {
+        return logMap.remove(topicName);
+    }
+
+    public int size() {
+        return logMap.size();
+    }
 }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
@@ -13,6 +13,7 @@
  */
 package io.streamnative.pulsar.handlers.kop.storage;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import io.streamnative.pulsar.handlers.kop.DelayedFetch;
 import io.streamnative.pulsar.handlers.kop.DelayedProduceAndFetch;
@@ -71,6 +72,20 @@ public class ReplicaManager {
 
     public PartitionLog getPartitionLog(TopicPartition topicPartition, String namespacePrefix) {
         return logManager.getLog(topicPartition, namespacePrefix);
+    }
+
+    public void removePartitionLog(String topicName) {
+        PartitionLog partitionLog = logManager.removeLog(topicName);
+        if (log.isDebugEnabled()) {
+            if (partitionLog != null) {
+                log.debug("PartitionLog: {} has bean removed.", partitionLog);
+            }
+        }
+    }
+
+    @VisibleForTesting
+    public int size() {
+        return logManager.size();
     }
 
     @AllArgsConstructor

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
@@ -76,10 +76,8 @@ public class ReplicaManager {
 
     public void removePartitionLog(String topicName) {
         PartitionLog partitionLog = logManager.removeLog(topicName);
-        if (log.isDebugEnabled()) {
-            if (partitionLog != null) {
-                log.debug("PartitionLog: {} has bean removed.", partitionLog);
-            }
+        if (log.isDebugEnabled() && partitionLog != null) {
+            log.debug("PartitionLog: {} has bean removed.", partitionLog);
         }
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CacheInvalidatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CacheInvalidatorTest.java
@@ -75,6 +75,7 @@ public class CacheInvalidatorTest extends KopProtocolHandlerTestBase {
         }
 
         assertFalse(KopBrokerLookupManager.LOOKUP_CACHE.isEmpty());
+        log.info("Before unload, ReplicaManager log size: {}", getProtocolHandler().getReplicaManager().size());
 
         log.info("Before unload, LOOKUP_CACHE is {}", KopBrokerLookupManager.LOOKUP_CACHE);
         String namespace = conf.getKafkaTenant() + "/" + conf.getKafkaNamespace();
@@ -94,6 +95,10 @@ public class CacheInvalidatorTest extends KopProtocolHandlerTestBase {
 
         Awaitility.await().untilAsserted(() -> {
             assertTrue(KopBrokerLookupManager.LOOKUP_CACHE.isEmpty());
+        });
+
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(getProtocolHandler().getReplicaManager().size(), 0);
         });
 
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -805,8 +805,7 @@ public abstract class KopProtocolHandlerTestBase {
         final GroupCoordinator groupCoordinator = handler.getGroupCoordinator(conf.getKafkaMetadataTenant());
         final TransactionCoordinator transactionCoordinator =
                 handler.getTransactionCoordinator(conf.getKafkaMetadataTenant());
-        final ReplicaManager replicaManager =
-                handler.getReplicaManager(conf.getKafkaMetadataTenant());
+        final ReplicaManager replicaManager = handler.getReplicaManager();
 
         return handler
                 .getChannelInitializerMap()
@@ -825,11 +824,6 @@ public abstract class KopProtocolHandlerTestBase {
                     @Override
                     public TransactionCoordinator getTransactionCoordinator(String tenant) {
                         return transactionCoordinator;
-                    }
-
-                    @Override
-                    public ReplicaManager getReplicaManager(String tenant) {
-                        return replicaManager;
                     }
                 });
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -22,7 +22,6 @@ import com.google.common.util.concurrent.MoreExecutors;
 import io.netty.channel.EventLoopGroup;
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupCoordinator;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
-import io.streamnative.pulsar.handlers.kop.storage.ReplicaManager;
 import io.streamnative.pulsar.handlers.kop.utils.MetadataUtils;
 import java.io.Closeable;
 import java.lang.reflect.Field;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -805,7 +805,6 @@ public abstract class KopProtocolHandlerTestBase {
         final GroupCoordinator groupCoordinator = handler.getGroupCoordinator(conf.getKafkaMetadataTenant());
         final TransactionCoordinator transactionCoordinator =
                 handler.getTransactionCoordinator(conf.getKafkaMetadataTenant());
-        final ReplicaManager replicaManager = handler.getReplicaManager();
 
         return handler
                 .getChannelInitializerMap()


### PR DESCRIPTION
### Motivation

Currently, the `PartitionLog` object from `PartitionLogManager` is never removed, even if the topic has been unloaded. Also, if the topic is removed, the object of `PartitionLog` will still in the memory.

### Modifications

* Remove the `PartitionLog` object from `PartitionLogManager`.
* Delete useless `ReplicaManager` by tenant map.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

