### PR TITLE
[fix][schema] Return JSON error message for failed request

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryManager.java
@@ -142,7 +142,7 @@ public class SchemaRegistryManager {
                                 username, role, tenant, topicName);
                         throw new SchemaStorageException("Role " + role + " cannot access topic " + topicName + " "
                                 + "tenant " + tenant + " does not exist (wrong username?)",
-                                HttpResponseStatus.FORBIDDEN.code());
+                                HttpResponseStatus.FORBIDDEN);
                     }
                     Boolean hasPermission = authorizer
                             .canProduceAsync(kafkaPrincipal, Resource.of(ResourceType.TOPIC, topicName))
@@ -151,7 +151,7 @@ public class SchemaRegistryManager {
                         log.debug("SchemaRegistry username {} role {} tenant {} cannot access topic {}",
                                 username, role, tenant, topicName);
                         throw new SchemaStorageException("Role " + role + " cannot access topic " + topicName,
-                                HttpResponseStatus.FORBIDDEN.code());
+                                HttpResponseStatus.FORBIDDEN);
                     }
                 } catch (ExecutionException err) {
                     throw new SchemaStorageException(err.getCause());
@@ -166,12 +166,12 @@ public class SchemaRegistryManager {
             if (authenticationHeader.isEmpty()) {
                 // no auth
                 throw new SchemaStorageException("Missing AUTHORIZATION header",
-                        HttpResponseStatus.UNAUTHORIZED.code());
+                        HttpResponseStatus.UNAUTHORIZED);
             }
 
             if (!authenticationHeader.startsWith("Basic ")) {
                 throw new SchemaStorageException("Bad authentication scheme, only Basic is supported",
-                        HttpResponseStatus.UNAUTHORIZED.code());
+                        HttpResponseStatus.UNAUTHORIZED);
             }
             String strippedAuthenticationHeader = authenticationHeader.substring("Basic ".length());
 
@@ -179,7 +179,7 @@ public class SchemaRegistryManager {
                     .decode(strippedAuthenticationHeader), StandardCharsets.UTF_8);
             int colon = usernamePassword.indexOf(":");
             if (colon <= 0) {
-                throw new SchemaStorageException("Bad authentication header", HttpResponseStatus.BAD_REQUEST.code());
+                throw new SchemaStorageException("Bad authentication header", HttpResponseStatus.BAD_REQUEST);
             }
             String rawUsername = usernamePassword.substring(0, colon);
             String rawPassword = usernamePassword.substring(colon + 1);

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/ErrorMessage.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/ErrorMessage.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.schemaregistry;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Migrate from io.confluent.kafka.schemaregistry.client.rest.entities.ErrorMessage.
+ */
+public class ErrorMessage {
+
+    private final int errorCode;
+    private final String message;
+
+    public ErrorMessage(@JsonProperty("error_code") int errorCode, @JsonProperty("message") String message) {
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+
+    @JsonProperty("error_code")
+    public int getErrorCode() {
+        return this.errorCode;
+    }
+
+    @JsonProperty
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/HttpJsonRequestProcessor.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/HttpJsonRequestProcessor.java
@@ -78,7 +78,8 @@ public abstract class HttpJsonRequestProcessor<K, R> extends HttpRequestProcesso
             }
             return result.thenApply(resp -> {
                 if (resp == null) {
-                    return buildErrorResponse(NOT_FOUND, "Not found", "text/plain");
+                    return buildErrorResponse(NOT_FOUND,
+                            request.method() + " " + request.uri() + " Not found");
                 }
                 if (resp.getClass() == String.class) {
                     return buildStringResponse(((String) resp), RESPONSE_CONTENT_TYPE);
@@ -92,7 +93,7 @@ public abstract class HttpJsonRequestProcessor<K, R> extends HttpRequestProcesso
         } catch (IOException err) {
             log.error("Cannot decode request", err);
             return CompletableFuture.completedFuture(buildErrorResponse(HttpResponseStatus.BAD_REQUEST,
-                    "Cannot decode request: " + err.getMessage(), "text/plain"));
+                    "Cannot decode request: " + err.getMessage()));
         }
     }
 

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/SchemaStorageException.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/SchemaStorageException.java
@@ -19,19 +19,19 @@ import lombok.Getter;
 @Getter
 public class SchemaStorageException extends Exception {
 
-    private final int httpStatusCode;
+    private final HttpResponseStatus httpStatusCode;
 
     public SchemaStorageException(Throwable cause) {
         super(cause);
-        this.httpStatusCode = HttpResponseStatus.INTERNAL_SERVER_ERROR.code();
+        this.httpStatusCode = HttpResponseStatus.INTERNAL_SERVER_ERROR;
     }
 
     public SchemaStorageException(String message) {
         super(message);
-        this.httpStatusCode = HttpResponseStatus.INTERNAL_SERVER_ERROR.code();
+        this.httpStatusCode = HttpResponseStatus.INTERNAL_SERVER_ERROR;
     }
 
-    public SchemaStorageException(String message, int httpStatusCode) {
+    public SchemaStorageException(String message, HttpResponseStatus httpStatusCode) {
         super(message);
         this.httpStatusCode = httpStatusCode;
     }

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/AbstractResource.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/AbstractResource.java
@@ -53,7 +53,7 @@ public abstract class AbstractResource {
         }
         if (currentTenant == null) {
             throw new SchemaStorageException("Missing or failed authentication",
-                    HttpResponseStatus.UNAUTHORIZED.code());
+                    HttpResponseStatus.UNAUTHORIZED);
         }
         return schemaStorageAccessor.getSchemaStorageForTenant(currentTenant);
     }

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SubjectResource.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SubjectResource.java
@@ -257,7 +257,7 @@ public class SubjectResource extends AbstractResource {
                 }
                 if (err instanceof CompatibilityChecker.IncompatibleSchemaChangeException) {
                     throw new CompletionException(
-                            new SchemaStorageException(err.getMessage(), HttpResponseStatus.CONFLICT.code()));
+                            new SchemaStorageException(err.getMessage(), HttpResponseStatus.CONFLICT));
                 } else {
                     throw new CompletionException(err);
                 }
