### PR TITLE
[Schema Registry] Fix the delete operation not work

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -104,6 +104,8 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     private KopEventManager kopEventManager;
     private OrderedScheduler sendResponseScheduler;
     private NamespaceBundleOwnershipListenerImpl bundleListener;
+    @VisibleForTesting
+    @Getter
     private SchemaRegistryManager schemaRegistryManager;
     private MigrationManager migrationManager;
     private ReplicaManager replicaManager;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryManager.java
@@ -13,6 +13,7 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -42,6 +43,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.naming.AuthenticationException;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.authentication.AuthenticationProvider;
@@ -60,6 +62,9 @@ public class SchemaRegistryManager {
     private final PulsarService pulsar;
     private final SchemaRegistryRequestAuthenticator schemaRegistryRequestAuthenticator;
     private final PulsarClient pulsarClient;
+    @Getter
+    @VisibleForTesting
+    private SchemaStorageAccessor schemaStorage;
 
     public SchemaRegistryManager(KafkaServiceConfiguration kafkaConfig,
                                  PulsarService pulsar,
@@ -201,7 +206,7 @@ public class SchemaRegistryManager {
         }
         PulsarAdmin pulsarAdmin = pulsar.getAdminClient();
         SchemaRegistryHandler handler = new SchemaRegistryHandler();
-        SchemaStorageAccessor schemaStorage = new PulsarSchemaStorageAccessor((tenant) -> {
+        schemaStorage = new PulsarSchemaStorageAccessor((tenant) -> {
             try {
                 BrokerService brokerService = pulsar.getBrokerService();
                 final ClusterData clusterData = ClusterData.builder()

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorage.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/impl/PulsarSchemaStorage.java
@@ -331,11 +331,15 @@ public class PulsarSchemaStorage implements SchemaStorage, Closeable {
             try {
                 compatibility.put(op.subject, CompatibilityChecker.Mode.valueOf(op.compatibilityMode));
             } catch (IllegalArgumentException err) {
-                log.error("Unrecognized mode, skip op", op);
+                log.error("Unrecognized mode, skip op", err);
             }
         } else {
-            SchemaEntry schemaEntry = op.toSchemaEntry();
-            schemas.put(schemaEntry.id, schemaEntry);
+            if (op.status == SchemaStatus.DELETED) {
+                schemas.remove(op.schemaId);
+            } else {
+                SchemaEntry schemaEntry = op.toSchemaEntry();
+                schemas.put(schemaEntry.id, schemaEntry);
+            }
         }
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRestApiTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRestApiTest.java
@@ -70,7 +70,7 @@ public class SchemaRestApiTest extends KopProtocolHandlerTestBase {
         assertEquals(getSubjects(), Collections.singletonList(subject));
 
         sendHttpRequest("DELETE", "/subjects/" + subject, null);
-
+        assertTrue(getSubjects().isEmpty());
         resetSchemaStorage();
         assertTrue(getSubjects().isEmpty());
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRestApiTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SchemaRestApiTest.java
@@ -1,0 +1,111 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import io.streamnative.pulsar.handlers.kop.schemaregistry.resources.SubjectResource;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import lombok.Cleanup;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Test the Schema related REST APIs.
+ */
+public class SchemaRestApiTest extends KopProtocolHandlerTestBase {
+
+    protected static final ObjectMapper MAPPER = new ObjectMapper()
+            .configure(SerializationFeature.INDENT_OUTPUT, true);
+    private String baseUrl;
+
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        super.enableSchemaRegistry = true;
+        this.internalSetup();
+        baseUrl = "http://localhost:" + conf.getKopSchemaRegistryPort();
+    }
+
+    @AfterClass
+    @Override
+    protected void cleanup() throws Exception {
+        this.internalCleanup();
+    }
+
+    @Test
+    public void testDeleteSubject() throws Exception {
+        final var createSchemaRequest = new SubjectResource.CreateSchemaRequest();
+        createSchemaRequest.setSchema("{\"type\":\"record\",\"name\":\"User1\",\"namespace\":\"example.avro\""
+                + ",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"age\",\"type\":\"int\"}]}");
+        final var subject = "my-subject";
+        sendHttpRequest("POST", "/subjects/" + subject + "/versions",
+                MAPPER.writeValueAsString(createSchemaRequest));
+
+        assertEquals(getSubjects(), Collections.singletonList(subject));
+        resetSchemaStorage();
+        assertEquals(getSubjects(), Collections.singletonList(subject));
+
+        sendHttpRequest("DELETE", "/subjects/" + subject, null);
+
+        resetSchemaStorage();
+        assertTrue(getSubjects().isEmpty());
+    }
+
+    private void resetSchemaStorage() {
+        final var handler = getProtocolHandler();
+        handler.getSchemaRegistryManager().getSchemaStorage().close();
+    }
+
+    private List<String> getSubjects() throws IOException {
+        final var output = sendHttpRequest("GET", "/subjects", null);
+        return Arrays.asList(MAPPER.readValue(output, String[].class));
+    }
+
+    private String sendHttpRequest(final String method, final String path, final String body) throws IOException {
+        final var url = new URL(baseUrl + path);
+        final var conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod(method);
+        if (body != null) {
+            conn.setDoOutput(true);
+            conn.setRequestProperty("Content-Type", "application/json");
+            conn.setRequestProperty("Content-Length", Integer.toString(body.length()));
+            final var output = conn.getOutputStream();
+            output.write(body.getBytes(StandardCharsets.UTF_8));
+            output.close();
+        }
+        @Cleanup final var in = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+        final var buffer = new StringBuilder();
+        while (true) {
+            final var line = in.readLine();
+            if (line == null) {
+                break;
+            }
+            buffer.append(line);
+        }
+        return buffer.toString();
+    }
+}


### PR DESCRIPTION
### Motivation

When I tried to delete a subject, the subject could still be queried even after I restarted the broker.

```bash
$ curl -L http://localhost:8001/subjects
[ test ]
$ curl -X DELETE -L http://localhost:8001/subjects/test
$ curl -L http://localhost:8001/subjects
[ test ]
```

The reason is that the `SchemaStatus.DELETED` is never processed.

### Modifications

In `PulsarSchemaStorage#applyOpToLocalMemory`, when the status is `DELETED`, remove the entry with the same schema id from the `schemas` cache.

Add `SchemaRestApiTest#testDeleteSubject` to verify this change. To verify modifications also work after the restart, expose the schema storage for tests and add `resetSchemaStorage` to clear the storage.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

