### PR TITLE
[feature] Support message publish rate limiting

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/InternalServerCnx.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/InternalServerCnx.java
@@ -66,21 +66,6 @@ public class InternalServerCnx extends ServerCnx {
     }
 
     @Override
-    public void enableCnxAutoRead() {
-        // do nothing is this mock
-    }
-
-    @Override
-    public void disableCnxAutoRead() {
-        // do nothing is this mock
-    }
-
-    @Override
-    public void cancelPublishBufferLimiting() {
-        // do nothing is this mock
-    }
-
-    @Override
     public boolean equals(Object o) {
         return super.equals(o);
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -829,7 +829,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                         topicManager,
                         this::startSendOperationForThrottling,
                         this::completeSendOperationForThrottling,
-                        pendingTopicFuturesMap);
+                        pendingTopicFuturesMap,
+                        ctx);
                 ReplicaManager replicaManager = getReplicaManager();
                 replicaManager.appendRecords(
                         timeoutMs,
@@ -2233,7 +2234,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                     topicManager,
                     this::startSendOperationForThrottling,
                     this::completeSendOperationForThrottling,
-                    this.pendingTopicFuturesMap);
+                    this.pendingTopicFuturesMap,
+                    ctx);
             getReplicaManager().appendRecords(
                     kafkaConfig.getRequestTimeoutMs(),
                     true,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/AppendRecordsContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/AppendRecordsContext.java
@@ -13,6 +13,7 @@
  */
 package io.streamnative.pulsar.handlers.kop.storage;
 
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.Recycler;
 import io.streamnative.pulsar.handlers.kop.KafkaTopicManager;
 import io.streamnative.pulsar.handlers.kop.PendingTopicFutures;
@@ -37,6 +38,7 @@ public class AppendRecordsContext {
     private Consumer<Integer> startSendOperationForThrottling;
     private Consumer<Integer> completeSendOperationForThrottling;
     private Map<TopicPartition, PendingTopicFutures> pendingTopicFuturesMap;
+    private ChannelHandlerContext ctx;
 
     private AppendRecordsContext(Recycler.Handle<AppendRecordsContext> recyclerHandle) {
         this.recyclerHandle = recyclerHandle;
@@ -46,12 +48,14 @@ public class AppendRecordsContext {
     public static AppendRecordsContext get(final KafkaTopicManager topicManager,
                                            final Consumer<Integer> startSendOperationForThrottling,
                                            final Consumer<Integer> completeSendOperationForThrottling,
-                                           final Map<TopicPartition, PendingTopicFutures> pendingTopicFuturesMap) {
+                                           final Map<TopicPartition, PendingTopicFutures> pendingTopicFuturesMap,
+                                           final ChannelHandlerContext ctx) {
         AppendRecordsContext context = RECYCLER.get();
         context.topicManager = topicManager;
         context.startSendOperationForThrottling = startSendOperationForThrottling;
         context.completeSendOperationForThrottling = completeSendOperationForThrottling;
         context.pendingTopicFuturesMap = pendingTopicFuturesMap;
+        context.ctx = ctx;
 
         return context;
     }
@@ -62,6 +66,7 @@ public class AppendRecordsContext {
         completeSendOperationForThrottling = null;
         pendingTopicFuturesMap = null;
         recyclerHandle.recycle(this);
+        ctx = null;
     }
 
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -864,9 +864,9 @@ public class PartitionLog {
         });
     }
 
-    protected void checkAndRecordPublishQuota(Topic topic, int msgSize, int numMessages,
+    private void checkAndRecordPublishQuota(Topic topic, int msgSize, int numMessages,
                                               AppendRecordsContext appendRecordsContext) {
-        boolean isPublishRateExceeded;
+        final boolean isPublishRateExceeded;
         if (preciseTopicPublishRateLimitingEnable) {
             boolean isPreciseTopicPublishRateExceeded =
                     topic.isTopicPublishRateExceeded(numMessages, msgSize);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -17,6 +17,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.Recycler;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import io.streamnative.pulsar.handlers.kop.KafkaTopicConsumerManager;
@@ -76,6 +77,7 @@ import org.apache.kafka.common.record.Records;
 import org.apache.kafka.common.requests.FetchRequest;
 import org.apache.kafka.common.requests.FetchResponse;
 import org.apache.kafka.common.utils.Time;
+import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.service.plugin.EntryFilterWithClassLoader;
 import org.apache.pulsar.common.naming.TopicName;
@@ -111,6 +113,7 @@ public class PartitionLog {
     private final ProducerStateManager producerStateManager;
 
     private final ImmutableMap<String, EntryFilterWithClassLoader> entryfilterMap;
+    private final boolean preciseTopicPublishRateLimitingEnable;
 
     public PartitionLog(KafkaServiceConfiguration kafkaConfig,
                         RequestStats requestStats,
@@ -126,6 +129,7 @@ public class PartitionLog {
         this.topicPartition = topicPartition;
         this.fullPartitionName = fullPartitionName;
         this.producerStateManager = producerStateManager;
+        this.preciseTopicPublishRateLimitingEnable = kafkaConfig.isPreciseTopicPublishRateLimiterEnable();
     }
 
     private CompletableFuture<EntryFormatter> getEntryFormatter(
@@ -802,6 +806,8 @@ public class PartitionLog {
             return;
         }
         PersistentTopic persistentTopic = persistentTopicOpt.get();
+        checkAndRecordPublishQuota(persistentTopic, appendInfo.validBytes(),
+                appendInfo.numMessages(), appendRecordsContext);
         if (persistentTopic.isSystemTopic()) {
             encodeResult.recycle();
             log.error("Not support producing message to system topic: {}", persistentTopic);
@@ -856,6 +862,37 @@ public class PartitionLog {
             }
             encodeResult.recycle();
         });
+    }
+
+    protected void checkAndRecordPublishQuota(Topic topic, int msgSize, int numMessages,
+                                              AppendRecordsContext appendRecordsContext) {
+        boolean isPublishRateExceeded;
+        if (preciseTopicPublishRateLimitingEnable) {
+            boolean isPreciseTopicPublishRateExceeded =
+                    topic.isTopicPublishRateExceeded(numMessages, msgSize);
+            if (isPreciseTopicPublishRateExceeded) {
+                topic.disableCnxAutoRead();
+                return;
+            }
+            isPublishRateExceeded = topic.isBrokerPublishRateExceeded();
+        } else {
+            if (topic.isResourceGroupRateLimitingEnabled()) {
+                final boolean resourceGroupPublishRateExceeded =
+                        topic.isResourceGroupPublishRateExceeded(numMessages, msgSize);
+                if (resourceGroupPublishRateExceeded) {
+                    topic.disableCnxAutoRead();
+                    return;
+                }
+            }
+            isPublishRateExceeded = topic.isPublishRateExceeded();
+        }
+
+        if (isPublishRateExceeded) {
+            ChannelHandlerContext ctx = appendRecordsContext.getCtx();
+            if (ctx != null && ctx.channel().config().isAutoRead()) {
+                ctx.channel().config().setAutoRead(false);
+            }
+        }
     }
 
     /**

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MessagePublishThrottlingTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MessagePublishThrottlingTest.java
@@ -1,0 +1,285 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.google.common.collect.Sets;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.pulsar.broker.service.Producer;
+import org.apache.pulsar.broker.service.PublishRateLimiter;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.PublishRate;
+import org.apache.pulsar.common.policies.data.RetentionPolicies;
+import org.awaitility.Awaitility;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Test KoP message publish throttling.
+ */
+@Slf4j
+public class MessagePublishThrottlingTest extends KopProtocolHandlerTestBase {
+
+    private final boolean preciseTopicPublishRateLimiterEnable;
+
+    public MessagePublishThrottlingTest(boolean preciseTopicPublishRateLimiterEnable) {
+        this.preciseTopicPublishRateLimiterEnable = preciseTopicPublishRateLimiterEnable;
+    }
+
+    public MessagePublishThrottlingTest() {
+        this(false);
+    }
+
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        conf.setPreciseTopicPublishRateLimiterEnable(preciseTopicPublishRateLimiterEnable);
+        super.internalSetup();
+        log.info("success internal setup");
+
+        if (!admin.namespaces().getNamespaces("public").contains("public/__kafka")) {
+            admin.namespaces().createNamespace("public/__kafka");
+            admin.namespaces().setNamespaceReplicationClusters("public/__kafka", Sets.newHashSet("test"));
+            admin.namespaces().setRetention("public/__kafka",
+                    new RetentionPolicies(-1, -1));
+        }
+    }
+
+    @AfterClass
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @DataProvider(name = "isTopicLevel")
+    protected static Object[][] topicLevelProvider() {
+        // isTopicLevel
+        return new Object[][]{
+                {true},
+                {false}
+        };
+    }
+
+    @Test(timeOut = 30 * 1000, dataProvider = "isTopicLevel")
+    public void testPublishByteThrottling(boolean isTopicLevel) throws Exception {
+
+        final String namespace = "public/throttling_publish" + (isTopicLevel ? "_topic_level" : "_namespace_level");
+        final String topicName = "persistent://" + namespace + "/testPublishByteThrottling";
+
+        admin.namespaces().createNamespace(namespace, Sets.newHashSet("test"));
+        PublishRate topicPublishMsgRate = new PublishRate();
+        long topicByteRate = 400;
+        topicPublishMsgRate.publishThrottlingRateInByte = topicByteRate;
+
+        // Produce message with Kafka producer, to make sure topic are created.
+        @Cleanup
+        KafkaProducer<Integer, byte[]> producer = createKafkaProducer();
+        producer.send(new ProducerRecord<>(topicName, new byte[50])).get();
+
+        String topicNameWithPartition = TopicName.get(topicName).getPartition(0).toString();
+        PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService()
+                .getTopicIfExists(topicNameWithPartition).get().get();
+        // Verify both broker and topic limiter is disabled
+        assertEquals(topic.getTopicPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
+
+        // Enable throttling
+        if (isTopicLevel) {
+            admin.topicPolicies().setPublishRate(topicName, topicPublishMsgRate);
+        } else {
+            admin.namespaces().setPublishRate(namespace, topicPublishMsgRate);
+        }
+
+        Awaitility.await().untilAsserted(() -> {
+            assertNotEquals(topic.getTopicPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
+        });
+
+        Producer prod = topic.getProducers().values().iterator().next();
+        // reset counter
+        prod.updateRates();
+        int numMessage = 10;
+        int msgBytes = 110;
+        int numThread = 4;
+        ExecutorService executorService = Executors.newFixedThreadPool(numThread);
+        CountDownLatch latch = new CountDownLatch(numThread);
+        for (int n = 0; n < numThread; n++) {
+            executorService.submit(() -> {
+                for (int i = 0; i < numMessage; i++) {
+                    try {
+                        producer.send(new ProducerRecord<>(topicName, new byte[msgBytes])).get();
+                    } catch (InterruptedException | ExecutionException e) {
+                        log.error("Send message failed.", e);
+                    }
+                }
+                latch.countDown();
+            });
+        }
+        latch.await();
+
+        prod.updateRates();
+        double rateIn = prod.getStats().msgThroughputIn;
+
+        int totalBytes = numMessage * msgBytes * numThread;
+
+        log.info("Byte rate in: {} byte/s, total: {} bytes", rateIn, numMessage * msgBytes * numThread);
+        if (preciseTopicPublishRateLimiterEnable) {
+            // 400 - 100 <= rateIn <= 400 + 100
+            assertTrue(rateIn <= topicByteRate + 100);
+            assertTrue(rateIn >= topicByteRate - 100);
+        } else {
+            assertTrue(rateIn <= totalBytes);
+        }
+
+        // Disable throttling
+        topicPublishMsgRate.publishThrottlingRateInByte = -1;
+        if (isTopicLevel) {
+            admin.topicPolicies().setPublishRate(topicName, topicPublishMsgRate);
+        } else {
+            admin.namespaces().setPublishRate(namespace, topicPublishMsgRate);
+        }
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(topic.getTopicPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
+        });
+        // reset counter
+        prod.updateRates();
+        for (int i = 0; i < numMessage; i++) {
+            producer.send(new ProducerRecord<>(topicName, new byte[msgBytes])).get();
+        }
+
+        prod.updateRates();
+        rateIn = prod.getStats().msgThroughputIn;
+
+        log.info("Byte rate in: {} byte/s, total: {} bytes. (Disabled throttling)", rateIn, numMessage * msgBytes);
+        assertTrue(rateIn >= numMessage * msgBytes);
+    }
+
+    @Test(timeOut = 30 * 1000, dataProvider = "isTopicLevel")
+    public void testPublishMsgNumThrottling(boolean isTopicLevel) throws Exception {
+
+        final String namespace = "public/throttling_publish_msg_num"
+                + (isTopicLevel ? "_topic_level" : "_namespace_level");
+        final String topicName = "persistent://" + namespace + "/testPublishMsgNumThrottling";
+
+        admin.namespaces().createNamespace(namespace, Sets.newHashSet("test"));
+        PublishRate topicPublishMsgRate = new PublishRate();
+        int topicPublishRateInMsg = 10;
+        topicPublishMsgRate.publishThrottlingRateInMsg = topicPublishRateInMsg;
+
+        // Produce message with Kafka producer, to make sure topic are created.
+        @Cleanup
+        KafkaProducer<Integer, byte[]> producer = createKafkaProducer();
+        producer.send(new ProducerRecord<>(topicName, new byte[50])).get();
+
+        String topicNameWithPartition = TopicName.get(topicName).getPartition(0).toString();
+        PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService()
+                .getTopicIfExists(topicNameWithPartition).get().get();
+        // Verify both broker and topic limiter is disabled
+        assertEquals(topic.getTopicPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
+
+        // Enable throttling
+        if (isTopicLevel) {
+            admin.topicPolicies().setPublishRate(topicName, topicPublishMsgRate);
+        } else {
+            admin.namespaces().setPublishRate(namespace, topicPublishMsgRate);
+        }
+
+        Awaitility.await().untilAsserted(() -> {
+            assertNotEquals(topic.getTopicPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
+        });
+
+        Producer prod = topic.getProducers().values().iterator().next();
+        // reset counter
+        prod.updateRates();
+        int numMessage = 20;
+        int msgBytes = 50;
+        int numThread = 4;
+        ExecutorService executorService = Executors.newFixedThreadPool(numThread);
+        CountDownLatch latch = new CountDownLatch(numThread);
+        for (int n = 0; n < numThread; n++) {
+            executorService.submit(() -> {
+                for (int i = 0; i < numMessage; i++) {
+                    try {
+                        producer.send(new ProducerRecord<>(topicName, new byte[msgBytes])).get();
+                    } catch (InterruptedException | ExecutionException e) {
+                        log.error("Send message failed.", e);
+                    }
+                }
+                latch.countDown();
+            });
+        }
+        latch.await();
+
+        prod.updateRates();
+        double rateIn = prod.getStats().getMsgRateIn();
+
+
+        log.info("Msg rate in: {} msgs/s, total: {} msgs", rateIn, numMessage * numThread);
+        if (preciseTopicPublishRateLimiterEnable) {
+            // 0 <= topicPublishRateInMsg <= 20
+            assertTrue(rateIn <= topicPublishRateInMsg + 10);
+            assertTrue(rateIn >= topicPublishRateInMsg - 10);
+        } else {
+            assertTrue(rateIn >= topicPublishRateInMsg);
+        }
+
+        // Disable throttling
+        topicPublishMsgRate.publishThrottlingRateInMsg = -1;
+        if (isTopicLevel) {
+            admin.topicPolicies().setPublishRate(topicName, topicPublishMsgRate);
+        } else {
+            admin.namespaces().setPublishRate(namespace, topicPublishMsgRate);
+        }
+        Awaitility.await().untilAsserted(() -> {
+            assertEquals(topic.getTopicPublishRateLimiter(), PublishRateLimiter.DISABLED_RATE_LIMITER);
+        });
+        // reset counter
+        prod.updateRates();
+        for (int i = 0; i < numMessage; i++) {
+            producer.send(new ProducerRecord<>(topicName, new byte[msgBytes])).get();
+        }
+
+        prod.updateRates();
+        rateIn = prod.getStats().getMsgRateIn();
+
+        log.info("Msg rate in: {} msg/s, total: {} msgs. (Disabled throttling)", rateIn, numMessage);
+        assertTrue(rateIn >= numMessage);
+    }
+
+    protected KafkaProducer<Integer, byte[]> createKafkaProducer() {
+        final Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getKafkaBrokerPort());
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+
+        return new KafkaProducer<>(props);
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/PreciselyMessagePublishThrottlingTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/PreciselyMessagePublishThrottlingTest.java
@@ -1,0 +1,24 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+/**
+ * Test KoP precisely messages publish throttling.
+ */
+public class PreciselyMessagePublishThrottlingTest extends MessagePublishThrottlingTest {
+
+    public PreciselyMessagePublishThrottlingTest() {
+        super(true);
+    }
+}


### PR DESCRIPTION
### Motivation

Currently, KoP doesn't support publish rate limit, but it is a helpful feature for users,
In this PR, it introduced the message publish rate limit, and the rate limit is reused from
Pulsar, it can work with Pulsar together.

### Modifications
* Support message publish rate limit.
* Added units test to verify it.

### TODO
Need check if the KoP needs to support this KIP: https://cwiki.apache.org/confluence/display/KAFKA/KIP-219+-+Improve+quota+communication

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

