### PR TITLE
[oauthclient] Create a zero-dependencies jar:

### DIFF
--- a/oauth-client/pom.xml
+++ b/oauth-client/pom.xml
@@ -29,11 +29,6 @@
   <name>StreamNative :: Pulsar Protocol Handler :: OAuth 2.0 Client</name>
   <description>OAuth 2.0 login callback handler for Kafka client</description>
 
-  <properties>
-    <async-http-client.version>2.12.1</async-http-client.version>
-    <guava.version>31.1-jre</guava.version>
-  </properties>
-
   <!-- include the dependencies -->
   <dependencies>
     <dependency>
@@ -45,30 +40,12 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.asynchttpclient</groupId>
-      <artifactId>async-http-client</artifactId>
-      <version>${async-http-client.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>
@@ -83,4 +60,43 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <relocations>
+                <relocation>
+                  <pattern>com.fasterxml.jackson</pattern>
+                  <shadedPattern>kafka.oauthclient.com.fasterxml.jackson</shadedPattern>
+                </relocation>
+              </relocations>
+              <artifactSet>
+                <includes>
+                  <include>com.fasterxml.jackson.core:*</include>
+                </includes>
+              </artifactSet>
+              <filters>
+                <filter>
+                  <artifact>com.fasterxml.jackson.core:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/**</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
-    <maven-shade-plugin.version>3.4.0</maven-shade-plugin.version>
+    <maven-shade-plugin.version>3.4.1</maven-shade-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
     <puppycrawl.checkstyle.version>8.37</puppycrawl.checkstyle.version>
     <spotbugs-maven-plugin.version>4.2.2</spotbugs-maven-plugin.version>


### PR DESCRIPTION
- remove Async HTTP client and use the standard JDK Http client
- shade and relocate Jackson Databind, used for JSON

### Motivation

Currently the OAuth client requires Async HTTP Client and Reactive Streams.
This is pretty awkward for users that are not using a dependency management system (like simply dropping the .jar file into the libs directory in order to run CLI tools)

### Modifications

- Remove the dependency from Async HTTP client and use the standard JDK URLConnection
- Shade the Jackson Mapper dependency
- Keep only the necessary classes into the jar (we are inheriting SNAKEYAML and other useless stuff from the parent pom) 

### Verifying this change


This change is already covered by existing tests

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 

This change is not visibile to most of the users  
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

