### PR TITLE
Fix pulsar entry formatter encode zero timestamp record caused exception

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/PulsarEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/PulsarEntryFormatter.java
@@ -159,7 +159,7 @@ public class PulsarEntryFormatter extends AbstractEntryFormatter {
 
         // timestamp
         if (record.timestamp() >= 0) {
-            builder.eventTime(record.timestamp());
+            builder.getMetadataBuilder().setEventTime(record.timestamp());
             builder.getMetadataBuilder().setPublishTime(record.timestamp());
         } else {
             builder.getMetadataBuilder().setPublishTime(System.currentTimeMillis());

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/PulsarMessageBuilder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/PulsarMessageBuilder.java
@@ -93,12 +93,6 @@ public class PulsarMessageBuilder {
         return this;
     }
 
-    public PulsarMessageBuilder eventTime(long timestamp) {
-        checkArgument(timestamp > 0, "Invalid timestamp : '%s'", timestamp);
-        metadata.setEventTime(timestamp);
-        return this;
-    }
-
     public MessageMetadata getMetadataBuilder() {
         return metadata;
     }


### PR DESCRIPTION
### Motivation

When using pulsar entry formatter and publishing zero timestamp record will cause request timeout,
the root cause is we will set the event time when timestamp >= 0, but the event time has a check to ensure time > 0.
See:
```java
    public PulsarMessageBuilder eventTime(long timestamp) {
        checkArgument(timestamp > 0, "Invalid timestamp : '%s'", timestamp);
        metadata.setEventTime(timestamp);
        return this;
    }
```

### Modifications
* Do not check the event time before setting the event time.
* Add test to verify this issue.


### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

