### PR TITLE
[fix] Restore 'advertisedAddress' placeholder

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -29,6 +29,7 @@ import lombok.NonNull;
 import lombok.Setter;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.ServiceConfigurationUtils;
 import org.apache.pulsar.common.configuration.Category;
 import org.apache.pulsar.common.configuration.FieldContext;
 
@@ -531,7 +532,7 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
             AdvertisedListener advertisedListener = AdvertisedListener.create(listener);
             String hostname = advertisedListener.getHostname();
             if (hostname.equals("advertisedAddress")) {
-                hostname = getAdvertisedAddress();
+                hostname = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(getAdvertisedAddress());
                 listenersReBuilder.append(advertisedListener.getListenerName())
                         .append("://")
                         .append(hostname)


### PR DESCRIPTION
### Motivation
The behaviour of the advertisedAddress placeholder was broken recently (probably by https://github.com/streamnative/kop/commit/e142152d77187ae2edf299e2de60d35fee41f522).

### Modifications

Use the same way Pulsar Broker does in order to compute AdvertisedAddress

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

