### PR TITLE
Use brokerClientTlsEnabled to configure pulsar client

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AbstractPulsarClient.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/AbstractPulsarClient.java
@@ -64,7 +64,7 @@ public abstract class AbstractPulsarClient {
                                                          final Consumer<ClientConfigurationData> customConfig) {
         // It's migrated from PulsarService#getClient()
         final ClientConfigurationData conf = new ClientConfigurationData();
-        conf.setServiceUrl(kafkaConfig.isTlsEnabled()
+        conf.setServiceUrl(kafkaConfig.isBrokerClientTlsEnabled()
                 ? pulsarService.getBrokerServiceUrlTls()
                 : pulsarService.getBrokerServiceUrl());
         conf.setTlsAllowInsecureConnection(kafkaConfig.isTlsAllowInsecureConnection());


### PR DESCRIPTION
### Motivation

The `createPulsarClient` method is meant to model the PulsarServer method named `getClient`. However, it uses a different config to determine when to enable TLS. This leads to divergent behavior within the broker. Here is the pulsar code:

https://github.com/apache/pulsar/blob/092819b5c4a68dbc39d9a650d5370af9455e805d/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java#L1554-L1555

### Modifications

* Replace `isTlsEnabled` with `isBrokerClientTlsEnabled` when creating pulsar client

### Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

### Documentation
  
- [x] `no-need-doc` 
  

