### PR TITLE
Fix usage of Pulsar's AuthenticationState object

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SchemaRegistryManager.java
@@ -109,7 +109,7 @@ public class SchemaRegistryManager {
                 AuthData authData = AuthData.of(password.getBytes(StandardCharsets.UTF_8));
                 final AuthenticationState authState = authenticationProvider
                         .newAuthState(authData, null, null);
-                authState.authenticateAsync(authData).get(kafkaConfig.getRequestTimeoutMs(), TimeUnit.MILLISECONDS);
+                authState.authenticate(authData);
                 final String role = authState.getAuthRole();
 
                 final String tenant;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/PlainSaslServer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/PlainSaslServer.java
@@ -86,7 +86,7 @@ public class PlainSaslServer implements SaslServer {
         try {
             final AuthData authData = AuthData.of(saslAuth.getAuthData().getBytes(StandardCharsets.UTF_8));
             final AuthenticationState authState = authenticationProvider.newAuthState(authData, null, null);
-            authState.authenticateAsync(authData).get(config.getRequestTimeoutMs(), TimeUnit.MILLISECONDS);
+            authState.authenticate(authData);
             final String role = authState.getAuthRole();
             if (StringUtils.isEmpty(role)) {
                 throw new AuthenticationException("Role cannot be empty.");

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/OauthValidatorCallbackHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/OauthValidatorCallbackHandler.java
@@ -135,7 +135,7 @@ public class OauthValidatorCallbackHandler implements AuthenticateCallbackHandle
             AuthData authData = AuthData.of(token.getBytes(StandardCharsets.UTF_8));
             final AuthenticationState authState = authenticationProvider.newAuthState(
                     authData, null, null);
-            authState.authenticateAsync(authData).get(requestTimeoutMs, TimeUnit.MILLISECONDS);
+            authState.authenticate(authData);
             final String role = authState.getAuthRole();
             AuthenticationDataSource authDataSource = authState.getAuthDataSource();
             callback.token(new KopOAuthBearerToken() {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/oauth/OauthValidatorCallbackHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/oauth/OauthValidatorCallbackHandlerTest.java
@@ -48,7 +48,7 @@ public class OauthValidatorCallbackHandlerTest {
 
         doReturn(state).when(mockAuthProvider).newAuthState(any(), any(), any());
 
-        doReturn(CompletableFuture.completedFuture(null)).when(state).authenticateAsync(any());
+        doReturn(null).when(state).authenticate(any());
 
         KopOAuthBearerValidatorCallback callbackWithTenant =
                 new KopOAuthBearerValidatorCallback("my-tenant" + OAuthTokenDecoder.DELIMITER + "my-token");


### PR DESCRIPTION
The original patch was written by @michaeljmarshall [here](https://github.com/datastax/starlight-for-kafka/pull/85)

### Motivation

There is a breaking API change in upcoming Pulsar versions:
https://github.com/apache/pulsar/pull/19295

This patch allows KOP to run on newer Pulsar versions.

### Modifications

Use the authenticate() method instead of authenticateAsync() 

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *(please describe tests)*.

### Documentation


Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

