### PR TITLE
Upgrade the Pulsar version to 3.0.0.1-rc1

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/DelayedFetch.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/DelayedFetch.java
@@ -91,7 +91,7 @@ public class DelayedFetch extends DelayedOperation {
         replicaManager.readFromLocalLog(
             readCommitted, fetchMaxBytes, maxReadEntriesNum, readPartitionInfo, context
         ).thenAccept(readRecordsResult -> {
-            this.context.getStatsLogger().getWaitingFetchesTriggered().add(1);
+            this.context.getStatsLogger().getWaitingFetchesTriggered().addCount(1);
             this.callback.complete(readRecordsResult);
         }).thenAccept(__ -> {
             // Ensure the old decode result are recycled.

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -189,7 +189,7 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         // Get a buffer that contains the full frame
         ByteBuf buffer = (ByteBuf) msg;
-        requestStats.getNetworkTotalBytesIn().add(buffer.readableBytes());
+        requestStats.getNetworkTotalBytesIn().addCount(buffer.readableBytes());
 
         // Update parse request latency metrics
         final BiConsumer<Long, Throwable> registerRequestParseLatency = (timeBeforeParse, throwable) -> {
@@ -448,7 +448,7 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
                         if (!future.isSuccess()) {
                             log.error("[{}] Failed to write {}", channel, request.getHeader(), future.cause());
                         } else {
-                            requestStats.getNetworkTotalBytesOut().add(resultSize);
+                            requestStats.getNetworkTotalBytesOut().addCount(resultSize);
                         }
                     });
                     requestStats.getRequestStatsLogger(apiKey, KopServerStats.REQUEST_QUEUED_LATENCY)
@@ -474,7 +474,7 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
         final int resultSize = result.readableBytes();
         channel.writeAndFlush(result).addListener(future -> {
             if (future.isSuccess()) {
-                requestStats.getNetworkTotalBytesOut().add(resultSize);
+                requestStats.getNetworkTotalBytesOut().addCount(resultSize);
             }
         });
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/DecodeResult.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/DecodeResult.java
@@ -99,7 +99,7 @@ public class DecodeResult {
 
         final StatsLogger statsLoggerForThisPartition = statsLogger.getStatsLoggerForTopicPartition(topicPartition);
 
-        statsLoggerForThisPartition.getCounter(CONSUME_MESSAGE_CONVERSIONS).add(conversionCount);
+        statsLoggerForThisPartition.getCounter(CONSUME_MESSAGE_CONVERSIONS).addCount(conversionCount);
         statsLoggerForThisPartition.getOpStatsLogger(CONSUME_MESSAGE_CONVERSIONS_TIME_NANOS)
                 .registerSuccessfulEvent(conversionTimeNanos, TimeUnit.NANOSECONDS);
         final StatsLogger statsLoggerForThisGroup;
@@ -108,9 +108,9 @@ public class DecodeResult {
         } else {
             statsLoggerForThisGroup = statsLoggerForThisPartition;
         }
-        statsLoggerForThisGroup.getCounter(BYTES_OUT).add(records.sizeInBytes());
-        statsLoggerForThisGroup.getCounter(MESSAGE_OUT).add(numMessages);
-        statsLoggerForThisGroup.getCounter(ENTRIES_OUT).add(entrySize);
+        statsLoggerForThisGroup.getCounter(BYTES_OUT).addCount(records.sizeInBytes());
+        statsLoggerForThisGroup.getCounter(MESSAGE_OUT).addCount(numMessages);
+        statsLoggerForThisGroup.getCounter(ENTRIES_OUT).addCount(entrySize);
 
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/EncodeResult.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/EncodeResult.java
@@ -89,9 +89,9 @@ public class EncodeResult {
 
         final StatsLogger statsLoggerForThisPartition = requestStats.getStatsLoggerForTopicPartition(topicPartition);
 
-        statsLoggerForThisPartition.getCounter(BYTES_IN).add(numBytes);
-        statsLoggerForThisPartition.getCounter(MESSAGE_IN).add(numMessages);
-        statsLoggerForThisPartition.getCounter(PRODUCE_MESSAGE_CONVERSIONS).add(conversionCount);
+        statsLoggerForThisPartition.getCounter(BYTES_IN).addCount(numBytes);
+        statsLoggerForThisPartition.getCounter(MESSAGE_IN).addCount(numMessages);
+        statsLoggerForThisPartition.getCounter(PRODUCE_MESSAGE_CONVERSIONS).addCount(conversionCount);
         statsLoggerForThisPartition.getOpStatsLogger(PRODUCE_MESSAGE_CONVERSIONS_TIME_NANOS)
                 .registerSuccessfulEvent(conversionTimeNanos, TimeUnit.NANOSECONDS);
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/stats/LongAdderCounter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/stats/LongAdderCounter.java
@@ -14,6 +14,7 @@
 package io.streamnative.pulsar.handlers.kop.stats;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
 import org.apache.bookkeeper.stats.Counter;
 
@@ -48,8 +49,13 @@ public class LongAdderCounter implements Counter {
     }
 
     @Override
-    public void add(long delta) {
+    public void addCount(long delta) {
         counter.add(delta);
+    }
+
+    @Override
+    public void addLatency(long l, TimeUnit timeUnit) {
+        // No-op
     }
 
     @Override

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/stats/NullStatsLogger.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/stats/NullStatsLogger.java
@@ -88,7 +88,12 @@ public class NullStatsLogger implements StatsLogger {
         }
 
         @Override
-        public void add(long delta) {
+        public void addCount(long delta) {
+            // nop
+        }
+
+        @Override
+        public void addLatency(long l, TimeUnit timeUnit) {
             // nop
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <lombok.version>1.18.24</lombok.version>
     <mockito.version>4.11.0</mockito.version>
     <pulsar.group.id>io.streamnative</pulsar.group.id>
-    <pulsar.version>3.0.0.1-SNAPSHOT</pulsar.version>
+    <pulsar.version>3.0.0.1-rc1</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.12</spotbugs-annotations.version>
     <apicurio.version>2.1.3.Final</apicurio.version>

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaMessageOrderTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaMessageOrderTestBase.java
@@ -40,8 +40,7 @@ import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.impl.BatchMessageIdImpl;
-import org.apache.pulsar.client.impl.TopicMessageIdImpl;
+import org.apache.pulsar.client.api.MessageIdAdv;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.testng.annotations.AfterClass;
@@ -158,8 +157,7 @@ public abstract class KafkaMessageOrderTestBase extends KopProtocolHandlerTestBa
 
                     consumer.acknowledge(msg);
 
-                    BatchMessageIdImpl id =
-                            (BatchMessageIdImpl) ((TopicMessageIdImpl) msg.getMessageId()).getInnerMessageId();
+                    MessageIdAdv id = (MessageIdAdv) msg.getMessageId();
                     if (id.getBatchIndex() == 0) {
                         numBatches++;
                     }


### PR DESCRIPTION
### Motivation

There was an API change in `org.apache.bookkeeper.stats.Counter`, which made the build failed for 3.0.0.1-rc1.

### Modifications

Upgrade the dependency and use the new API.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

