### PR TITLE
[Schema] Return 401 error when no HTTP authentication is configured

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -325,7 +325,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>${maven-javadoc-plugin.version}</version>
         <configuration>
-          <source>8</source>
+          <source>17</source>
           <doclint>none</doclint>
         </configuration>
       </plugin>

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/HttpJsonRequestProcessor.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/HttpJsonRequestProcessor.java
@@ -19,6 +19,7 @@ import io.netty.buffer.ByteBufInputStream;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.model.impl.SchemaStorageException;
 import java.io.DataInput;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -87,8 +88,16 @@ public abstract class HttpJsonRequestProcessor<K, R> extends HttpRequestProcesso
                     return buildJsonResponse(resp, RESPONSE_CONTENT_TYPE);
                 }
             }).exceptionally(err -> {
-                log.error("Error while processing request", err);
-                return buildJsonErrorResponse(err);
+                Throwable throwable = err;
+                while (throwable.getCause() != null) {
+                    throwable = throwable.getCause();
+                }
+                if (throwable instanceof SchemaStorageException e) {
+                    return buildErrorResponse(e.getHttpStatusCode(), e.getMessage());
+                } else {
+                    log.error("Error while processing request", err);
+                    return buildJsonErrorResponse(err);
+                }
             });
         } catch (IOException err) {
             log.error("Cannot decode request", err);


### PR DESCRIPTION
[Schema] Return 401 error when no HTTP authentication is configured

### Motivation

When authentication is enabled, if the Schema REST requests were sent without HTTP authentication header, the Schema Registry will return 404, rather than 401.

### Modifications

- When `SchemaStorageException` is thrown, build the response with the error code and the exception message.
- Add `testSchemaNoAuth` to verify 401 unauthorized will be returned.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

