### PR TITLE
[fix] Use correct path for pulsar client TlsTrustCertsFilePath

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AbstractPulsarClient.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AbstractPulsarClient.java
@@ -75,7 +75,7 @@ public abstract class AbstractPulsarClient implements Closeable {
                 ? pulsarService.getBrokerServiceUrlTls()
                 : pulsarService.getBrokerServiceUrl());
         conf.setTlsAllowInsecureConnection(kafkaConfig.isTlsAllowInsecureConnection());
-        conf.setTlsTrustCertsFilePath(kafkaConfig.getTlsCertificateFilePath());
+        conf.setTlsTrustCertsFilePath(kafkaConfig.getTlsTrustCertsFilePath());
 
         if (kafkaConfig.isBrokerClientTlsEnabled()) {
             if (kafkaConfig.isBrokerClientTlsEnabledWithKeyStore()) {
@@ -87,7 +87,7 @@ public abstract class AbstractPulsarClient implements Closeable {
                 conf.setTlsTrustCertsFilePath(
                         isNotBlank(kafkaConfig.getBrokerClientTrustCertsFilePath())
                                 ? kafkaConfig.getBrokerClientTrustCertsFilePath()
-                                : kafkaConfig.getTlsCertificateFilePath());
+                                : kafkaConfig.getTlsTrustCertsFilePath());
             }
         }
 


### PR DESCRIPTION
### Motivation

This is a trivial fix. The `getTlsCertificateFilePath` is meant to be the tls certificate chain when sending to a peer, and the `getTlsTrustCertsFilePath` is meant to be the root CAs.

This PR could technically break installations. I'm unsure how we'd like to handle backwards compatibility here.

Note that this PR is the same as https://github.com/apache/pulsar/pull/18712.

### Modifications

* Fix an incorrect reference to trusted certificates.

### Verifying this change

This is a trivial change.

### Documentation

- [x] `no-need-doc` 
  
No docs are required, but a release note might be helpful for some users.