### PR TITLE
fix: ListOffset interface returns an incorrect result

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -1129,7 +1129,10 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                     return;
                 }
                 if (position.compareTo(lac) > 0) {
-                    partitionData.complete(Pair.of(Errors.NONE, latestOffset));
+                    // If all the data expires, the entry of lac becomes -1,
+                    // and the actual offset will be 1 smaller than LATEST,
+                    // here is special treatment, add 1 back
+                    partitionData.complete(Pair.of(Errors.NONE, latestOffset + 1));
                 } else {
                     MessageMetadataUtils.getOffsetOfPosition(managedLedger, position, false,
                             timestamp, skipMessagesWithoutIndex)


### PR DESCRIPTION
The commit offset and partition data expire at the same time, and the ListOffset interface returns an incorrect result


<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #1737


### Motivation

The commit offset and partition data expire at the same time, and the ListOffset interface returns an incorrect result

### Modifications

If all the data expires, the entry of lac becomes -1, and the actual offset will be 1 smaller than LATEST,  add 1 back

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

