### PR TITLE
[tests] Unflaky MessagePublishBufferThrottleTestBase

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -812,8 +812,13 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             }
             disableCnxAutoRead();
             autoReadDisabledPublishBufferLimiting = true;
-            pulsarService.getBrokerService().pausedConnections(1);
+            setPausedConnections(pulsarService, 1);
         }
+    }
+
+    @VisibleForTesting
+    public static void setPausedConnections(PulsarService pulsarService, int numConnections) {
+        pulsarService.getBrokerService().pausedConnections(numConnections);
     }
 
     private void completeSendOperationForThrottling(long msgSize) {
@@ -825,8 +830,13 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             }
             autoReadDisabledPublishBufferLimiting = false;
             enableCnxAutoRead();
-            pulsarService.getBrokerService().resumedConnections(1);
+            resumePausedConnections(pulsarService, 1);
         }
+    }
+
+    @VisibleForTesting
+    public static void resumePausedConnections(PulsarService pulsarService, int numConnections) {
+        pulsarService.getBrokerService().resumedConnections(numConnections);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <jackson-databind.version>2.13.4.1</jackson-databind.version>
     <kafka.version>2.8.0</kafka.version>
     <lombok.version>1.18.24</lombok.version>
-    <mockito.version>5.1.1</mockito.version>
+    <mockito.version>4.11.0</mockito.version>
     <pulsar.group.id>io.streamnative</pulsar.group.id>
     <pulsar.version>2.11.0.0-rc5</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <jackson-databind.version>2.13.4.1</jackson-databind.version>
     <kafka.version>2.8.0</kafka.version>
     <lombok.version>1.18.24</lombok.version>
-    <mockito.version>2.22.0</mockito.version>
+    <mockito.version>3.4.0</mockito.version>
     <pulsar.group.id>io.streamnative</pulsar.group.id>
     <pulsar.version>2.11.0.0-rc5</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
@@ -243,6 +243,12 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
+        <version>${mockito.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-inline</artifactId>
         <version>${mockito.version}</version>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <jackson-databind.version>2.13.4.1</jackson-databind.version>
     <kafka.version>2.8.0</kafka.version>
     <lombok.version>1.18.24</lombok.version>
-    <mockito.version>3.4.0</mockito.version>
+    <mockito.version>5.1.1</mockito.version>
     <pulsar.group.id>io.streamnative</pulsar.group.id>
     <pulsar.version>2.11.0.0-rc5</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -84,6 +84,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>

--- a/tests/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/tests/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
### Motivation

MessagePublishBufferThrottleTestBase sometimes fails on my CI

### Modifications

- Upgrade Mockito
- Use MockStatic in order to precisely intercept the pausing/resuming of connections
- Update the test


### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