@@ -290,7 +290,7 @@ public class SubjectResource extends AbstractResource {
                         }
                         if (err instanceof CompatibilityChecker.IncompatibleSchemaChangeException) {
                             throw new CompletionException(
-                                    new SchemaStorageException(err.getMessage(), HttpResponseStatus.CONFLICT.code()));
+                                    new SchemaStorageException(err.getMessage(), HttpResponseStatus.CONFLICT));
                         } else {
                             throw new CompletionException(err);
                         }

--- a/schema-registry/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryHandlerTest.java
+++ b/schema-registry/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/SchemaRegistryHandlerTest.java
@@ -165,11 +165,11 @@ public class SchemaRegistryHandlerTest {
             String subject = groups.get(0);
             if (subject.equals("errorsubject401")) {
                 return FutureUtil.failedFuture(
-                        new SchemaStorageException("Bad auth", HttpResponseStatus.UNAUTHORIZED.code()));
+                        new SchemaStorageException("Bad auth", HttpResponseStatus.UNAUTHORIZED));
             }
             if (subject.equals("errorsubject403")) {
                 return FutureUtil.failedFuture(
-                        new SchemaStorageException("Forbidden", HttpResponseStatus.FORBIDDEN.code()));
+                        new SchemaStorageException("Forbidden", HttpResponseStatus.FORBIDDEN));
             }
             if (subject.equals("errorsubject500")) {
                 return FutureUtil.failedFuture(new SchemaStorageException("Error"));


### PR DESCRIPTION
### Motivation

Sometimes when a schema REST request failed, `buildErrorResponse` might be called and a HTTP response whose content type is `text/plain` will be sent to the client. However, Confluent's Schema Registry client expects the response content is a JSON representation of `ErrorMessage` class:

```java
ErrorMessage errorMessage;
try {
  errorMessage = (ErrorMessage)jsonDeserializer.readValue(es, ErrorMessage.class);
} catch (JsonProcessingException e) {
  errorMessage = new ErrorMessage(JSON_PARSE_ERROR_CODE, e.getMessage());
}
```

https://github.com/confluentinc/schema-registry/blob/7bc2a042f794416f28f2e79598a6abb972243741/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java#L199

For example, when a 404 Not Found error is returned, the error message at client side might look like:

> Unrecognized token ‘Not’: was expecting ‘null’, ‘true’, ‘false’ or NaN

### Modifications

- Migrate `ErrorMessage` from Confluent's Schema Registry, then remove the `ErrorModel` class.
- In `buildErrorResponse`, serialize the code and message into `ErrorMessage`'s JSON representation.
- Reduce the duplicated code by calling `buildErrorResponse` in `buildJsonResponse` and `buildJsonErrorResponse`.
- Add `SchemaRegistryTest#testGetLatestSchemaMetadata` to verify a correct `RestClientException` will be thrown.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

