### PR TITLE
[cleanup] Remove static LOOKUP_CLIENT_MAP

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
@@ -50,6 +50,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
     private final KopBrokerLookupManager kopBrokerLookupManager;
     @Getter
     private final KafkaTopicManagerSharedState kafkaTopicManagerSharedState;
+    private final LookupClient lookupClient;
 
     private final AdminManager adminManager;
     private DelayedOperationPurgatory<DelayedOperation> producePurgatory;
@@ -80,13 +81,15 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
                                    boolean skipMessagesWithoutIndex,
                                    RequestStats requestStats,
                                    OrderedScheduler sendResponseScheduler,
-                                   KafkaTopicManagerSharedState kafkaTopicManagerSharedState) {
+                                   KafkaTopicManagerSharedState kafkaTopicManagerSharedState,
+                                   LookupClient lookupClient) {
         super();
         this.pulsarService = pulsarService;
         this.kafkaConfig = kafkaConfig;
         this.tenantContextManager = tenantContextManager;
         this.replicaManager = replicaManager;
         this.kopBrokerLookupManager = kopBrokerLookupManager;
+        this.lookupClient = lookupClient;
         this.adminManager = adminManager;
         this.producePurgatory = producePurgatory;
         this.fetchPurgatory = fetchPurgatory;
@@ -127,7 +130,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
                 tenantContextManager, replicaManager, kopBrokerLookupManager, adminManager,
                 producePurgatory, fetchPurgatory,
                 enableTls, advertisedEndPoint, skipMessagesWithoutIndex, requestStats, sendResponseScheduler,
-                kafkaTopicManagerSharedState);
+                kafkaTopicManagerSharedState, lookupClient);
     }
 
     @VisibleForTesting
@@ -138,6 +141,6 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
                 enableTls, advertisedEndPoint, skipMessagesWithoutIndex,
                 requestStats,
                 sendResponseScheduler,
-                kafkaTopicManagerSharedState);
+                kafkaTopicManagerSharedState, lookupClient);
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -43,7 +43,6 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.commons.configuration.Configuration;
@@ -52,7 +51,6 @@ import org.apache.kafka.common.internals.Topic;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.utils.Time;
 import org.apache.pulsar.broker.PulsarServerException;
-import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.protocol.ProtocolHandler;
@@ -71,8 +69,6 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
 
     public static final String PROTOCOL_NAME = "kafka";
     public static final String TLS_HANDLER = "tls";
-    private static final Map<PulsarService, LookupClient> LOOKUP_CLIENT_MAP = new ConcurrentHashMap<>();
-
     @Getter
     private RequestStats requestStats;
     private PrometheusMetricsProvider statsProvider;
@@ -84,6 +80,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     private SystemTopicClient txnTopicClient;
     private DelayedOperationPurgatory<DelayedOperation> producePurgatory;
     private DelayedOperationPurgatory<DelayedOperation> fetchPurgatory;
+    private LookupClient lookupClient;
     @VisibleForTesting
     @Getter
     private Map<InetSocketAddress, ChannelInitializer<SocketChannel>> channelInitializerMap;
@@ -202,12 +199,12 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
             throw new IllegalStateException(e);
         }
 
-        LOOKUP_CLIENT_MAP.put(brokerService.pulsar(), new LookupClient(brokerService.pulsar(), kafkaConfig));
+        lookupClient = new LookupClient(brokerService.pulsar(), kafkaConfig);
         offsetTopicClient = new SystemTopicClient(brokerService.pulsar(), kafkaConfig);
         txnTopicClient = new SystemTopicClient(brokerService.pulsar(), kafkaConfig);
 
         try {
-            kopBrokerLookupManager = new KopBrokerLookupManager(kafkaConfig, brokerService.getPulsar());
+            kopBrokerLookupManager = new KopBrokerLookupManager(kafkaConfig, brokerService.getPulsar(), lookupClient);
         } catch (Exception ex) {
             log.error("Failed to get kopBrokerLookupManager", ex);
             throw new IllegalStateException(ex);
@@ -402,7 +399,8 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 kafkaConfig.isSkipMessagesWithoutIndex(),
                 requestStats,
                 sendResponseScheduler,
-                kafkaTopicManagerSharedState);
+                kafkaTopicManagerSharedState,
+                lookupClient);
     }
 
     // this is called after initialize, and with kafkaConfig, brokerService all set.
@@ -456,16 +454,6 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
 
     @Override
     public void close() {
-        Optional.ofNullable(LOOKUP_CLIENT_MAP.remove(brokerService.pulsar())).ifPresent(LookupClient::close);
-        if (offsetTopicClient != null) {
-            offsetTopicClient.close();
-        }
-        if (txnTopicClient != null) {
-            txnTopicClient.close();
-        }
-        if (adminManager != null) {
-            adminManager.shutdown();
-        }
         if (producePurgatory != null) {
             producePurgatory.shutdown();
         }
@@ -483,6 +471,19 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
         kopBrokerLookupManager.close();
         statsProvider.stop();
         sendResponseScheduler.shutdown();
+
+        if (offsetTopicClient != null) {
+            offsetTopicClient.close();
+        }
+        if (txnTopicClient != null) {
+            txnTopicClient.close();
+        }
+        if (adminManager != null) {
+            adminManager.shutdown();
+        }
+        if (lookupClient != null) {
+            lookupClient.close();
+        }
     }
 
     @VisibleForTesting
@@ -570,9 +571,5 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
         transactionCoordinator.startup(kafkaConfig.isKafkaTransactionalIdExpirationEnable()).get();
 
         return transactionCoordinator;
