### PR TITLE
[transactions] Implement transaction recovery

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/DelayedFetch.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/DelayedFetch.java
@@ -89,7 +89,7 @@ public class DelayedFetch extends DelayedOperation {
             return;
         }
         replicaManager.readFromLocalLog(
-            readCommitted, fetchMaxBytes, maxReadEntriesNum, readPartitionInfo, context
+                readCommitted, fetchMaxBytes, maxReadEntriesNum, readPartitionInfo, context
         ).thenAccept(readRecordsResult -> {
             this.context.getStatsLogger().getWaitingFetchesTriggered().add(1);
             this.callback.complete(readRecordsResult);
@@ -109,7 +109,7 @@ public class DelayedFetch extends DelayedOperation {
         for (Map.Entry<TopicPartition, PartitionLog.ReadRecordsResult> entry : readRecordsResult.entrySet()) {
             TopicPartition tp = entry.getKey();
             PartitionLog.ReadRecordsResult result = entry.getValue();
-            PartitionLog partitionLog = replicaManager.getPartitionLog(tp, context.getNamespacePrefix());
+            PartitionLog partitionLog = result.partitionLog();
             PositionImpl currLastPosition = (PositionImpl) partitionLog.getLastPosition(context.getTopicManager());
             if (currLastPosition.compareTo(PositionImpl.EARLIEST) == 0) {
                 HAS_ERROR_UPDATER.set(this, true);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
@@ -50,6 +50,8 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
     private final KopBrokerLookupManager kopBrokerLookupManager;
     @Getter
     private final KafkaTopicManagerSharedState kafkaTopicManagerSharedState;
+    private final KafkaTopicLookupService kafkaTopicLookupService;
+    private final LookupClient lookupClient;
 
     private final AdminManager adminManager;
     private DelayedOperationPurgatory<DelayedOperation> producePurgatory;
@@ -80,7 +82,9 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
                                    boolean skipMessagesWithoutIndex,
                                    RequestStats requestStats,
                                    OrderedScheduler sendResponseScheduler,
-                                   KafkaTopicManagerSharedState kafkaTopicManagerSharedState) {
+                                   KafkaTopicManagerSharedState kafkaTopicManagerSharedState,
+                                   KafkaTopicLookupService kafkaTopicLookupService,
+                                   LookupClient lookupClient) {
         super();
         this.pulsarService = pulsarService;
         this.kafkaConfig = kafkaConfig;
@@ -102,6 +106,8 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
         this.sendResponseScheduler = sendResponseScheduler;
         this.kafkaTopicManagerSharedState = kafkaTopicManagerSharedState;
         this.lengthFieldPrepender = new LengthFieldPrepender(4);
+        this.kafkaTopicLookupService = kafkaTopicLookupService;
+        this.lookupClient = lookupClient;
     }
 
     @Override
@@ -127,7 +133,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
                 tenantContextManager, replicaManager, kopBrokerLookupManager, adminManager,
                 producePurgatory, fetchPurgatory,
                 enableTls, advertisedEndPoint, skipMessagesWithoutIndex, requestStats, sendResponseScheduler,
-                kafkaTopicManagerSharedState);
+                kafkaTopicManagerSharedState, kafkaTopicLookupService, lookupClient);
     }
 
     @VisibleForTesting
@@ -138,6 +144,8 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
                 enableTls, advertisedEndPoint, skipMessagesWithoutIndex,
                 requestStats,
                 sendResponseScheduler,
-                kafkaTopicManagerSharedState);
+                kafkaTopicManagerSharedState,
+                kafkaTopicLookupService,
+                lookupClient);
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -607,6 +607,9 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 .transactionLogNumPartitions(kafkaConfig.getKafkaTxnLogTopicNumPartitions())
                 .transactionMetadataTopicName(MetadataUtils.constructTxnLogTopicBaseName(tenant, kafkaConfig))
                 .transactionProducerIdTopicName(MetadataUtils.constructTxnProducerIdTopicBaseName(tenant, kafkaConfig))
+                .transactionProducerStateSnapshotTopicName(MetadataUtils.constructTxProducerStateTopicBaseName(tenant,
+                        kafkaConfig))
+                .producerStateTopicNumPartitions(kafkaConfig.getKafkaTxnProducerStateTopicNumPartitions())
                 .abortTimedOutTransactionsIntervalMs(kafkaConfig.getKafkaTxnAbortTimedOutTransactionCleanupIntervalMs())
                 .transactionalIdExpirationMs(kafkaConfig.getKafkaTransactionalIdExpirationMs())
                 .removeExpiredTransactionalIdsIntervalMs(

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -46,9 +46,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
-
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.util.OrderedExecutor;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
@@ -58,7 +56,6 @@ import org.apache.kafka.common.internals.Topic;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.utils.Time;
 import org.apache.pulsar.broker.PulsarServerException;
-import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.protocol.ProtocolHandler;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -872,7 +872,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                         PartitionLog.AppendOrigin.Client,
                         appendRecordsContext
                 ).whenComplete((response, ex) -> {
-                    appendRecordsContext.recycle();
                     if (ex != null) {
                         resultFuture.completeExceptionally(ex.getCause());
                         return;
@@ -2384,7 +2383,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                     PartitionLog.AppendOrigin.Coordinator,
                     appendRecordsContext
             ).whenComplete((result, ex) -> {
-                appendRecordsContext.recycle();
                 if (ex != null) {
                     log.error("[{}] Append txn marker ({}) failed.", ctx.channel(), marker, ex);
                     Map<TopicPartition, Errors> currentErrors = new HashMap<>();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -213,6 +213,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     private final TenantContextManager tenantContextManager;
     private final ReplicaManager replicaManager;
     private final KopBrokerLookupManager kopBrokerLookupManager;
+    private final LookupClient lookupClient;
     @Getter
     private final KafkaTopicManagerSharedState kafkaTopicManagerSharedState;
 
@@ -313,12 +314,15 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                boolean skipMessagesWithoutIndex,
                                RequestStats requestStats,
                                OrderedScheduler sendResponseScheduler,
-                               KafkaTopicManagerSharedState kafkaTopicManagerSharedState) throws Exception {
+                               KafkaTopicManagerSharedState kafkaTopicManagerSharedState,
+                               KafkaTopicLookupService kafkaTopicLookupService,
+                               LookupClient lookupClient) throws Exception {
         super(requestStats, kafkaConfig, sendResponseScheduler);
         this.pulsarService = pulsarService;
         this.tenantContextManager = tenantContextManager;
         this.replicaManager = replicaManager;
         this.kopBrokerLookupManager = kopBrokerLookupManager;
+        this.lookupClient = lookupClient;
         this.clusterName = kafkaConfig.getClusterName();
         this.executor = pulsarService.getExecutor();
         this.admin = pulsarService.getAdminClient();
@@ -338,7 +342,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         this.tlsEnabled = tlsEnabled;
         this.advertisedEndPoint = advertisedEndPoint;
         this.skipMessagesWithoutIndex = skipMessagesWithoutIndex;
-        this.topicManager = new KafkaTopicManager(this);
+        this.topicManager = new KafkaTopicManager(this, kafkaTopicLookupService);
         this.defaultNumPartitions = kafkaConfig.getDefaultNumPartitions();
         this.maxReadEntriesNum = kafkaConfig.getMaxReadEntriesNum();
         this.currentConnectedGroup = new ConcurrentHashMap<>();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -55,6 +55,7 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
     private static final int OffsetsMessageTTL = 3 * 24 * 3600;
     // txn configuration
     public static final int DefaultTxnLogTopicNumPartitions = 50;
+    public static final int DefaultTxnProducerStateLogTopicNumPartitions = 8;
     public static final int DefaultTxnCoordinatorSchedulerNum = 1;
     public static final int DefaultTxnStateManagerSchedulerNum = 1;
     public static final long DefaultAbortTimedOutTransactionsIntervalMs = TimeUnit.SECONDS.toMillis(10);
@@ -415,9 +416,39 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
 
     @FieldContext(
             category = CATEGORY_KOP_TRANSACTION,
+            doc = "Flag to enable disable producer state recovery"
+    )
+    private boolean kafkaTransactionStateProducerRecoveryEnabled = true;
+
+    @FieldContext(
+            category = CATEGORY_KOP_TRANSACTION,
             doc = "Number of partitions for the transaction log topic"
     )
     private int kafkaTxnLogTopicNumPartitions = DefaultTxnLogTopicNumPartitions;
+
+    @FieldContext(
+            category = CATEGORY_KOP_TRANSACTION,
+            doc = "Number of partitions for the transaction producer state topic"
+    )
+    private int kafkaTxnProducerStateTopicNumPartitions = DefaultTxnProducerStateLogTopicNumPartitions;
+
+    @FieldContext(
+            category = CATEGORY_KOP_TRANSACTION,
+            doc = "Interval for taking snapshots of the status of pending transactions"
+    )
+    private int kafkaTxnProducerStateTopicSnapshotIntervalSeconds = 300;
+
+    @FieldContext(
+            category = CATEGORY_KOP_TRANSACTION,
+            doc = "Interval for purging aborted transactions from memory (requires reads from storage)"
+    )
+    private int kafkaTxnPurgeAbortedTxnIntervalSeconds = 0;
+
+    @FieldContext(
+            category = CATEGORY_KOP_TRANSACTION,
+            doc = "Number of threads dedicated to transaction recovery"
+    )
+    private int kafkaTransactionRecoveryNumThreads = 8;
 
     @FieldContext(
             category = CATEGORY_KOP_TRANSACTION,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManager.java
@@ -48,7 +48,6 @@ import org.apache.pulsar.common.util.FutureUtil;
 public class KafkaTopicConsumerManager implements Closeable {
 
     private final PersistentTopic topic;
-    private final KafkaRequestHandler requestHandler;
 
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
@@ -67,13 +66,21 @@ public class KafkaTopicConsumerManager implements Closeable {
 
     private final boolean skipMessagesWithoutIndex;
 
+    private final String description;
+
     KafkaTopicConsumerManager(KafkaRequestHandler requestHandler, PersistentTopic topic) {
+        this(requestHandler.ctx.channel() + "",
+                requestHandler.isSkipMessagesWithoutIndex(),
+                topic);
+    }
+
+    public KafkaTopicConsumerManager(String description, boolean skipMessagesWithoutIndex, PersistentTopic topic) {
         this.topic = topic;
         this.cursors = new ConcurrentHashMap<>();
         this.createdCursors = new ConcurrentHashMap<>();
         this.lastAccessTimes = new ConcurrentHashMap<>();
-        this.requestHandler = requestHandler;
-        this.skipMessagesWithoutIndex = requestHandler.isSkipMessagesWithoutIndex();
+        this.description =  description;
+        this.skipMessagesWithoutIndex = skipMessagesWithoutIndex;
     }
 
     // delete expired cursors, so backlog can be cleared.
@@ -96,7 +103,7 @@ public class KafkaTopicConsumerManager implements Closeable {
         if (cursorFuture != null) {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Cursor timed out for offset: {}, cursors cache size: {}",
-                        requestHandler.ctx.channel(), offset, cursors.size());
+                        description, offset, cursors.size());
             }
 
             // TODO: Should we just cancel this future?
@@ -118,14 +125,19 @@ public class KafkaTopicConsumerManager implements Closeable {
                 public void deleteCursorComplete(Object ctx) {
                     if (log.isDebugEnabled()) {
                         log.debug("[{}] Cursor {} for topic {} deleted successfully for reason: {}.",
-                            requestHandler.ctx.channel(), cursor.getName(), topic.getName(), reason);
+                                description, cursor.getName(), topic.getName(), reason);
                     }
                 }
 
                 @Override
                 public void deleteCursorFailed(ManagedLedgerException exception, Object ctx) {
-                    log.warn("[{}] Error deleting cursor {} for topic {} for reason: {}.",
-                        requestHandler.ctx.channel(), cursor.getName(), topic.getName(), reason, exception);
+                    if (exception instanceof ManagedLedgerException.CursorNotFoundException) {
+                        log.debug("[{}] Cursor already deleted {} for topic {} for reason: {} - {}.",
+                                description, cursor.getName(), topic.getName(), reason, exception + "");
+                    } else {
+                        log.warn("[{}] Error deleting cursor {} for topic {} for reason: {}.",
+                                description, cursor.getName(), topic.getName(), reason, exception);
+                    }
                 }
             }, null);
             createdCursors.remove(cursor.getName());
@@ -148,7 +160,7 @@ public class KafkaTopicConsumerManager implements Closeable {
 
         if (log.isDebugEnabled()) {
             log.debug("[{}] Get cursor for offset: {} in cache. cache size: {}",
-                    requestHandler.ctx.channel(), offset, cursors.size());
+                    description, offset, cursors.size());
         }
         return cursorFuture;
     }
@@ -182,7 +194,7 @@ public class KafkaTopicConsumerManager implements Closeable {
 
         if (log.isDebugEnabled()) {
             log.debug("[{}] Add cursor back {} for offset: {}",
-                    requestHandler.ctx.channel(), pair.getLeft().getName(), offset);
+                    description, pair.getLeft().getName(), offset);
         }
     }
 
@@ -194,7 +206,7 @@ public class KafkaTopicConsumerManager implements Closeable {
         }
         if (log.isDebugEnabled()) {
             log.debug("[{}] Close TCM for topic {}.",
-                requestHandler.ctx.channel(), topic.getName());
+                    description, topic.getName());
         }
         final List<CompletableFuture<Pair<ManagedCursor, Long>>> cursorFuturesToClose = new ArrayList<>();
         cursors.forEach((ignored, cursorFuture) -> cursorFuturesToClose.add(cursorFuture));
@@ -217,7 +229,7 @@ public class KafkaTopicConsumerManager implements Closeable {
 
         // delete dangling createdCursors
         cursorsToClose.forEach(cursor ->
-            deleteOneCursorAsync(cursor, "TopicConsumerManager close but cursor is still outstanding"));
+                deleteOneCursorAsync(cursor, "TopicConsumerManager close but cursor is still outstanding"));
         cursorsToClose.clear();
     }
 
@@ -231,7 +243,7 @@ public class KafkaTopicConsumerManager implements Closeable {
         if (((ManagedLedgerImpl) ledger).getState() == ManagedLedgerImpl.State.Closed) {
             log.error("[{}] Async get cursor for offset {} for topic {} failed, "
                             + "because current managedLedger has been closed",
-                    requestHandler.ctx.channel(), offset, topic.getName());
+                    description, offset, topic.getName());
             CompletableFuture<Pair<ManagedCursor, Long>> future = new CompletableFuture<>();
             future.completeExceptionally(new Exception("Current managedLedger for "
                     + topic.getName() + " has been closed."));
@@ -250,7 +262,7 @@ public class KafkaTopicConsumerManager implements Closeable {
             final PositionImpl previous = ((ManagedLedgerImpl) ledger).getPreviousPosition((PositionImpl) position);
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Create cursor {} for offset: {}. position: {}, previousPosition: {}",
-                        requestHandler.ctx.channel(), cursorName, offset, position, previous);
+                        description, cursorName, offset, position, previous);
             }
             try {
                 final ManagedCursor newCursor = ledger.newNonDurableCursor(previous, cursorName);
@@ -259,7 +271,7 @@ public class KafkaTopicConsumerManager implements Closeable {
                 return Pair.of(newCursor, offset);
             } catch (ManagedLedgerException e) {
                 log.error("[{}] Error new cursor for topic {} at offset {} - {}. will cause fetch data error.",
-                        requestHandler.ctx.channel(), topic.getName(), offset, previous, e);
+                        description, topic.getName(), offset, previous, e);
                 return null;
             }
         });
