### PR TITLE
[improvement][transactions] Implement ProducerStateManager recovery

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/DelayedFetch.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/DelayedFetch.java
@@ -109,7 +109,7 @@ public class DelayedFetch extends DelayedOperation {
         for (Map.Entry<TopicPartition, PartitionLog.ReadRecordsResult> entry : readRecordsResult.entrySet()) {
             TopicPartition tp = entry.getKey();
             PartitionLog.ReadRecordsResult result = entry.getValue();
-            PartitionLog partitionLog = replicaManager.getPartitionLog(tp, context.getNamespacePrefix());
+            PartitionLog partitionLog = result.partitionLog();
             PositionImpl currLastPosition = (PositionImpl) partitionLog.getLastPosition(context.getTopicManager());
             if (currLastPosition.compareTo(PositionImpl.EARLIEST) == 0) {
                 HAS_ERROR_UPDATER.set(this, true);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
@@ -54,6 +54,8 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
     @Getter
     private final KafkaTopicManagerSharedState kafkaTopicManagerSharedState;
 
+    private final KafkaTopicLookupService kafkaTopicLookupService;
+
     private final AdminManager adminManager;
     private DelayedOperationPurgatory<DelayedOperation> producePurgatory;
     private DelayedOperationPurgatory<DelayedOperation> fetchPurgatory;
@@ -83,7 +85,8 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
                                    boolean skipMessagesWithoutIndex,
                                    RequestStats requestStats,
                                    OrderedScheduler sendResponseScheduler,
-                                   KafkaTopicManagerSharedState kafkaTopicManagerSharedState) {
+                                   KafkaTopicManagerSharedState kafkaTopicManagerSharedState,
+                                   KafkaTopicLookupService kafkaTopicLookupService) {
         super();
         this.pulsarService = pulsarService;
         this.kafkaConfig = kafkaConfig;
@@ -104,6 +107,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
         }
         this.sendResponseScheduler = sendResponseScheduler;
         this.kafkaTopicManagerSharedState = kafkaTopicManagerSharedState;
+        this.kafkaTopicLookupService = kafkaTopicLookupService;
         this.lengthFieldPrepender = new LengthFieldPrepender(4);
     }
 
@@ -130,7 +134,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
                 tenantContextManager, replicaManager, kopBrokerLookupManager, adminManager,
                 producePurgatory, fetchPurgatory,
                 enableTls, advertisedEndPoint, skipMessagesWithoutIndex, requestStats, sendResponseScheduler,
-                kafkaTopicManagerSharedState);
+                kafkaTopicManagerSharedState, kafkaTopicLookupService);
     }
 
     @VisibleForTesting
@@ -143,6 +147,6 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
                 enableTls, advertisedEndPoint, skipMessagesWithoutIndex,
                 new RequestStats(rootStatsLogger.scope(SERVER_SCOPE)),
                 sendResponseScheduler,
-                kafkaTopicManagerSharedState);
+                kafkaTopicManagerSharedState, kafkaTopicLookupService);
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -86,6 +86,8 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     private SystemTopicClient txnTopicClient;
     private DelayedOperationPurgatory<DelayedOperation> producePurgatory;
     private DelayedOperationPurgatory<DelayedOperation> fetchPurgatory;
+
+    private KafkaTopicLookupService kafkaTopicLookupService;
     private ProducerStateManagerSnapshotBuffer producerStateManagerSnapshotBuffer;
     @VisibleForTesting
     @Getter
@@ -405,7 +407,8 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 kafkaConfig.isSkipMessagesWithoutIndex(),
                 requestStats,
                 sendResponseScheduler,
-                kafkaTopicManagerSharedState);
+                kafkaTopicManagerSharedState,
+                kafkaTopicLookupService);
     }
 
     // this is called after initialize, and with kafkaConfig, brokerService all set.
@@ -425,6 +428,8 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
 
         producerStateManagerSnapshotBuffer = new MemoryProducerStateManagerSnapshotBuffer();
 
