### PR TITLE
Disable CodeCov annotation check in code review

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -22,13 +22,5 @@ comment:
   require_base: no
   require_head: yes
 
-coverage:
-  status:
-    patch:
-      default:
-        target: auto
-        informational: true
-    project:
-      default:
-        target: auto
-        informational: true
+github_checks:
+  annotations: false


### PR DESCRIPTION
### Motivation

It's hard to do a code review when there are many CodeCov annotations on the page, and It doesn't help much. So let's disable it.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

