### PR TITLE
[improve] Transactions: use Epoll for eventLoopGroup when available

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
@@ -18,6 +18,7 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import io.streamnative.pulsar.handlers.kop.EndPoint;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import io.streamnative.pulsar.handlers.kop.KopBrokerLookupManager;
@@ -56,6 +57,7 @@ import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.impl.AuthenticationUtil;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.netty.ChannelFutures;
+import org.apache.pulsar.common.util.netty.EventLoopUtil;
 import org.eclipse.jetty.util.BlockingArrayQueue;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 
@@ -177,7 +179,8 @@ public class TransactionMarkerChannelManager {
             authentication = AuthenticationUtil.create(auth, authParams);
             authentication.start();
         }
-        eventLoopGroup = new NioEventLoopGroup();
+        eventLoopGroup = EventLoopUtil
+                .newEventLoopGroup(0, false, new DefaultThreadFactory("kop-txn"));
         bootstrap = new Bootstrap();
         bootstrap.group(eventLoopGroup);
         bootstrap.channel(NioSocketChannel.class);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
@@ -183,7 +183,7 @@ public class TransactionMarkerChannelManager {
                 .newEventLoopGroup(0, false, new DefaultThreadFactory("kop-txn"));
         bootstrap = new Bootstrap();
         bootstrap.group(eventLoopGroup);
-        bootstrap.channel(NioSocketChannel.class);
+        bootstrap.channel(EventLoopUtil.getClientSocketChannelClass(eventLoopGroup));
         bootstrap.handler(new TransactionMarkerChannelInitializer(kafkaConfig, enableTls, this));
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
@@ -16,8 +16,6 @@ package io.streamnative.pulsar.handlers.kop.coordinator.transaction;
 import com.google.common.annotations.VisibleForTesting;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.nio.NioEventLoopGroup;
-import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.streamnative.pulsar.handlers.kop.EndPoint;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;


### PR DESCRIPTION
### Motivation

We are using `NioEventLoop` instead of `Epoll`. It is recommended to use `Epoll`: https://netty.io/wiki/native-transports.html.

### Modifications

* Use the Apache Pulsar method `EventLoopUtil#newEventLoopGroup` to load the best event loop. Instead of adding any configuration, I am simply using the defaults that we've already relied on. Please let me know if we want to make it configurable. Note that 0 threads defaults to 2 times the number of available processors.

### Verifying this change

This change is trivial, and since the broker already uses this method to create the event loop, it should be low risk. The only down side is that Apache Pulsar could move this method and break our usage.

### Documentation
  
- [x] `no-need-doc` 
  
This is an internal improvement.