### PR TITLE
Increase timeout for KafkaListenerNameTest

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaListenerNameTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaListenerNameTest.java
@@ -63,7 +63,7 @@ public class KafkaListenerNameTest extends KopProtocolHandlerTestBase {
         // Clean up in the test method
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 60000)
     public void testMetadataRequestForMultiListeners() throws Exception {
         final Map<Integer, String> bindPortToAdvertisedAddress = new HashMap<>();
         final int anotherKafkaPort = PortManager.nextFreePort();
@@ -131,7 +131,7 @@ public class KafkaListenerNameTest extends KopProtocolHandlerTestBase {
         super.internalCleanup();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 60000)
     public void testListenerName() throws Exception {
         super.resetConfig();
         conf.setAdvertisedAddress(null);
@@ -149,7 +149,7 @@ public class KafkaListenerNameTest extends KopProtocolHandlerTestBase {
         super.internalCleanup();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 60000)
     public void testLegacyMultipleListenerName() throws Exception {
         super.resetConfig();
         conf.setAdvertisedAddress(null);
@@ -186,7 +186,7 @@ public class KafkaListenerNameTest extends KopProtocolHandlerTestBase {
         super.internalCleanup();
     }
 
-    @Test(timeOut = 20000)
+    @Test(timeOut = 60000)
     public void testConnectListenerNotExist() throws Exception {
         final int externalPort = PortManager.nextFreePort();
         super.resetConfig();
@@ -214,7 +214,7 @@ public class KafkaListenerNameTest extends KopProtocolHandlerTestBase {
         super.internalCleanup();
     }
 
-    @Test(timeOut = 30000)
+    @Test(timeOut = 60000)
     public void testIpv6ListenerName() throws Exception {
         super.resetConfig();
         conf.setAdvertisedAddress(null);


### PR DESCRIPTION
Fixes https://github.com/streamnative/kop/issues/1830

### Motivation

Different from other tests, the `KafkaListenerNameTest` sets up and cleans up the broker service during the test method, which will take much more time than other tests. `testConnectListenerNotExist` is more flaky because the timeout is 20 seconds while other methods are 30.

### Modifications

Increase all timeout of `KafkaListenerNameTest` to 1 minute.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

