### PR TITLE
[performance] Remove dummy 10ms throttling on FetchResponse

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -1657,7 +1657,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                 new FetchResponse<>(
                                     Errors.NONE,
                                     partitions,
-                                    THROTTLE_TIME_MS,
+                                    0,
                                     request.metadata().sessionId()),
                                 () -> resultMap.forEach((__, readRecordsResult) -> {
                                     readRecordsResult.recycle();


### PR DESCRIPTION
### Motivation

With the upgrade of the Kafka clients to 2.8.x we introduced a performance regression

### Modifications

Remove the fixed 10ms delay

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

