### PR TITLE
Optimize performance of EncodeResult.updateProducerStats and DecodeResult.updateConsumerStats

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
@@ -14,7 +14,6 @@
 package io.streamnative.pulsar.handlers.kop;
 
 import static io.streamnative.pulsar.handlers.kop.KafkaProtocolHandler.TLS_HANDLER;
-import static io.streamnative.pulsar.handlers.kop.KopServerStats.SERVER_SCOPE;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.netty.channel.ChannelInitializer;
@@ -23,8 +22,6 @@ import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.IdleStateHandler;
-import io.streamnative.pulsar.handlers.kop.stats.PrometheusMetricsProvider;
-import io.streamnative.pulsar.handlers.kop.stats.StatsLogger;
 import io.streamnative.pulsar.handlers.kop.storage.ReplicaManager;
 import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperation;
 import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperationPurgatory;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
@@ -135,13 +135,11 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
 
     @VisibleForTesting
     public KafkaRequestHandler newCnx(final TenantContextManager tenantContextManager) throws Exception {
-        PrometheusMetricsProvider statsProvider = new PrometheusMetricsProvider();
-        StatsLogger rootStatsLogger = statsProvider.getStatsLogger("");
         return new KafkaRequestHandler(pulsarService, kafkaConfig,
                 tenantContextManager, replicaManager, kopBrokerLookupManager, adminManager,
                 producePurgatory, fetchPurgatory,
                 enableTls, advertisedEndPoint, skipMessagesWithoutIndex,
-                new RequestStats(rootStatsLogger.scope(SERVER_SCOPE)),
+                requestStats,
                 sendResponseScheduler,
                 kafkaTopicManagerSharedState);
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/RequestStats.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/RequestStats.java
@@ -35,6 +35,7 @@ import static io.streamnative.pulsar.handlers.kop.KopServerStats.RESPONSE_BLOCKE
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.SERVER_SCOPE;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.TOPIC_SCOPE;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.WAITING_FETCHES_TRIGGERED;
+
 import com.google.common.annotations.VisibleForTesting;
 import io.streamnative.pulsar.handlers.kop.stats.NullStatsLogger;
 import io.streamnative.pulsar.handlers.kop.stats.StatsLogger;
@@ -157,7 +158,8 @@ public class RequestStats {
     private final Map<ApiKeys, StatsLogger> apiKeysToStatsLogger = new ConcurrentHashMap<>();
 
     private final Map<TopicPartition, StatsLogger> cachedLoggersForTopicPartitions = new ConcurrentHashMap<>();
-    private final Map<Pair<TopicPartition, String>, StatsLogger> cachedLoggersForTopicPartitionsAndGroups = new ConcurrentHashMap<>();
+    private final Map<Pair<TopicPartition, String>, StatsLogger> cachedLoggersForTopicPartitionsAndGroups =
+            new ConcurrentHashMap<>();
 
     private final Map<String, RequestStats> cachedRequestStatsForTenants = new ConcurrentHashMap<>();
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/RequestStats.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/RequestStats.java
@@ -156,6 +156,8 @@ public class RequestStats {
 
     private final Map<TopicPartition, StatsLogger> cachedLoggersForTopicPartitions = new ConcurrentHashMap<>();
 
+    private final Map<String, RequestStats> cachedRequestStatsForTenants = new ConcurrentHashMap<>();
+
     public RequestStats(StatsLogger statsLogger) {
         this.statsLogger = statsLogger;
 
@@ -250,6 +252,7 @@ public class RequestStats {
     }
 
     public RequestStats forTenant(String tenant) {
-        return new RequestStats(statsLogger.scopeLabel("tenant", tenant));
+        return cachedRequestStatsForTenants.computeIfAbsent(tenant,
+                __ -> new RequestStats(statsLogger.scopeLabel("tenant", tenant)));
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/DecodeResult.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/DecodeResult.java
@@ -18,6 +18,7 @@ import static io.streamnative.pulsar.handlers.kop.KopServerStats.CONSUME_MESSAGE
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.CONSUME_MESSAGE_CONVERSIONS_TIME_NANOS;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.ENTRIES_OUT;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.MESSAGE_OUT;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.Recycler;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/DecodeResult.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/DecodeResult.java
@@ -17,11 +17,7 @@ import static io.streamnative.pulsar.handlers.kop.KopServerStats.BYTES_OUT;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.CONSUME_MESSAGE_CONVERSIONS;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.CONSUME_MESSAGE_CONVERSIONS_TIME_NANOS;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.ENTRIES_OUT;
-import static io.streamnative.pulsar.handlers.kop.KopServerStats.GROUP_SCOPE;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.MESSAGE_OUT;
-import static io.streamnative.pulsar.handlers.kop.KopServerStats.PARTITION_SCOPE;
-import static io.streamnative.pulsar.handlers.kop.KopServerStats.TOPIC_SCOPE;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.Recycler;
@@ -100,16 +96,14 @@ public class DecodeResult {
                                     RequestStats statsLogger) {
         final int numMessages = EntryFormatter.parseNumMessages(records);
 
-        final StatsLogger statsLoggerForThisPartition = statsLogger.getStatsLogger()
-                .scopeLabel(TOPIC_SCOPE, topicPartition.topic())
-                .scopeLabel(PARTITION_SCOPE, String.valueOf(topicPartition.partition()));
+        final StatsLogger statsLoggerForThisPartition = statsLogger.getStatsLoggerForTopicPartition(topicPartition);
 
         statsLoggerForThisPartition.getCounter(CONSUME_MESSAGE_CONVERSIONS).add(conversionCount);
         statsLoggerForThisPartition.getOpStatsLogger(CONSUME_MESSAGE_CONVERSIONS_TIME_NANOS)
                 .registerSuccessfulEvent(conversionTimeNanos, TimeUnit.NANOSECONDS);
         final StatsLogger statsLoggerForThisGroup;
         if (groupId != null) {
-            statsLoggerForThisGroup = statsLoggerForThisPartition.scopeLabel(GROUP_SCOPE, groupId);
+            statsLoggerForThisGroup = statsLogger.getStatsLoggerForTopicPartitionAndGroup(topicPartition, groupId);
         } else {
             statsLoggerForThisGroup = statsLoggerForThisPartition;
         }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/EncodeResult.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/EncodeResult.java
@@ -15,11 +15,8 @@ package io.streamnative.pulsar.handlers.kop.format;
 
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.BYTES_IN;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.MESSAGE_IN;
-import static io.streamnative.pulsar.handlers.kop.KopServerStats.PARTITION_SCOPE;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.PRODUCE_MESSAGE_CONVERSIONS;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.PRODUCE_MESSAGE_CONVERSIONS_TIME_NANOS;
-import static io.streamnative.pulsar.handlers.kop.KopServerStats.TOPIC_SCOPE;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.util.Recycler;
 import io.streamnative.pulsar.handlers.kop.RequestStats;
@@ -89,9 +86,7 @@ public class EncodeResult {
         producer.updateRates(numMessages, numBytes);
         producer.getTopic().incrementPublishCount(numMessages, numBytes);
 
-        final StatsLogger statsLoggerForThisPartition = requestStats.getStatsLogger()
-                .scopeLabel(TOPIC_SCOPE, topicPartition.topic())
-                .scopeLabel(PARTITION_SCOPE, String.valueOf(topicPartition.partition()));
+        final StatsLogger statsLoggerForThisPartition = requestStats.getStatsLoggerForTopicPartition(topicPartition);
 
         statsLoggerForThisPartition.getCounter(BYTES_IN).add(numBytes);
         statsLoggerForThisPartition.getCounter(MESSAGE_IN).add(numMessages);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/EncodeResult.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/EncodeResult.java
@@ -17,6 +17,7 @@ import static io.streamnative.pulsar.handlers.kop.KopServerStats.BYTES_IN;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.MESSAGE_IN;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.PRODUCE_MESSAGE_CONVERSIONS;
 import static io.streamnative.pulsar.handlers.kop.KopServerStats.PRODUCE_MESSAGE_CONVERSIONS_TIME_NANOS;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.util.Recycler;
 import io.streamnative.pulsar.handlers.kop.RequestStats;


### PR DESCRIPTION
- reduce unnecessary garbage created by adding some caching

This came up in some profiling

![image](https://user-images.githubusercontent.com/66864/209136588-027071f1-2c96-4dd9-9182-986a540cbd86.png)
![image](https://user-images.githubusercontent.com/66864/209136672-5398e5a2-1b38-4492-bae1-304e3d0cb297.png)


### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->