### PR TITLE
[Schema] Fix wrong response when querying schema by subject and version

### DIFF
--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/Schema.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/model/Schema.java
@@ -13,6 +13,7 @@
  */
 package io.streamnative.pulsar.handlers.kop.schemaregistry.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -20,12 +21,15 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+// This class is migrated from io.confluent.kafka.schemaregistry.client.rest.entities.Schema
 @Data
 @AllArgsConstructor
 @Builder
 @EqualsAndHashCode
+@NoArgsConstructor
 @ToString
 public final class Schema {
 
@@ -35,15 +39,19 @@ public final class Schema {
     private static final List<String> ALL_TYPES =
             Collections.unmodifiableList(Arrays.asList(TYPE_AVRO, TYPE_JSON, TYPE_PROTOBUF));
 
-    private final String tenant;
-    private final int id;
-    private final int version;
-    private final String schemaDefinition;
-    private final String subject;
-    private final String type;
+    private String tenant;
+    @JsonProperty("id")
+    private int id;
+    @JsonProperty("version")
+    private int version;
+    @JsonProperty("schema")
+    private String schemaDefinition;
+    @JsonProperty("subject")
+    private String subject;
+    @JsonProperty("type")
+    private String type;
 
     public static List<String> getAllTypes() {
         return ALL_TYPES;
     }
-
 }

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SubjectResource.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SubjectResource.java
@@ -57,7 +57,6 @@ public class SubjectResource extends AbstractResource {
         private String schema;
         private String subject;
         private int version;
-        private String type;
     }
 
     @Data
@@ -151,7 +150,7 @@ public class SubjectResource extends AbstractResource {
                         .thenApply(s -> s == null ? null : new GetSchemaBySubjectAndVersionResponse(
                                 s.getId(),
                                 s.getSchemaDefinition(),
-                                s.getSubject(), s.getVersion(), s.getType()));
+                                s.getSubject(), s.getVersion()));
             });
         }
 
@@ -204,7 +203,7 @@ public class SubjectResource extends AbstractResource {
                     return null;
                 }
                 return new GetSchemaBySubjectAndVersionResponse(s.getId(), s.getSchemaDefinition(), s.getSubject(),
-                        s.getVersion(), s.getType());
+                        s.getVersion());
             });
         }
 


### PR DESCRIPTION
### Motivation

The response is wrong when querying schema by subject and version.

Here is an example response of Confluent Schema Registry:

```json
{
  "subject":"test-value",
  "version":1,
  "id":1,
  "schema":"{\"type\":\"record\",\"name\":\"User\",\"namespace\":\"com.example\",\"fields\":[{\"name\":\"name\",\"type\":[\"string\",\"null\"]},{\"name\":\"age\",\"type\":\"int\"}]}"
}
```

Here is the corresponding response of KoP:

```json
{
  "id" : 1,
  "schema" :
    "{\"type\":\"record\",\"name\":\"User\",\"namespace\":\"com.example\",\"fields\":[{\"name\":\"name\",\"type\":[\"string\",\"null\"]},{\"name\":\"age\",\"type\":\"int\"}]}",
  "subject" : "test-value",
  "version" : 1,
  "type" : "AVRO"
}
```

KoP has an extra "type" field, for some old versions of `KafkaAvroSerializer`, they would fail to parse the response.

### Modifications

- Remove the `type` field from `GetSchemaBySubjectAndVersionResponse`.
- Add `testGetSubjectByVersion` to verify correct responses are returned.
- Modify `testGetLatestSchemaMetadata` to verify `KafkaAvroSerializer` 5.0.0, which is depended by KoP, could get the latest schema of a subject.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)
