### PR TITLE
[fix] Use thread-safe list in TransactionMarkerChannelManager

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
@@ -268,7 +269,7 @@ public class TransactionMarkerChannelManager {
         Integer txnTopicPartition = txnStateManager.partitionFor(transactionalId);
 
         Map<InetSocketAddress, List<TopicPartition>> addressAndPartitionMap = new ConcurrentHashMap<>();
-        List<TopicPartition> unknownBrokerTopicList = new ArrayList<>();
+        List<TopicPartition> unknownBrokerTopicList = new CopyOnWriteArrayList<>();
 
         List<CompletableFuture<Void>> addressFutureList = new ArrayList<>();
         for (TopicPartition topicPartition : topicPartitions) {


### PR DESCRIPTION
### Motivation

The `TransactionMarkerChannelManager#addTxnMarkersToBrokerQueue` method modifies an `ArrayList` from callbacks on futures, which could result in unsafe modification of the list.

### Modifications

* Replace `ArrayList` with `CopyOnWriteArrayList`. I chose `CopyOnWriteArrayList` since it is simple and the expected number of writes to the list is low.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation
  
- [x] `no-need-doc` 
  
This is a simple fix.