+        kafkaTopicLookupService = new KafkaTopicLookupService(brokerService);
+
         replicaManager = new ReplicaManager(
                 kafkaConfig,
                 requestStats,
@@ -432,7 +437,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 brokerService.getEntryFilters(),
                 producePurgatory,
                 fetchPurgatory,
-                kafkaTopicManagerSharedState,
+                kafkaTopicLookupService,
                 producerStateManagerSnapshotBuffer);
 
         try {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -587,6 +587,8 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 .transactionLogNumPartitions(kafkaConfig.getKafkaTxnLogTopicNumPartitions())
                 .transactionMetadataTopicName(MetadataUtils.constructTxnLogTopicBaseName(tenant, kafkaConfig))
                 .transactionProducerIdTopicName(MetadataUtils.constructTxnProducerIdTopicBaseName(tenant, kafkaConfig))
+                .transactionProducerStateSnapshotTopicName(MetadataUtils.constructTxProducerStateTopicBaseName(tenant,
+                        kafkaConfig))
                 .abortTimedOutTransactionsIntervalMs(kafkaConfig.getKafkaTxnAbortTimedOutTransactionCleanupIntervalMs())
                 .transactionalIdExpirationMs(kafkaConfig.getKafkaTransactionalIdExpirationMs())
                 .removeExpiredTransactionalIdsIntervalMs(

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -313,7 +313,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                boolean skipMessagesWithoutIndex,
                                RequestStats requestStats,
                                OrderedScheduler sendResponseScheduler,
-                               KafkaTopicManagerSharedState kafkaTopicManagerSharedState) throws Exception {
+                               KafkaTopicManagerSharedState kafkaTopicManagerSharedState,
+                               KafkaTopicLookupService kafkaTopicLookupService) throws Exception {
         super(requestStats, kafkaConfig, sendResponseScheduler);
         this.pulsarService = pulsarService;
         this.tenantContextManager = tenantContextManager;
@@ -338,7 +339,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         this.tlsEnabled = tlsEnabled;
         this.advertisedEndPoint = advertisedEndPoint;
         this.skipMessagesWithoutIndex = skipMessagesWithoutIndex;
-        this.topicManager = new KafkaTopicManager(this);
+        this.topicManager = new KafkaTopicManager(this, kafkaTopicLookupService);
         this.defaultNumPartitions = kafkaConfig.getDefaultNumPartitions();
         this.maxReadEntriesNum = kafkaConfig.getMaxReadEntriesNum();
         this.currentConnectedGroup = new ConcurrentHashMap<>();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -54,6 +54,7 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
     private static final int OffsetsMessageTTL = 3 * 24 * 3600;
     // txn configuration
     public static final int DefaultTxnLogTopicNumPartitions = 50;
+    public static final int DefaultTxnProducerStateLogTopicNumPartitions = 8;
     public static final int DefaultTxnCoordinatorSchedulerNum = 1;
     public static final int DefaultTxnStateManagerSchedulerNum = 1;
     public static final long DefaultAbortTimedOutTransactionsIntervalMs = TimeUnit.SECONDS.toMillis(10);
@@ -422,7 +423,7 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
             category = CATEGORY_KOP_TRANSACTION,
             doc = "Number of partitions for the transaction producer state topic"
     )
-    private int kafkaTxnProducerStateTopicNumPartitions = DefaultTxnLogTopicNumPartitions;
+    private int kafkaTxnProducerStateTopicNumPartitions = DefaultTxnProducerStateLogTopicNumPartitions;
 
     @FieldContext(
             category = CATEGORY_KOP_TRANSACTION,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -427,6 +427,12 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
 
     @FieldContext(
             category = CATEGORY_KOP_TRANSACTION,
+            doc = "Interval for taking snapshots of the status of pending transactions"
+    )
+    private int kafkaTxnProducerStateTopicSnapshotIntervalSeconds = 60;
+
+    @FieldContext(
+            category = CATEGORY_KOP_TRANSACTION,
             doc = "The interval in milliseconds at which to rollback transactions that have timed out."
     )
     private long kafkaTxnAbortTimedOutTransactionCleanupIntervalMs = DefaultAbortTimedOutTransactionsIntervalMs;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -420,6 +420,12 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
 
     @FieldContext(
             category = CATEGORY_KOP_TRANSACTION,
+            doc = "Number of partitions for the transaction producer state topic"
+    )
+    private int kafkaTxnProducerStateTopicNumPartitions = DefaultTxnLogTopicNumPartitions;
+
+    @FieldContext(
+            category = CATEGORY_KOP_TRANSACTION,
             doc = "The interval in milliseconds at which to rollback transactions that have timed out."
     )
     private long kafkaTxnAbortTimedOutTransactionCleanupIntervalMs = DefaultAbortTimedOutTransactionsIntervalMs;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
@@ -41,13 +41,13 @@ public class KafkaTopicManager {
 
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
-    KafkaTopicManager(KafkaRequestHandler kafkaRequestHandler) {
+    KafkaTopicManager(KafkaRequestHandler kafkaRequestHandler, KafkaTopicLookupService kafkaTopicLookupService) {
         this.requestHandler = kafkaRequestHandler;
         PulsarService pulsarService = kafkaRequestHandler.getPulsarService();
         this.brokerService = pulsarService.getBrokerService();
         this.internalServerCnx = new InternalServerCnx(requestHandler);
         this.lookupClient = KafkaProtocolHandler.getLookupClient(pulsarService);
-        this.kafkaTopicLookupService = new KafkaTopicLookupService(pulsarService.getBrokerService());
+        this.kafkaTopicLookupService = kafkaTopicLookupService;
      }
 
     // update Ctx information, since at internalServerCnx create time there is no ctx passed into kafkaRequestHandler.

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinator.java
@@ -82,7 +82,7 @@ public class GroupCoordinator {
         Time time
     ) {
         ScheduledExecutorService coordinatorExecutor = OrderedScheduler.newSchedulerBuilder()
-                .name("group-coordinator-executor")
+                .name("group-coordinator-executor-" + tenant)
                 .numThreads(1)
                 .build();
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionConfig.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionConfig.java
@@ -26,6 +26,7 @@ import lombok.Data;
 public class TransactionConfig {
 
     public static final String DefaultTransactionMetadataTopicName = "public/default/__transaction_state";
+    public static final String DefaultProducerStateSnapshotTopicName = "public/default/__transaction_state";
     public static final String DefaultProducerIdTopicName = "public/default/__transaction_producerid_generator";
     public static final long DefaultTransactionsMaxTimeoutMs = TimeUnit.MINUTES.toMillis(15);
     public static final long DefaultTransactionalIdExpirationMs = TimeUnit.DAYS.toMillis(7);
@@ -41,6 +42,8 @@ public class TransactionConfig {
     private String transactionProducerIdTopicName = DefaultProducerIdTopicName;
     @Default
     private String transactionMetadataTopicName = DefaultTransactionMetadataTopicName;
+    @Default
+    private String transactionProducerStateSnapshotTopicName = DefaultProducerStateSnapshotTopicName;
     @Default
     private long transactionMaxTimeoutMs = DefaultTransactionsMaxTimeoutMs;
     @Default

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionConfig.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionConfig.java
@@ -26,7 +26,7 @@ import lombok.Data;
 public class TransactionConfig {
 
     public static final String DefaultTransactionMetadataTopicName = "public/default/__transaction_state";
-    public static final String DefaultProducerStateSnapshotTopicName = "public/default/__transaction_state";
+    public static final String DefaultProducerStateSnapshotTopicName = "public/default/__transaction_producer_state";
     public static final String DefaultProducerIdTopicName = "public/default/__transaction_producerid_generator";
     public static final long DefaultTransactionsMaxTimeoutMs = TimeUnit.MINUTES.toMillis(15);
     public static final long DefaultTransactionalIdExpirationMs = TimeUnit.DAYS.toMillis(7);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -837,10 +837,8 @@ public class TransactionCoordinator {
     @VisibleForTesting
     protected void abortTimedOutTransactions(
             BiConsumer<TransactionStateManager.TransactionalIdAndProducerIdEpoch, Errors> onComplete) {
-        log.info("abortTimedOutTransactions.....");
         for (TransactionStateManager.TransactionalIdAndProducerIdEpoch txnIdAndPidEpoch :
                 txnManager.timedOutTransactions()) {
-            log.info("abortTimedOutTransactions.....{}", txnIdAndPidEpoch);
             txnManager.getTransactionState(txnIdAndPidEpoch.getTransactionalId())
                     .map(option -> option.map(epochAndTxnMetadata -> {
                         TransactionMetadata txnMetadata = epochAndTxnMetadata.getTransactionMetadata();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -27,6 +27,8 @@ import io.streamnative.pulsar.handlers.kop.SystemTopicClient;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionMetadata.TxnTransitMetadata;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionStateManager.CoordinatorEpochAndTxnMetadata;
 import io.streamnative.pulsar.handlers.kop.scala.Either;
+import io.streamnative.pulsar.handlers.kop.storage.MemoryProducerStateManagerSnapshotBuffer;
+import io.streamnative.pulsar.handlers.kop.storage.ProducerStateManagerSnapshotBuffer;
 import io.streamnative.pulsar.handlers.kop.utils.MetadataUtils;
 import io.streamnative.pulsar.handlers.kop.utils.ProducerIdAndEpoch;
 import java.util.HashSet;
@@ -68,6 +70,9 @@ public class TransactionCoordinator {
     @Getter
     private final TransactionStateManager txnManager;
     private final TransactionMarkerChannelManager transactionMarkerChannelManager;
+
+    @Getter
+    private ProducerStateManagerSnapshotBuffer producerStateManagerSnapshotBuffer;
 
     private final ScheduledExecutorService scheduler;
 
@@ -115,6 +120,7 @@ public class TransactionCoordinator {
         this.transactionMarkerChannelManager = transactionMarkerChannelManager;
         this.scheduler = scheduler;
         this.time = time;
+        this.producerStateManagerSnapshotBuffer = new MemoryProducerStateManagerSnapshotBuffer();
     }
 
     public static TransactionCoordinator of(String tenant,
@@ -902,6 +908,7 @@ public class TransactionCoordinator {
         producerIdManager.shutdown();
         txnManager.shutdown();
         transactionMarkerChannelManager.close();
+        producerStateManagerSnapshotBuffer.shutdown();
         scheduler.shutdown();
         // TODO shutdown txn
         log.info("Shutdown transaction coordinator complete.");

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -837,8 +837,10 @@ public class TransactionCoordinator {
     @VisibleForTesting
     protected void abortTimedOutTransactions(
             BiConsumer<TransactionStateManager.TransactionalIdAndProducerIdEpoch, Errors> onComplete) {
+        log.info("abortTimedOutTransactions.....");
         for (TransactionStateManager.TransactionalIdAndProducerIdEpoch txnIdAndPidEpoch :
                 txnManager.timedOutTransactions()) {
+            log.info("abortTimedOutTransactions.....{}", txnIdAndPidEpoch);
             txnManager.getTransactionState(txnIdAndPidEpoch.getTransactionalId())
                     .map(option -> option.map(epochAndTxnMetadata -> {
                         TransactionMetadata txnMetadata = epochAndTxnMetadata.getTransactionMetadata();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/AbortedTxn.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/AbortedTxn.java
@@ -13,7 +13,6 @@
  */
 package io.streamnative.pulsar.handlers.kop.storage;
 
-import java.nio.ByteBuffer;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.experimental.Accessors;
@@ -40,19 +39,9 @@ public final class AbortedTxn {
 
     private static final Short CurrentVersion = 0;
 
-    private final Long producerId;
-    private final Long firstOffset;
-    private final Long lastOffset;
-    private final Long lastStableOffset;
+    private final long producerId;
+    private final long firstOffset;
+    private final long lastOffset;
+    private final long lastStableOffset;
 
-    protected ByteBuffer toByteBuffer() {
-        ByteBuffer buffer = ByteBuffer.allocate(AbortedTxn.TotalSize);
-        buffer.putShort(CurrentVersion);
-        buffer.putLong(producerId);
-        buffer.putLong(firstOffset);
-        buffer.putLong(lastOffset);
-        buffer.putLong(lastStableOffset);
-        buffer.flip();
-        return buffer;
-    }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/AbortedTxn.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/AbortedTxn.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.storage;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.nio.ByteBuffer;
+
+/**
+ * AbortedTxn is used cache the aborted index.
+ */
+@Data
+@Accessors(fluent = true)
+@AllArgsConstructor
+public final class AbortedTxn {
+
+    private static final int VersionOffset = 0;
+    private static final int VersionSize = 2;
+    private static final int ProducerIdOffset = VersionOffset + VersionSize;
+    private static final int ProducerIdSize = 8;
+    private static final int FirstOffsetOffset = ProducerIdOffset + ProducerIdSize;
+    private static final int FirstOffsetSize = 8;
+    private static final int LastOffsetOffset = FirstOffsetOffset + FirstOffsetSize;
+    private static final int LastOffsetSize = 8;
+    private static final int LastStableOffsetOffset = LastOffsetOffset + LastOffsetSize;
+    private static final int LastStableOffsetSize = 8;
+    private static final int TotalSize = LastStableOffsetOffset + LastStableOffsetSize;
+
+    private static final Short CurrentVersion = 0;
+
+    private final Long producerId;
+    private final Long firstOffset;
+    private final Long lastOffset;
+    private final Long lastStableOffset;
+
+    protected ByteBuffer toByteBuffer() {
+        ByteBuffer buffer = ByteBuffer.allocate(AbortedTxn.TotalSize);
+        buffer.putShort(CurrentVersion);
+        buffer.putLong(producerId);
+        buffer.putLong(firstOffset);
+        buffer.putLong(lastOffset);
+        buffer.putLong(lastStableOffset);
+        buffer.flip();
+        return buffer;
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/AbortedTxn.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/AbortedTxn.java
@@ -13,11 +13,10 @@
  */
 package io.streamnative.pulsar.handlers.kop.storage;
 
+import java.nio.ByteBuffer;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.experimental.Accessors;
-
-import java.nio.ByteBuffer;
 
 /**
  * AbortedTxn is used cache the aborted index.

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/AppendRecordsContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/AppendRecordsContext.java
@@ -34,7 +34,7 @@ public class AppendRecordsContext {
     };
 
     private final Recycler.Handle<AppendRecordsContext> recyclerHandle;
-    private KafkaTopicManager topicManager;
+    private volatile KafkaTopicManager topicManager;
     private Consumer<Integer> startSendOperationForThrottling;
     private Consumer<Integer> completeSendOperationForThrottling;
     private Map<TopicPartition, PendingTopicFutures> pendingTopicFuturesMap;
@@ -51,22 +51,21 @@ public class AppendRecordsContext {
                                            final Map<TopicPartition, PendingTopicFutures> pendingTopicFuturesMap,
                                            final ChannelHandlerContext ctx) {
         AppendRecordsContext context = RECYCLER.get();
-        context.topicManager = topicManager;
         context.startSendOperationForThrottling = startSendOperationForThrottling;
         context.completeSendOperationForThrottling = completeSendOperationForThrottling;
         context.pendingTopicFuturesMap = pendingTopicFuturesMap;
         context.ctx = ctx;
-
+        context.topicManager = topicManager;
         return context;
     }
 
     public void recycle() {
-        topicManager = null;
         startSendOperationForThrottling = null;
         completeSendOperationForThrottling = null;
         pendingTopicFuturesMap = null;
-        recyclerHandle.recycle(this);
         ctx = null;
+        topicManager = null;
+        recyclerHandle.recycle(this);
     }
 
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/CompletedTxn.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/CompletedTxn.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.storage;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(fluent = true)
+@AllArgsConstructor
+public final class CompletedTxn {
+    private Long producerId;
+    private Long firstOffset;
+    private Long lastOffset;
+    private Boolean isAborted;
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/CompletedTxn.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/CompletedTxn.java
@@ -21,8 +21,8 @@ import lombok.experimental.Accessors;
 @Accessors(fluent = true)
 @AllArgsConstructor
 public final class CompletedTxn {
-    private Long producerId;
-    private Long firstOffset;
-    private Long lastOffset;
-    private Boolean isAborted;
+    private long producerId;
+    private long firstOffset;
+    private long lastOffset;
+    private boolean isAborted;
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/MemoryProducerStateManagerSnapshotBuffer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/MemoryProducerStateManagerSnapshotBuffer.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.storage;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class MemoryProducerStateManagerSnapshotBuffer implements ProducerStateManagerSnapshotBuffer {
+    private Map<String, ProducerStateManagerSnapshot> latestSnapshots = new ConcurrentHashMap<>();
+
+    @Override
+    public CompletableFuture<Void> write(ProducerStateManagerSnapshot snapshot) {
+        return CompletableFuture.runAsync(() -> {
+            latestSnapshots.compute(snapshot.getTopicPartition(), (tp, current) -> {
+                if (current == null || current.getOffset() <= snapshot.getOffset()) {
+                    return snapshot;
+                } else {
+                    return current;
+                }
+            });
+        });
+    }
+
+    @Override
+    public CompletableFuture<ProducerStateManagerSnapshot> readLatestSnapshot(String topicPartition) {
+        return CompletableFuture.supplyAsync(() -> latestSnapshots.get(topicPartition));
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -327,7 +327,7 @@ public class PartitionLog {
             this.lastStableOffset = -1;
             this.highWatermark = -1;
             this.abortedTransactions = null;
-            this.partitionLog = partitionLog;
+            this.partitionLog = null;
             if (this.decodeResult != null) {
                 this.decodeResult.recycle();
                 this.decodeResult = null;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -144,8 +144,15 @@ public class PartitionLog {
       this.preciseTopicPublishRateLimitingEnable = kafkaConfig.isPreciseTopicPublishRateLimiterEnable();
     }
 
-    public CompletableFuture<PartitionLog> recover() {
-        return producerStateManager.recover(this).thenApply(___ -> this);
+    public CompletableFuture<PartitionLog> recoverTransactions() {
+        if (kafkaConfig.isKafkaTransactionCoordinatorEnabled()) {
+            return producerStateManager
+                    .recover(this)
+                    .thenApply(___ -> this);
+        } else {
+            return CompletableFuture
+                    .completedFuture(this);
+        }
     }
 
     private CompletableFuture<EntryFormatter> getEntryFormatter(

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -1147,7 +1147,6 @@ public class PartitionLog {
 
                     decodedEntries.thenAccept((decodeResult) -> {
                         try {
-
                             MemoryRecords records = decodeResult.getRecords();
                             Optional<Long> firstOffset = Optional
                                     .ofNullable(records.firstBatch())
@@ -1177,12 +1176,11 @@ public class PartitionLog {
                             if (log.isDebugEnabled()) {
                                 log.debug("Completed recovery of batch {} {}", analyzeResult, fullPartitionName);
                             }
-
-                            readNextEntriesForRecovery(cursor, cursorOffset, tcm, topic, entryCounter, future);
-
                         } finally {
                             decodeResult.recycle();
                         }
+                        readNextEntriesForRecovery(cursor, cursorOffset, tcm, topic, entryCounter, future);
+
                     }).exceptionally(error -> {
                         log.error("Bad error while recovering {}", fullPartitionName, error);
                         future.completeExceptionally(error);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -1061,9 +1061,6 @@ public class PartitionLog {
                 final ManagedCursor cursor = cursorLongPair.getLeft();
                 final AtomicLong cursorOffset = new AtomicLong(cursorLongPair.getRight());
 
-                requestStats.getPrepareMetadataStats().registerSuccessfulEvent(
-                        MathUtils.elapsedNanos(startPrepareMetadataNanos), TimeUnit.NANOSECONDS);
-
                 readNextEntriesForRecovery(cursor, cursorOffset, tcm, topic.get(), future);
 
             }).exceptionally(ex -> {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -1115,7 +1115,7 @@ public class PartitionLog {
                                             AtomicLong entryCounter,
                                             CompletableFuture<Long> future) {
         log.info("readNextEntriesForRecovery {} cursorOffset {}", fullPartitionName, cursorOffset);
-        int maxReadEntriesNum = 2;
+        int maxReadEntriesNum = 200;
         long adjustedMaxBytes = Long.MAX_VALUE;
         readEntries(cursor, topicPartition, cursorOffset, maxReadEntriesNum, adjustedMaxBytes,
                 (partitionName) -> {})

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
@@ -16,13 +16,11 @@ package io.streamnative.pulsar.handlers.kop.storage;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
-import io.streamnative.pulsar.handlers.kop.KafkaTopicManager;
-import io.streamnative.pulsar.handlers.kop.KafkaTopicManagerSharedState;
+import io.streamnative.pulsar.handlers.kop.KafkaTopicLookupService;
 import io.streamnative.pulsar.handlers.kop.RequestStats;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-
 import lombok.AllArgsConstructor;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Time;
@@ -40,7 +38,7 @@ public class PartitionLogManager {
     private final Time time;
     private final ImmutableMap<String, EntryFilterWithClassLoader> entryfilterMap;
 
-    private final KafkaTopicManagerSharedState sharedState;
+    private final KafkaTopicLookupService kafkaTopicLookupService;
 
     private final ProducerStateManagerSnapshotBuffer producerStateManagerSnapshotBuffer;
 
@@ -48,14 +46,14 @@ public class PartitionLogManager {
                                RequestStats requestStats,
                                final ImmutableMap<String, EntryFilterWithClassLoader> entryfilterMap,
                                Time time,
-                               KafkaTopicManagerSharedState sharedState,
+                               KafkaTopicLookupService kafkaTopicLookupService,
                                ProducerStateManagerSnapshotBuffer producerStateManagerSnapshotBuffer) {
         this.kafkaConfig = kafkaConfig;
         this.requestStats = requestStats;
         this.logMap = Maps.newConcurrentMap();
         this.entryfilterMap = entryfilterMap;
         this.time = time;
-        this.sharedState = sharedState;
+        this.kafkaTopicLookupService = kafkaTopicLookupService;
         this.producerStateManagerSnapshotBuffer = producerStateManagerSnapshotBuffer;
     }
 
@@ -64,7 +62,8 @@ public class PartitionLogManager {
 
         return logMap.computeIfAbsent(kopTopic, key -> {
                 return new PartitionLog(kafkaConfig, requestStats, time, topicPartition, kopTopic, entryfilterMap,
-                        sharedState, producerStateManagerSnapshotBuffer)
+                        kafkaTopicLookupService,
+                        producerStateManagerSnapshotBuffer)
                         .recover(); // TODO: retry on failures
         });
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
@@ -22,6 +22,7 @@ import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Time;
 import org.apache.pulsar.broker.service.plugin.EntryFilterWithClassLoader;
@@ -30,6 +31,7 @@ import org.apache.pulsar.broker.service.plugin.EntryFilterWithClassLoader;
  * Manage {@link PartitionLog}.
  */
 @AllArgsConstructor
+@Slf4j
 public class PartitionLogManager {
 
     private final KafkaServiceConfiguration kafkaConfig;
@@ -69,6 +71,7 @@ public class PartitionLogManager {
     }
 
     public CompletableFuture<PartitionLog> removeLog(String topicName) {
+        log.info("removeLog", topicName);
         return logMap.remove(topicName);
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerAppendInfo.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerAppendInfo.java
@@ -69,8 +69,9 @@ public class ProducerAppendInfo {
         initUpdatedEntry();
     }
 
-    private void checkProducerEpoch(Short producerEpoch) {
-        if (producerEpoch < updatedEntry.producerEpoch()) {
+    private void checkProducerEpoch(short producerEpoch) {
+        if (updatedEntry.producerEpoch() != null
+                && producerEpoch < updatedEntry.producerEpoch()) {
             String message = String.format("Producer's epoch in %s is %s, which is smaller than the last seen "
                     + "epoch %s", topicPartition, producerEpoch, currentEntry.producerEpoch());
             throw new IllegalArgumentException(message);
@@ -126,7 +127,7 @@ public class ProducerAppendInfo {
 
     public Optional<CompletedTxn> appendEndTxnMarker(
             EndTransactionMarker endTxnMarker,
-            Short producerEpoch,
+            short producerEpoch,
             long offset,
             long timestamp) {
         checkProducerEpoch(producerEpoch);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerAppendInfo.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerAppendInfo.java
@@ -40,7 +40,7 @@ public class ProducerAppendInfo {
     private final String topicPartition;
 
     // The id of the producer appending to the log
-    private final Long producerId;
+    private final long producerId;
 
     // The current entry associated with the producer id which contains metadata for a fixed number of
     // the most recent appends made by the producer. Validation of the first incoming append will
@@ -127,8 +127,8 @@ public class ProducerAppendInfo {
     public Optional<CompletedTxn> appendEndTxnMarker(
             EndTransactionMarker endTxnMarker,
             Short producerEpoch,
-            Long offset,
-            Long timestamp) {
+            long offset,
+            long timestamp) {
         checkProducerEpoch(producerEpoch);
 
         // Only emit the `CompletedTxn` for non-empty transactions. A transaction marker

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateEntry.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateEntry.java
@@ -38,7 +38,8 @@ public class ProducerStateEntry {
 
 
     public boolean maybeUpdateProducerEpoch(Short producerEpoch) {
-        if (!this.producerEpoch.equals(producerEpoch)) {
+        if (this.producerEpoch == null
+                || !this.producerEpoch.equals(producerEpoch)) {
             this.producerEpoch = producerEpoch;
             return true;
         } else {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateEntry.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateEntry.java
@@ -30,7 +30,7 @@ import org.apache.kafka.common.record.RecordBatch;
 @AllArgsConstructor
 public class ProducerStateEntry {
 
-    private Long producerId;
+    private long producerId;
     private Short producerEpoch;
     private Integer coordinatorEpoch;
     private Long lastTimestamp;
@@ -52,7 +52,7 @@ public class ProducerStateEntry {
         this.lastTimestamp(nextEntry.lastTimestamp);
     }
 
-    public static ProducerStateEntry empty(Long producerId){
+    public static ProducerStateEntry empty(long producerId){
         return new ProducerStateEntry(producerId,
                 RecordBatch.NO_PRODUCER_EPOCH, -1, RecordBatch.NO_TIMESTAMP, Optional.empty());
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManagerSnapshot.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManagerSnapshot.java
@@ -13,8 +13,6 @@
  */
 package io.streamnative.pulsar.handlers.kop.storage;
 
-import com.google.common.collect.Maps;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -26,10 +24,10 @@ import lombok.Data;
 public final class ProducerStateManagerSnapshot {
     private final String topicPartition;
     private final long offset;
-    private final Map<Long, ProducerStateEntry> producers = Maps.newConcurrentMap();
+    private final Map<Long, ProducerStateEntry> producers;
 
     // ongoing transactions sorted by the first offset of the transaction
-    private final TreeMap<Long, TxnMetadata> ongoingTxns = Maps.newTreeMap();
-    private final List<AbortedTxn> abortedIndexList = new ArrayList<>();
+    private final TreeMap<Long, TxnMetadata> ongoingTxns;
+    private final List<AbortedTxn> abortedIndexList;
 
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManagerSnapshot.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManagerSnapshot.java
@@ -14,15 +14,12 @@
 package io.streamnative.pulsar.handlers.kop.storage;
 
 import com.google.common.collect.Maps;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import org.apache.bookkeeper.mledger.Position;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 
 @Data
 @AllArgsConstructor

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManagerSnapshot.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManagerSnapshot.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.storage;
+
+import com.google.common.collect.Maps;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.bookkeeper.mledger.Position;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+@Data
+@AllArgsConstructor
+public final class ProducerStateManagerSnapshot {
+    private final String topicPartition;
+    private final long offset;
+    private final Map<Long, ProducerStateEntry> producers = Maps.newConcurrentMap();
+
+    // ongoing transactions sorted by the first offset of the transaction
+    private final TreeMap<Long, TxnMetadata> ongoingTxns = Maps.newTreeMap();
+    private final List<AbortedTxn> abortedIndexList = new ArrayList<>();
+
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManagerSnapshotBuffer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManagerSnapshotBuffer.java
@@ -14,7 +14,6 @@
 package io.streamnative.pulsar.handlers.kop.storage;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 
 /**
  * Stores snapshots of the state of ProducerStateManagers.
@@ -23,14 +22,14 @@ import java.util.function.Consumer;
 public interface ProducerStateManagerSnapshotBuffer {
 
     /**
-     * Writes a snapshot to the storage
+     * Writes a snapshot to the storage.
      * @param snapshot
      * @return a handle to the operation
      */
     CompletableFuture<Void> write(ProducerStateManagerSnapshot snapshot);
 
     /**
-     * Reads the latest available snapshot for a given partition
+     * Reads the latest available snapshot for a given partition.
      * @param topicPartition
      * @return
      */

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManagerSnapshotBuffer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManagerSnapshotBuffer.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.storage;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+/**
+ * Stores snapshots of the state of ProducerStateManagers.
+ * One ProducerStateManagerSnapshotBuffer handles all the topics for a Tenant.
+ */
+public interface ProducerStateManagerSnapshotBuffer {
+
+    /**
+     * Writes a snapshot to the storage
+     * @param snapshot
+     * @return a handle to the operation
+     */
+    CompletableFuture<Void> write(ProducerStateManagerSnapshot snapshot);
+
+    /**
+     * Reads the latest available snapshot for a given partition
+     * @param topicPartition
+     * @return
+     */
+    CompletableFuture<ProducerStateManagerSnapshot> readLatestSnapshot(String topicPartition);
+
+
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManagerSnapshotBuffer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManagerSnapshotBuffer.java
@@ -35,5 +35,9 @@ public interface ProducerStateManagerSnapshotBuffer {
      */
     CompletableFuture<ProducerStateManagerSnapshot> readLatestSnapshot(String topicPartition);
 
+    /**
+     * Shutdown and release resources.
+     */
+    default void shutdown() {}
 
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBuffer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBuffer.java
@@ -222,7 +222,6 @@ public class PulsarTopicProducerStateManagerSnapshotBuffer implements ProducerSt
     }
 
     private static ProducerStateManagerSnapshot deserialize(ByteBuffer buffer) {
-
         try (DataInputStream dataInputStream =
                      new DataInputStream(new ByteBufInputStream(Unpooled.wrappedBuffer(buffer)));) {
             String topicPartition = dataInputStream.readUTF();
@@ -279,7 +278,7 @@ public class PulsarTopicProducerStateManagerSnapshotBuffer implements ProducerSt
             return new ProducerStateManagerSnapshot(topicPartition, offset,
                     producers, ongoingTxns, abortedTxnList);
 
-        } catch (IOException err) {
+        } catch (Throwable err) {
             log.error("Cannot deserialize snapshot", err);
             return null;
         }
@@ -294,9 +293,6 @@ public class PulsarTopicProducerStateManagerSnapshotBuffer implements ProducerSt
                     log.info("found snapshot for {} : {}", deserialize.getTopicPartition(), deserialize);
                 }
                 latestSnapshots.put(deserialize.getTopicPartition(), deserialize);
-            } else {
-                log.error("Found erroneous snapshot with key {} but for topic {}: {}",
-                        key, deserialize.getTopicPartition(), deserialize);
             }
         }
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBuffer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBuffer.java
@@ -14,7 +14,6 @@
 package io.streamnative.pulsar.handlers.kop.storage;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufOutputStream;
 import io.netty.buffer.Unpooled;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBuffer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBuffer.java
@@ -163,7 +163,7 @@ public class PulsarTopicProducerStateManagerSnapshotBuffer implements ProducerSt
 
     private static ByteBuffer serialize(ProducerStateManagerSnapshot snapshot) {
 
-        ByteBuf byteBuf = ByteBufAllocator.DEFAULT.buffer();
+        ByteBuf byteBuf = Unpooled.buffer();
         try (DataOutputStream dataOutputStream =
                      new DataOutputStream(new ByteBufOutputStream(byteBuf));) {
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBuffer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBuffer.java
@@ -153,10 +153,10 @@ public class PulsarTopicProducerStateManagerSnapshotBuffer implements ProducerSt
 
     private static ByteBuffer serialize(ProducerStateManagerSnapshot snapshot) {
 
-        try {
-            ByteBuf byteBuf = ByteBufAllocator.DEFAULT.buffer();
-            DataOutputStream dataOutputStream =
-                    new DataOutputStream(new ByteBufOutputStream(byteBuf));
+        ByteBuf byteBuf = ByteBufAllocator.DEFAULT.buffer();
+        try (DataOutputStream dataOutputStream =
+                     new DataOutputStream(new ByteBufOutputStream(byteBuf));) {
+
             dataOutputStream.writeUTF(snapshot.getTopicPartition());
             dataOutputStream.writeLong(snapshot.getOffset());
 
@@ -214,9 +214,8 @@ public class PulsarTopicProducerStateManagerSnapshotBuffer implements ProducerSt
 
     private static ProducerStateManagerSnapshot deserialize(ByteBuffer buffer) {
 
-        try {
-            DataInputStream dataInputStream =
-                    new DataInputStream(new ByteBufInputStream(Unpooled.wrappedBuffer(buffer)));
+        try (DataInputStream dataInputStream =
+                     new DataInputStream(new ByteBufInputStream(Unpooled.wrappedBuffer(buffer)));) {
             String topicPartition = dataInputStream.readUTF();
             long offset = dataInputStream.readLong();
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBuffer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBuffer.java
@@ -1,0 +1,178 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.storage;
+
+import io.streamnative.pulsar.handlers.kop.SystemTopicClient;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.Reader;
+
+@Slf4j
+public class PulsarTopicProducerStateManagerSnapshotBuffer implements ProducerStateManagerSnapshotBuffer {
+
+    private Map<String, ProducerStateManagerSnapshot> latestSnapshots = new ConcurrentHashMap<>();
+    private final String topic;
+    private final SystemTopicClient pulsarClient;
+    private CompletableFuture<Reader<ByteBuffer>> reader;
+    private CompletableFuture<Void> currentReadHandle;
+
+    private synchronized CompletableFuture<Reader<ByteBuffer>> ensureReaderHandle() {
+        if (reader == null) {
+            reader = pulsarClient.newReaderBuilder()
+                    .topic(topic)
+                    .startMessageId(MessageId.earliest)
+                    .readCompacted(true)
+                    .createAsync();
+        }
+        return reader;
+    }
+
+    private CompletableFuture<Void> readNextMessageIfAvailable(Reader<ByteBuffer> reader) {
+        return reader
+                .hasMessageAvailableAsync()
+                .thenCompose(hasMessageAvailable -> {
+                    if (hasMessageAvailable == null
+                            || !hasMessageAvailable) {
+                        return CompletableFuture.completedFuture(null);
+                    } else {
+                        CompletableFuture<Message<ByteBuffer>> opMessage = reader.readNextAsync();
+                        return opMessage.thenCompose(msg -> {
+                            processMessage(msg);
+                            return readNextMessageIfAvailable(reader);
+                        });
+                    }
+                });
+    }
+
+
+    private synchronized CompletableFuture<Void> ensureLatestData(boolean beforeWrite) {
+        if (currentReadHandle != null) {
+            if (beforeWrite) {
+                // we are inside a write loop, so
+                // we must ensure that we start to read now
+                // otherwise the write would use non up-to-date data
+                // so let's finish the current loop
+                if (log.isDebugEnabled()) {
+                    log.debug("A read was already pending, starting a new one in order to ensure consistency");
+                }
+                return currentReadHandle
+                        .thenCompose(___ -> ensureLatestData(false));
+            }
+            // if there is an ongoing read operation then complete it
+            return currentReadHandle;
+        }
+        // please note that the read operation is async,
+        // and it is not execute inside this synchronized block
+        CompletableFuture<Reader<ByteBuffer>> readerHandle = ensureReaderHandle();
+        final CompletableFuture<Void> newReadHandle =
+                readerHandle.thenCompose(this::readNextMessageIfAvailable);
+        currentReadHandle = newReadHandle;
+        return newReadHandle.thenApply((__) -> {
+            endReadLoop(newReadHandle);
+            return null;
+        });
+    }
+
+    private synchronized void endReadLoop(CompletableFuture<?> handle) {
+        if (handle == currentReadHandle) {
+            currentReadHandle = null;
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> write(ProducerStateManagerSnapshot snapshot) {
+        ByteBuffer serialized = serialize(snapshot);
+        CompletableFuture<Producer<ByteBuffer>> producerHandle = pulsarClient.newProducerBuilder()
+                .enableBatching(false)
+                .topic(topic)
+                .blockIfQueueFull(true)
+                .createAsync();
+        return producerHandle.thenCompose(opProducer -> {
+            // nobody can write now to the topic
+            // wait for local cache to be up-to-date
+            CompletableFuture<Void> dummy = ensureLatestData(true)
+                    .thenCompose((___) -> {
+                        return opProducer
+                                .newMessage()
+                                .key(snapshot.getTopicPartition()) // leverage compaction
+                                .value(serialized)
+                                .sendAsync()
+                                .thenApply((msgId) -> {
+                                    if (log.isDebugEnabled()) {
+                                        log.debug("{} written {} as {}", this, snapshot, msgId);
+                                    }
+                                    latestSnapshots.put(snapshot.getTopicPartition(), snapshot);
+                                    return null;
+                                });
+                    });
+            // ensure that we release the exclusive producer in any case
+            return dummy.whenComplete((___, err) -> {
+                opProducer.closeAsync().whenComplete((____, errorClose) -> {
+                    if (errorClose != null) {
+                        log.error("Error closing producer for {}", topic, errorClose);
+                    }
+                });
+            });
+        });
+    }
+
+    private static ByteBuffer serialize(ProducerStateManagerSnapshot snapshot) {
+        return ByteBuffer.allocate(0);
+    }
+
+    private static ProducerStateManagerSnapshot deserialize(ByteBuffer buffer) {
+        return null;
+    }
+
+    private void processMessage(Message<ByteBuffer> msg) {
+        ProducerStateManagerSnapshot deserialize = deserialize(msg.getValue());
+        if (deserialize != null) {
+            latestSnapshots.put(deserialize.getTopicPartition(), deserialize);
+        }
+    }
+
+    @Override
+    public CompletableFuture<ProducerStateManagerSnapshot> readLatestSnapshot(String topicPartition) {
+        return ensureLatestData(false).thenApply(__ -> {
+            return latestSnapshots.get(topicPartition);
+        });
+    }
+
+    public PulsarTopicProducerStateManagerSnapshotBuffer(String topicName, SystemTopicClient pulsarClient) {
+        this.topic = topicName;
+        this.pulsarClient = pulsarClient;
+    }
+
+
+    @Override
+    public synchronized void shutdown() {
+        if (reader != null) {
+            reader.whenComplete((r, e) -> {
+                if (r != null) {
+                    r.closeAsync().whenComplete((___, err) -> {
+                        if (err != null) {
+                            log.error("Error closing reader for {}", topic, err);
+                        }
+                    });
+                }
+            });
+        }
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBuffer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBuffer.java
@@ -130,7 +130,7 @@ public class PulsarTopicProducerStateManagerSnapshotBuffer implements ProducerSt
             CompletableFuture<Void> dummy = ensureLatestData(true)
                     .thenCompose((___) -> {
                         ProducerStateManagerSnapshot latest = latestSnapshots.get(snapshot.getTopicPartition());
-                        if (latest != null && latest.getOffset() >= snapshot.getOffset()) {
+                        if (latest != null && latest.getOffset() > snapshot.getOffset()) {
                             log.error("Topic ownership changed for {}. Found a snapshot at {} "
                                     + "while trying to write the snapshot at {}", snapshot.getTopicPartition(),
                                     latest.getOffset(), snapshot.getOffset());

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -66,7 +67,7 @@ public class ReplicaManager {
                           DelayedOperationPurgatory<DelayedOperation> producePurgatory,
                           DelayedOperationPurgatory<DelayedOperation> fetchPurgatory,
                           KafkaTopicLookupService kafkaTopicLookupService,
-                          ProducerStateManagerSnapshotBuffer producerStateManagerSnapshotBuffer) {
+                          Function<String, ProducerStateManagerSnapshotBuffer> producerStateManagerSnapshotBuffer) {
         this.logManager = new PartitionLogManager(kafkaConfig, requestStats, entryfilterMap,
                 time, kafkaTopicLookupService, producerStateManagerSnapshotBuffer);
         this.producePurgatory = producePurgatory;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
@@ -18,8 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import io.streamnative.pulsar.handlers.kop.DelayedFetch;
 import io.streamnative.pulsar.handlers.kop.DelayedProduceAndFetch;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
-import io.streamnative.pulsar.handlers.kop.KafkaTopicManager;
-import io.streamnative.pulsar.handlers.kop.KafkaTopicManagerSharedState;
+import io.streamnative.pulsar.handlers.kop.KafkaTopicLookupService;
 import io.streamnative.pulsar.handlers.kop.MessageFetchContext;
 import io.streamnative.pulsar.handlers.kop.RequestStats;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
@@ -66,10 +65,10 @@ public class ReplicaManager {
                           ImmutableMap<String, EntryFilterWithClassLoader> entryfilterMap,
                           DelayedOperationPurgatory<DelayedOperation> producePurgatory,
                           DelayedOperationPurgatory<DelayedOperation> fetchPurgatory,
-                          KafkaTopicManagerSharedState sharedState,
+                          KafkaTopicLookupService kafkaTopicLookupService,
                           ProducerStateManagerSnapshotBuffer producerStateManagerSnapshotBuffer) {
         this.logManager = new PartitionLogManager(kafkaConfig, requestStats, entryfilterMap,
-                time, sharedState, producerStateManagerSnapshotBuffer);
+                time, kafkaTopicLookupService, producerStateManagerSnapshotBuffer);
         this.producePurgatory = producePurgatory;
         this.fetchPurgatory = fetchPurgatory;
         this.metadataNamespace = kafkaConfig.getKafkaMetadataNamespace();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
@@ -281,4 +281,9 @@ public class ReplicaManager {
         }
     }
 
+
+    public CompletableFuture<Void> takeProducerStateSnapshots() {
+        return logManager.takeProducerStateSnapshots();
+    }
+
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/TxnMetadata.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/TxnMetadata.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.storage;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(fluent = true)
+@EqualsAndHashCode
+public final class TxnMetadata {
+    private final long producerId;
+    private final long firstOffset;
+    private long lastOffset;
+
+    public TxnMetadata(long producerId, long firstOffset) {
+        this.producerId = producerId;
+        this.firstOffset = firstOffset;
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
@@ -48,6 +48,11 @@ public class MetadataUtils {
                 + "/" + Topic.TRANSACTION_STATE_TOPIC_NAME;
     }
 
+    public static String constructTxProducerStateTopicBaseName(String tenant, KafkaServiceConfiguration conf) {
+        return tenant + "/" + conf.getKafkaMetadataNamespace()
+                + "/__transaction_producer_state";
+    }
+
     public static String constructTxnProducerIdTopicBaseName(String tenant, KafkaServiceConfiguration conf) {
         return tenant + "/" + conf.getKafkaMetadataNamespace()
                 + "/__transaction_producerid_generator";
@@ -85,6 +90,10 @@ public class MetadataUtils {
                 constructMetadataNamespace(tenant, conf));
         createKafkaMetadataIfMissing(tenant, conf.getKafkaMetadataNamespace(), pulsarAdmin, clusterData, conf, kopTopic,
                 conf.getKafkaTxnLogTopicNumPartitions(), false);
+        KopTopic kopTopicProducerState = new KopTopic(constructTxProducerStateTopicBaseName(tenant, conf),
+                constructMetadataNamespace(tenant, conf));
+        createKafkaMetadataIfMissing(tenant, conf.getKafkaMetadataNamespace(), pulsarAdmin, clusterData, conf,
+                kopTopicProducerState, conf.getKafkaTxnProducerStateTopicNumPartitions(), false);
         if (conf.isKafkaTransactionProducerIdsStoredOnPulsar()) {
             KopTopic producerIdKopTopic = new KopTopic(constructTxnProducerIdTopicBaseName(tenant, conf),
                     constructMetadataNamespace(tenant, conf));

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EncodePerformanceTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EncodePerformanceTest.java
@@ -13,10 +13,12 @@
  */
 package io.streamnative.pulsar.handlers.kop.format;
 
+import static org.mockito.Mockito.mock;
+
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
+import io.streamnative.pulsar.handlers.kop.KafkaTopicLookupService;
 import io.streamnative.pulsar.handlers.kop.storage.MemoryProducerStateManagerSnapshotBuffer;
 import io.streamnative.pulsar.handlers.kop.storage.PartitionLog;
-import io.streamnative.pulsar.handlers.kop.storage.ProducerStateManager;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Optional;
@@ -29,7 +31,6 @@ import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.SimpleRecord;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.Time;
-
 
 /**
  * The performance test for {@link EntryFormatter#encode(EncodeRequest)}.
@@ -49,7 +50,8 @@ public class EncodePerformanceTest {
             new TopicPartition("test", 1),
             "test",
             null,
-            new ProducerStateManager("test", new MemoryProducerStateManagerSnapshotBuffer()));
+            mock(KafkaTopicLookupService.class),
+            new MemoryProducerStateManagerSnapshotBuffer());
 
     public static void main(String[] args) {
         pulsarServiceConfiguration.setEntryFormat("pulsar");

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EncodePerformanceTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EncodePerformanceTest.java
@@ -14,6 +14,7 @@
 package io.streamnative.pulsar.handlers.kop.format;
 
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
+import io.streamnative.pulsar.handlers.kop.storage.MemoryProducerStateManagerSnapshotBuffer;
 import io.streamnative.pulsar.handlers.kop.storage.PartitionLog;
 import io.streamnative.pulsar.handlers.kop.storage.ProducerStateManager;
 import java.nio.ByteBuffer;
@@ -48,7 +49,7 @@ public class EncodePerformanceTest {
             new TopicPartition("test", 1),
             "test",
             null,
-            new ProducerStateManager("test"));
+            new ProducerStateManager("test", new MemoryProducerStateManagerSnapshotBuffer()));
 
     public static void main(String[] args) {
         pulsarServiceConfiguration.setEntryFormat("pulsar");

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterTest.java
@@ -20,9 +20,9 @@ import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableMap;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
+import io.streamnative.pulsar.handlers.kop.KafkaTopicLookupService;
 import io.streamnative.pulsar.handlers.kop.storage.MemoryProducerStateManagerSnapshotBuffer;
 import io.streamnative.pulsar.handlers.kop.storage.PartitionLog;
-import io.streamnative.pulsar.handlers.kop.storage.ProducerStateManager;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -81,7 +81,8 @@ public class EntryFormatterTest {
             new TopicPartition("test", 1),
             "test",
             null,
-            new ProducerStateManager("test", new MemoryProducerStateManagerSnapshotBuffer()));
+            mock(KafkaTopicLookupService.class),
+            new MemoryProducerStateManagerSnapshotBuffer());
 
     private void init() {
         pulsarServiceConfiguration.setEntryFormat("pulsar");

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableMap;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
+import io.streamnative.pulsar.handlers.kop.storage.MemoryProducerStateManagerSnapshotBuffer;
 import io.streamnative.pulsar.handlers.kop.storage.PartitionLog;
 import io.streamnative.pulsar.handlers.kop.storage.ProducerStateManager;
 import java.io.DataOutputStream;
@@ -80,7 +81,7 @@ public class EntryFormatterTest {
             new TopicPartition("test", 1),
             "test",
             null,
-            new ProducerStateManager("test"));
+            new ProducerStateManager("test", new MemoryProducerStateManagerSnapshotBuffer()));
 
     private void init() {
         pulsarServiceConfiguration.setEntryFormat("pulsar");

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
@@ -87,7 +87,8 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
         doReturn(mockChannel).when(mockCtx).channel();
         kafkaRequestHandler.ctx = mockCtx;
 
-        kafkaTopicManager = new KafkaTopicManager(kafkaRequestHandler);
+        kafkaTopicManager = new KafkaTopicManager(kafkaRequestHandler,
+                new KafkaTopicLookupService(pulsar.getBrokerService()));
         kafkaTopicManager.setRemoteAddress(InternalServerCnx.MOCKED_REMOTE_ADDRESS);
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.expectThrows;
+import static org.testng.Assert.fail;
 
 import com.google.common.collect.ImmutableMap;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionState;
@@ -73,6 +74,12 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
         this.conf.setKafkaTxnLogTopicNumPartitions(50);
         this.conf.setKafkaTransactionCoordinatorEnabled(true);
         this.conf.setBrokerDeduplicationEnabled(true);
+
+        // enable tx expiration, but producers have
+        // a very long TRANSACTION_TIMEOUT_CONFIG
+        // so they won't expire by default
+        this.conf.setKafkaTransactionalIdExpirationMs(5000);
+        this.conf.setKafkaTransactionalIdExpirationEnable(true);
         super.internalSetup();
         log.info("success internal setup");
     }
@@ -140,7 +147,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
                 });
     }
 
-    public void basicProduceAndConsumeTest(String topicName,
+    private void basicProduceAndConsumeTest(String topicName,
                                            String transactionalId,
                                            String isolation,
                                            boolean isBatch) throws Exception {
@@ -182,7 +189,19 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
             }
         }
 
-        consumeTxnMessage(topicName, totalTxnCount * messageCountPerTxn, lastMessage, isolation);
+        final int expected;
+        switch (isolation) {
+            case "read_committed":
+                expected = totalTxnCount * messageCountPerTxn / 2;
+                break;
+            case "read_uncommitted":
+                expected = totalTxnCount * messageCountPerTxn;
+                break;
+            default:
+                expected = -1;
+                fail();
+        }
+        consumeTxnMessage(topicName, expected, lastMessage, isolation);
     }
 
     private void consumeTxnMessage(String topicName,
@@ -202,7 +221,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
             boolean readFinish = false;
             for (ConsumerRecord<Integer, String> record : consumerRecords) {
                 if (isolation.equals("read_committed")) {
-                    assertFalse(record.value().contains("abort msg txnIndex"));
+                    assertFalse(record.value().contains("abort"));
                 }
                 log.info("Fetch for receive record offset: {}, key: {}, value: {}",
                         record.offset(), record.key(), record.value());
@@ -219,12 +238,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
             }
         }
         log.info("Fetch for receive message finish. isolation: {}, receive count: {}", isolation, receiveCount.get());
-
-        if (isolation.equals("read_committed")) {
-            Assert.assertEquals(receiveCount.get(), totalMessageCount / 2);
-        } else {
-            Assert.assertEquals(receiveCount.get(), totalMessageCount);
-        }
+        Assert.assertEquals(receiveCount.get(), totalMessageCount);
         log.info("Fetch for finish consume messages. isolation: {}", isolation);
     }
 
@@ -288,7 +302,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
                 if (records.isEmpty()) {
                     msgCnt.decrementAndGet();
                 } else {
-                    Assert.fail("The transaction was committed, the consumer shouldn't receive any more messages.");
+                    fail("The transaction was committed, the consumer shouldn't receive any more messages.");
                 }
             } else {
                 for (ConsumerRecord<Integer, String> record : records) {
@@ -373,7 +387,213 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
         // unload the namespace, this will force a recovery
         pulsar.getAdminClient().namespaces().unload(namespace);
 
-        consumeTxnMessage(topicName, totalTxnCount * messageCountPerTxn, lastMessage, isolation);
+        final int expected;
+        switch (isolation) {
+            case "read_committed":
+                expected = totalTxnCount * messageCountPerTxn / 2;
+                break;
+            case "read_uncommitted":
+                expected = totalTxnCount * messageCountPerTxn;
+                break;
+            default:
+                expected = -1;
+                fail();
+        }
+        consumeTxnMessage(topicName, expected, lastMessage, isolation);
+    }
+
+    @DataProvider(name = "takeSnapshotBeforeRecovery")
+    protected static Object[][] takeSnapshotBeforeRecovery() {
+        // isBatch
+        return new Object[][]{
+                {true},
+                {false}
+        };
+    }
+
+    @Test(timeOut = 1000 * 20, dataProvider = "takeSnapshotBeforeRecovery")
+    public void basicRecoveryAbortedTransaction(boolean takeSnapshotBeforeRecovery) throws Exception {
+
+        String topicName = "basicRecoveryTestAfterTopicUnload2";
+        String transactionalId = "myProducer";
+        String isolation = "read_committed";
+
+        String namespace = TopicName.get(topicName).getNamespace();
+
+        @Cleanup
+        KafkaProducer<Integer, String> producer = buildTransactionProducer(transactionalId);
+
+        producer.initTransactions();
+
+        KafkaProtocolHandler protocolHandler = (KafkaProtocolHandler)
+                pulsar.getProtocolHandlers().protocol("kafka");
+
+        producer.beginTransaction();
+
+        String firstMessage = "aborted msg 1";
+
+        producer.send(new ProducerRecord<>(topicName, 0, firstMessage)).get();
+        producer.flush();
+        // force take snapshot
+        protocolHandler
+                .getReplicaManager()
+                .takeProducerStateSnapshots()
+                .get();
+
+        // recovery will re-process the topic from this point onwards
+        String secondMessage = "aborted msg 2";
+        producer.send(new ProducerRecord<>(topicName, 0, secondMessage)).get();
+
+        producer.abortTransaction();
+
+        producer.beginTransaction();
+        String lastMessage = "committed mgs";
+        producer.send(new ProducerRecord<>(topicName, 0, lastMessage)).get();
+        producer.send(new ProducerRecord<>(topicName, 0, lastMessage)).get();
+        producer.commitTransaction();
+
+        if (takeSnapshotBeforeRecovery) {
+            protocolHandler
+                    .getReplicaManager()
+                    .takeProducerStateSnapshots()
+                    .get();
+        }
+
+        // unload the namespace, this will force a recovery
+        pulsar.getAdminClient().namespaces().unload(namespace);
+
+        consumeTxnMessage(topicName, 2, lastMessage, isolation);
+    }
+
+    @Test(timeOut = 1000 * 20, dataProvider = "takeSnapshotBeforeRecovery")
+    public void basicRecoveryAbortedTransactionDueToProducerFenced(boolean takeSnapshotBeforeRecovery)
+            throws Exception {
+
+        String topicName = "basicRecoveryTestAfterTopicUnload2";
+        String transactionalId = "myProducer";
+        String isolation = "read_committed";
+
+        String namespace = TopicName.get(topicName).getNamespace();
+
+        @Cleanup
+        KafkaProducer<Integer, String> producer = buildTransactionProducer(transactionalId);
+
+        producer.initTransactions();
+
+        KafkaProtocolHandler protocolHandler = (KafkaProtocolHandler)
+                pulsar.getProtocolHandlers().protocol("kafka");
+
+        producer.beginTransaction();
+
+        String firstMessage = "aborted msg 1";
+
+        producer.send(new ProducerRecord<>(topicName, 0, firstMessage)).get();
+        producer.flush();
+        // force take snapshot
+        protocolHandler
+                .getReplicaManager()
+                .takeProducerStateSnapshots()
+                .get();
+
+        // recovery will re-process the topic from this point onwards
+        String secondMessage = "aborted msg 2";
+        producer.send(new ProducerRecord<>(topicName, 0, secondMessage)).get();
+
+
+        @Cleanup
+        KafkaProducer<Integer, String> producer2 = buildTransactionProducer(transactionalId);
+        producer2.initTransactions();
+
+        // the transaction is automatically aborted, because the first instance of the
+        // producer has been fenced
+        expectThrows(ProducerFencedException.class, () -> {
+            producer.commitTransaction();
+        });
+
+
+        producer2.beginTransaction();
+        String lastMessage = "committed mgs";
+        producer2.send(new ProducerRecord<>(topicName, 0, lastMessage)).get();
+        producer2.send(new ProducerRecord<>(topicName, 0, lastMessage)).get();
+        producer2.commitTransaction();
+
+        if (takeSnapshotBeforeRecovery) {
+            // force take snapshot
+            protocolHandler
+                    .getReplicaManager()
+                    .takeProducerStateSnapshots()
+                    .get();
+        }
+
+        // unload the namespace, this will force a recovery
+        pulsar.getAdminClient().namespaces().unload(namespace);
+
+        consumeTxnMessage(topicName, 2, lastMessage, isolation);
+    }
+
+
+    @Test(timeOut = 1000 * 20, dataProvider = "takeSnapshotBeforeRecovery")
+    public void basicRecoveryAbortedTransactionDueToProducerTimedOut(boolean takeSnapshotBeforeRecovery)
+            throws Exception {
+
+        String topicName = "basicRecoveryTestAfterTopicUnload2";
+        String transactionalId = "myProducer";
+        String isolation = "read_committed";
+
+        String namespace = TopicName.get(topicName).getNamespace();
+
+        @Cleanup
+        KafkaProducer<Integer, String> producer = buildTransactionProducer(transactionalId, 1777);
+
+        producer.initTransactions();
+
+        KafkaProtocolHandler protocolHandler = (KafkaProtocolHandler)
+                pulsar.getProtocolHandlers().protocol("kafka");
+
+        producer.beginTransaction();
+
+        String firstMessage = "aborted msg 1";
+
+        producer.send(new ProducerRecord<>(topicName, 0, firstMessage)).get();
+        producer.flush();
+        // force take snapshot
+        protocolHandler
+                .getReplicaManager()
+                .takeProducerStateSnapshots()
+                .get();
+
+        // recovery will re-process the topic from this point onwards
+        String secondMessage = "aborted msg 2";
+        producer.send(new ProducerRecord<>(topicName, 0, secondMessage)).get();
+
+        Thread.sleep(conf.getKafkaTransactionalIdExpirationMs() + 5000);
+
+        // the transaction is automatically aborted, because of producer timeout
+        expectThrows(ProducerFencedException.class, () -> {
+            producer.commitTransaction();
+        });
+
+        @Cleanup
+        KafkaProducer<Integer, String> producer2 = buildTransactionProducer(transactionalId, 1000);
+        producer2.initTransactions();
+        producer2.beginTransaction();
+        String lastMessage = "committed mgs";
+        producer2.send(new ProducerRecord<>(topicName, 0, lastMessage)).get();
+        producer2.send(new ProducerRecord<>(topicName, 0, lastMessage)).get();
+        producer2.commitTransaction();
+
+        if (takeSnapshotBeforeRecovery) {
+            // force take snapshot
+            protocolHandler
+                    .getReplicaManager()
+                    .takeProducerStateSnapshots()
+                    .get();
+        }
+
+        // unload the namespace, this will force a recovery
+        pulsar.getAdminClient().namespaces().unload(namespace);
+
+        consumeTxnMessage(topicName, 2, lastMessage, isolation);
     }
 
     private List<String> prepareData(String sourceTopicName,
@@ -408,7 +628,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
             Thread.sleep(200);
         }
         if (!flag.get()) {
-            Assert.fail("The txn markers are not wrote.");
+            fail("The txn markers are not wrote.");
         }
     }
 
@@ -424,12 +644,22 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
     }
 
     private KafkaProducer<Integer, String> buildTransactionProducer(String transactionalId) {
+        return buildTransactionProducer(transactionalId, -1);
+    }
+
+    private KafkaProducer<Integer, String> buildTransactionProducer(String transactionalId, int txTimeout) {
         Properties producerProps = new Properties();
         producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, getKafkaServerAdder());
         producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class.getName());
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         producerProps.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 1000 * 10);
         producerProps.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId);
+        if (txTimeout > 0) {
+            producerProps.put(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, txTimeout);
+        } else {
+            // very long time-out
+            producerProps.put(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, 600 * 1000);
+        }
         addCustomizeProps(producerProps);
 
         return new KafkaProducer<>(producerProps);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
@@ -414,7 +414,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
     @Test(timeOut = 1000 * 20, dataProvider = "takeSnapshotBeforeRecovery")
     public void basicRecoveryAbortedTransaction(boolean takeSnapshotBeforeRecovery) throws Exception {
 
-        String topicName = "basicRecoveryTestAfterTopicUnload2";
+        String topicName = "basicRecoveryAbortedTransaction_" + takeSnapshotBeforeRecovery;
         String transactionalId = "myProducer";
         String isolation = "read_committed";
 
@@ -469,7 +469,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
     public void basicRecoveryAbortedTransactionDueToProducerFenced(boolean takeSnapshotBeforeRecovery)
             throws Exception {
 
-        String topicName = "basicRecoveryTestAfterTopicUnload2";
+        String topicName = "basicRecoveryAbortedTransactionDueToProducerFenced_" + takeSnapshotBeforeRecovery;
         String transactionalId = "myProducer";
         String isolation = "read_committed";
 
@@ -536,14 +536,14 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
     public void basicRecoveryAbortedTransactionDueToProducerTimedOut(boolean takeSnapshotBeforeRecovery)
             throws Exception {
 
-        String topicName = "basicRecoveryTestAfterTopicUnload2";
+        String topicName = "basicRecoveryAbortedTransactionDueToProducerTimedOut_" + takeSnapshotBeforeRecovery;
         String transactionalId = "myProducer";
         String isolation = "read_committed";
 
         String namespace = TopicName.get(topicName).getNamespace();
 
         @Cleanup
-        KafkaProducer<Integer, String> producer = buildTransactionProducer(transactionalId, 1777);
+        KafkaProducer<Integer, String> producer = buildTransactionProducer(transactionalId, 1000);
 
         producer.initTransactions();
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
@@ -233,13 +233,13 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
         txnOffsetTest("txn-offset-abort-test", 10, false);
     }
 
-    @Test
+    @Test(timeOut = 1000 * 20)
     public void basicRecoveryTestAfterTopicUnload() throws Exception {
 
         String topicName = "basicRecoveryTestAfterTopicUnload";
         String transactionalId = "myProducer";
         String isolation = "read_committed";
-        boolean isBatch  = false;
+        boolean isBatch = false;
 
         String namespace = TopicName.get(topicName).getNamespace();
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionWithOAuthBearerAuthTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionWithOAuthBearerAuthTest.java
@@ -25,6 +25,7 @@ import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationFactoryOAuth2;
 import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 @Slf4j
 public class TransactionWithOAuthBearerAuthTest extends TransactionTest {
@@ -97,6 +98,13 @@ public class TransactionWithOAuthBearerAuthTest extends TransactionTest {
                 adminCredentialPath,
                 AUDIENCE
         ));
+    }
+
+
+    @Test(enabled = false)
+    @Override
+    public void basicRecoveryAbortedTransactionDueToProducerTimedOut(boolean takeSnapshotBeforeRecovery) {
+        // this test is disabled in this suite because the token expires
     }
 
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinatorTest.java
@@ -32,6 +32,7 @@ import com.google.common.collect.Sets;
 import io.streamnative.pulsar.handlers.kop.KafkaProtocolHandler;
 import io.streamnative.pulsar.handlers.kop.KopProtocolHandlerTestBase;
 import io.streamnative.pulsar.handlers.kop.scala.Either;
+import io.streamnative.pulsar.handlers.kop.storage.MemoryProducerStateManagerSnapshotBuffer;
 import io.streamnative.pulsar.handlers.kop.utils.ProducerIdAndEpoch;
 import io.streamnative.pulsar.handlers.kop.utils.timer.MockTime;
 import java.util.Collections;
@@ -134,7 +135,9 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
                 transactionManager,
                 time,
                 METADATA_NAMESPACE_PREFIX,
-                NAMESPACE_PREFIX);
+                NAMESPACE_PREFIX,
+                (config) -> new MemoryProducerStateManagerSnapshotBuffer()
+                );
         result = null;
         error = Errors.NONE;
         capturedTxn = ArgumentCaptor.forClass(TransactionMetadata.class);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogTest.java
@@ -13,7 +13,10 @@
  */
 package io.streamnative.pulsar.handlers.kop.storage;
 
+import static org.mockito.Mockito.mock;
+
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
+import io.streamnative.pulsar.handlers.kop.KafkaTopicLookupService;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
@@ -46,7 +49,8 @@ public class PartitionLogTest {
             new TopicPartition("test", 1),
             "test",
             null,
-            new ProducerStateManager("test", new MemoryProducerStateManagerSnapshotBuffer()));
+            mock(KafkaTopicLookupService.class),
+            new MemoryProducerStateManagerSnapshotBuffer());
 
     @DataProvider(name = "compressionTypes")
     Object[] allCompressionTypes() {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogTest.java
@@ -46,7 +46,7 @@ public class PartitionLogTest {
             new TopicPartition("test", 1),
             "test",
             null,
-            new ProducerStateManager("test"));
+            new ProducerStateManager("test", new MemoryProducerStateManagerSnapshotBuffer()));
 
     @DataProvider(name = "compressionTypes")
     Object[] allCompressionTypes() {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManagerTest.java
@@ -46,6 +46,7 @@ public class ProducerStateManagerTest extends KopProtocolHandlerTestBase {
     private final Long producerId = 1L;
     private final MockTime time = new MockTime();
     private ProducerStateManager stateManager;
+    private ProducerStateManagerSnapshotBuffer producerStateManagerSnapshotBuffer;
 
     @BeforeClass
     @Override
@@ -59,7 +60,8 @@ public class ProducerStateManagerTest extends KopProtocolHandlerTestBase {
 
     @BeforeMethod
     protected void setUp() {
-        stateManager = new ProducerStateManager(partition.toString());
+        producerStateManagerSnapshotBuffer = new MemoryProducerStateManagerSnapshotBuffer();
+        stateManager = new ProducerStateManager(partition.toString(), producerStateManagerSnapshotBuffer);
     }
 
     @AfterMethod
@@ -208,7 +210,7 @@ public class ProducerStateManagerTest extends KopProtocolHandlerTestBase {
     @Test(timeOut = defaultTestTimeout)
     public void testSequenceNotValidatedForGroupMetadataTopic() {
         TopicPartition partition = new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0);
-        stateManager = new ProducerStateManager(partition.toString());
+        stateManager = new ProducerStateManager(partition.toString(), producerStateManagerSnapshotBuffer);
         short epoch = 0;
         append(stateManager, producerId, epoch, 99L, time.milliseconds(),
                 true, PartitionLog.AppendOrigin.Coordinator);


### PR DESCRIPTION
Master Issue: #960 

### Motivation

Implement Snapshots for ProducerStateManager


### Modifications

TODO list:
- introduce ProducerStateManagerSnapshotBuffer abstraction
- implement a in-memory ProducerStateManagerSnapshotBuffer for tests
- implement recovery by fully reading from the partition from the offset to the latest snapshot onwards
- add tests about recovery in absence of snapshots (basically this is the upgrade from the previous version of KOP)
- MetadataUtils: create the new system topic _producer_state_snapshots
- implement ProducerStateManagerSnapshotBuffer that writes and reads from the Pulsar topic _producer_state_snapshots
- add integration tests with failure scenarios
- add end-to-end tests

### Verifying this change

This change adds tests

### Documentation

Check the box below.

Need to update docs? 

- [x] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

