### PR TITLE
Fix flaky-test: KafkaNonPartitionedTopicTest.testNonPartitionedTopic

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaNonPartitionedTopicTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaNonPartitionedTopicTest.java
@@ -101,7 +101,7 @@ public class KafkaNonPartitionedTopicTest extends KopProtocolHandlerTestBase {
                     .getConsumer().listTopics(Duration.ofSeconds(1));
             assertEquals(result.size(), 1);
         } finally {
-            admin.topics().delete(topic);
+            admin.topics().delete(topic, true);
         }
     }
 


### PR DESCRIPTION
Fix: #1852

### Motivation

When the topic has an active producer or consumer, then we are not able to delete the topic by using `admin.topics().delete(topic)`, we should force delete it.

### Modifications

Use the force option to delete the topic in the test.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