-    }
-
-    public static @NonNull LookupClient getLookupClient(final PulsarService pulsarService) {
-        return LOOKUP_CLIENT_MAP.computeIfAbsent(pulsarService, ignored -> new LookupClient(pulsarService));
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -213,6 +213,9 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
     private final TenantContextManager tenantContextManager;
     private final ReplicaManager replicaManager;
     private final KopBrokerLookupManager kopBrokerLookupManager;
+
+    @Getter
+    private final LookupClient lookupClient;
     @Getter
     private final KafkaTopicManagerSharedState kafkaTopicManagerSharedState;
 
@@ -313,12 +316,14 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                boolean skipMessagesWithoutIndex,
                                RequestStats requestStats,
                                OrderedScheduler sendResponseScheduler,
-                               KafkaTopicManagerSharedState kafkaTopicManagerSharedState) throws Exception {
+                               KafkaTopicManagerSharedState kafkaTopicManagerSharedState,
+                               LookupClient lookupClient) throws Exception {
         super(requestStats, kafkaConfig, sendResponseScheduler);
         this.pulsarService = pulsarService;
         this.tenantContextManager = tenantContextManager;
         this.replicaManager = replicaManager;
         this.kopBrokerLookupManager = kopBrokerLookupManager;
+        this.lookupClient = lookupClient;
         this.clusterName = kafkaConfig.getClusterName();
         this.executor = pulsarService.getExecutor();
         this.admin = pulsarService.getAdminClient();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
@@ -46,7 +46,7 @@ public class KafkaTopicManager {
         PulsarService pulsarService = kafkaRequestHandler.getPulsarService();
         this.brokerService = pulsarService.getBrokerService();
         this.internalServerCnx = new InternalServerCnx(requestHandler);
-        this.lookupClient = KafkaProtocolHandler.getLookupClient(pulsarService);
+        this.lookupClient = kafkaRequestHandler.getLookupClient();
         this.kafkaTopicLookupService = new KafkaTopicLookupService(pulsarService.getBrokerService());
      }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManager.java
@@ -48,9 +48,10 @@ public class KopBrokerLookupManager {
     public static final ConcurrentHashMap<String, CompletableFuture<InetSocketAddress>>
             LOOKUP_CACHE = new ConcurrentHashMap<>();
 
-    public KopBrokerLookupManager(KafkaServiceConfiguration conf, PulsarService pulsarService) throws Exception {
+    public KopBrokerLookupManager(KafkaServiceConfiguration conf, PulsarService pulsarService,
+                                  LookupClient lookupClient) throws Exception {
         this.pulsar = pulsarService;
-        this.lookupClient = KafkaProtocolHandler.getLookupClient(pulsarService);
+        this.lookupClient = lookupClient;
         this.metadataStoreCacheLoader = new MetadataStoreCacheLoader(pulsarService.getPulsarResources(),
                 conf.getBrokerLookupTimeoutMs());
         this.selfAdvertisedListeners = conf.getKafkaAdvertisedListeners();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/LookupClient.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/LookupClient.java
@@ -30,12 +30,6 @@ public class LookupClient extends AbstractPulsarClient {
         super(createPulsarClient(pulsarService, kafkaConfig, conf -> {}));
     }
 
-    public LookupClient(final PulsarService pulsarService) {
-        super(createPulsarClient(pulsarService));
-        log.warn("This constructor should not be called, it's only called "
-                + "when the PulsarService doesn't exist in KafkaProtocolHandlers.LOOKUP_CLIENT_UP");
-    }
-
     public CompletableFuture<InetSocketAddress> getBrokerAddress(final TopicName topicName) {
         return getPulsarClient().getLookup().getBroker(topicName).thenApply(Pair::getLeft);
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopBrokerLookupManagerTest.java
@@ -30,6 +30,7 @@ public class KopBrokerLookupManagerTest extends KopProtocolHandlerTestBase {
     private static final String TENANT = "test";
     private static final String NAMESPACE = TENANT + "/" + "kop-broker-lookup-manager-test";
 
+    private LookupClient lookupClient;
     private KopBrokerLookupManager kopBrokerLookupManager;
 
     @BeforeClass
@@ -43,13 +44,16 @@ public class KopBrokerLookupManagerTest extends KopProtocolHandlerTestBase {
                 .build());
         admin.namespaces().createNamespace(NAMESPACE);
         admin.namespaces().setDeduplicationStatus(NAMESPACE, true);
-        kopBrokerLookupManager = new KopBrokerLookupManager(conf, pulsar);
+        lookupClient = new LookupClient(pulsar, conf);
+        kopBrokerLookupManager = new KopBrokerLookupManager(conf, pulsar, lookupClient);
     }
 
     @AfterClass
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();
+        kopBrokerLookupManager.close();
+        lookupClient.close();
     }
 
     @Test(timeOut = 20 * 1000)

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -247,7 +247,7 @@ public abstract class KopProtocolHandlerTestBase {
     }
 
     protected void createClient() throws Exception {
-        this.pulsarClient = KafkaProtocolHandler.getLookupClient(pulsar).getPulsarClient();
+        this.pulsarClient = new LookupClient(pulsar, conf).getPulsarClient();
     }
 
     protected String getAdvertisedAddress() {


### PR DESCRIPTION
### Motivation

There is no need to use a static Map to access the LookupClient.

### Modifications

Keep only a reference to the field in the ProtocolHandler and pass it.
This way the lifecycle is cleaner.
Also we close all the "clients" as last step, otherwise other components may see unexpected errors due to the clients being shutdown.

### Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

