### PR TITLE
[flaky-test] Fix MultiLedgerTest.testListOffsetForEmptyRolloverLedger flaky test

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MultiLedgerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/MultiLedgerTest.java
@@ -219,8 +219,12 @@ public class MultiLedgerTest extends KopProtocolHandlerTestBase {
         // Rollover and delete the old ledgers, wait until there is only one empty ledger
         managedLedger.getConfig().setRetentionTime(0, TimeUnit.MILLISECONDS);
         managedLedger.rollCurrentLedgerIfFull();
-        Awaitility.await().atMost(Duration.ofSeconds(3))
-                .until(() -> managedLedger.getLedgersInfo().size() == 1);
+        Awaitility.await().atMost(Duration.ofSeconds(10))
+                .until(() -> {
+                    log.info("Managed ledger status: [{}], ledgers info: [{}]",
+                            managedLedger.getState(), managedLedger.getLedgersInfo().toString());
+                    return managedLedger.getLedgersInfo().size() == 1;
+                });
         final List<LedgerInfo> ledgerInfoList = managedLedger.getLedgersInfoAsList();
         assertEquals(ledgerInfoList.size(), 1);
         assertEquals(ledgerInfoList.get(0).getEntries(), 0);


### PR DESCRIPTION
Fixes #1542

### Motivation

The `MultiLedgerTest.testListOffsetForEmptyRolloverLedger` method is flaky, 
but the root cause is hard to find, it may be caused by short timeout, 
we can add more timeout to check the ledger's size.


### Modifications
* Increase timeout to check the ledger's size.
* Add more logs to get more context when the flaky test happens again.

### Documentation

Check the box below.

Need to update docs? 

- [x] `no-need-doc` 


