### PR TITLE
[ksqldb] Add implementation for describeCluster

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -109,6 +109,7 @@ import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.DeleteGroupsRequestData;
 import org.apache.kafka.common.message.DeleteRecordsRequestData;
 import org.apache.kafka.common.message.DeleteTopicsRequestData;
+import org.apache.kafka.common.message.DescribeClusterResponseData;
 import org.apache.kafka.common.message.DescribeConfigsRequestData;
 import org.apache.kafka.common.message.DescribeConfigsResponseData;
 import org.apache.kafka.common.message.EndTxnRequestData;
@@ -147,6 +148,8 @@ import org.apache.kafka.common.requests.CreateTopicsRequest;
 import org.apache.kafka.common.requests.DeleteGroupsRequest;
 import org.apache.kafka.common.requests.DeleteRecordsRequest;
 import org.apache.kafka.common.requests.DeleteTopicsRequest;
+import org.apache.kafka.common.requests.DescribeClusterRequest;
+import org.apache.kafka.common.requests.DescribeClusterResponse;
 import org.apache.kafka.common.requests.DescribeConfigsRequest;
 import org.apache.kafka.common.requests.DescribeConfigsResponse;
 import org.apache.kafka.common.requests.DescribeGroupsRequest;
@@ -490,18 +493,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             }
             return KafkaResponseUtils.newApiVersions(versionList);
         }
-    }
-
-    @Override
-    protected void handleError(KafkaHeaderAndRequest kafkaHeaderAndRequest,
-                               CompletableFuture<AbstractResponse> resultFuture) {
-        String err = String.format("Kafka API (%s) Not supported by kop server.",
-            kafkaHeaderAndRequest.getHeader().apiKey());
-        log.error(err);
-
-        AbstractResponse apiResponse = kafkaHeaderAndRequest.getRequest()
-            .getErrorResponse(new UnsupportedOperationException(err));
-        resultFuture.complete(apiResponse);
     }
 
     @Override
@@ -2099,6 +2090,32 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             }
         });
 
+    }
+
+    @Override
+    protected void handleDescribeCluster(KafkaHeaderAndRequest describeConfigs,
+                                         CompletableFuture<AbstractResponse> resultFuture) {
+        checkArgument(describeConfigs.getRequest() instanceof DescribeClusterRequest);
+        DescribeClusterResponseData data = new DescribeClusterResponseData();
+        List<Node> allNodes = Collections.synchronizedList(
+                new ArrayList<>(adminManager.getBrokers(advertisedEndPoint.getListenerName())));
+
+        // Each Pulsar broker can manage metadata like controller in Kafka,
+        // Kafka's AdminClient needs to find a controller node for metadata management.
+        // So here we return an random broker as a controller for the given listenerName.
+        final int controllerId = adminManager.getControllerId(advertisedEndPoint.getListenerName());
+        DescribeClusterResponse response = new DescribeClusterResponse(data);
+        data.setControllerId(controllerId);
+        data.setClusterId(clusterName);
+        data.setErrorCode(Errors.NONE.code());
+        data.setErrorMessage(Errors.NONE.message());
+        allNodes.forEach(node -> {
+            data.brokers().add(new DescribeClusterResponseData.DescribeClusterBroker()
+                    .setBrokerId(node.id())
+                    .setHost(node.host())
+                    .setPort(node.port()));
+        });
+        resultFuture.complete(response);
     }
 
     @Override

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -2097,8 +2097,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                          CompletableFuture<AbstractResponse> resultFuture) {
         checkArgument(describeConfigs.getRequest() instanceof DescribeClusterRequest);
         DescribeClusterResponseData data = new DescribeClusterResponseData();
-        List<Node> allNodes = Collections.synchronizedList(
-                new ArrayList<>(adminManager.getBrokers(advertisedEndPoint.getListenerName())));
+        List<Node> allNodes = new ArrayList<>(adminManager.getBrokers(advertisedEndPoint.getListenerName()));
 
         // Each Pulsar broker can manage metadata like controller in Kafka,
         // Kafka's AdminClient needs to find a controller node for metadata management.

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
@@ -641,11 +641,6 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
         DescribeClusterResult describeClusterResult = admin.describeCluster();
         assertEquals(describeClusterResult.clusterId().get(), conf.getClusterName());
         assertNotNull(describeClusterResult.controller().get());
-        if (isProxyStarted()) {
-            // proxy hides the complexity of the cluster
-            assertEquals(1, describeClusterResult.nodes().get().size());
-        } else {
-            assertEquals(2, describeClusterResult.nodes().get().size());
-        }
+        assertEquals(2, describeClusterResult.nodes().get().size());
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
@@ -16,6 +16,7 @@ package io.streamnative.pulsar.handlers.kop;
 import static org.apache.kafka.common.internals.Topic.GROUP_METADATA_TOPIC_NAME;
 import static org.apache.pulsar.common.naming.TopicName.PARTITIONED_TOPIC_SUFFIX;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.Lists;
@@ -32,6 +33,9 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import lombok.Cleanup;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.DescribeClusterResult;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -628,5 +632,20 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
         kProducer.close();
         kConsumer1.close();
         kConsumer2.close();
+    }
+
+    @Test(timeOut = 20000)
+    public void testDescribeCluster() throws Exception {
+        @Cleanup
+        AdminClient admin = AdminClient.create(newKafkaAdminClientProperties());
+        DescribeClusterResult describeClusterResult = admin.describeCluster();
+        assertEquals(describeClusterResult.clusterId().get(), conf.getClusterName());
+        assertNotNull(describeClusterResult.controller().get());
+        if (isProxyStarted()) {
+            // proxy hides the complexity of the cluster
+            assertEquals(1, describeClusterResult.nodes().get().size());
+        } else {
+            assertEquals(2, describeClusterResult.nodes().get().size());
+        }
     }
 }


### PR DESCRIPTION
### Motivation

After upgrading the Kafka client library to 2.8.x some clients, like the KSQLDB server, require that describeCluster API is implemented.

### Modifications

- implement describeCluster
- response with UnsupportedVersionException to unknown APIs

### Verifying this change

This change added tests

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
No need to add docs, this is a standard API

- [ ] `doc` 
  
  (If this PR contains doc changes)

