### PR TITLE
[fix] Release leaked entries in getCommittedEntries

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -693,6 +693,10 @@ public class PartitionLog {
                         entry.getLedgerId(), entry.getEntryId());
             }
         }
+        // Release all the entries that are not in the result
+        for (int i = committedEntries.size(); i < entries.size(); i ++) {
+            entries.get(i).release();
+        }
         return committedEntries;
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -694,7 +694,7 @@ public class PartitionLog {
             }
         }
         // Release all the entries that are not in the result
-        for (int i = committedEntries.size(); i < entries.size(); i ++) {
+        for (int i = committedEntries.size(); i < entries.size(); i++) {
             entries.get(i).release();
         }
         return committedEntries;


### PR DESCRIPTION
### Motivation

When entries are filtered out in the `PartitionLog#getCommittedEntries` method, they are not released, which is a leak.

Here is the relevant stack trace from netty indicating there is an issue in the `handleEntries` method:

```
2022-12-12T17:51:34,277+0000 [pulsar-io-4-26] ERROR io.netty.util.ResourceLeakDetector - LEAK: ByteBuf.release() was not called before
 it's garbage-collected. See https://netty.io/wiki/reference-counted-objects.html for more information.
Recent access records: 
#1:
        io.netty.buffer.AdvancedLeakAwareByteBuf.nioBuffer(AdvancedLeakAwareByteBuf.java:713)
        io.streamnative.pulsar.handlers.kop.utils.ByteBufUtils.getNioBuffer(ByteBufUtils.java:96)
        io.streamnative.pulsar.handlers.kop.format.AbstractEntryFormatter.decodeSync(AbstractEntryFormatter.java:232)
        io.streamnative.pulsar.handlers.kop.format.AbstractEntryFormatter.decode(AbstractEntryFormatter.java:65)
        io.streamnative.pulsar.handlers.kop.storage.PartitionLog.lambda$handleEntries$14(PartitionLog.java:634)
        java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859)
        java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:837)
        java.base/java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:478)
        java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
        java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
        java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        java.base/java.lang.Thread.run(Thread.java:829)
```

### Modifications

* Release the filtered entries.

### Verifying this change

I read through the code to verify these entries are not released anywhere else. I am not sure that it is easy to test, though.

### Documentation

- [x] `no-need-doc` 

This is a bug fix.