### PR TITLE
[bugfix] Fix regression with the upgrade to 2.8.x: Count corrently the number of partitions in ProduceRequest

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -830,7 +830,12 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         checkArgument(produceHar.getRequest() instanceof ProduceRequest);
         ProduceRequest produceRequest = (ProduceRequest) produceHar.getRequest();
 
-        final int numPartitions = produceRequest.data().topicData().size();
+        final int numPartitions = produceRequest
+                .data()
+                .topicData()
+                .stream()
+                .mapToInt(t -> t.partitionData().size())
+                .sum();
         if (numPartitions == 0) {
             resultFuture.complete(new ProduceResponse(Collections.emptyMap()));
             return;


### PR DESCRIPTION
### Motivation

With the upgrade to Kafka 2.8.x we introduced a regression in the handleProduceRequest method, we are not counting
correctly the number of partitions.
If the client sends data for more than one partition for the same topic, then the result is a REQUEST_TIMED_OUT because we are calling "completeOne.run()" once per partition, but we are using the number of topics as the expected number of "completeOne" calls.

### Modifications

Count correctly the number of partitions.

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

