### PR TITLE
[feat][schema] Support getting schema string by id

### DIFF
--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SchemaResource.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SchemaResource.java
@@ -40,6 +40,7 @@ public class SchemaResource extends AbstractResource {
      */
     public void register(SchemaRegistryHandler schemaRegistryHandler) {
         schemaRegistryHandler.addProcessor(new GetSchemaById());
+        schemaRegistryHandler.addProcessor(new GetSchemaStringById());
         schemaRegistryHandler.addProcessor(new GetSchemaTypes());
         schemaRegistryHandler.addProcessor(new GetSchemaAliases());
     }
@@ -49,6 +50,8 @@ public class SchemaResource extends AbstractResource {
     @AllArgsConstructor
     public static final class GetSchemaResponse {
         private String schema;
+        private String schemaType;
+        //todo: references, metadata, ruleSet, maxId
     }
 
     // /schemas/types
@@ -74,7 +77,6 @@ public class SchemaResource extends AbstractResource {
         private int version;
     }
 
-    // GET /schemas/ids/{int: id}
     public class GetSchemaById extends HttpJsonRequestProcessor<Void, GetSchemaResponse> {
 
         public GetSchemaById() {
@@ -92,7 +94,30 @@ public class SchemaResource extends AbstractResource {
                 if (s == null) {
                     return null;
                 }
-                return new GetSchemaResponse(s.getSchemaDefinition());
+                return new GetSchemaResponse(s.getSchemaDefinition(), s.getType());
+            });
+        }
+    }
+
+    // GET /schemas/ids/{int: id}/schema     Get one schema string
+    public class GetSchemaStringById extends HttpJsonRequestProcessor<Void, String> {
+
+        public GetSchemaStringById() {
+            super(Void.class, "/schemas/ids/" + INT_PATTERN + "/schema", GET);
+        }
+
+        @Override
+        protected CompletableFuture<String> processRequest(Void payload, List<String> patternGroups,
+                                                                      FullHttpRequest request)
+                throws Exception {
+            int id = getInt(0, patternGroups);
+            SchemaStorage schemaStorage = getSchemaStorage(request);
+            CompletableFuture<Schema> schemaById = schemaStorage.findSchemaById(id);
+            return schemaById.thenApply(s -> {
+                if (s == null) {
+                    return null;
+                }
+                return s.getSchemaDefinition();
             });
         }
 

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SchemaResource.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SchemaResource.java
@@ -13,6 +13,7 @@
  */
 package io.streamnative.pulsar.handlers.kop.schemaregistry.resources;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.streamnative.pulsar.handlers.kop.schemaregistry.HttpJsonRequestProcessor;
 import io.streamnative.pulsar.handlers.kop.schemaregistry.SchemaRegistryHandler;
@@ -48,10 +49,15 @@ public class SchemaResource extends AbstractResource {
     @Data
     @NoArgsConstructor
     @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public static final class GetSchemaResponse {
         private String schema;
         private String schemaType;
         //todo: references, metadata, ruleSet, maxId
+
+        public String getSchemaType() {
+            return "AVRO".equals(schemaType) ? null : schemaType;
+        }
     }
 
     // /schemas/types

--- a/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SchemaResource.java
+++ b/schema-registry/src/main/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SchemaResource.java
@@ -83,6 +83,7 @@ public class SchemaResource extends AbstractResource {
         private int version;
     }
 
+    // GET /schemas/ids/{int: id}
     public class GetSchemaById extends HttpJsonRequestProcessor<Void, GetSchemaResponse> {
 
         public GetSchemaById() {

--- a/schema-registry/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SchemaResourceTest.java
+++ b/schema-registry/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SchemaResourceTest.java
@@ -114,8 +114,17 @@ public class SchemaResourceTest {
         String result = server.executeGet("/schemas/ids/1");
         log.info("result {}", result);
         assertEquals(result, "{\n"
-                + "  \"schema\" : \"{SCHEMA-1}\"\n"
+                + "  \"schema\" : \"{SCHEMA-1}\",\n"
+                + "  \"schemaType\" : \"AVRO\"\n"
                 + "}");
+    }
+
+    @Test
+    public void getSchemaStringByIdTest() throws Exception {
+        putSchema(1, "{SCHEMA-1}");
+        String result = server.executeGet("/schemas/ids/1/schema");
+        log.info("result {}", result);
+        assertEquals(result, "{SCHEMA-1}");
     }
 
     @Test
@@ -124,7 +133,8 @@ public class SchemaResourceTest {
         String result = server.executeGet("/schemas/ids/1?fetchMaxId=false");
         log.info("result {}", result);
         assertEquals(result, "{\n"
-                + "  \"schema\" : \"{SCHEMA-1}\"\n"
+                + "  \"schema\" : \"{SCHEMA-1}\",\n"
+                + "  \"schemaType\" : \"AVRO\"\n"
                 + "}");
     }
 
@@ -239,7 +249,8 @@ public class SchemaResourceTest {
         assertEquals(result, "{\n"
                 + "  \"schema\" : \"{       \\\"type\\\": \\\"record\\\",       \\\"name\\\": \\\"test\\\",       "
                 + "\\\"fields\\\":         [           {             \\\"type\\\": \\\"string\\\",             "
-                + "\\\"name\\\": \\\"field1\\\"           }          ]     }\"\n"
+                + "\\\"name\\\": \\\"field1\\\"           }          ]     }\",\n"
+                + "  \"schemaType\" : \"AVRO\"\n"
                 + "}");
     }
 
@@ -271,7 +282,8 @@ public class SchemaResourceTest {
         assertEquals(result, "{\n"
                 + "  \"schema\" : \"{       \\\"type\\\": \\\"record\\\",       \\\"name\\\": \\\"test\\\",       "
                 + "\\\"fields\\\":         [           {             \\\"type\\\": \\\"string\\\",             "
-                + "\\\"name\\\": \\\"field1\\\"           }          ]     }\"\n"
+                + "\\\"name\\\": \\\"field1\\\"           }          ]     }\",\n"
+                + "  \"schemaType\" : \"AVRO\"\n"
                 + "}");
     }
 

--- a/schema-registry/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SchemaResourceTest.java
+++ b/schema-registry/src/test/java/io/streamnative/pulsar/handlers/kop/schemaregistry/resources/SchemaResourceTest.java
@@ -114,8 +114,7 @@ public class SchemaResourceTest {
         String result = server.executeGet("/schemas/ids/1");
         log.info("result {}", result);
         assertEquals(result, "{\n"
-                + "  \"schema\" : \"{SCHEMA-1}\",\n"
-                + "  \"schemaType\" : \"AVRO\"\n"
+                + "  \"schema\" : \"{SCHEMA-1}\"\n"
                 + "}");
     }
 
@@ -133,8 +132,7 @@ public class SchemaResourceTest {
         String result = server.executeGet("/schemas/ids/1?fetchMaxId=false");
         log.info("result {}", result);
         assertEquals(result, "{\n"
-                + "  \"schema\" : \"{SCHEMA-1}\",\n"
-                + "  \"schemaType\" : \"AVRO\"\n"
+                + "  \"schema\" : \"{SCHEMA-1}\"\n"
                 + "}");
     }
 
@@ -249,8 +247,7 @@ public class SchemaResourceTest {
         assertEquals(result, "{\n"
                 + "  \"schema\" : \"{       \\\"type\\\": \\\"record\\\",       \\\"name\\\": \\\"test\\\",       "
                 + "\\\"fields\\\":         [           {             \\\"type\\\": \\\"string\\\",             "
-                + "\\\"name\\\": \\\"field1\\\"           }          ]     }\",\n"
-                + "  \"schemaType\" : \"AVRO\"\n"
+                + "\\\"name\\\": \\\"field1\\\"           }          ]     }\"\n"
                 + "}");
     }
 
@@ -282,8 +279,7 @@ public class SchemaResourceTest {
         assertEquals(result, "{\n"
                 + "  \"schema\" : \"{       \\\"type\\\": \\\"record\\\",       \\\"name\\\": \\\"test\\\",       "
                 + "\\\"fields\\\":         [           {             \\\"type\\\": \\\"string\\\",             "
-                + "\\\"name\\\": \\\"field1\\\"           }          ]     }\",\n"
-                + "  \"schemaType\" : \"AVRO\"\n"
+                + "\\\"name\\\": \\\"field1\\\"           }          ]     }\"\n"
                 + "}");
     }
 


### PR DESCRIPTION
See: https://docs.confluent.io/platform/current/schema-registry/develop/api.html#get--schemas-ids-int-%20id-schema

And the PR also fixed the missed schema type for "GET /schemas/ids/{int: id}"
https://docs.confluent.io/platform/current/schema-registry/develop/api.html#get--schemas-ids-int-%20id

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