@@ -286,7 +298,7 @@ public class KafkaTopicConsumerManager implements Closeable {
     /**
      * Returns the position in the ManagedLedger for the given offset.
      * @param offset
-     * @return null if not found, PositionImpl.latest if the offset matches the end of the topic
+     * @return null if not found, PositionImpl.LATEST if the offset matches the end of the topic
      */
     public CompletableFuture<Position> findPositionForIndex(Long offset) {
         if (closed.get()) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicLookupService.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicLookupService.java
@@ -13,7 +13,6 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
-import io.netty.channel.Channel;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import lombok.NonNull;
@@ -34,10 +33,10 @@ public class KafkaTopicLookupService {
 
     public KafkaTopicLookupService(BrokerService brokerService) {
         this.brokerService = brokerService;
-     }
+    }
 
     // A wrapper of `BrokerService#getTopic` that is to find the topic's associated `PersistentTopic` instance
-    public CompletableFuture<Optional<PersistentTopic>> getTopic(String topicName, Channel channel) {
+    public CompletableFuture<Optional<PersistentTopic>> getTopic(String topicName, Object requestor) {
         CompletableFuture<Optional<PersistentTopic>> topicCompletableFuture = new CompletableFuture<>();
         brokerService.getTopicIfExists(topicName).whenComplete((t2, throwable) -> {
             TopicName topicNameObject = TopicName.get(topicName);
@@ -47,7 +46,7 @@ public class KafkaTopicLookupService {
                 if (topicNameObject.getPartitionIndex() == 0) {
                     log.warn("Get partition-0 error [{}].", throwable.getMessage());
                 } else {
-                    handleGetTopicException(topicName, topicCompletableFuture, throwable, channel);
+                    handleGetTopicException(topicName, topicCompletableFuture, throwable, requestor);
                     return;
                 }
             }
@@ -60,11 +59,11 @@ public class KafkaTopicLookupService {
                 String nonPartitionedTopicName = topicNameObject.getPartitionedTopicName();
                 if (log.isDebugEnabled()) {
                     log.debug("[{}]Try to get non-partitioned topic for name {}",
-                            channel, nonPartitionedTopicName);
+                            requestor, nonPartitionedTopicName);
                 }
                 brokerService.getTopicIfExists(nonPartitionedTopicName).whenComplete((nonPartitionedTopic, ex) -> {
                     if (ex != null) {
-                        handleGetTopicException(nonPartitionedTopicName, topicCompletableFuture, ex, channel);
+                        handleGetTopicException(nonPartitionedTopicName, topicCompletableFuture, ex, requestor);
                         // Failed to getTopic from current broker, remove non-partitioned topic cache,
                         // which added in getTopicBroker.
                         KopBrokerLookupManager.removeTopicManagerCache(nonPartitionedTopicName);
@@ -75,14 +74,14 @@ public class KafkaTopicLookupService {
                         topicCompletableFuture.complete(Optional.of(persistentTopic));
                     } else {
                         log.error("[{}]Get empty non-partitioned topic for name {}",
-                                channel, nonPartitionedTopicName);
+                                requestor, nonPartitionedTopicName);
                         KopBrokerLookupManager.removeTopicManagerCache(nonPartitionedTopicName);
                         topicCompletableFuture.complete(Optional.empty());
                     }
                 });
                 return;
             }
-            log.error("[{}]Get empty topic for name {}", channel, topicName);
+            log.error("[{}]Get empty topic for name {}", requestor, topicName);
             KopBrokerLookupManager.removeTopicManagerCache(topicName);
             topicCompletableFuture.complete(Optional.empty());
         });
@@ -93,15 +92,15 @@ public class KafkaTopicLookupService {
                                          @NonNull
                                          final CompletableFuture<Optional<PersistentTopic>> topicCompletableFuture,
                                          @NonNull final Throwable ex,
-                                         @NonNull final Channel channel) {
+                                         @NonNull final Object requestor) {
         // The ServiceUnitNotReadyException is retryable, so we should print a warning log instead of error log
         if (ex instanceof BrokerServiceException.ServiceUnitNotReadyException) {
             log.warn("[{}] Failed to getTopic {}: {}",
-                    channel, topicName, ex.getMessage());
+                    requestor, topicName, ex.getMessage());
             topicCompletableFuture.complete(Optional.empty());
         } else {
             log.error("[{}] Failed to getTopic {}. exception:",
-                    channel, topicName, ex);
+                    requestor, topicName, ex);
             topicCompletableFuture.completeExceptionally(ex);
         }
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
@@ -73,30 +73,30 @@ public class KafkaTopicManager {
             return CompletableFuture.completedFuture(null);
         }
         return requestHandler.getKafkaTopicManagerSharedState().getKafkaTopicConsumerManagerCache().computeIfAbsent(
-                topicName,
-                remoteAddress,
-                () -> {
-                    final CompletableFuture<KafkaTopicConsumerManager> tcmFuture = new CompletableFuture<>();
-                    getTopic(topicName).whenComplete((persistentTopic, throwable) -> {
-                        if (throwable == null && persistentTopic.isPresent()) {
-                            if (log.isDebugEnabled()) {
-                                log.debug("[{}] Call getTopicConsumerManager for {}, and create TCM for {}.",
-                                        requestHandler.ctx.channel(), topicName, persistentTopic);
-                            }
-                            tcmFuture.complete(new KafkaTopicConsumerManager(requestHandler, persistentTopic.get()));
-                        } else {
-                            if (throwable != null) {
-                                log.error("[{}] Failed to getTopicConsumerManager caused by getTopic '{}' throws {}",
-                                        requestHandler.ctx.channel(), topicName, throwable.getMessage());
-                            } else { // persistentTopic == null
-                                log.error("[{}] Failed to getTopicConsumerManager caused by getTopic '{}' returns empty",
-                                        requestHandler.ctx.channel(), topicName);
-                            }
-                            tcmFuture.complete(null);
+            topicName,
+            remoteAddress,
+            () -> {
+                final CompletableFuture<KafkaTopicConsumerManager> tcmFuture = new CompletableFuture<>();
+                getTopic(topicName).whenComplete((persistentTopic, throwable) -> {
+                    if (throwable == null && persistentTopic.isPresent()) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("[{}] Call getTopicConsumerManager for {}, and create TCM for {}.",
+                                    requestHandler.ctx.channel(), topicName, persistentTopic);
                         }
-                    });
-                    return tcmFuture;
-                }
+                        tcmFuture.complete(new KafkaTopicConsumerManager(requestHandler, persistentTopic.get()));
+                    } else {
+                        if (throwable != null) {
+                            log.error("[{}] Failed to getTopicConsumerManager caused by getTopic '{}' throws {}",
+                                    requestHandler.ctx.channel(), topicName, throwable.getMessage());
+                        } else { // persistentTopic == null
+                            log.error("[{}] Failed to getTopicConsumerManager caused by getTopic '{}' returns empty",
+                                    requestHandler.ctx.channel(), topicName);
+                        }
+                        tcmFuture.complete(null);
+                    }
+                });
+                return tcmFuture;
+            }
         );
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
@@ -16,6 +16,7 @@ package io.streamnative.pulsar.handlers.kop;
 import java.net.SocketAddress;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.PulsarService;
@@ -41,14 +42,14 @@ public class KafkaTopicManager {
 
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
-    KafkaTopicManager(KafkaRequestHandler kafkaRequestHandler) {
+    KafkaTopicManager(KafkaRequestHandler kafkaRequestHandler, KafkaTopicLookupService kafkaTopicLookupService) {
         this.requestHandler = kafkaRequestHandler;
         PulsarService pulsarService = kafkaRequestHandler.getPulsarService();
         this.brokerService = pulsarService.getBrokerService();
         this.internalServerCnx = new InternalServerCnx(requestHandler);
-        this.lookupClient = KafkaProtocolHandler.getLookupClient(pulsarService);
-        this.kafkaTopicLookupService = new KafkaTopicLookupService(pulsarService.getBrokerService());
-     }
+        this.lookupClient = kafkaRequestHandler.getLookupClient();
+        this.kafkaTopicLookupService = kafkaTopicLookupService;
+    }
 
     // update Ctx information, since at internalServerCnx create time there is no ctx passed into kafkaRequestHandler.
     public void setRemoteAddress(SocketAddress remoteAddress) {
@@ -72,41 +73,41 @@ public class KafkaTopicManager {
             return CompletableFuture.completedFuture(null);
         }
         return requestHandler.getKafkaTopicManagerSharedState().getKafkaTopicConsumerManagerCache().computeIfAbsent(
-            topicName,
-            remoteAddress,
-            () -> {
-                final CompletableFuture<KafkaTopicConsumerManager> tcmFuture = new CompletableFuture<>();
-                getTopic(topicName).whenComplete((persistentTopic, throwable) -> {
-                    if (throwable == null && persistentTopic.isPresent()) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}] Call getTopicConsumerManager for {}, and create TCM for {}.",
-                                    requestHandler.ctx.channel(), topicName, persistentTopic);
+                topicName,
+                remoteAddress,
+                () -> {
+                    final CompletableFuture<KafkaTopicConsumerManager> tcmFuture = new CompletableFuture<>();
+                    getTopic(topicName).whenComplete((persistentTopic, throwable) -> {
+                        if (throwable == null && persistentTopic.isPresent()) {
+                            if (log.isDebugEnabled()) {
+                                log.debug("[{}] Call getTopicConsumerManager for {}, and create TCM for {}.",
+                                        requestHandler.ctx.channel(), topicName, persistentTopic);
+                            }
+                            tcmFuture.complete(new KafkaTopicConsumerManager(requestHandler, persistentTopic.get()));
+                        } else {
+                            if (throwable != null) {
+                                log.error("[{}] Failed to getTopicConsumerManager caused by getTopic '{}' throws {}",
+                                        requestHandler.ctx.channel(), topicName, throwable.getMessage());
+                            } else { // persistentTopic == null
+                                log.error("[{}] Failed to getTopicConsumerManager caused by getTopic '{}' returns empty",
+                                        requestHandler.ctx.channel(), topicName);
+                            }
+                            tcmFuture.complete(null);
                         }
-                        tcmFuture.complete(new KafkaTopicConsumerManager(requestHandler, persistentTopic.get()));
-                    } else {
-                        if (throwable != null) {
-                            log.error("[{}] Failed to getTopicConsumerManager caused by getTopic '{}' throws {}",
-                                    requestHandler.ctx.channel(), topicName, throwable.getMessage());
-                        } else { // persistentTopic == null
-                            log.error("[{}] Failed to getTopicConsumerManager caused by getTopic '{}' returns empty",
-                                    requestHandler.ctx.channel(), topicName);
-                        }
-                        tcmFuture.complete(null);
-                    }
-                });
-                return tcmFuture;
-            }
+                    });
+                    return tcmFuture;
+                }
         );
     }
 
     private Producer registerInPersistentTopic(PersistentTopic persistentTopic) {
         Producer producer = new InternalProducer(persistentTopic, internalServerCnx,
-            lookupClient.getPulsarClient().newRequestId(),
-            brokerService.generateUniqueProducerName());
+                lookupClient.getPulsarClient().newRequestId(),
+                brokerService.generateUniqueProducerName());
 
         if (log.isDebugEnabled()) {
             log.debug("[{}] Register Mock Producer {} into PersistentTopic {}",
-                requestHandler.ctx.channel(), producer, persistentTopic.getName());
+                    requestHandler.ctx.channel(), producer, persistentTopic.getName());
         }
 
         // this will register and add USAGE_COUNT_UPDATER.
