### PR TITLE
Support passing the token directly as the password for Schema Registry

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -263,6 +263,17 @@ sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginMo
    oauth.audience="https://broker.example.com";
 ```
 
+### Authentication for the Schema Registry
+
+KoP supports Confluent's Schema Registry since 2.11. See [schema.md](./schema.md) for a quick start.
+
+When KoP enables the authentication, the Schema Registry also requires the authentication from the Kafka client. You need to set the following properties on the client side.
+
+```properties
+basic.auth.credentials.source=USER_INFO
+basic.auth.user.info=<tenant>:<token>
+```
+
 ### Together with Pulsar's authentication
 
 Since KoP reuses Pulsar's authentication providers for authentication, you can enable KoP's authentication and Pulsar authentication at the same time.

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryManager.java
@@ -183,14 +183,11 @@ public class SchemaRegistryManager {
             }
             String rawUsername = usernamePassword.substring(0, colon);
             String rawPassword = usernamePassword.substring(colon + 1);
-            if (!rawPassword.startsWith("token:")) {
-                throw new SchemaStorageException("Password must start with 'token:'",
-                        HttpResponseStatus.UNAUTHORIZED.code());
+            if (rawPassword.startsWith("token:")) {
+                return new UsernamePasswordPair(rawUsername, rawPassword.substring("token:".length()));
+            } else {
+                return new UsernamePasswordPair(rawUsername, rawPassword);
             }
-            String token = rawPassword.substring("token:".length());
-
-            UsernamePasswordPair usernamePasswordPair = new UsernamePasswordPair(rawUsername, token);
-            return usernamePasswordPair;
         }
     }
 


### PR DESCRIPTION
### Motivation

Currently, when authentication is enabled, we have to pass `token:<token>` as the password in the `basic.auth.user.info` config. However, some clients don't allow a colon appearing in the password.

See
https://github.com/confluentinc/confluent-kafka-python/blob/f3055be4d2aa18ffc833cc88f7b08b173d4da433/src/confluent_kafka/schema_registry/schema_registry_client.py#L108-L111

### Modifications
- Support passing the token directly, i.e. without the "token:" prefix, as the password
- Add the document to describe how to configure the authentication for Schema Registry

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [x] `doc` 
  
  (If this PR contains doc changes)

