### PR TITLE
Fix javadoc plugin configuration version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -551,7 +551,7 @@
               </execution>
             </executions>
             <configuration>
-              <source>8</source>
+              <source>17</source>
               <doclint>none</doclint>
             </configuration>
           </plugin>


### PR DESCRIPTION
### Motivation

Kop uses some jdk8+ grammar which is not supported by Javadoc plugin source 8 configuration when the version is 2.11+, so we need to upgrade it.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