@@ -122,8 +123,9 @@ public class KafkaTopicManager {
             }
             return Optional.empty();
         }
-        return Optional.of(requestHandler.getKafkaTopicManagerSharedState()
-                .getReferences().computeIfAbsent(topicName, (__) -> registerInPersistentTopic(persistentTopic)));
+        ConcurrentHashMap<String, Producer> references = requestHandler
+                .getKafkaTopicManagerSharedState().getReferences();
+        return Optional.of(references.computeIfAbsent(topicName, (__) -> registerInPersistentTopic(persistentTopic)));
     }
 
     // when channel close, release all the topics reference in persistentTopic
@@ -141,18 +143,23 @@ public class KafkaTopicManager {
     }
 
     public CompletableFuture<Optional<PersistentTopic>> getTopic(String topicName) {
-        if (closed.get()) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Return null for getTopic({}) since channel is closing",
-                        requestHandler.ctx.channel(), topicName);
+        try {
+            if (closed.get()) {
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] Return null for getTopic({}) since channel is closing",
+                            requestHandler.ctx.channel(), topicName);
+                }
+                return CompletableFuture.completedFuture(Optional.empty());
             }
+            CompletableFuture<Optional<PersistentTopic>> topicCompletableFuture =
+                    kafkaTopicLookupService.getTopic(topicName, requestHandler.ctx.channel());
+            // cache for removing producer
+            requestHandler.getKafkaTopicManagerSharedState().getTopics().put(topicName, topicCompletableFuture);
+            return topicCompletableFuture;
+        } catch (Throwable error) {
+            log.error("Unhandled error here for {}", topicName, error);
             return CompletableFuture.completedFuture(Optional.empty());
         }
-        CompletableFuture<Optional<PersistentTopic>> topicCompletableFuture =
-                kafkaTopicLookupService.getTopic(topicName, requestHandler.ctx.channel());
-        // cache for removing producer
-        requestHandler.getKafkaTopicManagerSharedState().getTopics().put(topicName, topicCompletableFuture);
-        return topicCompletableFuture;
     }
 
     public void invalidateCacheForFencedManagerLedgerOnTopic(String fullTopicName) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
