### PR TITLE
[bugfix] Fix memory leak in case of closed connections with pending requests

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -21,6 +21,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.timeout.IdleStateEvent;
+import io.netty.util.ReferenceCountUtil;
 import java.io.Closeable;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
@@ -113,7 +114,7 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
             final ResponseAndRequest responseAndRequest = requestQueue.poll();
             if (responseAndRequest != null) {
                 // Trigger writeAndFlushResponseToClient immediately, but it will do nothing because isActive is false
-                responseAndRequest.getResponseFuture().cancel(true);
+                responseAndRequest.cancel();
             } else {
                 // queue is empty
                 break;
@@ -130,11 +131,6 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
         if (log.isDebugEnabled()) {
             log.debug("Channel writability has changed to: {}", ctx.channel().isWritable());
         }
-    }
-
-    // turn input ByteBuf msg, which send from client side, into KafkaHeaderAndRequest
-    protected KafkaHeaderAndRequest byteBufToRequest(ByteBuf msg) {
-        return byteBufToRequest(msg, null);
     }
 
     protected KafkaHeaderAndRequest byteBufToRequest(ByteBuf msg,
@@ -584,7 +580,7 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
     protected abstract void
     handleCreatePartitions(KafkaHeaderAndRequest kafkaHeaderAndRequest, CompletableFuture<AbstractResponse> response);
 
-    public static class KafkaHeaderAndRequest implements Closeable {
+    public static class KafkaHeaderAndRequest {
 
         private static final String DEFAULT_CLIENT_HOST = "";
 
@@ -637,9 +633,8 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
                 this.header, this.request, this.remoteAddress);
         }
 
-        @Override
         public void close() {
-            this.buffer.release();
+            ReferenceCountUtil.safeRelease(this.buffer);
         }
     }
 
@@ -720,6 +715,11 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
 
         public boolean expired(final int requestTimeoutMs) {
             return MathUtils.elapsedNanos(createdTimestamp) > TimeUnit.MILLISECONDS.toNanos(requestTimeoutMs);
+        }
+
+        public void cancel() {
+            responseFuture.cancel(true);
+            request.close();
         }
 
         ResponseAndRequest(CompletableFuture<AbstractResponse> response, KafkaHeaderAndRequest request) {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -194,7 +194,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
         inputBuf.writeBytes(serializedRequest);
 
         // 2. turn Bytebuf into KafkaHeaderAndRequest.
-        KafkaHeaderAndRequest request = handler.byteBufToRequest(inputBuf);
+        KafkaHeaderAndRequest request = handler.byteBufToRequest(inputBuf, null);
 
         // 3. verify byteBufToRequest works well.
         assertEquals(request.getHeader().data(), header.data());


### PR DESCRIPTION
### Motivation

When a connection is closed while having pending requests, the ByteBuf is not released.

### Modifications

Release the ByteBuf attached to the original request

### Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

