### PR TITLE
[improve] Enable transaction and schema registry on docker compose

### DIFF
--- a/docker-compose-cluster.yaml
+++ b/docker-compose-cluster.yaml
@@ -19,7 +19,7 @@ networks:
 services:
   # Start zookeeper
   zookeeper:
-    image: streamnative/sn-pulsar:2.10.3.4
+    image: streamnative/sn-pulsar:2.11.0.5
     container_name: zookeeper
     restart: "no"
     networks:
@@ -109,6 +109,9 @@ services:
       - PULSAR_PREFIX_kafkaAdvertisedListeners=PLAINTEXT://127.0.0.1:9092
       - PULSAR_PREFIX_brokerEntryMetadataInterceptors=org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor
       - PULSAR_PREFIX_brokerDeleteInactiveTopicsEnabled=false
+      - PULSAR_PREFIX_kopSchemaRegistryEnable=true
+      - PULSAR_PREFIX_kopSchemaRegistryPort=8081
+      - PULSAR_PREFIX_kafkaTransactionCoordinatorEnabled=true
     depends_on:
       zookeeper:
         condition: service_healthy
@@ -119,4 +122,5 @@ services:
       - "8080:8080"
       #- "8001:8001" # what is this for?
       - "9092:9092"
+      - "8081:8081"
     command: bash -c "bin/apply-config-from-env.py conf/broker.conf &&  exec bin/pulsar broker"

--- a/docker-compose-cluster.yaml
+++ b/docker-compose-cluster.yaml
@@ -45,7 +45,7 @@ services:
   pulsar-init:
     container_name: pulsar-init
     hostname: pulsar-init
-    image: streamnative/sn-pulsar:2.10.3.4
+    image: streamnative/sn-pulsar:2.11.0.5
     networks:
       - pulsar
     command: >
@@ -61,7 +61,7 @@ services:
 
   # Start bookie
   bookie:
-    image: streamnative/sn-pulsar:2.10.3.4
+    image: streamnative/sn-pulsar:2.11.0.5
     container_name: bookie
     restart: "no"
     networks:
@@ -86,7 +86,7 @@ services:
 
   # Start broker
   broker:
-    image: streamnative/sn-pulsar:2.10.3.4
+    image: streamnative/sn-pulsar:2.11.0.5
     container_name: broker
     hostname: broker
     restart: "no"

--- a/docker-compose-cluster.yaml
+++ b/docker-compose-cluster.yaml
@@ -19,7 +19,7 @@ networks:
 services:
   # Start zookeeper
   zookeeper:
-    image: streamnative/sn-pulsar:2.11.0.5
+    image: streamnative/sn-pulsar:2.11.1.0
     container_name: zookeeper
     restart: "no"
     networks:
@@ -45,7 +45,7 @@ services:
   pulsar-init:
     container_name: pulsar-init
     hostname: pulsar-init
-    image: streamnative/sn-pulsar:2.11.0.5
+    image: streamnative/sn-pulsar:2.11.1.0
     networks:
       - pulsar
     command: >
@@ -61,7 +61,7 @@ services:
 
   # Start bookie
   bookie:
-    image: streamnative/sn-pulsar:2.11.0.5
+    image: streamnative/sn-pulsar:2.11.1.0
     container_name: bookie
     restart: "no"
     networks:
@@ -86,7 +86,7 @@ services:
 
   # Start broker
   broker:
-    image: streamnative/sn-pulsar:2.11.0.5
+    image: streamnative/sn-pulsar:2.11.1.0
     container_name: broker
     hostname: broker
     restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
   standalone:
     container_name: standalone
     hostname: localhost
-    image: streamnative/sn-pulsar:2.9.1.1
+    image: streamnative/sn-pulsar:2.11.0.5
     command: >
       bash -c "bin/apply-config-from-env.py conf/standalone.conf &&
       exec bin/pulsar standalone -nss -nfw" # disable stream storage and functions worker
@@ -29,7 +29,11 @@ services:
       PULSAR_PREFIX_kafkaListeners: PLAINTEXT://0.0.0.0:9092
       PULSAR_PREFIX_kafkaAdvertisedListeners: PLAINTEXT://127.0.0.1:19092
       PULSAR_PREFIX_brokerEntryMetadataInterceptors: org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor
+      PULSAR_PREFIX_kopSchemaRegistryEnable: true
+      PULSAR_PREFIX_kopSchemaRegistryPort: 8081
+      PULSAR_PREFIX_kafkaTransactionCoordinatorEnabled: true
     ports:
       - 6650:6650
       - 8080:8080
       - 19092:9092
+      - 8081:8081

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
   standalone:
     container_name: standalone
     hostname: localhost
-    image: streamnative/sn-pulsar:2.11.0.5
+    image: streamnative/sn-pulsar:2.11.1.0
     command: >
       bash -c "bin/apply-config-from-env.py conf/standalone.conf &&
       exec bin/pulsar standalone -nss -nfw" # disable stream storage and functions worker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       brokerDeleteInactiveTopicsEnabled: "false"
       PULSAR_PREFIX_messagingProtocols: kafka
       PULSAR_PREFIX_kafkaListeners: PLAINTEXT://0.0.0.0:9092
-      PULSAR_PREFIX_kafkaAdvertisedListeners: PLAINTEXT://127.0.0.1:19092
+      PULSAR_PREFIX_kafkaAdvertisedListeners: PLAINTEXT://127.0.0.1:9092
       PULSAR_PREFIX_brokerEntryMetadataInterceptors: org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor
       PULSAR_PREFIX_kopSchemaRegistryEnable: true
       PULSAR_PREFIX_kopSchemaRegistryPort: 8081
@@ -35,5 +35,5 @@ services:
     ports:
       - 6650:6650
       - 8080:8080
-      - 19092:9092
+      - 9092:9092
       - 8081:8081


### PR DESCRIPTION
### Motivation

Currently, the KoP supports schema registry and transaction, 
But this feature is not enabled in the standalone and cluster docker-compose by default.

### Modifications

* Enable transaction and schema registry on docker-compose yaml.
* Upgrade the docker-compose sn-pulsar version to 2.11.0.5.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

