### PR TITLE
[improvement] Upgrade internal Kafka client library to 2.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <!-- dependencies -->
     <jackson.version>2.14.0</jackson.version>
     <jackson-databind.version>2.13.4.1</jackson-databind.version>
-    <kafka.version>2.8.0</kafka.version>
+    <kafka.version>2.8.2</kafka.version>
     <lombok.version>1.18.24</lombok.version>
     <mockito.version>2.22.0</mockito.version>
     <pulsar.group.id>io.streamnative</pulsar.group.id>


### PR DESCRIPTION

Fixes #1630

### Motivation

Sometimes the 2.8.0 client hangs on AOuth2 autentication

### Modifications

Upgrade to 2.8.2

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

