### PR TITLE
[improve] Add message.max.bytes for describe broker config

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AdminManager.java
@@ -66,6 +66,7 @@ public class AdminManager {
 
     private final PulsarAdmin admin;
     private final int defaultNumPartitions;
+    private final int maxMessageSize;
 
     private volatile Map<String, Set<Node>> brokersCache = Maps.newHashMap();
     private final ReentrantReadWriteLock brokersCacheLock = new ReentrantReadWriteLock();
@@ -77,6 +78,7 @@ public class AdminManager {
     public AdminManager(PulsarAdmin admin, KafkaServiceConfiguration conf) {
         this.admin = admin;
         this.defaultNumPartitions = conf.getDefaultNumPartitions();
+        this.maxMessageSize = conf.getMaxMessageSize();
     }
 
     public void shutdown() {
@@ -214,6 +216,7 @@ public class AdminManager {
                                 List<DescribeConfigsResponse.ConfigEntry> dummyConfig = new ArrayList<>();
                                 dummyConfig.add(buildDummyEntryConfig("num.partitions",
                                         this.defaultNumPartitions + ""));
+                                dummyConfig.add(buildDummyEntryConfig("message.max.bytes", maxMessageSize + ""));
                                 // this is useless in KOP, but some tools like KSQL need a value
                                 dummyConfig.add(buildDummyEntryConfig("default.replication.factor", "1"));
                                 dummyConfig.add(buildDummyEntryConfig("delete.topic.enable", "true"));

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -579,6 +579,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
         assertEquals(brokerConfig.get("num.partitions").value(), conf.getDefaultNumPartitions() + "");
         assertEquals(brokerConfig.get("default.replication.factor").value(), "1");
         assertEquals(brokerConfig.get("delete.topic.enable").value(), "true");
+        assertEquals(brokerConfig.get("message.max.bytes").value(), conf.getMaxMessageSize() + "");
     }
 
     @Test(timeOut = 10000)


### PR DESCRIPTION
### Motivation

Some of the Producer requires the `message.max.bytes` configuration.
```
Error: [CDC:ErrKafkaNewSaramaProducer]new sarama producer: [CDC:ErrKafkaBrokerConfigNotFound]cannot find the `message.max.bytes` from the broker's configuration

```

### Modifications

* Add `message.max.bytes` for describe broker config. The config is reused pulsar config.


### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

