### PR TITLE
[fix] Fix read unstable messages

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -528,7 +528,8 @@ public class PartitionLog {
                 long adjustedMaxBytes = Math.min(partitionData.maxBytes, limitBytes.get());
                 if (readCommitted && producerStateManager.firstUndecidedOffset().isPresent()
                         && producerStateManager.firstUndecidedOffset().get().compareTo(offset) <= 0) {
-                    future.complete(ReadRecordsResult.error(Errors.NONE));
+                    future.complete(ReadRecordsResult.error(
+                            tcm.getManagedLedger().getLastConfirmedEntry(), Errors.NONE));
                     return;
                 }
                 readEntries(cursor, topicPartition, cursorOffset, maxReadEntriesNum, adjustedMaxBytes, topicManager)

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
@@ -47,7 +47,6 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.serialization.IntegerDeserializer;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
@@ -573,7 +573,6 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
             if (records.isEmpty()) {
                 break;
             }
-            assertFalse(records.isEmpty());
             for (ConsumerRecord<Integer, String> record : records) {
                 assertEquals(record.value(), baseMsg + messageCount.getAndIncrement());
             }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
@@ -558,8 +558,6 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
         producer.flush();
 
         readAndCheckMessages(consumer, baseMsg, messageCount, isolation.equals("read_committed") ? 2 : 4);
-        ConsumerRecords<Integer, String> records = consumer.poll(Duration.ofSeconds(3));
-        assertTrue(records.isEmpty());
 
         consumer.close();
         producer.close();
@@ -576,7 +574,10 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
                 assertEquals(record.value(), baseMsg + messageCount.getAndIncrement());
             }
         }
-        // make sure only receive two stable messages
+        // make sure there is no message can be received
+        ConsumerRecords<Integer, String> records = consumer.poll(Duration.ofSeconds(3));
+        assertTrue(records.isEmpty());
+        // make sure only receive the expected number of stable messages
         assertEquals(messageCount.get(), expectedMessageCount);
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/TransactionTest.java
@@ -530,7 +530,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
     }
 
     @Test(dataProvider = "isolationProvider", timeOut = 1000 * 30)
-    public void readUnStableMessagesTest(String isolation) throws InterruptedException, ExecutionException {
+    public void readUnstableMessagesTest(String isolation) throws InterruptedException, ExecutionException {
         String topic = "unstable-message-test-" + RandomStringUtils.randomAlphabetic(5);
 
         KafkaConsumer<Integer, String> consumer = buildTransactionConsumer("unstable-read", isolation);


### PR DESCRIPTION
### Motivation

Currently, the consumer can read unstable messages in `read_committed` mode.

### Modifications

1. If the fetch offset is equal to or greater than LSO(last stable offset), skip reading entries to avoid useless reading.
2. If the entires' offset is equal to or greater than LSO, discard them to avoid sending them to the consumer.

### Verifying this change

Add a new unit to verify consumers can't receive unstable messages.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

