### PR TITLE
[branch-2.10] Use a more efficient implementation of sanitizeMetricName

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/stats/PrometheusStatsLogger.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/stats/PrometheusStatsLogger.java
@@ -14,7 +14,6 @@
 package io.streamnative.pulsar.handlers.kop.stats;
 
 import com.google.common.base.Joiner;
-import io.prometheus.client.Collector;
 import java.util.Map;
 import java.util.TreeMap;
 import org.apache.bookkeeper.stats.Counter;
@@ -78,6 +77,22 @@ public class PrometheusStatsLogger implements StatsLogger {
     }
 
     private String completeName(String name) {
-        return Collector.sanitizeMetricName(scope.isEmpty() ? name : Joiner.on('_').join(scope, name));
+        return sanitizeMetricName(scope.isEmpty() ? name : Joiner.on('_').join(scope, name));
+    }
+
+    private static String sanitizeMetricName(String metricName) {
+        int length = metricName.length();
+        char[] sanitized = new char[length];
+
+        for (int i = 0; i < length; i++) {
+            char ch = metricName.charAt(i);
+            if (ch != ':' && (ch < 'a' || ch > 'z') && (ch < 'A' || ch > 'Z') && (i == 0 || ch < '0' || ch > '9')) {
+                sanitized[i] = '_';
+            } else {
+                sanitized[i] = ch;
+            }
+        }
+
+        return new String(sanitized);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/streamnative/kop/issues/1652

### Motivation

Pulsar 2.10 or earlier depends on io.prometheus:simpleclient:0.5.0, whose implementation of `Collectors.sanitizeMetricName` uses regex, which is inefficient and costs much CPU.

### Modifications

Migrate the implementation of `sanitizeMetricName` from io:prometheus:simpleclient:0.16.0 to branch-2.10 or earlier.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

