### PR TITLE
Fix flaky KopEventManagerTest.testOneTopicGroupState

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopEventManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopEventManagerTest.java
@@ -38,6 +38,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.ConsumerGroupState;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.awaitility.Awaitility;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -91,8 +92,10 @@ public class KopEventManagerTest extends KopProtocolHandlerTestBase {
 
         final KafkaConsumer<String, String> kafkaConsumer1 = new KafkaConsumer<>(properties);
         kafkaConsumer1.subscribe(Collections.singletonList(topic1));
-        ConsumerRecords<String, String> records = kafkaConsumer1.poll(Duration.ofSeconds(1));
-        assertEquals(records.count(), 1);
+        Awaitility.await().atMost(Duration.ofSeconds(5)).until(() -> {
+            ConsumerRecords<String, String> records = kafkaConsumer1.poll(Duration.ofSeconds(1));
+            return records.count() == 1;
+        });
 
         // 4. check group state must be Stable
         Map<String, ConsumerGroupDescription> describeGroup1 =


### PR DESCRIPTION
Fixes https://github.com/streamnative/kop/issues/1772

### Motivation

The `testOneTopicGroupState` assumes the message can be polled in one second. However, it often failed because of the rebalance delay.

### Modification

Wait at most 5 seconds until a message is polled.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

