### PR TITLE
Fix the compatibility issue with Pulsar 2.11.0

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ByteBufUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ByteBufUtils.java
@@ -182,18 +182,19 @@ public class ByteBufUtils {
             final long timestamp = (metadata.getEventTime() > 0)
                     ? metadata.getEventTime()
                     : metadata.getPublishTime();
+            final ByteBuffer value = metadata.isNullValue() ? null : getNioBuffer(uncompressedPayload);
             if (magic >= RecordBatch.MAGIC_VALUE_V2) {
                 final Header[] headers = getHeadersFromMetadata(metadata.getPropertiesList());
                 builder.appendWithOffset(baseOffset,
                         timestamp,
                         getKeyByteBuffer(metadata),
-                        getNioBuffer(uncompressedPayload),
+                        value,
                         headers);
             } else {
                 builder.appendWithOffset(baseOffset,
                         timestamp,
                         getKeyByteBuffer(metadata),
-                        getNioBuffer(uncompressedPayload));
+                        value);
             }
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <lombok.version>1.18.24</lombok.version>
     <mockito.version>2.22.0</mockito.version>
     <pulsar.group.id>io.streamnative</pulsar.group.id>
-    <pulsar.version>2.11.0.0-rc3</pulsar.version>
+    <pulsar.version>2.11.0.0-rc5</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.12</spotbugs-annotations.version>
     <apicurio.version>2.1.3.Final</apicurio.version>
@@ -491,6 +491,10 @@
       <id>central</id>
       <layout>default</layout>
       <url>https://repo1.maven.org/maven2</url>
+    </repository>
+    <repository>
+      <id>ossrh01</id>
+      <url>https://s01.oss.sonatype.org/service/local/repositories/iostreamnative-2022/content</url>
     </repository>
   </repositories>
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/PulsarStorageProducerIdManagerImplTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/PulsarStorageProducerIdManagerImplTest.java
@@ -23,12 +23,12 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.pulsar.common.policies.data.InactiveTopicDeleteMode;
 import org.apache.pulsar.common.policies.data.InactiveTopicPolicies;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.awaitility.Awaitility;
-import org.powermock.reflect.Whitebox;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -187,7 +187,7 @@ public class PulsarStorageProducerIdManagerImplTest extends KopProtocolHandlerTe
 
         PersistentTopicInternalStats stats = pulsar.getAdminClient().topics().getInternalStats(topic);
         log.info("stats {}", stats);
-        Whitebox.invokeMethod(pulsar.getBrokerService(), "checkConsumedLedgers");
+        MethodUtils.invokeMethod(pulsar.getBrokerService(), true, "checkConsumedLedgers");
 
         // wait for topic to be automatically trimmed
         Awaitility
@@ -195,7 +195,7 @@ public class PulsarStorageProducerIdManagerImplTest extends KopProtocolHandlerTe
                 .pollInterval(5, TimeUnit.SECONDS)
                 .untilAsserted(
                 () -> {
-                    Whitebox.invokeMethod(pulsar.getBrokerService(), "checkConsumedLedgers");
+                    MethodUtils.invokeMethod(pulsar.getBrokerService(), true, "checkConsumedLedgers");
                     PersistentTopicInternalStats stats2 = pulsar.getAdminClient().topics().getInternalStats(topic);
                     log.info("stats2 {}", stats2);
                     assertEquals(0, stats2.numberOfEntries);


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/17696 removes the
`powermock-reflect` dependency, which leads to a compilation error in
KoP.

### Modifications

Upgrade the Pulsar dependency to 2.11.0.0-rc5. Then replace
`Whitebox.invokeMethod` with `MethodUtils.invokeMethod`.

It also fixes the bug that null values are not handled well for
non-batched messages. This bug was exposed because of
[PIP-189](https://github.com/apache/pulsar/pull/16605).

### TODO

Migrate the bug fix for non-batched messages to branch-2.10.x and
branch-2.9.x.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

