### PR TITLE
Fix the incompatibility with Pulsar 3.0.0.1-SNAPSHOT

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -428,7 +428,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 kafkaConfig,
                 requestStats,
                 Time.SYSTEM,
-                brokerService.getEntryFilters(),
+                brokerService.getEntryFilterProvider().getBrokerEntryFilters(),
                 producePurgatory,
                 fetchPurgatory);
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryManager.java
@@ -104,8 +104,7 @@ public class SchemaRegistryManager {
                 AuthData authData = AuthData.of(password.getBytes(StandardCharsets.UTF_8));
                 final AuthenticationState authState = authenticationProvider
                         .newAuthState(authData, null, null);
-                // TODO: Use the configurable timeout
-                authState.authenticateAsync(authData).get(10, TimeUnit.SECONDS);
+                authState.authenticateAsync(authData).get(kafkaConfig.getRequestTimeoutMs(), TimeUnit.MILLISECONDS);
                 final String role = authState.getAuthRole();
 
                 final String tenant;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/AbstractEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/AbstractEntryFormatter.java
@@ -16,7 +16,6 @@ package io.streamnative.pulsar.handlers.kop.format;
 import static org.apache.kafka.common.record.Records.MAGIC_OFFSET;
 import static org.apache.kafka.common.record.Records.OFFSET_OFFSET;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.streamnative.pulsar.handlers.kop.exceptions.MetadataCorruptedException;
@@ -32,7 +31,6 @@ import org.apache.kafka.common.record.ConvertedRecords;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.utils.Time;
 import org.apache.pulsar.broker.service.plugin.EntryFilter;
-import org.apache.pulsar.broker.service.plugin.EntryFilterWithClassLoader;
 import org.apache.pulsar.broker.service.plugin.FilterContext;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.api.proto.KeyValue;
@@ -45,9 +43,9 @@ public abstract class AbstractEntryFormatter implements EntryFormatter {
     public static final String IDENTITY_KEY = "entry.format";
     public static final String IDENTITY_VALUE = EntryFormatterFactory.EntryFormat.KAFKA.name().toLowerCase();
     private final Time time = Time.SYSTEM;
-    private final ImmutableList<EntryFilterWithClassLoader> entryfilters;
+    private final List<EntryFilter> entryfilters;
 
-    protected AbstractEntryFormatter(ImmutableList<EntryFilterWithClassLoader> entryfilters) {
+    protected AbstractEntryFormatter(List<EntryFilter> entryfilters) {
         this.entryfilters = entryfilters;
     }
 
@@ -140,7 +138,7 @@ public abstract class AbstractEntryFormatter implements EntryFormatter {
     }
 
     protected EntryFilter.FilterResult filterOnlyByMsgMetadata(MessageMetadata msgMetadata, Entry entry,
-                                                                    List<EntryFilterWithClassLoader> entryFilters) {
+                                                               List<EntryFilter> entryFilters) {
         if (entryFilters == null || entryFilters.isEmpty()) {
             return EntryFilter.FilterResult.ACCEPT;
         }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterFactory.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterFactory.java
@@ -13,10 +13,9 @@
  */
 package io.streamnative.pulsar.handlers.kop.format;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
-import org.apache.pulsar.broker.service.plugin.EntryFilterWithClassLoader;
+import java.util.List;
+import org.apache.pulsar.broker.service.plugin.EntryFilter;
 
 /**
  * Factory of EntryFormatter.
@@ -32,21 +31,18 @@ public class EntryFormatterFactory {
     }
 
     public static EntryFormatter create(final KafkaServiceConfiguration kafkaConfig,
-                                        final ImmutableMap<String, EntryFilterWithClassLoader> entryfilterMap,
+                                        final List<EntryFilter> entryFilters,
                                         final String format) {
         try {
             EntryFormat entryFormat = Enum.valueOf(EntryFormat.class, format.toUpperCase());
 
-            ImmutableList<EntryFilterWithClassLoader> entryfilters =
-                    entryfilterMap == null ? ImmutableList.of() : entryfilterMap.values().asList();
-
             switch (entryFormat) {
                 case PULSAR:
-                    return new PulsarEntryFormatter(entryfilters);
+                    return new PulsarEntryFormatter(entryFilters);
                 case KAFKA:
-                    return new KafkaV1EntryFormatter(entryfilters);
+                    return new KafkaV1EntryFormatter(entryFilters);
                 case MIXED_KAFKA:
-                    return new KafkaMixedEntryFormatter(entryfilters);
+                    return new KafkaMixedEntryFormatter(entryFilters);
                 default:
                     throw new Exception("No EntryFormatter for " + entryFormat);
             }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaMixedEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaMixedEntryFormatter.java
@@ -13,7 +13,6 @@
  */
 package io.streamnative.pulsar.handlers.kop.format;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.streamnative.pulsar.handlers.kop.storage.PartitionLog;
@@ -25,7 +24,7 @@ import org.apache.bookkeeper.mledger.Entry;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.TimestampType;
-import org.apache.pulsar.broker.service.plugin.EntryFilterWithClassLoader;
+import org.apache.pulsar.broker.service.plugin.EntryFilter;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.protocol.Commands;
 
@@ -37,7 +36,7 @@ import org.apache.pulsar.common.protocol.Commands;
 @Slf4j
 public class KafkaMixedEntryFormatter extends AbstractEntryFormatter {
 
-    protected KafkaMixedEntryFormatter(ImmutableList<EntryFilterWithClassLoader> entryfilters) {
+    protected KafkaMixedEntryFormatter(List<EntryFilter> entryfilters) {
         super(entryfilters);
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaV1EntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/KafkaV1EntryFormatter.java
@@ -13,14 +13,13 @@
  */
 package io.streamnative.pulsar.handlers.kop.format;
 
-import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.kafka.common.record.MemoryRecords;
-import org.apache.pulsar.broker.service.plugin.EntryFilterWithClassLoader;
+import org.apache.pulsar.broker.service.plugin.EntryFilter;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.apache.pulsar.common.protocol.Commands;
 
@@ -32,7 +31,7 @@ import org.apache.pulsar.common.protocol.Commands;
 @Slf4j
 public class KafkaV1EntryFormatter extends AbstractEntryFormatter {
 
-    protected KafkaV1EntryFormatter(ImmutableList<EntryFilterWithClassLoader> entryfilters) {
+    protected KafkaV1EntryFormatter(List<EntryFilter> entryfilters) {
         super(entryfilters);
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/PulsarEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/PulsarEntryFormatter.java
@@ -15,7 +15,6 @@ package io.streamnative.pulsar.handlers.kop.format;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import io.netty.buffer.ByteBuf;
 import io.streamnative.pulsar.handlers.kop.utils.PulsarMessageBuilder;
@@ -28,7 +27,7 @@ import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.record.ControlRecordType;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.Record;
-import org.apache.pulsar.broker.service.plugin.EntryFilterWithClassLoader;
+import org.apache.pulsar.broker.service.plugin.EntryFilter;
 import org.apache.pulsar.client.impl.MessageImpl;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.api.proto.MarkerType;
@@ -46,8 +45,8 @@ public class PulsarEntryFormatter extends AbstractEntryFormatter {
     private static final int INITIAL_BATCH_BUFFER_SIZE = 1024;
     private static final int MAX_MESSAGE_BATCH_SIZE_BYTES = 128 * 1024;
 
-    protected PulsarEntryFormatter(ImmutableList<EntryFilterWithClassLoader> entryfilters) {
-        super(entryfilters);
+    protected PulsarEntryFormatter(List<EntryFilter> entryFilters) {
+        super(entryFilters);
     }
 
     @Override

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/OauthValidatorCallbackHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/OauthValidatorCallbackHandler.java
@@ -50,6 +50,8 @@ public class OauthValidatorCallbackHandler implements AuthenticateCallbackHandle
 
     private ServerConfig config = null;
     private AuthenticationService authenticationService;
+    private int requestTimeoutMs;
+
 
     public OauthValidatorCallbackHandler() {}
 
@@ -81,6 +83,7 @@ public class OauthValidatorCallbackHandler implements AuthenticateCallbackHandle
 
         this.authenticationService = (AuthenticationService) configs.get(SaslAuthenticator.AUTHENTICATION_SERVER_OBJ);
         this.config = new ServerConfig(options);
+        this.requestTimeoutMs = (Integer) configs.get(SaslAuthenticator.REQUEST_TIMEOUT_MS);
     }
 
     @Override
@@ -132,8 +135,7 @@ public class OauthValidatorCallbackHandler implements AuthenticateCallbackHandle
             AuthData authData = AuthData.of(token.getBytes(StandardCharsets.UTF_8));
             final AuthenticationState authState = authenticationProvider.newAuthState(
                     authData, null, null);
-            // TODO: Use the configurable timeout
-            authState.authenticateAsync(authData).get(10, TimeUnit.SECONDS);
+            authState.authenticateAsync(authData).get(requestTimeoutMs, TimeUnit.MILLISECONDS);
             final String role = authState.getAuthRole();
             AuthenticationDataSource authDataSource = authState.getAuthDataSource();
             callback.token(new KopOAuthBearerToken() {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -14,7 +14,6 @@
 package io.streamnative.pulsar.handlers.kop.storage;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
@@ -79,7 +78,7 @@ import org.apache.kafka.common.requests.FetchResponse;
 import org.apache.kafka.common.utils.Time;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
-import org.apache.pulsar.broker.service.plugin.EntryFilterWithClassLoader;
+import org.apache.pulsar.broker.service.plugin.EntryFilter;
 import org.apache.pulsar.common.naming.TopicName;
 
 /**
@@ -112,7 +111,7 @@ public class PartitionLog {
     private final AtomicReference<CompletableFuture<EntryFormatter>> entryFormatter = new AtomicReference<>();
     private final ProducerStateManager producerStateManager;
 
-    private final ImmutableMap<String, EntryFilterWithClassLoader> entryfilterMap;
+    private final List<EntryFilter> entryFilters;
     private final boolean preciseTopicPublishRateLimitingEnable;
 
     public PartitionLog(KafkaServiceConfiguration kafkaConfig,
@@ -120,10 +119,10 @@ public class PartitionLog {
                         Time time,
                         TopicPartition topicPartition,
                         String fullPartitionName,
-                        ImmutableMap<String, EntryFilterWithClassLoader> entryfilterMap,
+                        List<EntryFilter> entryFilters,
                         ProducerStateManager producerStateManager) {
         this.kafkaConfig = kafkaConfig;
-        this.entryfilterMap = entryfilterMap;
+        this.entryFilters = entryFilters;
         this.requestStats = requestStats;
         this.time = time;
         this.topicPartition = topicPartition;
@@ -183,7 +182,7 @@ public class PartitionLog {
             log.debug("entryFormat for {} is {} (topicProperties {})", fullPartitionName,
                     entryFormat, topicProperties);
         }
-        return EntryFormatterFactory.create(kafkaConfig, entryfilterMap, entryFormat);
+        return EntryFormatterFactory.create(kafkaConfig, entryFilters, entryFormat);
     }
 
     @Data

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
@@ -13,16 +13,16 @@
  */
 package io.streamnative.pulsar.handlers.kop.storage;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import io.streamnative.pulsar.handlers.kop.RequestStats;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
+import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Time;
-import org.apache.pulsar.broker.service.plugin.EntryFilterWithClassLoader;
+import org.apache.pulsar.broker.service.plugin.EntryFilter;
 
 /**
  * Manage {@link PartitionLog}.
@@ -34,16 +34,16 @@ public class PartitionLogManager {
     private final RequestStats requestStats;
     private final Map<String, PartitionLog> logMap;
     private final Time time;
-    private final ImmutableMap<String, EntryFilterWithClassLoader> entryfilterMap;
+    private final List<EntryFilter> entryFilters;
 
     public PartitionLogManager(KafkaServiceConfiguration kafkaConfig,
                                RequestStats requestStats,
-                               final ImmutableMap<String, EntryFilterWithClassLoader> entryfilterMap,
+                               final List<EntryFilter> entryFilters,
                                Time time) {
         this.kafkaConfig = kafkaConfig;
         this.requestStats = requestStats;
         this.logMap = Maps.newConcurrentMap();
-        this.entryfilterMap = entryfilterMap;
+        this.entryFilters = entryFilters;
         this.time = time;
     }
 
@@ -51,7 +51,7 @@ public class PartitionLogManager {
         String kopTopic = KopTopic.toString(topicPartition, namespacePrefix);
 
         return logMap.computeIfAbsent(kopTopic, key -> {
-                return new PartitionLog(kafkaConfig, requestStats, time, topicPartition, kopTopic, entryfilterMap,
+                return new PartitionLog(kafkaConfig, requestStats, time, topicPartition, kopTopic, entryFilters,
                         new ProducerStateManager(kopTopic));
         });
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
@@ -14,7 +14,6 @@
 package io.streamnative.pulsar.handlers.kop.storage;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import io.streamnative.pulsar.handlers.kop.DelayedFetch;
 import io.streamnative.pulsar.handlers.kop.DelayedProduceAndFetch;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
@@ -45,7 +44,7 @@ import org.apache.kafka.common.requests.FetchRequest;
 import org.apache.kafka.common.requests.ProduceResponse;
 import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
-import org.apache.pulsar.broker.service.plugin.EntryFilterWithClassLoader;
+import org.apache.pulsar.broker.service.plugin.EntryFilter;
 
 /**
  * Used to append records. Mapping to Kafka ReplicaManager.scala.
@@ -60,11 +59,10 @@ public class ReplicaManager {
     public ReplicaManager(KafkaServiceConfiguration kafkaConfig,
                           RequestStats requestStats,
                           Time time,
-                          ImmutableMap<String, EntryFilterWithClassLoader> entryfilterMap,
+                          List<EntryFilter> entryFilters,
                           DelayedOperationPurgatory<DelayedOperation> producePurgatory,
                           DelayedOperationPurgatory<DelayedOperation> fetchPurgatory) {
-        this.logManager = new PartitionLogManager(kafkaConfig, requestStats, entryfilterMap,
-                time);
+        this.logManager = new PartitionLogManager(kafkaConfig, requestStats, entryFilters, time);
         this.producePurgatory = producePurgatory;
         this.fetchPurgatory = fetchPurgatory;
         this.metadataNamespace = kafkaConfig.getKafkaMetadataNamespace();

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterTest.java
@@ -18,7 +18,6 @@ import static org.apache.kafka.common.record.LegacyRecord.RECORD_OVERHEAD_V1;
 import static org.apache.kafka.common.record.Records.LOG_OVERHEAD;
 import static org.mockito.Mockito.mock;
 
-import com.google.common.collect.ImmutableMap;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import io.streamnative.pulsar.handlers.kop.storage.PartitionLog;
 import io.streamnative.pulsar.handlers.kop.storage.ProducerStateManager;
@@ -27,6 +26,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.bookkeeper.mledger.Entry;
@@ -48,7 +48,6 @@ import org.apache.kafka.common.utils.ByteBufferOutputStream;
 import org.apache.kafka.common.utils.Crc32C;
 import org.apache.kafka.common.utils.Time;
 import org.apache.pulsar.broker.service.plugin.EntryFilter;
-import org.apache.pulsar.broker.service.plugin.EntryFilterWithClassLoader;
 import org.apache.pulsar.broker.service.plugin.FilterContext;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
 import org.testng.Assert;
@@ -171,7 +170,6 @@ public class EntryFormatterTest {
         Entry entry2 = mock(Entry.class);
 
         // Filter the entries
-        ImmutableMap.Builder<String, EntryFilterWithClassLoader> builder = ImmutableMap.builder();
         EntryFilter mockEntryFilter = new EntryFilter() {
             @Override
             public FilterResult filterEntry(Entry entry, FilterContext context) {
@@ -188,15 +186,14 @@ public class EntryFormatterTest {
                 // Ignore
             }
         };
-        builder.put("mockEntryFilter", new EntryFilterWithClassLoader(mockEntryFilter, null));
         Assert.assertEquals(
                 entryFormatter.filterOnlyByMsgMetadata(new MessageMetadata().setReplicatedFrom("cluster-1"),
                         entry1,
-                        builder.build().values().asList()), EntryFilter.FilterResult.REJECT);
+                        Collections.singletonList(mockEntryFilter)), EntryFilter.FilterResult.REJECT);
         Assert.assertEquals(
                 entryFormatter.filterOnlyByMsgMetadata(new MessageMetadata(),
                         entry2,
-                        builder.build().values().asList()), EntryFilter.FilterResult.ACCEPT);
+                        Collections.singletonList(mockEntryFilter)), EntryFilter.FilterResult.ACCEPT);
     }
 
     private static void checkWrongOffset(MemoryRecords records,

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/security/PlainSaslServerTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/security/PlainSaslServerTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
+import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
@@ -83,7 +84,8 @@ public class PlainSaslServerTest {
             }
         };
         when(provider.newAuthState(any(AuthData.class), any(), any())).thenReturn(state);
-        PlainSaslServer server = new PlainSaslServer(authenticationService, null, proxyRoles);
+        PlainSaslServer server = new PlainSaslServer(authenticationService,
+                new KafkaServiceConfiguration(), proxyRoles);
 
         String challengeNoProxy = "XXXXX\000" + username + "\000token:xxxxx";
         server.evaluateResponse(challengeNoProxy.getBytes(StandardCharsets.US_ASCII));

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <lombok.version>1.18.24</lombok.version>
     <mockito.version>2.22.0</mockito.version>
     <pulsar.group.id>io.streamnative</pulsar.group.id>
-    <pulsar.version>2.11.0.0-rc5</pulsar.version>
+    <pulsar.version>3.0.0.1-SNAPSHOT</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.12</spotbugs-annotations.version>
     <apicurio.version>2.1.3.Final</apicurio.version>
@@ -495,6 +495,14 @@
     <repository>
       <id>ossrh01</id>
       <url>https://s01.oss.sonatype.org/service/local/repositories/iostreamnative-2022/content</url>
+    </repository>
+    <repository>
+      <id>ossrh02</id>
+      <url>https://s01.oss.sonatype.org/service/local/repositories/0/content</url>
+    </repository>
+    <repository>
+      <id>nexus-snapshot01</id>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
     </repository>
   </repositories>
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/DistributedClusterTest.java
@@ -39,6 +39,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
+import org.apache.pulsar.common.policies.data.TopicType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
@@ -86,7 +87,7 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
         kConfig.setAuthenticationEnabled(false);
         kConfig.setAuthorizationEnabled(false);
         kConfig.setAllowAutoTopicCreation(true);
-        kConfig.setAllowAutoTopicCreationType("partitioned");
+        kConfig.setAllowAutoTopicCreationType(TopicType.PARTITIONED);
         kConfig.setBrokerDeleteInactiveTopicsEnabled(false);
         kConfig.setGroupInitialRebalanceDelayMs(0);
         kConfig.setBrokerShutdownTimeoutMs(0);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/InnerTopicProtectionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/InnerTopicProtectionTest.java
@@ -27,6 +27,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
+import org.apache.pulsar.common.policies.data.TopicType;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -58,7 +59,7 @@ public class InnerTopicProtectionTest extends KopProtocolHandlerTestBase {
         kConfig.setAuthenticationEnabled(false);
         kConfig.setAuthorizationEnabled(false);
         kConfig.setAllowAutoTopicCreation(true);
-        kConfig.setAllowAutoTopicCreationType("partitioned");
+        kConfig.setAllowAutoTopicCreationType(TopicType.PARTITIONED);
         kConfig.setBrokerDeleteInactiveTopicsEnabled(false);
         kConfig.setSystemTopicEnabled(true);
         kConfig.setTopicLevelPoliciesEnabled(true);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -71,6 +71,7 @@ import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.TopicType;
 import org.apache.pulsar.metadata.api.MetadataStoreException;
 import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
@@ -171,7 +172,7 @@ public abstract class KopProtocolHandlerTestBase {
         kafkaConfig.setAuthenticationEnabled(false);
         kafkaConfig.setAuthorizationEnabled(false);
         kafkaConfig.setAllowAutoTopicCreation(true);
-        kafkaConfig.setAllowAutoTopicCreationType("partitioned");
+        kafkaConfig.setAllowAutoTopicCreationType(TopicType.PARTITIONED);
         kafkaConfig.setBrokerDeleteInactiveTopicsEnabled(false);
 
         kafkaConfig.setForceDeleteTenantAllowed(true);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
@@ -118,6 +118,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
     @BeforeClass
     @Override
     public void setup() throws Exception {
+        conf.setOffsetsTopicNumPartitions(numOffsetsPartitions);
         super.internalSetup();
     }
 
@@ -166,6 +167,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
 
     @AfterMethod
     protected void tearDown() throws PulsarClientException {
+        conf.setOffsetsTopicNumPartitions(numOffsetsPartitions);
         if (consumer != null) {
             consumer.close();
         }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/KafkaMockAuthorizationProvider.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/KafkaMockAuthorizationProvider.java
@@ -128,21 +128,6 @@ public class KafkaMockAuthorizationProvider implements AuthorizationProvider {
     }
 
     @Override
-    public CompletableFuture<Boolean> allowTenantOperationAsync(String tenantName, String originalRole, String role,
-                                                                TenantOperation operation,
-                                                                AuthenticationDataSource authenticationData) {
-        Assert.assertNotNull(authenticationData);
-        return roleAuthorizedAsync(role);
-    }
-
-    @Override
-    public Boolean allowTenantOperation(String tenantName, String originalRole, String role, TenantOperation operation,
-                                        AuthenticationDataSource authenticationData) {
-        Assert.assertNotNull(authenticationData);
-        return roleAuthorized(role);
-    }
-
-    @Override
     public CompletableFuture<Boolean> allowTenantOperationAsync(String tenantName, String role,
                                                                 TenantOperation operation,
                                                                 AuthenticationDataSource authenticationData) {
@@ -175,27 +160,6 @@ public class KafkaMockAuthorizationProvider implements AuthorizationProvider {
         return roleAuthorized(role);
     }
 
-
-    @Override
-    public CompletableFuture<Boolean> allowNamespaceOperationAsync(NamespaceName namespaceName,
-                                                                   String originalRole,
-                                                                   String role,
-                                                                   NamespaceOperation operation,
-                                                                   AuthenticationDataSource authenticationData) {
-        Assert.assertNotNull(authenticationData);
-        return roleAuthorizedAsync(role);
-    }
-
-    @Override
-    public Boolean allowNamespaceOperation(NamespaceName namespaceName,
-                                           String originalRole,
-                                           String role,
-                                           NamespaceOperation operation,
-                                           AuthenticationDataSource authenticationData) {
-        Assert.assertNotNull(authenticationData);
-        return roleAuthorized(role);
-    }
-
     @Override
     public CompletableFuture<Boolean> allowNamespacePolicyOperationAsync(NamespaceName namespaceName,
                                                                          PolicyName policy,
@@ -217,28 +181,6 @@ public class KafkaMockAuthorizationProvider implements AuthorizationProvider {
     }
 
     @Override
-    public CompletableFuture<Boolean> allowNamespacePolicyOperationAsync(NamespaceName namespaceName,
-                                                                         PolicyName policy,
-                                                                         PolicyOperation operation,
-                                                                         String originalRole,
-                                                                         String role,
-                                                                         AuthenticationDataSource authenticationData) {
-        Assert.assertNotNull(authenticationData);
-        return roleAuthorizedAsync(role);
-    }
-
-    @Override
-    public Boolean allowNamespacePolicyOperation(NamespaceName namespaceName,
-                                                 PolicyName policy,
-                                                 PolicyOperation operation,
-                                                 String originalRole,
-                                                 String role,
-                                                 AuthenticationDataSource authenticationData) {
-        Assert.assertNotNull(authenticationData);
-        return roleAuthorized(role);
-    }
-
-    @Override
     public CompletableFuture<Boolean> allowTopicOperationAsync(TopicName topic,
                                                                String role,
                                                                TopicOperation operation,
@@ -249,26 +191,6 @@ public class KafkaMockAuthorizationProvider implements AuthorizationProvider {
 
     @Override
     public Boolean allowTopicOperation(TopicName topicName,
-                                       String role,
-                                       TopicOperation operation,
-                                       AuthenticationDataSource authenticationData) {
-        Assert.assertNotNull(authenticationData);
-        return roleAuthorized(role);
-    }
-
-    @Override
-    public CompletableFuture<Boolean> allowTopicOperationAsync(TopicName topic,
-                                                               String originalRole,
-                                                               String role,
-                                                               TopicOperation operation,
-                                                               AuthenticationDataSource authenticationData) {
-        Assert.assertNotNull(authenticationData);
-        return roleAuthorizedAsync(role);
-    }
-
-    @Override
-    public Boolean allowTopicOperation(TopicName topicName,
-                                       String originalRole,
                                        String role,
                                        TopicOperation operation,
                                        AuthenticationDataSource authenticationData) {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/oauth/OauthValidatorCallbackHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/oauth/OauthValidatorCallbackHandlerTest.java
@@ -22,6 +22,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
 import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
 import javax.naming.AuthenticationException;
 import org.apache.pulsar.broker.authentication.AuthenticationProvider;
 import org.apache.pulsar.broker.authentication.AuthenticationService;
@@ -46,6 +47,8 @@ public class OauthValidatorCallbackHandlerTest {
         AuthenticationState state = mock(AuthenticationState.class);
 
         doReturn(state).when(mockAuthProvider).newAuthState(any(), any(), any());
+
+        doReturn(CompletableFuture.completedFuture(null)).when(state).authenticateAsync(any());
 
         KopOAuthBearerValidatorCallback callbackWithTenant =
                 new KopOAuthBearerValidatorCallback("my-tenant" + OAuthTokenDecoder.DELIMITER + "my-token");


### PR DESCRIPTION
### Modifications

- Upgrade the Pulsar dependency to 3.0.0.1-SNAPSHOT
- Use `List<EntryFilter>` from https://github.com/apache/pulsar/pull/19364 as the filters
- Remove the removed APIs in `AuthorizationService`
- Use `TopicType` instead of String.
- Fix SaslAuthenticator failure caused by https://github.com/apache/pulsar/pull/19295

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

