### PR TITLE
[improvement] Do not cache topics in KafkaTopicManagerSharedState

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
@@ -256,7 +256,7 @@ public class AdminManager {
                             Consumer<String> successConsumer,
                             Consumer<String> errorConsumer) {
         admin.topics()
-                .deletePartitionedTopicAsync(topicToDelete)
+                .deletePartitionedTopicAsync(topicToDelete, true, true)
                 .thenRun(() -> {
                     log.info("delete topic {} successfully.", topicToDelete);
                     successConsumer.accept(topicToDelete);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
@@ -122,8 +122,10 @@ public class KafkaTopicManager {
             }
             return Optional.empty();
         }
-        return Optional.of(requestHandler.getKafkaTopicManagerSharedState()
-                .getReferences().computeIfAbsent(requestHandler, (__) -> registerInPersistentTopic(persistentTopic)));
+        return requestHandler
+                .getKafkaTopicManagerSharedState()
+                .registerProducer(topicName, requestHandler,
+                        () -> registerInPersistentTopic(persistentTopic));
     }
 
     // when channel close, release all the topics reference in persistentTopic

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
@@ -123,7 +123,7 @@ public class KafkaTopicManager {
             return Optional.empty();
         }
         return Optional.of(requestHandler.getKafkaTopicManagerSharedState()
-                .getReferences().computeIfAbsent(topicName, (__) -> registerInPersistentTopic(persistentTopic)));
+                .getReferences().computeIfAbsent(requestHandler, (__) -> registerInPersistentTopic(persistentTopic)));
     }
 
     // when channel close, release all the topics reference in persistentTopic
@@ -150,8 +150,6 @@ public class KafkaTopicManager {
         }
         CompletableFuture<Optional<PersistentTopic>> topicCompletableFuture =
                 kafkaTopicLookupService.getTopic(topicName, requestHandler.ctx.channel());
-        // cache for removing producer
-        requestHandler.getKafkaTopicManagerSharedState().getTopics().put(topicName, topicCompletableFuture);
         return topicCompletableFuture;
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManagerSharedState.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManagerSharedState.java
@@ -80,8 +80,10 @@ public final class KafkaTopicManagerSharedState {
     private void removePersistentTopicAndReferenceProducer(final KafkaRequestHandler producerId) {
         // 1. Remove PersistentTopic and Producer from caches, these calls are thread safe
         final Producer producer = references.remove(producerId);
-        PersistentTopic topic = (PersistentTopic) producer.getTopic();
-        topic.removeProducer(producer);
+        if (producer != null) {
+            PersistentTopic topic = (PersistentTopic) producer.getTopic();
+            topic.removeProducer(producer);
+        }
     }
 
     public void handlerKafkaRequestHandlerClosed(SocketAddress remoteAddress, KafkaRequestHandler requestHandler) {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopEventManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopEventManagerTest.java
@@ -74,7 +74,7 @@ public class KopEventManagerTest extends KopProtocolHandlerTestBase {
         super.internalCleanup();
     }
 
-    @Test(timeOut = 6000)
+    @Test(timeOut = 60000000)
     public void testOneTopicGroupState() throws Exception {
         // 1. create topics
         createTopics(Collections.singletonList(topic1));
@@ -111,7 +111,7 @@ public class KopEventManagerTest extends KopProtocolHandlerTestBase {
         assertTrue(describeGroup1.containsKey(groupId1));
         assertEquals(ConsumerGroupState.EMPTY, describeGroup2.get(groupId1).state());
         // 7. delete topic1
-        adminClient.deleteTopics(Collections.singletonList(topic1));
+        adminClient.deleteTopics(Collections.singletonList(topic1)).all().get();
         // 8. describe group who only consume topic1 which have been deleted
         // check group state must be Dead
         retryUntilStateDead(groupId1, 5);
@@ -163,7 +163,7 @@ public class KopEventManagerTest extends KopProtocolHandlerTestBase {
         List<String> deleteTopics = Lists.newArrayList();
         deleteTopics.add(topic2);
         deleteTopics.add(topic3);
-        adminClient.deleteTopics(deleteTopics);
+        adminClient.deleteTopics(deleteTopics).all().get();
         // 8. check group state must be Dead
         retryUntilStateDead(groupId2, 5);
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopEventManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopEventManagerTest.java
@@ -74,7 +74,7 @@ public class KopEventManagerTest extends KopProtocolHandlerTestBase {
         super.internalCleanup();
     }
 
-    @Test(timeOut = 60000000)
+    @Test(timeOut = 6000)
     public void testOneTopicGroupState() throws Exception {
         // 1. create topics
         createTopics(Collections.singletonList(topic1));


### PR DESCRIPTION
### Motivation

Currently KafkaTopicManagerSharedState contains a cache of PersistentTopic references that is useless and makes the code harder to understand. It is also possible that sometimes we fail to remove the references to the Producer registered on the PersistentTopic.

### Modifications

Clean up the code and do not cache the "topics". From the Producer we can have the reference to the topic and also we can use the KafkaRequestHandler as cache key.

With this change we are going to create one Producer per KafkaRequestHandler, this also allows to track correctly the number of producers and the IP addreses.

### Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

