### PR TITLE
Remove unnecessary Boolean boxing

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -180,7 +180,7 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
         }
     }
 
-    protected Boolean channelReady() {
+    protected boolean channelReady() {
         return hasAuthenticated();
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -553,7 +553,7 @@ public class TransactionCoordinator {
                                 Long producerId,
                                 Short producerEpoch,
                                 TransactionResult txnMarkerResult,
-                                Boolean isFromClient,
+                                boolean isFromClient,
                                 Consumer<Errors> callback) {
         AtomicBoolean isEpochFence = new AtomicBoolean(false);
         if (transactionalId == null || transactionalId.isEmpty()) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMetadata.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMetadata.java
@@ -389,7 +389,7 @@ public class TransactionMetadata {
     public TxnTransitMetadata prepareProducerIdRotation(Long newProducerId,
                                   Integer newTxnTimeoutMs,
                                   Long updateTimestamp,
-                                  Boolean recordLastEpoch) {
+                                  boolean recordLastEpoch) {
         if (hasPendingTransaction()) {
             throw new IllegalStateException("Cannot rotate producer ids while a transaction is still pending");
         }
@@ -491,7 +491,7 @@ public class TransactionMetadata {
         topicPartitions.addAll(partitions);
     }
 
-    public Boolean pendingTransitionInProgress() {
+    public boolean pendingTransitionInProgress() {
         return this.pendingState.isPresent();
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/stats/PrometheusTextFormatUtil.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/stats/PrometheusTextFormatUtil.java
@@ -90,9 +90,9 @@ public class PrometheusTextFormatUtil {
     }
 
     private static void writeQuantile(SimpleTextOutputStream w, DataSketchesOpStatsLogger opStat, String name,
-                                      Boolean success, double quantile) {
+                                      boolean success, double quantile) {
         w.write(name)
-                .write("{success=\"").write(success.toString())
+                .write("{success=\"").write(success)
                 .write("\",quantile=\"").write(Double.toString(quantile));
         if (!opStat.getLabels().isEmpty()) {
             w.write("\", ");
@@ -105,8 +105,8 @@ public class PrometheusTextFormatUtil {
     }
 
     private static void writeCount(SimpleTextOutputStream w, DataSketchesOpStatsLogger opStat, String name,
-                                   Boolean success) {
-        w.write(name).write("_count{success=\"").write(success.toString());
+                                   boolean success) {
+        w.write(name).write("_count{success=\"").write(success);
         if (!opStat.getLabels().isEmpty()) {
             w.write("\", ");
             writeLabelsNoBraces(w, opStat.getLabels());
@@ -118,8 +118,8 @@ public class PrometheusTextFormatUtil {
     }
 
     private static void writeSum(SimpleTextOutputStream w, DataSketchesOpStatsLogger opStat, String name,
-                                 Boolean success) {
-        w.write(name).write("_sum{success=\"").write(success.toString());
+                                 boolean success) {
+        w.write(name).write("_sum{success=\"").write(success);
         if (!opStat.getLabels().isEmpty()) {
             w.write("\", ");
             writeLabelsNoBraces(w, opStat.getLabels());


### PR DESCRIPTION
### Motivation

There is some unnecessary boxing of `boolean` primitives in the code. This PR removes that boxing.

### Modifications

* Replace `Boolean` with `boolean` when appropriate.

### Verifying this change

No new tests are added, but the changes are pretty minor and are easy to understand. In all cases, we can see that the calling methods and the usage of the variables expect a primitive `boolean`.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