@@ -48,9 +48,10 @@ public class KopBrokerLookupManager {
     public static final ConcurrentHashMap<String, CompletableFuture<InetSocketAddress>>
             LOOKUP_CACHE = new ConcurrentHashMap<>();
 
-    public KopBrokerLookupManager(KafkaServiceConfiguration conf, PulsarService pulsarService) throws Exception {
+    public KopBrokerLookupManager(KafkaServiceConfiguration conf, PulsarService pulsarService,
+                                  LookupClient lookupClient) throws Exception {
         this.pulsar = pulsarService;
-        this.lookupClient = KafkaProtocolHandler.getLookupClient(pulsarService);
+        this.lookupClient = lookupClient;
         this.metadataStoreCacheLoader = new MetadataStoreCacheLoader(pulsarService.getPulsarResources(),
                 conf.getBrokerLookupTimeoutMs());
         this.selfAdvertisedListeners = conf.getKafkaAdvertisedListeners();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionConfig.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionConfig.java
@@ -26,6 +26,7 @@ import lombok.Data;
 public class TransactionConfig {
 
     public static final String DefaultTransactionMetadataTopicName = "public/default/__transaction_state";
+    public static final String DefaultProducerStateSnapshotTopicName = "public/default/__transaction_producer_state";
     public static final String DefaultProducerIdTopicName = "public/default/__transaction_producerid_generator";
     public static final long DefaultTransactionsMaxTimeoutMs = TimeUnit.MINUTES.toMillis(15);
     public static final long DefaultTransactionalIdExpirationMs = TimeUnit.DAYS.toMillis(7);
@@ -34,6 +35,7 @@ public class TransactionConfig {
     public static final int DefaultTransactionCoordinatorSchedulerNum = 1;
     public static final int DefaultTransactionStateManagerSchedulerNum = 1;
     public static final int DefaultTransactionLogNumPartitions = 8;
+    public static final int DefaultTransactionStateNumPartitions = 8;
 
     @Default
     private int brokerId = 1;
@@ -42,11 +44,15 @@ public class TransactionConfig {
     @Default
     private String transactionMetadataTopicName = DefaultTransactionMetadataTopicName;
     @Default
+    private String transactionProducerStateSnapshotTopicName = DefaultProducerStateSnapshotTopicName;
+    @Default
     private long transactionMaxTimeoutMs = DefaultTransactionsMaxTimeoutMs;
     @Default
     private long transactionalIdExpirationMs = DefaultTransactionalIdExpirationMs;
     @Default
     private int transactionLogNumPartitions = DefaultTransactionLogNumPartitions;
+    @Default
+    private int producerStateTopicNumPartitions = DefaultTransactionStateNumPartitions;
     @Default
     private long abortTimedOutTransactionsIntervalMs = DefaultAbortTimedOutTransactionsIntervalMs;
     @Default

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -647,7 +647,8 @@ public class TransactionCoordinator {
                                 epochAndMetadata.getTransactionMetadata().setPendingState(Optional.empty());
 
                                 log.warn("The coordinator failed to write an epoch fence transition for producer "
-                                                + "{} to the transaction log with error {}. The epoch was increased to {} "
+                                                + "{} to the transaction log with error {}. "
+                                                + "The epoch was increased to {} "
                                                 + "but not returned to the client", transactionalId, errors,
                                         preAppendResult.getRight().getProducerEpoch());
                             }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
@@ -443,7 +443,8 @@ public class TransactionMarkerChannelManager {
                         switch (errors) {
                             case NOT_COORDINATOR:
                                 log.info("No longer the coordinator for transactionalId: {} while trying to append to "
-                                        + "transaction log, skip writing to transaction log", txnLogAppend.transactionalId);
+                                        + "transaction log, skip writing to transaction log",
+                                        txnLogAppend.transactionalId);
                                 break;
                             case COORDINATOR_NOT_AVAILABLE:
                                 log.info("Not available to append {}: possible causes include {}, {}, {} and {}; "
@@ -455,13 +456,14 @@ public class TransactionMarkerChannelManager {
                                 txnLogAppendRetryQueue.add(txnLogAppend);
                                 break;
                             case COORDINATOR_LOAD_IN_PROGRESS:
-                                log.info("Coordinator is loading the partition {} and hence cannot complete append of {}; "
-                                                + "skip writing to transaction log as the loading process should complete it",
+                                log.info("Coordinator is loading the partition {} and hence cannot complete append of "
+                                                + "{}; skip writing to transaction log as the loading process should "
+                                                + "complete it",
                                         txnStateManager.partitionFor(txnLogAppend.transactionalId), txnLogAppend);
                                 break;
                             default:
-                                String errorMsg = String.format("Unexpected error %s while appending to transaction log for %s",
-                                        errors.exceptionName(), txnLogAppend.transactionalId);
+                                String errorMsg = String.format("Unexpected error %s while appending to transaction "
+                                                + "log for %s", errors.exceptionName(), txnLogAppend.transactionalId);
                                 log.error(errorMsg);
                                 throw new IllegalStateException(errorMsg);
                         }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerRequestCompletionHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerRequestCompletionHandler.java
@@ -79,7 +79,7 @@ public class TransactionMarkerRequestCompletionHandler implements Consumer<Respo
                         break;
                     case COORDINATOR_LOAD_IN_PROGRESS:
                         log.info("I am loading the transaction partition that contains {} which means the current "
-                                + "markers have to be obsoleted; cancel sending transaction markers {} to the brokers",
+                                        + "markers have to be obsoleted; cancel sending transaction markers {} to the brokers",
                                 transactionalId, txnMarker);
                         txnMarkerChannelManager.removeMarkersForTxnId(transactionalId);
                         break;
@@ -163,15 +163,15 @@ public class TransactionMarkerRequestCompletionHandler implements Consumer<Respo
                             throw new IllegalStateException("Received fatal error " + error.exceptionName()
                                     + " while sending txn marker for " + transactionalId);
                         case UNKNOWN_TOPIC_OR_PARTITION:
-                        // this error was introduced in newer kafka client version,
-                        // recover this condition after bump the kafka client version
-                        // case NOT_LEADER_OR_FOLLOWER:
+                            // this error was introduced in newer kafka client version,
+                            // recover this condition after bump the kafka client version
                         case NOT_ENOUGH_REPLICAS:
                         case NOT_ENOUGH_REPLICAS_AFTER_APPEND:
                         case REQUEST_TIMED_OUT:
+                        case UNKNOWN_SERVER_ERROR:
                         case KAFKA_STORAGE_ERROR: // these are retriable errors
                             log.info("Sending {}'s transaction marker for partition {} has failed with error {}, "
-                                    + "retrying with current coordinator epoch {}", transactionalId, topicPartition,
+                                            + "retrying with current coordinator epoch {}", transactionalId, topicPartition,
                                     error.exceptionName(), epochAndMetadata.getCoordinatorEpoch());
                             abortSendingAndRetryPartitions.retryPartitions.add(topicPartition);
                             break;
@@ -189,8 +189,8 @@ public class TransactionMarkerRequestCompletionHandler implements Consumer<Respo
                             // producer or coordinator epoch has changed, this txn can now be ignored
                         case TRANSACTION_COORDINATOR_FENCED:
                             log.info("Sending {}'s transaction marker for partition {} has permanently failed "
-                                    + "with error {} with the current coordinator epoch {}; cancel sending any "
-                                    + "more transaction markers {} to the brokers", transactionalId, topicPartition,
+                                            + "with error {} with the current coordinator epoch {}; cancel sending any "
+                                            + "more transaction markers {} to the brokers", transactionalId, topicPartition,
                                     error.exceptionName(), epochAndMetadata.getCoordinatorEpoch(), txnMarker);
                             txnMarkerChannelManager.removeMarkersForTxnId(transactionalId);
                             abortSendingAndRetryPartitions.abortSending.set(true);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerRequestCompletionHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerRequestCompletionHandler.java
@@ -79,7 +79,8 @@ public class TransactionMarkerRequestCompletionHandler implements Consumer<Respo
                         break;
                     case COORDINATOR_LOAD_IN_PROGRESS:
                         log.info("I am loading the transaction partition that contains {} which means the current "
-                                        + "markers have to be obsoleted; cancel sending transaction markers {} to the brokers",
+                                        + "markers have to be obsoleted; cancel sending transaction markers {} to the "
+                                        + "brokers",
                                 transactionalId, txnMarker);
                         txnMarkerChannelManager.removeMarkersForTxnId(transactionalId);
                         break;
@@ -171,8 +172,8 @@ public class TransactionMarkerRequestCompletionHandler implements Consumer<Respo
                         case UNKNOWN_SERVER_ERROR:
                         case KAFKA_STORAGE_ERROR: // these are retriable errors
                             log.info("Sending {}'s transaction marker for partition {} has failed with error {}, "
-                                            + "retrying with current coordinator epoch {}", transactionalId, topicPartition,
-                                    error.exceptionName(), epochAndMetadata.getCoordinatorEpoch());
+                                            + "retrying with current coordinator epoch {}", transactionalId,
+                                    topicPartition, error.exceptionName(), epochAndMetadata.getCoordinatorEpoch());
                             abortSendingAndRetryPartitions.retryPartitions.add(topicPartition);
                             break;
                         case LEADER_NOT_AVAILABLE:
@@ -190,8 +191,9 @@ public class TransactionMarkerRequestCompletionHandler implements Consumer<Respo
                         case TRANSACTION_COORDINATOR_FENCED:
                             log.info("Sending {}'s transaction marker for partition {} has permanently failed "
                                             + "with error {} with the current coordinator epoch {}; cancel sending any "
-                                            + "more transaction markers {} to the brokers", transactionalId, topicPartition,
-                                    error.exceptionName(), epochAndMetadata.getCoordinatorEpoch(), txnMarker);
+                                            + "more transaction markers {} to the brokers", transactionalId,
+                                    topicPartition, error.exceptionName(),
+                                    epochAndMetadata.getCoordinatorEpoch(), txnMarker);
                             txnMarkerChannelManager.removeMarkersForTxnId(transactionalId);
                             abortSendingAndRetryPartitions.abortSending.set(true);
                             break;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMetadata.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMetadata.java
@@ -480,9 +480,9 @@ public class TransactionMetadata {
     public void removePartition(TopicPartition topicPartition) {
         if (state != TransactionState.PREPARE_COMMIT && state != TransactionState.PREPARE_ABORT) {
             throw new IllegalStateException(
-                    String.format("Transaction metadata's current state is %s, and its pending state is %s while "
-                                    + "trying to remove partitions whose txn marker has been sent, this is not expected",
-                            state, pendingState));
+                String.format("Transaction metadata's current state is %s, and its pending state is %s while "
+                                + "trying to remove partitions whose txn marker has been sent, this is not expected",
+                        state, pendingState));
         }
         Set<TopicPartition> newTopicPartitions = new HashSet<>(topicPartitions);
         newTopicPartitions.remove(topicPartition);
@@ -493,7 +493,8 @@ public class TransactionMetadata {
         if (state != TransactionState.PREPARE_COMMIT && state != TransactionState.PREPARE_ABORT) {
             throw new IllegalStateException(
                     String.format("Transaction metadata's current state is %s, and its pending state is %s while "
-                                    + "trying to remove partitions whose txn marker has been sent, this is not expected",
+                                    + "trying to remove partitions whose txn marker has been sent, "
+                                    + "this is not expected",
                             state, pendingState));
         }
         Set<TopicPartition> newTopicPartitions = new HashSet<>(topicPartitions);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMetadata.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMetadata.java
@@ -128,13 +128,13 @@ public class TransactionMetadata {
     }
 
     public TxnTransitMetadata prepareTransitionTo(TransactionState newState,
-                                     long newProducerId,
-                                     short newEpoch,
-                                     short newLastEpoch,
-                                     int newTxnTimeoutMs,
-                                     Set<TopicPartition> newTopicPartitions,
-                                     long newTxnStartTimestamp,
-                                     long updateTimestamp) {
+                                                  long newProducerId,
+                                                  short newEpoch,
+                                                  short newLastEpoch,
+                                                  int newTxnTimeoutMs,
+                                                  Set<TopicPartition> newTopicPartitions,
+                                                  long newTxnStartTimestamp,
+                                                  long updateTimestamp) {
         if (pendingState.isPresent()) {
             throw new IllegalStateException("Preparing transaction state transition to " + newState
                     + " while it already a pending state " + pendingState.get());
@@ -157,7 +157,7 @@ public class TransactionMetadata {
                     .lastProducerEpoch(newLastEpoch)
                     .txnTimeoutMs(newTxnTimeoutMs)
                     .txnState(newState)
-                    .topicPartitions(newTopicPartitions)
+                    .topicPartitions(Collections.unmodifiableSet(newTopicPartitions))
                     .txnStartTimestamp(newTxnStartTimestamp)
                     .txnLastUpdateTimestamp(updateTimestamp).build();
             if (log.isDebugEnabled()) {
@@ -236,7 +236,7 @@ public class TransactionMetadata {
                         throwStateTransitionFailure(transitMetadata);
                     } else {
                         txnStartTimestamp = transitMetadata.txnStartTimestamp;
-                        topicPartitions.addAll(transitMetadata.topicPartitions);
+                        addPartitions(transitMetadata.topicPartitions);
                     }
                     break;
                 case PREPARE_ABORT: // from endTxn
@@ -258,7 +258,7 @@ public class TransactionMetadata {
                         throwStateTransitionFailure(transitMetadata);
                     } else {
                         this.txnStartTimestamp = transitMetadata.txnStartTimestamp;
-                        this.topicPartitions.clear();
+                        this.topicPartitions = Collections.emptySet();
                     }
                     break;
                 case PREPARE_EPOCH_FENCE:
@@ -369,7 +369,7 @@ public class TransactionMetadata {
             } else {
                 // Otherwise, the producer has a fenced epoch and should receive an PRODUCER_FENCED error
                 log.info("Expected producer epoch {} does not match current "
-                        + "producer epoch {} or previous producer epoch {}",
+                                + "producer epoch {} or previous producer epoch {}",
                         expectedProducerEpoch, producerEpoch, lastProducerEpoch);
                 errorsOrBumpEpochResult = Either.left(Errors.PRODUCER_FENCED);
             }
@@ -387,9 +387,9 @@ public class TransactionMetadata {
     }
 
     public TxnTransitMetadata prepareProducerIdRotation(Long newProducerId,
-                                  Integer newTxnTimeoutMs,
-                                  Long updateTimestamp,
-                                  boolean recordLastEpoch) {
+                                                        Integer newTxnTimeoutMs,
+                                                        Long updateTimestamp,
+                                                        boolean recordLastEpoch) {
         if (hasPendingTransaction()) {
             throw new IllegalStateException("Cannot rotate producer ids while a transaction is still pending");
         }
@@ -481,14 +481,30 @@ public class TransactionMetadata {
         if (state != TransactionState.PREPARE_COMMIT && state != TransactionState.PREPARE_ABORT) {
             throw new IllegalStateException(
                     String.format("Transaction metadata's current state is %s, and its pending state is %s while "
-                                + "trying to remove partitions whose txn marker has been sent, this is not expected",
-                                state, pendingState));
+                                    + "trying to remove partitions whose txn marker has been sent, this is not expected",
+                            state, pendingState));
         }
-        topicPartitions.remove(topicPartition);
+        Set<TopicPartition> newTopicPartitions = new HashSet<>(topicPartitions);
+        newTopicPartitions.remove(topicPartition);
+        this.topicPartitions = Collections.unmodifiableSet(newTopicPartitions);
+    }
+
+    public void removePartitions(Set<TopicPartition> topicPartitions) {
+        if (state != TransactionState.PREPARE_COMMIT && state != TransactionState.PREPARE_ABORT) {
+            throw new IllegalStateException(
+                    String.format("Transaction metadata's current state is %s, and its pending state is %s while "
+                                    + "trying to remove partitions whose txn marker has been sent, this is not expected",
+                            state, pendingState));
+        }
+        Set<TopicPartition> newTopicPartitions = new HashSet<>(topicPartitions);
+        newTopicPartitions.removeAll(topicPartitions);
+        this.topicPartitions = Collections.unmodifiableSet(newTopicPartitions);
     }
 
     public void addPartitions(Set<TopicPartition> partitions) {
-        topicPartitions.addAll(partitions);
+        Set<TopicPartition> newTopicPartitions = new HashSet<>(topicPartitions);
+        newTopicPartitions.addAll(partitions);
+        this.topicPartitions = Collections.unmodifiableSet(newTopicPartitions);
     }
 
     public boolean pendingTransitionInProgress() {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/AbortedTxn.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/AbortedTxn.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.storage;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+/**
+ * AbortedTxn is used cache the aborted index.
+ */
+@Data
+@Accessors(fluent = true)
+@AllArgsConstructor
+public final class AbortedTxn {
+
+    private static final int VersionOffset = 0;
+    private static final int VersionSize = 2;
+    private static final int ProducerIdOffset = VersionOffset + VersionSize;
+    private static final int ProducerIdSize = 8;
+    private static final int FirstOffsetOffset = ProducerIdOffset + ProducerIdSize;
+    private static final int FirstOffsetSize = 8;
+    private static final int LastOffsetOffset = FirstOffsetOffset + FirstOffsetSize;
+    private static final int LastOffsetSize = 8;
+    private static final int LastStableOffsetOffset = LastOffsetOffset + LastOffsetSize;
+    private static final int LastStableOffsetSize = 8;
+    private static final int TotalSize = LastStableOffsetOffset + LastStableOffsetSize;
+
+    private static final Short CurrentVersion = 0;
+
+    private final long producerId;
+    private final long firstOffset;
+    private final long lastOffset;
+    private final long lastStableOffset;
+
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/AppendRecordsContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/AppendRecordsContext.java
@@ -14,35 +14,27 @@
 package io.streamnative.pulsar.handlers.kop.storage;
 
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.util.Recycler;
 import io.streamnative.pulsar.handlers.kop.KafkaTopicManager;
 import io.streamnative.pulsar.handlers.kop.PendingTopicFutures;
 import java.util.Map;
 import java.util.function.Consumer;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.TopicPartition;
 
 /**
  * AppendRecordsContext is use for pass parameters to ReplicaManager, to avoid long parameter lists.
  */
+@Slf4j
+@AllArgsConstructor
 @Getter
 public class AppendRecordsContext {
-    private static final Recycler<AppendRecordsContext> RECYCLER = new Recycler<AppendRecordsContext>() {
-        protected AppendRecordsContext newObject(Handle<AppendRecordsContext> handle) {
-            return new AppendRecordsContext(handle);
-        }
-    };
-
-    private final Recycler.Handle<AppendRecordsContext> recyclerHandle;
     private KafkaTopicManager topicManager;
     private Consumer<Integer> startSendOperationForThrottling;
     private Consumer<Integer> completeSendOperationForThrottling;
     private Map<TopicPartition, PendingTopicFutures> pendingTopicFuturesMap;
     private ChannelHandlerContext ctx;
-
-    private AppendRecordsContext(Recycler.Handle<AppendRecordsContext> recyclerHandle) {
-        this.recyclerHandle = recyclerHandle;
-    }
 
     // recycler and get for this object
     public static AppendRecordsContext get(final KafkaTopicManager topicManager,
@@ -50,23 +42,11 @@ public class AppendRecordsContext {
                                            final Consumer<Integer> completeSendOperationForThrottling,
                                            final Map<TopicPartition, PendingTopicFutures> pendingTopicFuturesMap,
                                            final ChannelHandlerContext ctx) {
-        AppendRecordsContext context = RECYCLER.get();
-        context.topicManager = topicManager;
-        context.startSendOperationForThrottling = startSendOperationForThrottling;
-        context.completeSendOperationForThrottling = completeSendOperationForThrottling;
-        context.pendingTopicFuturesMap = pendingTopicFuturesMap;
-        context.ctx = ctx;
-
-        return context;
-    }
-
-    public void recycle() {
-        topicManager = null;
-        startSendOperationForThrottling = null;
-        completeSendOperationForThrottling = null;
-        pendingTopicFuturesMap = null;
-        recyclerHandle.recycle(this);
-        ctx = null;
+        return new AppendRecordsContext(topicManager,
+                startSendOperationForThrottling,
+                completeSendOperationForThrottling,
+                pendingTopicFuturesMap,
+                ctx);
     }
 
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/CompletedTxn.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/CompletedTxn.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.storage;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(fluent = true)
+@AllArgsConstructor
+public final class CompletedTxn {
+    private long producerId;
+    private long firstOffset;
+    private long lastOffset;
+    private boolean isAborted;
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/MemoryProducerStateManagerSnapshotBuffer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/MemoryProducerStateManagerSnapshotBuffer.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.storage;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class MemoryProducerStateManagerSnapshotBuffer implements ProducerStateManagerSnapshotBuffer {
+    private Map<String, ProducerStateManagerSnapshot> latestSnapshots = new ConcurrentHashMap<>();
+
+    @Override
+    public CompletableFuture<Void> write(ProducerStateManagerSnapshot snapshot) {
+        return CompletableFuture.runAsync(() -> {
+            latestSnapshots.compute(snapshot.getTopicPartition(), (tp, current) -> {
+                if (current == null || current.getOffset() <= snapshot.getOffset()) {
+                    return snapshot;
+                } else {
+                    return current;
+                }
+            });
+        });
+    }
+
+    @Override
+    public CompletableFuture<ProducerStateManagerSnapshot> readLatestSnapshot(String topicPartition) {
+        return CompletableFuture.supplyAsync(() -> latestSnapshots.get(topicPartition));
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -85,7 +85,6 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.service.plugin.EntryFilterWithClassLoader;
 import org.apache.pulsar.common.naming.TopicName;
-import org.apache.pulsar.common.protocol.schema.BytesSchemaVersion;
 import org.apache.pulsar.common.util.FutureUtil;
 
 /**
@@ -1132,7 +1131,8 @@ public class PartitionLog {
                     }
 
 
-                    final CompletableFuture<Pair<ManagedCursor, Long>> cursorFuture = tcm.removeCursorFuture(offsetToStart);
+                    final CompletableFuture<Pair<ManagedCursor, Long>> cursorFuture =
+                            tcm.removeCursorFuture(offsetToStart);
 
                     if (cursorFuture == null) {
                         // tcm is closed, just return a NONE error because the channel may be still active

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -17,6 +17,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.Recycler;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import io.streamnative.pulsar.handlers.kop.KafkaTopicConsumerManager;
@@ -82,6 +83,7 @@ import org.apache.kafka.common.record.Records;
 import org.apache.kafka.common.requests.FetchRequest;
 import org.apache.kafka.common.requests.FetchResponse;
 import org.apache.kafka.common.utils.Time;
+import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.service.plugin.EntryFilterWithClassLoader;
 import org.apache.pulsar.common.naming.TopicName;
@@ -120,6 +122,7 @@ public class PartitionLog {
     private final KafkaTopicLookupService kafkaTopicLookupService;
 
     private final ImmutableMap<String, EntryFilterWithClassLoader> entryfilterMap;
+    private final boolean preciseTopicPublishRateLimitingEnable;
 
     private final ProducerStateManagerSnapshotBuffer producerStateManagerSnapshotBuffer;
 
@@ -143,6 +146,7 @@ public class PartitionLog {
         this.time = time;
         this.topicPartition = topicPartition;
         this.fullPartitionName = fullPartitionName;
+        this.preciseTopicPublishRateLimitingEnable = kafkaConfig.isPreciseTopicPublishRateLimiterEnable();
         this.kafkaTopicLookupService = kafkaTopicLookupService;
         this.producerStateManagerSnapshotBuffer = producerStateManagerSnapshotBuffer;
     }
@@ -847,6 +851,8 @@ public class PartitionLog {
             return;
         }
         PersistentTopic persistentTopic = persistentTopicOpt.get();
+        checkAndRecordPublishQuota(persistentTopic, appendInfo.validBytes(),
+                appendInfo.numMessages(), appendRecordsContext);
         if (persistentTopic.isSystemTopic()) {
             encodeResult.recycle();
             log.error("Not support producing message to system topic: {}", persistentTopic);
@@ -889,6 +895,37 @@ public class PartitionLog {
                     }
                     encodeResult.recycle();
                 });
+    }
+
+    private void checkAndRecordPublishQuota(Topic topic, int msgSize, int numMessages,
+                                            AppendRecordsContext appendRecordsContext) {
+        final boolean isPublishRateExceeded;
+        if (preciseTopicPublishRateLimitingEnable) {
+            boolean isPreciseTopicPublishRateExceeded =
+                    topic.isTopicPublishRateExceeded(numMessages, msgSize);
+            if (isPreciseTopicPublishRateExceeded) {
+                topic.disableCnxAutoRead();
+                return;
+            }
+            isPublishRateExceeded = topic.isBrokerPublishRateExceeded();
+        } else {
+            if (topic.isResourceGroupRateLimitingEnabled()) {
+                final boolean resourceGroupPublishRateExceeded =
+                        topic.isResourceGroupPublishRateExceeded(numMessages, msgSize);
+                if (resourceGroupPublishRateExceeded) {
+                    topic.disableCnxAutoRead();
+                    return;
+                }
+            }
+            isPublishRateExceeded = topic.isPublishRateExceeded();
+        }
+
+        if (isPublishRateExceeded) {
+            ChannelHandlerContext ctx = appendRecordsContext.getCtx();
+            if (ctx != null && ctx.channel().config().isAutoRead()) {
+                ctx.channel().config().setAutoRead(false);
+            }
+        }
     }
 
     /**

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerAppendInfo.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerAppendInfo.java
@@ -40,7 +40,7 @@ public class ProducerAppendInfo {
     private final String topicPartition;
 
     // The id of the producer appending to the log
-    private final Long producerId;
+    private final long producerId;
 
     // The current entry associated with the producer id which contains metadata for a fixed number of
     // the most recent appends made by the producer. Validation of the first incoming append will
@@ -69,8 +69,9 @@ public class ProducerAppendInfo {
         initUpdatedEntry();
     }
 
-    private void checkProducerEpoch(Short producerEpoch) {
-        if (producerEpoch < updatedEntry.producerEpoch()) {
+    private void checkProducerEpoch(short producerEpoch) {
+        if (updatedEntry.producerEpoch() != null
+                && producerEpoch < updatedEntry.producerEpoch()) {
             String message = String.format("Producer's epoch in %s is %s, which is smaller than the last seen "
                     + "epoch %s", topicPartition, producerEpoch, currentEntry.producerEpoch());
             throw new IllegalArgumentException(message);
@@ -126,9 +127,9 @@ public class ProducerAppendInfo {
 
     public Optional<CompletedTxn> appendEndTxnMarker(
             EndTransactionMarker endTxnMarker,
-            Short producerEpoch,
-            Long offset,
-            Long timestamp) {
+            short producerEpoch,
+            long offset,
+            long timestamp) {
         checkProducerEpoch(producerEpoch);
 
         // Only emit the `CompletedTxn` for non-empty transactions. A transaction marker
@@ -137,7 +138,7 @@ public class ProducerAppendInfo {
         Optional<CompletedTxn> completedTxn =
                 updatedEntry.currentTxnFirstOffset().map(firstOffset ->
                         new CompletedTxn(producerId, firstOffset, offset,
-                        endTxnMarker.controlType() == ControlRecordType.ABORT));
+                                endTxnMarker.controlType() == ControlRecordType.ABORT));
         updatedEntry.maybeUpdateProducerEpoch(producerEpoch);
         updatedEntry.currentTxnFirstOffset(Optional.empty());
         updatedEntry.lastTimestamp(timestamp);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateEntry.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateEntry.java
@@ -30,7 +30,7 @@ import org.apache.kafka.common.record.RecordBatch;
 @AllArgsConstructor
 public class ProducerStateEntry {
 
-    private Long producerId;
+    private long producerId;
     private Short producerEpoch;
     private Integer coordinatorEpoch;
     private Long lastTimestamp;
@@ -38,7 +38,8 @@ public class ProducerStateEntry {
 
 
     public boolean maybeUpdateProducerEpoch(Short producerEpoch) {
-        if (!this.producerEpoch.equals(producerEpoch)) {
+        if (this.producerEpoch == null
+                || !this.producerEpoch.equals(producerEpoch)) {
             this.producerEpoch = producerEpoch;
             return true;
         } else {
@@ -52,7 +53,7 @@ public class ProducerStateEntry {
         this.lastTimestamp(nextEntry.lastTimestamp);
     }
 
-    public static ProducerStateEntry empty(Long producerId){
+    public static ProducerStateEntry empty(long producerId){
         return new ProducerStateEntry(producerId,
                 RecordBatch.NO_PRODUCER_EPOCH, -1, RecordBatch.NO_TIMESTAMP, Optional.empty());
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManager.java
@@ -14,82 +14,20 @@
 package io.streamnative.pulsar.handlers.kop.storage;
 
 import com.google.common.collect.Maps;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.experimental.Accessors;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.bookkeeper.util.SafeRunnable;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.requests.FetchResponse;
-
-/**
- * AbortedTxn is used cache the aborted index.
- */
-@Data
-@Accessors(fluent = true)
-@AllArgsConstructor
-class AbortedTxn {
-
-    private static final int VersionOffset = 0;
-    private static final int VersionSize = 2;
-    private static final int ProducerIdOffset = VersionOffset + VersionSize;
-    private static final int ProducerIdSize = 8;
-    private static final int FirstOffsetOffset = ProducerIdOffset + ProducerIdSize;
-    private static final int FirstOffsetSize = 8;
-    private static final int LastOffsetOffset = FirstOffsetOffset + FirstOffsetSize;
-    private static final int LastOffsetSize = 8;
-    private static final int LastStableOffsetOffset = LastOffsetOffset + LastOffsetSize;
-    private static final int LastStableOffsetSize = 8;
-    private static final int TotalSize = LastStableOffsetOffset + LastStableOffsetSize;
-
-    private static final Short CurrentVersion = 0;
-
-    private final Long producerId;
-    private final Long firstOffset;
-    private final Long lastOffset;
-    private final Long lastStableOffset;
-
-    protected ByteBuffer toByteBuffer() {
-        ByteBuffer buffer = ByteBuffer.allocate(AbortedTxn.TotalSize);
-        buffer.putShort(CurrentVersion);
-        buffer.putLong(producerId);
-        buffer.putLong(firstOffset);
-        buffer.putLong(lastOffset);
-        buffer.putLong(lastStableOffset);
-        buffer.flip();
-        return buffer;
-    }
-}
-
-@Data
-@Accessors(fluent = true)
-@AllArgsConstructor
-class CompletedTxn {
-    private Long producerId;
-    private Long firstOffset;
-    private Long lastOffset;
-    private Boolean isAborted;
-}
-
-@Data
-@Accessors(fluent = true)
-@EqualsAndHashCode
-class TxnMetadata {
-    private final long producerId;
-    private final long firstOffset;
-    private long lastOffset;
-
-    public TxnMetadata(long producerId, long firstOffset) {
-        this.producerId = producerId;
-        this.firstOffset = firstOffset;
-    }
-}
 
 /**
  * Producer state manager.
@@ -97,15 +35,114 @@ class TxnMetadata {
 @Slf4j
 public class ProducerStateManager {
 
+    @Getter
     private final String topicPartition;
+    private final String kafkaTopicUUID;
+
     private final Map<Long, ProducerStateEntry> producers = Maps.newConcurrentMap();
 
     // ongoing transactions sorted by the first offset of the transaction
     private final TreeMap<Long, TxnMetadata> ongoingTxns = Maps.newTreeMap();
     private final List<AbortedTxn> abortedIndexList = new ArrayList<>();
 
-    public ProducerStateManager(String topicPartition) {
+    private final ProducerStateManagerSnapshotBuffer producerStateManagerSnapshotBuffer;
+
+    private volatile long mapEndOffset = -1;
+
+    public ProducerStateManager(String topicPartition, String kafkaTopicUUID,
+                                ProducerStateManagerSnapshotBuffer producerStateManagerSnapshotBuffer) {
         this.topicPartition = topicPartition;
+        this.kafkaTopicUUID = kafkaTopicUUID;
+        this.producerStateManagerSnapshotBuffer = producerStateManagerSnapshotBuffer;
+    }
+
+    public CompletableFuture<Void> recover(PartitionLog partitionLog, Executor executor) {
+        return producerStateManagerSnapshotBuffer
+                .readLatestSnapshot(topicPartition)
+                .thenCompose(snapshot -> applySnapshotAndRecover(snapshot, partitionLog, executor));
+    }
+
+    private CompletableFuture<Void> applySnapshotAndRecover(ProducerStateManagerSnapshot snapshot,
+                                                            PartitionLog partitionLog,
+                                                            Executor executor) {
+        if (snapshot != null && kafkaTopicUUID != null
+                && !kafkaTopicUUID.equals(snapshot.getTopicUUID())) {
+            log.info("The latest snapshot for topic {} was for UUID {} that is different from {}. "
+                            + "Ignoring it (topic has been re-created)", topicPartition, snapshot.getTopicUUID(),
+                    kafkaTopicUUID);
+            snapshot = null;
+        }
+        long offSetPosition = 0;
+        synchronized (abortedIndexList) {
+            this.abortedIndexList.clear();
+            this.producers.clear();
+            this.ongoingTxns.clear();
+            if (snapshot != null) {
+                this.abortedIndexList.addAll(snapshot.getAbortedIndexList());
+                this.producers.putAll(snapshot.getProducers());
+                this.ongoingTxns.putAll(snapshot.getOngoingTxns());
+                this.mapEndOffset = snapshot.getOffset();
+                offSetPosition = snapshot.getOffset();
+                log.info("Recover topic {} from offset {}", topicPartition, offSetPosition);
+            } else {
+                log.info("No snapshot found for topic {}, recovering from the beginning", topicPartition);
+            }
+        }
+        long startRecovery = System.currentTimeMillis();
+        // recover from log
+        CompletableFuture<Void> result =  partitionLog
+                .recoverTxEntries(offSetPosition, executor)
+                .thenApply(numEntries -> {
+                    log.info("Recovery of {} finished. Scanned {} entries, time {} ms, new mapEndOffset {}",
+                            topicPartition,
+                            numEntries,
+                            System.currentTimeMillis() - startRecovery,
+                            mapEndOffset);
+                    return null;
+                });
+
+        result.thenRun(() -> {
+            // that a snapshot when the recovery is done
+            // this will make the next recovery faster
+            takeSnapshot(executor);
+        });
+
+        return result;
+    }
+
+    public CompletableFuture<ProducerStateManagerSnapshot> takeSnapshot(Executor executor) {
+        CompletableFuture<ProducerStateManagerSnapshot> result = new CompletableFuture<>();
+        executor.execute(new SafeRunnable() {
+            @Override
+            public void safeRun() {
+                if (mapEndOffset == -1) {
+                    result.complete(null);
+                    return;
+                }
+                log.info("Taking snapshot for {} mapEndOffset is {}", topicPartition, mapEndOffset);
+                ProducerStateManagerSnapshot snapshot;
+                synchronized (abortedIndexList) {
+                    snapshot = new ProducerStateManagerSnapshot(topicPartition,
+                            kafkaTopicUUID,
+                            mapEndOffset,
+                            new HashMap<>(producers),
+                            new TreeMap<>(ongoingTxns),
+                            new ArrayList<>(abortedIndexList));
+                }
+                producerStateManagerSnapshotBuffer
+                        .write(snapshot)
+                        .whenComplete((res, error) -> {
+                            if (error != null) {
+                                result.completeExceptionally(error);
+                            } else {
+                                log.info("Snapshot for {} ({}) taken at offset {}",
+                                        topicPartition, kafkaTopicUUID, snapshot.getOffset());
+                                result.complete(snapshot);
+                            }
+                        });
+            }
+        });
+        return result;
     }
 
     public ProducerAppendInfo prepareUpdate(Long producerId, PartitionLog.AppendOrigin origin) {
@@ -120,7 +157,7 @@ public class ProducerStateManager {
      */
     public long lastStableOffset(CompletedTxn completedTxn) {
         for (TxnMetadata txnMetadata : ongoingTxns.values()) {
-            if (!completedTxn.producerId().equals(txnMetadata.producerId())) {
+            if (completedTxn.producerId() != txnMetadata.producerId()) {
                 return txnMetadata.firstOffset();
             }
         }
@@ -173,10 +210,16 @@ public class ProducerStateManager {
         }
     }
 
+    public void updateMapEndOffset(long mapEndOffset) {
+        this.mapEndOffset = mapEndOffset;
+    }
+
     public void updateTxnIndex(CompletedTxn completedTxn, long lastStableOffset) {
         if (completedTxn.isAborted()) {
-            abortedIndexList.add(new AbortedTxn(completedTxn.producerId(), completedTxn.firstOffset(),
-                    completedTxn.lastOffset(), lastStableOffset));
+            synchronized (abortedIndexList) {
+                abortedIndexList.add(new AbortedTxn(completedTxn.producerId(), completedTxn.firstOffset(),
+                        completedTxn.lastOffset(), lastStableOffset));
+            }
         }
     }
 
@@ -189,15 +232,39 @@ public class ProducerStateManager {
         }
     }
 
-    public List<FetchResponse.AbortedTransaction> getAbortedIndexList(long fetchOffset) {
-        List<FetchResponse.AbortedTransaction> abortedTransactions = new ArrayList<>();
-        for (AbortedTxn abortedTxn : abortedIndexList) {
-            if (abortedTxn.lastOffset() >= fetchOffset) {
-                abortedTransactions.add(
-                        new FetchResponse.AbortedTransaction(abortedTxn.producerId(), abortedTxn.firstOffset()));
+    public boolean hasSomeAbortedTransactions() {
+        return !abortedIndexList.isEmpty();
+    }
+
+    public long purgeAbortedTxns(long offset) {
+        AtomicLong count = new AtomicLong();
+        synchronized (abortedIndexList) {
+            abortedIndexList.removeIf(tx -> {
+                boolean toRemove = tx.lastOffset() < offset;
+                if (toRemove) {
+                    log.info("Transaction {} can be removed (lastOffset < {})", tx, tx.lastOffset(), offset);
+                    count.incrementAndGet();
+                }
+                return toRemove;
+            });
+            if (!abortedIndexList.isEmpty()) {
+                log.info("There are still {} aborted tx on {}", abortedIndexList.size(), topicPartition);
             }
         }
-        return abortedTransactions;
+        return count.get();
+    }
+
+    public List<FetchResponse.AbortedTransaction> getAbortedIndexList(long fetchOffset) {
+        synchronized (abortedIndexList) {
+            List<FetchResponse.AbortedTransaction> abortedTransactions = new ArrayList<>();
+            for (AbortedTxn abortedTxn : abortedIndexList) {
+                if (abortedTxn.lastOffset() >= fetchOffset) {
+                    abortedTransactions.add(
+                            new FetchResponse.AbortedTransaction(abortedTxn.producerId(), abortedTxn.firstOffset()));
+                }
+            }
+            return abortedTransactions;
+        }
     }
 
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManagerSnapshot.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManagerSnapshot.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.storage;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+@Data
+@AllArgsConstructor
+public final class ProducerStateManagerSnapshot {
+    private final String topicPartition;
+    private final String topicUUID;
+    private final long offset;
+    private final Map<Long, ProducerStateEntry> producers;
+
+    // ongoing transactions sorted by the first offset of the transaction
+    private final TreeMap<Long, TxnMetadata> ongoingTxns;
+    private final List<AbortedTxn> abortedIndexList;
+
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManagerSnapshot.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManagerSnapshot.java
@@ -13,12 +13,11 @@
  */
 package io.streamnative.pulsar.handlers.kop.storage;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 
 @Data
 @AllArgsConstructor

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManagerSnapshotBuffer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManagerSnapshotBuffer.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.storage;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Stores snapshots of the state of ProducerStateManagers.
+ * One ProducerStateManagerSnapshotBuffer handles all the topics for a Tenant.
+ */
+public interface ProducerStateManagerSnapshotBuffer {
+
+    /**
+     * Writes a snapshot to the storage.
+     * @param snapshot
+     * @return a handle to the operation
+     */
+    CompletableFuture<Void> write(ProducerStateManagerSnapshot snapshot);
+
+    /**
+     * Reads the latest available snapshot for a given partition.
+     * @param topicPartition
+     * @return
+     */
+    CompletableFuture<ProducerStateManagerSnapshot> readLatestSnapshot(String topicPartition);
+
+    /**
+     * Shutdown and release resources.
+     */
+    default void shutdown() {}
+
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarPartitionedTopicProducerStateManagerSnapshotBuffer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarPartitionedTopicProducerStateManagerSnapshotBuffer.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.storage;
+
+import io.streamnative.pulsar.handlers.kop.SystemTopicClient;
+import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.common.naming.TopicName;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+@Slf4j
+public class PulsarPartitionedTopicProducerStateManagerSnapshotBuffer implements ProducerStateManagerSnapshotBuffer {
+
+    private final List<ProducerStateManagerSnapshotBuffer> partitions = new ArrayList<>();
+
+    private ProducerStateManagerSnapshotBuffer pickPartition(String topic) {
+        return partitions
+                .get(TransactionCoordinator.partitionFor(topic, partitions.size()));
+    }
+
+    @Override
+    public CompletableFuture<Void> write(ProducerStateManagerSnapshot snapshot) {
+        return pickPartition(snapshot.getTopicPartition()).write(snapshot);
+    }
+
+    @Override
+    public CompletableFuture<ProducerStateManagerSnapshot> readLatestSnapshot(String topicPartition) {
+        return pickPartition(topicPartition).readLatestSnapshot(topicPartition);
+    }
+
+    public PulsarPartitionedTopicProducerStateManagerSnapshotBuffer(String topicName,
+                                                                    SystemTopicClient pulsarClient,
+                                                                    Executor executor,
+                                                                    int numPartitions) {
+        TopicName fullName = TopicName.get(topicName);
+        for (int i = 0; i < numPartitions; i++) {
+            PulsarTopicProducerStateManagerSnapshotBuffer partition =
+                    new PulsarTopicProducerStateManagerSnapshotBuffer(
+                            fullName.getPartition(i).toString(),
+                            pulsarClient, executor);
+            partitions.add(partition);
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        partitions.forEach(ProducerStateManagerSnapshotBuffer::shutdown);
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarPartitionedTopicProducerStateManagerSnapshotBuffer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarPartitionedTopicProducerStateManagerSnapshotBuffer.java
@@ -15,13 +15,12 @@ package io.streamnative.pulsar.handlers.kop.storage;
 
 import io.streamnative.pulsar.handlers.kop.SystemTopicClient;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.common.naming.TopicName;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.common.naming.TopicName;
 
 @Slf4j
 public class PulsarPartitionedTopicProducerStateManagerSnapshotBuffer implements ProducerStateManagerSnapshotBuffer {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBuffer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBuffer.java
@@ -1,0 +1,424 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.storage;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.buffer.ByteBufOutputStream;
+import io.netty.buffer.Unpooled;
+import io.streamnative.pulsar.handlers.kop.SystemTopicClient;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.errors.NotLeaderOrFollowerException;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.Reader;
+import org.apache.pulsar.common.util.FutureUtil;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+
+@Slf4j
+public class PulsarTopicProducerStateManagerSnapshotBuffer implements ProducerStateManagerSnapshotBuffer {
+
+    private Map<String, ProducerStateManagerSnapshot> latestSnapshots = new ConcurrentHashMap<>();
+    private final String topic;
+    private final SystemTopicClient pulsarClient;
+    private final Executor executor;
+    private CompletableFuture<Reader<ByteBuffer>> reader;
+
+    private CompletableFuture<Producer<ByteBuffer>> producer;
+
+    private CompletableFuture<Void> currentReadHandle;
+
+    private synchronized CompletableFuture<Reader<ByteBuffer>> ensureReaderHandle() {
+        if (reader == null) {
+            CompletableFuture<Reader<ByteBuffer>> newReader = pulsarClient.newReaderBuilder()
+                    .topic(topic)
+                    .startMessageId(MessageId.earliest)
+                    .readCompacted(true)
+                    .createAsync();
+            reader = newReader;
+
+            newReader.whenComplete((r, error) -> {
+                if (error != null) {
+                    discardReader(newReader);
+                }
+            });
+        }
+        return reader;
+    }
+
+    private synchronized void discardReader(CompletableFuture<Reader<ByteBuffer>> oldReader) {
+        if (reader == oldReader || (reader != null && reader.isCompletedExceptionally())) {
+            reader = null;
+            log.info("discard broken reader for {}", topic);
+        }
+    }
+
+    @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION")
+    private synchronized void discardReader(Reader<ByteBuffer> oldReader) {
+        if (reader == null) {
+            return;
+        }
+        if (reader.isCompletedExceptionally() || (reader.isDone()
+                && !reader.isCompletedExceptionally()
+                && reader.getNow(null) == oldReader)) {
+            log.info("discard broken reader for {}", topic);
+            reader = null;
+        }
+    }
+
+    private synchronized CompletableFuture<Producer<ByteBuffer>> ensureProducerHandle() {
+        if (producer == null) {
+            CompletableFuture<Producer<ByteBuffer>> newProducer = pulsarClient.newProducerBuilder()
+                    .enableBatching(false)
+                    .topic(topic)
+                    .blockIfQueueFull(true)
+                    .createAsync();
+
+            producer = newProducer;
+
+            newProducer.whenComplete((r, error) -> {
+                if (error != null) {
+                    discardProducer(newProducer);
+                }
+            });
+        }
+        return producer;
+    }
+
+    private synchronized void discardProducer(CompletableFuture<Producer<ByteBuffer>> oldProducer) {
+        if (producer == oldProducer) {
+            producer = null;
+        }
+    }
+
+    private CompletableFuture<Void> readNextMessageIfAvailable(Reader<ByteBuffer> reader) {
+        CompletableFuture<Void> result = reader
+                .hasMessageAvailableAsync()
+                .thenCompose(hasMessageAvailable -> {
+                    if (hasMessageAvailable == null
+                            || !hasMessageAvailable) {
+                        return CompletableFuture.completedFuture(null);
+                    } else {
+                        CompletableFuture<Message<ByteBuffer>> opMessage = reader.readNextAsync();
+                        return opMessage.thenComposeAsync(msg -> {
+                            processMessage(msg);
+                            return readNextMessageIfAvailable(reader);
+                        }, executor);
+                    }
+                });
+
+        result.whenComplete((r, error) -> {
+            if (error != null) {
+                discardReader(reader);
+            }
+        });
+
+        return result;
+    }
+
+
+    private synchronized CompletableFuture<Void> ensureLatestData(boolean beforeWrite) {
+        if (currentReadHandle != null && !currentReadHandle.isCompletedExceptionally()) {
+            if (beforeWrite) {
+                // we are inside a write loop, so
+                // we must ensure that we start to read now
+                // otherwise the write would use non up-to-date data
+                // so let's finish the current loop
+                if (log.isDebugEnabled()) {
+                    log.debug("A read was already pending, starting a new one in order to ensure consistency");
+                }
+                return currentReadHandle
+                        .thenCompose(___ -> ensureLatestData(false));
+            }
+            // if there is an ongoing read operation then complete it
+            return currentReadHandle;
+        }
+        // please note that the read operation is async,
+        // and it is not execute inside this synchronized block
+        CompletableFuture<Reader<ByteBuffer>> readerHandle = ensureReaderHandle();
+        final CompletableFuture<Void> newReadHandle =
+                readerHandle.thenCompose(this::readNextMessageIfAvailable);
+        currentReadHandle = newReadHandle;
+
+        newReadHandle.exceptionally(___ -> {
+            endReadLoop(newReadHandle);
+            return null;
+        });
+
+        return newReadHandle.thenApply((__) -> {
+            endReadLoop(newReadHandle);
+            return null;
+        });
+    }
+
+    private synchronized void endReadLoop(CompletableFuture<?> handle) {
+        if (handle == currentReadHandle) {
+            currentReadHandle = null;
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> write(ProducerStateManagerSnapshot snapshot) {
+        ByteBuffer serialized = serialize(snapshot);
+        if (serialized == null) {
+            // cannot serialise, skip
+            return CompletableFuture.completedFuture(null);
+        }
+        return ensureProducerHandle().thenCompose(opProducer -> {
+            // nobody can write now to the topic
+            // wait for local cache to be up-to-date
+            return ensureLatestData(true)
+                    .thenCompose((___) -> {
+                        ProducerStateManagerSnapshot latest = latestSnapshots.get(snapshot.getTopicPartition());
+                        if (latest != null && latest.getOffset() > snapshot.getOffset()) {
+                            log.error("Topic ownership changed for {}. Found a snapshot at {} "
+                                    + "while trying to write the snapshot at {}", snapshot.getTopicPartition(),
+                                    latest.getOffset(), snapshot.getOffset());
+                            return FutureUtil.failedFuture(new NotLeaderOrFollowerException("No more owner of "
+                                    + "ProducerState for topic " + topic));
+                        }
+                        return opProducer
+                                .newMessage()
+                                .key(snapshot.getTopicPartition()) // leverage compaction
+                                .value(serialized)
+                                .sendAsync()
+                                .thenApply((msgId) -> {
+                                    if (log.isDebugEnabled()) {
+                                        log.debug("{} written {} as {}", this, snapshot, msgId);
+                                    }
+                                    latestSnapshots.put(snapshot.getTopicPartition(), snapshot);
+                                    return null;
+                                });
+                    });
+        });
+    }
+
+    private static ByteBuffer serialize(ProducerStateManagerSnapshot snapshot) {
+
+        ByteBuf byteBuf = Unpooled.buffer();
+        try (DataOutputStream dataOutputStream =
+                     new DataOutputStream(new ByteBufOutputStream(byteBuf));) {
+
+            dataOutputStream.writeUTF(snapshot.getTopicPartition());
+            if (snapshot.getTopicUUID() != null) {
+                dataOutputStream.writeUTF(snapshot.getTopicUUID());
+            } else {
+                // topics created from Pulsar don't have the UUID
+                dataOutputStream.writeUTF("");
+            }
+            dataOutputStream.writeLong(snapshot.getOffset());
+
+            dataOutputStream.writeInt(snapshot.getProducers().size());
+            for (Map.Entry<Long, ProducerStateEntry> entry : snapshot.getProducers().entrySet()) {
+                ProducerStateEntry producer = entry.getValue();
+                dataOutputStream.writeLong(producer.producerId());
+                if (producer.producerEpoch() != null) {
+                    dataOutputStream.writeInt(producer.producerEpoch());
+                } else {
+                    dataOutputStream.writeInt(-1);
+                }
+                if (producer.coordinatorEpoch() != null) {
+                    dataOutputStream.writeInt(producer.coordinatorEpoch());
+                } else {
+                    dataOutputStream.writeInt(-1);
+                }
+                if (producer.lastTimestamp() != null) {
+                    dataOutputStream.writeLong(producer.lastTimestamp());
+                } else {
+                    dataOutputStream.writeLong(-1L);
+                }
+                if (producer.currentTxnFirstOffset().isPresent()) {
+                    dataOutputStream.writeLong(producer.currentTxnFirstOffset().get());
+                } else {
+                    dataOutputStream.writeLong(-1);
+                }
+            }
+
+            dataOutputStream.writeInt(snapshot.getOngoingTxns().size());
+            for (Map.Entry<Long, TxnMetadata> entry : snapshot.getOngoingTxns().entrySet()) {
+                TxnMetadata tx = entry.getValue();
+                dataOutputStream.writeLong(tx.producerId());
+                dataOutputStream.writeLong(tx.firstOffset());
+                dataOutputStream.writeLong(tx.lastOffset());
+            }
+
+            dataOutputStream.writeInt(snapshot.getAbortedIndexList().size());
+            for (AbortedTxn tx : snapshot.getAbortedIndexList()) {
+                dataOutputStream.writeLong(tx.producerId());
+                dataOutputStream.writeLong(tx.firstOffset());
+                dataOutputStream.writeLong(tx.lastOffset());
+                dataOutputStream.writeLong(tx.lastStableOffset());
+            }
+
+            dataOutputStream.flush();
+
+            return byteBuf.nioBuffer();
+
+        } catch (IOException err) {
+            log.error("Cannot serialise snapshot {}", snapshot, err);
+            return null;
+        }
+    }
+
+    private static ProducerStateManagerSnapshot deserialize(ByteBuffer buffer) {
+        try (DataInputStream dataInputStream =
+                     new DataInputStream(new ByteBufInputStream(Unpooled.wrappedBuffer(buffer)));) {
+            String topicPartition = dataInputStream.readUTF();
+            String topicUUID = dataInputStream.readUTF();
+            if (topicUUID.isEmpty()) {
+                topicUUID = null;
+            }
+            long offset = dataInputStream.readLong();
+
+            int numProducers = dataInputStream.readInt();
+            Map<Long, ProducerStateEntry> producers = new HashMap<>();
+            for (int i = 0; i < numProducers; i++) {
+                long producerId = dataInputStream.readLong();
+                Integer producerEpoch = dataInputStream.readInt();
+                if (producerEpoch == -1) {
+                    producerEpoch = null;
+                }
+                Integer coordinatorEpoch = dataInputStream.readInt();
+                if (coordinatorEpoch == -1) {
+                    coordinatorEpoch = null;
+                }
+                Long lastTimestamp = dataInputStream.readLong();
+                if (lastTimestamp == -1) {
+                    lastTimestamp = null;
+                }
+                Long currentTxFirstOffset = dataInputStream.readLong();
+                if (currentTxFirstOffset == -1) {
+                    currentTxFirstOffset = null;
+                }
+                ProducerStateEntry entry = ProducerStateEntry.empty(producerId)
+                        .producerEpoch(producerEpoch != null ? producerEpoch.shortValue() : null)
+                        .coordinatorEpoch(coordinatorEpoch)
+                        .lastTimestamp(lastTimestamp)
+                        .currentTxnFirstOffset(Optional.ofNullable(currentTxFirstOffset));
+                producers.put(producerId, entry);
+            }
+
+            int numOngoingTxns = dataInputStream.readInt();
+            TreeMap<Long, TxnMetadata> ongoingTxns = new TreeMap<>();
+            for (int i = 0; i < numOngoingTxns; i++) {
+                long producerId = dataInputStream.readLong();
+                long firstOffset = dataInputStream.readLong();
+                long lastOffset = dataInputStream.readLong();
+                ongoingTxns.put(firstOffset, new TxnMetadata(producerId, firstOffset)
+                        .lastOffset(lastOffset));
+            }
+
+            int numAbortedIndexList = dataInputStream.readInt();
+            List<AbortedTxn> abortedTxnList = new ArrayList<>();
+            for (int i = 0; i < numAbortedIndexList; i++) {
+                long producerId = dataInputStream.readLong();
+                long firstOffset = dataInputStream.readLong();
+                long lastOffset = dataInputStream.readLong();
+                long lastStableOffset = dataInputStream.readLong();
+                abortedTxnList.add(new AbortedTxn(producerId, firstOffset, lastOffset, lastStableOffset));
+            }
+
+            return new ProducerStateManagerSnapshot(topicPartition, topicUUID, offset,
+                    producers, ongoingTxns, abortedTxnList);
+
+        } catch (Throwable err) {
+            log.error("Cannot deserialize snapshot", err);
+            return null;
+        }
+    }
+
+    private void processMessage(Message<ByteBuffer> msg) {
+        ProducerStateManagerSnapshot deserialize = deserialize(msg.getValue());
+        if (deserialize != null) {
+            String key = msg.hasKey() ? msg.getKey() : null;
+            if (Objects.equals(key, deserialize.getTopicPartition())) {
+                if (log.isDebugEnabled()) {
+                    log.debug("found snapshot for {} ({}): {}",
+                            deserialize.getTopicPartition(),
+                            deserialize.getTopicUUID(),
+                            deserialize);
+                }
+                latestSnapshots.put(deserialize.getTopicPartition(), deserialize);
+            }
+        }
+    }
+
+    @Override
+    public CompletableFuture<ProducerStateManagerSnapshot> readLatestSnapshot(String topicPartition) {
+        if (log.isDebugEnabled()) {
+            log.debug("Reading latest snapshot for {}", topicPartition);
+        }
+        return ensureLatestData(false).thenApply(__ -> {
+            ProducerStateManagerSnapshot result =  latestSnapshots.get(topicPartition);
+            log.info("Latest snapshot for {} is {}", topicPartition, result);
+            return result;
+        });
+    }
+
+    public PulsarTopicProducerStateManagerSnapshotBuffer(String topicName,
+            SystemTopicClient pulsarClient,
+            Executor executor) {
+        this.topic = topicName;
+        this.pulsarClient = pulsarClient;
+        this.executor = executor;
+    }
+
+
+    @Override
+    public synchronized void shutdown() {
+        if (reader != null) {
+            reader.whenComplete((r, e) -> {
+                if (r != null) {
+                    r.closeAsync().whenComplete((___, err) -> {
+                        if (err != null) {
+                            log.error("Error closing reader for {}", topic, err);
+                        }
+                    });
+                }
+            });
+        }
+        if (producer != null) {
+            producer.whenComplete((r, e) -> {
+                if (r != null) {
+                    r.closeAsync().whenComplete((___, err) -> {
+                        if (err != null) {
+                            log.error("Error closing producer for {}", topic, err);
+                        }
+                    });
+                }
+            });
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "PulsarTopicProducerStateManagerSnapshotBuffer{" + topic + '}';
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBuffer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBuffer.java
@@ -19,14 +19,6 @@ import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufOutputStream;
 import io.netty.buffer.Unpooled;
 import io.streamnative.pulsar.handlers.kop.SystemTopicClient;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.kafka.common.errors.NotLeaderOrFollowerException;
-import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.api.MessageId;
-import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.Reader;
-import org.apache.pulsar.common.util.FutureUtil;
-
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -41,6 +33,14 @@ import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.errors.NotLeaderOrFollowerException;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.Reader;
+import org.apache.pulsar.common.util.FutureUtil;
+
 
 @Slf4j
 public class PulsarTopicProducerStateManagerSnapshotBuffer implements ProducerStateManagerSnapshotBuffer {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/TxnMetadata.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/TxnMetadata.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.storage;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(fluent = true)
+@EqualsAndHashCode
+public final class TxnMetadata {
+    private final long producerId;
+    private final long firstOffset;
+    private long lastOffset;
+
+    public TxnMetadata(long producerId, long firstOffset) {
+        this.producerId = producerId;
+        this.firstOffset = firstOffset;
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtils.java
@@ -48,6 +48,11 @@ public class MetadataUtils {
                 + "/" + Topic.TRANSACTION_STATE_TOPIC_NAME;
     }
 
+    public static String constructTxProducerStateTopicBaseName(String tenant, KafkaServiceConfiguration conf) {
+        return tenant + "/" + conf.getKafkaMetadataNamespace()
+                + "/__transaction_producer_state";
+    }
+
     public static String constructTxnProducerIdTopicBaseName(String tenant, KafkaServiceConfiguration conf) {
         return tenant + "/" + conf.getKafkaMetadataNamespace()
                 + "/__transaction_producerid_generator";
@@ -85,6 +90,10 @@ public class MetadataUtils {
                 constructMetadataNamespace(tenant, conf));
         createKafkaMetadataIfMissing(tenant, conf.getKafkaMetadataNamespace(), pulsarAdmin, clusterData, conf, kopTopic,
                 conf.getKafkaTxnLogTopicNumPartitions(), false);
+        KopTopic kopTopicProducerState = new KopTopic(constructTxProducerStateTopicBaseName(tenant, conf),
+                constructMetadataNamespace(tenant, conf));
+        createKafkaMetadataIfMissing(tenant, conf.getKafkaMetadataNamespace(), pulsarAdmin, clusterData, conf,
+                kopTopicProducerState, conf.getKafkaTxnProducerStateTopicNumPartitions(), false);
         if (conf.isKafkaTransactionProducerIdsStoredOnPulsar()) {
             KopTopic producerIdKopTopic = new KopTopic(constructTxnProducerIdTopicBaseName(tenant, conf),
                     constructMetadataNamespace(tenant, conf));

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EncodePerformanceTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EncodePerformanceTest.java
@@ -14,6 +14,8 @@
 package io.streamnative.pulsar.handlers.kop.format;
 
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
+import io.streamnative.pulsar.handlers.kop.KafkaTopicLookupService;
+import io.streamnative.pulsar.handlers.kop.storage.MemoryProducerStateManagerSnapshotBuffer;
 import io.streamnative.pulsar.handlers.kop.storage.PartitionLog;
 import io.streamnative.pulsar.handlers.kop.storage.ProducerStateManager;
 import java.nio.ByteBuffer;
@@ -28,6 +30,8 @@ import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.SimpleRecord;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.Time;
+
+import static org.mockito.Mockito.mock;
 
 
 /**
@@ -48,7 +52,8 @@ public class EncodePerformanceTest {
             new TopicPartition("test", 1),
             "test",
             null,
-            new ProducerStateManager("test"));
+            mock(KafkaTopicLookupService.class),
+            new MemoryProducerStateManagerSnapshotBuffer());
 
     public static void main(String[] args) {
         pulsarServiceConfiguration.setEntryFormat("pulsar");

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EncodePerformanceTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EncodePerformanceTest.java
@@ -13,11 +13,12 @@
  */
 package io.streamnative.pulsar.handlers.kop.format;
 
+import static org.mockito.Mockito.mock;
+
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import io.streamnative.pulsar.handlers.kop.KafkaTopicLookupService;
 import io.streamnative.pulsar.handlers.kop.storage.MemoryProducerStateManagerSnapshotBuffer;
 import io.streamnative.pulsar.handlers.kop.storage.PartitionLog;
-import io.streamnative.pulsar.handlers.kop.storage.ProducerStateManager;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Optional;
@@ -30,9 +31,6 @@ import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.SimpleRecord;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.Time;
-
-import static org.mockito.Mockito.mock;
-
 
 /**
  * The performance test for {@link EntryFormatter#encode(EncodeRequest)}.

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterTest.java
@@ -23,7 +23,6 @@ import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import io.streamnative.pulsar.handlers.kop.KafkaTopicLookupService;
 import io.streamnative.pulsar.handlers.kop.storage.MemoryProducerStateManagerSnapshotBuffer;
 import io.streamnative.pulsar.handlers.kop.storage.PartitionLog;
-import io.streamnative.pulsar.handlers.kop.storage.ProducerStateManager;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterTest.java
@@ -20,6 +20,8 @@ import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableMap;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
+import io.streamnative.pulsar.handlers.kop.KafkaTopicLookupService;
+import io.streamnative.pulsar.handlers.kop.storage.MemoryProducerStateManagerSnapshotBuffer;
 import io.streamnative.pulsar.handlers.kop.storage.PartitionLog;
 import io.streamnative.pulsar.handlers.kop.storage.ProducerStateManager;
 import java.io.DataOutputStream;
@@ -80,7 +82,8 @@ public class EntryFormatterTest {
             new TopicPartition("test", 1),
             "test",
             null,
-            new ProducerStateManager("test"));
+            mock(KafkaTopicLookupService.class),
+            new MemoryProducerStateManagerSnapshotBuffer());
 
     private void init() {
         pulsarServiceConfiguration.setEntryFormat("pulsar");

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtilsTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/utils/MetadataUtilsTest.java
@@ -66,6 +66,8 @@ public class MetadataUtilsTest {
                 .constructOffsetsTopicBaseName(conf.getKafkaMetadataTenant(), conf), namespacePrefix);
         final KopTopic txnTopic = new KopTopic(MetadataUtils
                 .constructTxnLogTopicBaseName(conf.getKafkaMetadataTenant(), conf), namespacePrefix);
+        final KopTopic txnProducerStateTopic = new KopTopic(MetadataUtils
+                .constructTxProducerStateTopicBaseName(conf.getKafkaMetadataTenant(), conf), namespacePrefix);
 
         List<String> emptyList = Lists.newArrayList();
 
@@ -83,6 +85,8 @@ public class MetadataUtilsTest {
         Topics mockTopics = mock(Topics.class);
         doReturn(offsetTopicMetadata).when(mockTopics).getPartitionedTopicMetadata(eq(offsetsTopic.getFullName()));
         doReturn(offsetTopicMetadata).when(mockTopics).getPartitionedTopicMetadata(eq(txnTopic.getFullName()));
+        doReturn(offsetTopicMetadata).when(mockTopics)
+                .getPartitionedTopicMetadata(eq(txnProducerStateTopic.getFullName()));
 
         PulsarAdmin mockPulsarAdmin = mock(PulsarAdmin.class);
 
@@ -125,6 +129,8 @@ public class MetadataUtilsTest {
                 eq(offsetsTopic.getFullName()), eq(conf.getOffsetsTopicNumPartitions()));
         verify(mockTopics, times(1)).createPartitionedTopic(
                 eq(txnTopic.getFullName()), eq(conf.getKafkaTxnLogTopicNumPartitions()));
+        verify(mockTopics, times(1)).createPartitionedTopic(
+                eq(txnProducerStateTopic.getFullName()), eq(conf.getKafkaTxnProducerStateTopicNumPartitions()));
         // check user topics namespace doesn't set the policy
         verify(mockNamespaces, times(1)).createNamespace(eq(conf.getKafkaTenant() + "/"
                 + conf.getKafkaNamespace()), any(Set.class));
@@ -177,6 +183,8 @@ public class MetadataUtilsTest {
                 .getPartitionedTopicMetadata(eq(offsetsTopic.getFullName()));
         doReturn(new PartitionedTopicMetadata(8)).when(mockTopics)
                 .getPartitionedTopicMetadata(eq(txnTopic.getFullName()));
+        doReturn(new PartitionedTopicMetadata(8)).when(mockTopics)
+                .getPartitionedTopicMetadata(eq(txnProducerStateTopic.getFullName()));
         doReturn(incompletePartitionList).when(mockTopics).getList(eq(conf.getKafkaMetadataTenant()
             + "/" + conf.getKafkaMetadataNamespace()));
 
@@ -184,10 +192,11 @@ public class MetadataUtilsTest {
         MetadataUtils.createTxnMetadataIfMissing(conf.getKafkaMetadataTenant(), mockPulsarAdmin, clusterData, conf);
 
         verify(mockTenants, times(1)).updateTenant(eq(conf.getKafkaMetadataTenant()), any(TenantInfo.class));
-        verify(mockNamespaces, times(2)).setNamespaceReplicationClusters(eq(conf.getKafkaMetadataTenant()
+        verify(mockNamespaces, times(3)).setNamespaceReplicationClusters(eq(conf.getKafkaMetadataTenant()
             + "/" + conf.getKafkaMetadataNamespace()), any(Set.class));
         verify(mockTopics, times(1)).createMissedPartitions(contains(offsetsTopic.getOriginalName()));
         verify(mockTopics, times(1)).createMissedPartitions(contains(txnTopic.getOriginalName()));
+        verify(mockTopics, times(1)).createMissedPartitions(contains(txnProducerStateTopic.getOriginalName()));
     }
 
     @Test(timeOut = 30000)

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManagerTest.java
@@ -30,6 +30,7 @@ public class KopBrokerLookupManagerTest extends KopProtocolHandlerTestBase {
     private static final String TENANT = "test";
     private static final String NAMESPACE = TENANT + "/" + "kop-broker-lookup-manager-test";
 
+    private LookupClient lookupClient;
     private KopBrokerLookupManager kopBrokerLookupManager;
 
     @BeforeClass
@@ -43,13 +44,16 @@ public class KopBrokerLookupManagerTest extends KopProtocolHandlerTestBase {
                 .build());
         admin.namespaces().createNamespace(NAMESPACE);
         admin.namespaces().setDeduplicationStatus(NAMESPACE, true);
-        kopBrokerLookupManager = new KopBrokerLookupManager(conf, pulsar);
+        lookupClient = new LookupClient(pulsar, conf);
+        kopBrokerLookupManager = new KopBrokerLookupManager(conf, pulsar, lookupClient);
     }
 
     @AfterClass
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();
+        kopBrokerLookupManager.close();
+        lookupClient.close();
     }
 
     @Test(timeOut = 20 * 1000)

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -17,6 +17,8 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.netty.channel.EventLoopGroup;
@@ -37,6 +39,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import lombok.Getter;
@@ -66,11 +70,13 @@ import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.auth.SameThreadOrderedSafeExecutor;
 import org.apache.pulsar.broker.namespace.NamespaceService;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
@@ -247,7 +253,7 @@ public abstract class KopProtocolHandlerTestBase {
     }
 
     protected void createClient() throws Exception {
-        this.pulsarClient = KafkaProtocolHandler.getLookupClient(pulsar).getPulsarClient();
+        this.pulsarClient = new LookupClient(pulsar, conf).getPulsarClient();
     }
 
     protected String getAdvertisedAddress() {
@@ -824,5 +830,49 @@ public abstract class KopProtocolHandlerTestBase {
                         return transactionCoordinator;
                     }
                 });
+    }
+
+    /**
+     * Execute the task that trims consumed ledgers.
+     * @throws Exception
+     */
+    public void trimConsumedLedgers(String topic) throws Exception {
+        log.info("trimConsumedLedgers {}", topic);
+        TopicName topicName = TopicName.get(topic);
+        String namespace = topicName.getNamespace();
+
+        RetentionPolicies oldRetentionPolicies = admin.namespaces().getRetention(namespace);
+        Integer deduplicationSnapshotInterval = admin.namespaces().getDeduplicationSnapshotInterval(namespace);
+        try {
+            admin.namespaces().setRetention(namespace, new RetentionPolicies(0, 0));
+            admin.namespaces().setDeduplicationSnapshotInterval(namespace, 1);
+
+            // ensure that the snapshot interval elapsed
+            Thread.sleep(2000);
+
+            KafkaTopicLookupService lookupService = new KafkaTopicLookupService(pulsar.getBrokerService());
+            PersistentTopic topicHandle = lookupService.getTopic(topic, "test").get().get();
+
+            // in transaction tests we have deduplication, that is a subscription
+            // and it may prevent the topic to be trimmed
+            topicHandle.checkDeduplicationSnapshot();
+
+            ObjectMapper mapper = new ObjectMapper();
+            mapper.enable(SerializationFeature.INDENT_OUTPUT);
+            log.info("Stats {}",
+                    mapper.writeValueAsString(admin
+                            .topics()
+                            .getInternalStats(topic)));
+
+            CompletableFuture<?> future = new CompletableFuture<>();
+            topicHandle.getManagedLedger()
+                    .getConfig().setRetentionTime(1, TimeUnit.SECONDS);
+            Thread.sleep(2000);
+            topicHandle.getManagedLedger().trimConsumedLedgersInBackground(future);
+            future.get(10, TimeUnit.SECONDS);
+        } finally {
+            admin.namespaces().setRetention(namespace, oldRetentionPolicies);
+            admin.namespaces().setDeduplicationSnapshotInterval(namespace, deduplicationSnapshotInterval);
+        }
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionWithOAuthBearerAuthTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionWithOAuthBearerAuthTest.java
@@ -25,6 +25,7 @@ import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationFactoryOAuth2;
 import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 @Slf4j
 public class TransactionWithOAuthBearerAuthTest extends TransactionTest {
@@ -99,4 +100,9 @@ public class TransactionWithOAuthBearerAuthTest extends TransactionTest {
         ));
     }
 
+    @Test(enabled = false)
+    @Override
+    public void basicRecoveryAbortedTransactionDueToProducerTimedOut(boolean takeSnapshotBeforeRecovery) {
+        // this test is disabled in this suite because the token expires
+    }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionWithOAuthBearerAuthTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionWithOAuthBearerAuthTest.java
@@ -105,4 +105,10 @@ public class TransactionWithOAuthBearerAuthTest extends TransactionTest {
     public void basicRecoveryAbortedTransactionDueToProducerTimedOut(boolean takeSnapshotBeforeRecovery) {
         // this test is disabled in this suite because the token expires
     }
+
+    @Test(enabled = false)
+    @Override
+    public void basicRecoveryAfterDeleteCreateTopic() {
+        // this test is disabled in this suite because the token expires
+    }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogTest.java
@@ -16,6 +16,8 @@ package io.streamnative.pulsar.handlers.kop.storage;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+
+import io.streamnative.pulsar.handlers.kop.KafkaTopicLookupService;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.RecordTooLargeException;
@@ -30,6 +32,8 @@ import org.apache.kafka.common.utils.Time;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
 
 /**
  * Unit test {@link PartitionLog}.
@@ -46,7 +50,8 @@ public class PartitionLogTest {
             new TopicPartition("test", 1),
             "test",
             null,
-            new ProducerStateManager("test"));
+            mock(KafkaTopicLookupService.class),
+            new MemoryProducerStateManagerSnapshotBuffer());
 
     @DataProvider(name = "compressionTypes")
     Object[] allCompressionTypes() {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogTest.java
@@ -13,11 +13,12 @@
  */
 package io.streamnative.pulsar.handlers.kop.storage;
 
+import static org.mockito.Mockito.mock;
+
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
+import io.streamnative.pulsar.handlers.kop.KafkaTopicLookupService;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-
-import io.streamnative.pulsar.handlers.kop.KafkaTopicLookupService;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.RecordTooLargeException;
@@ -32,8 +33,6 @@ import org.apache.kafka.common.utils.Time;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-
-import static org.mockito.Mockito.mock;
 
 /**
  * Unit test {@link PartitionLog}.


### PR DESCRIPTION
### Motivation

Currently KOP is not fully recovering the status of transactions (the so called ProducerState in Kafka). 

### Modifications

Summary of changes:
- introduce a new system topic __transaction_producer_state that stores SNAPSHOTs of the state of the transactions for each partition
- implement recovery: start from the latest snapshot and read all the messages up to the tail of the topic
- implement removal of old Aborted Transactions
- recovery operations happen on a dedicated thread pool
- there is a configuration flag to turn off ProducerState recovery (in case that there are problems, the operation may take some time on big topics if there is no available snapshot)
- assign a kafkaTopicUUID property to the topics created using the Kafka API (admin or auto-create), this is needed to support delete/create workflows, because we cannot use the SNAPSHOT takes from the "old" life of a topic and apply it for the recovery of the "new life" of the topic. Topics created using Pulsar APIs work decently but it is not 100% safe (if we detect that the current position is smaller than the latest snapshot, so the snapshot seems to be taken in the future, ignore the snapshot and we start from the beginning of the topic)
- AppendRecordContext must not be recyclable 

This change also includes a few improvements to the Topic Lookup system that are needed in order to recover well from failure scenarios during transaction recovery:
- broker outages
- network failures to some components
- full k8s node failures (nodes that contain brokers or bookies for instance)

One interesting point that makes KOP better that Kafka is that in Kafka they store the data and the snapshots on the local disks of the brokers, with Pulsar all the support data (SNAPHOTs and TX status) is stored on Pulsar topics, so the system is far more resilient to problems)



### Verifying this change

This change added tests

### Documentation

Check the box below.

Need to update docs? 

- [x] `doc-required` 
  
 We will have to document the new system topic
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

