### PR TITLE
[bugfix][transactions] Make TxnTransitMetadata.topicPartitions immutable

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -30,7 +30,6 @@ import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionSt
 import io.streamnative.pulsar.handlers.kop.scala.Either;
 import io.streamnative.pulsar.handlers.kop.utils.MetadataUtils;
 import io.streamnative.pulsar.handlers.kop.utils.ProducerIdAndEpoch;
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -20,6 +20,7 @@ import static io.streamnative.pulsar.handlers.kop.coordinator.transaction.Transa
 import static org.apache.pulsar.common.naming.TopicName.PARTITIONED_TOPIC_SUFFIX;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import io.streamnative.pulsar.handlers.kop.KopBrokerLookupManager;
@@ -502,7 +503,7 @@ public class TransactionCoordinator {
             } else {
                 return Either.right(new EpochAndTxnTransitMetadata(
                         coordinatorEpoch, txnMetadata.prepareAddPartitions(
-                        new HashSet<>(partitionList), time.milliseconds())));
+                        ImmutableSet.copyOf(partitionList), time.milliseconds())));
             }
         });
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMetadata.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMetadata.java
@@ -18,7 +18,6 @@ import com.google.common.collect.Sets;
 import io.streamnative.pulsar.handlers.kop.scala.Either;
 import io.streamnative.pulsar.handlers.kop.utils.CoreUtils;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -433,13 +432,12 @@ public class TransactionMetadata {
             default:
                 newTxnStartTimestamp = txnStartTimestamp;
         }
-        Set<TopicPartition> newPartitionSet = new HashSet<>();
-        if (topicPartitions != null) {
-            newPartitionSet.addAll(topicPartitions);
-        }
-        newPartitionSet.addAll(addedTopicPartitions);
+        ImmutableSet<TopicPartition> partitions = ImmutableSet.<TopicPartition>builder()
+                .addAll((topicPartitions != null) ? topicPartitions : ImmutableSet.of())
+                .addAll(addedTopicPartitions)
+                .build();
         return prepareTransitionTo(TransactionState.ONGOING, producerId, producerEpoch, lastProducerEpoch,
-                txnTimeoutMs, ImmutableSet.copyOf(newPartitionSet), newTxnStartTimestamp, updateTimestamp);
+                txnTimeoutMs, partitions, newTxnStartTimestamp, updateTimestamp);
     }
 
     public TxnTransitMetadata prepareAbortOrCommit(TransactionState newState, Long updateTimestamp) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMetadata.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMetadata.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import io.streamnative.pulsar.handlers.kop.scala.Either;
 import io.streamnative.pulsar.handlers.kop.utils.CoreUtils;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -422,7 +421,8 @@ public class TransactionMetadata {
         return flag;
     }
 
-    public TxnTransitMetadata prepareAddPartitions(ImmutableSet<TopicPartition> addedTopicPartitions, Long updateTimestamp) {
+    public TxnTransitMetadata prepareAddPartitions(ImmutableSet<TopicPartition> addedTopicPartitions,
+                                                   Long updateTimestamp) {
         long newTxnStartTimestamp;
         switch(state) {
             case EMPTY:

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinatorTest.java
@@ -28,6 +28,7 @@ import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import io.streamnative.pulsar.handlers.kop.KafkaProtocolHandler;
 import io.streamnative.pulsar.handlers.kop.KopProtocolHandlerTestBase;
@@ -840,7 +841,7 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
                 .lastProducerEpoch(RecordBatch.NO_PRODUCER_EPOCH)
                 .txnTimeoutMs(txnTimeoutMs)
                 .txnState(transactionState)
-                .topicPartitions(partitions)
+                .topicPartitions(ImmutableSet.copyOf(partitions))
                 .txnStartTimestamp(now)
                 .txnLastUpdateTimestamp(now)
                 .build();
@@ -1327,7 +1328,7 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
                                 RecordBatch.NO_PRODUCER_EPOCH,
                                 txnTimeoutMs,
                                 TransactionState.PREPARE_ABORT,
-                                partitions,
+                                ImmutableSet.copyOf(partitions),
                                 time.milliseconds(),
                                 time.milliseconds()
                         )),
@@ -1658,7 +1659,7 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
                         (short) -1,
                         txnTimeoutMs,
                         TransactionState.PREPARE_ABORT,
-                        partitions,
+                        ImmutableSet.copyOf(partitions),
                         now,
                         now + DefaultAbortTimedOutTransactionsIntervalMs);
         time.sleep(DefaultAbortTimedOutTransactionsIntervalMs);
@@ -1818,7 +1819,7 @@ public class TransactionCoordinatorTest extends KopProtocolHandlerTestBase {
                 .lastProducerEpoch(RecordBatch.NO_PRODUCER_EPOCH)
                 .txnTimeoutMs(txnTimeoutMs)
                 .txnState(TransactionState.PREPARE_ABORT)
-                .topicPartitions(partitions)
+                .topicPartitions(ImmutableSet.copyOf(partitions))
                 .txnStartTimestamp(now)
                 .txnLastUpdateTimestamp(now + TransactionConfig.DefaultAbortTimedOutTransactionsIntervalMs)
                 .build();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManagerTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import io.streamnative.pulsar.handlers.kop.KopBrokerLookupManager;
@@ -110,7 +111,7 @@ public class TransactionMarkerChannelManagerTest {
                 .lastProducerEpoch(RecordBatch.NO_PRODUCER_EPOCH)
                 .txnTimeoutMs(txnTimeoutMs)
                 .txnState(TransactionState.COMPLETE_COMMIT)
-                .topicPartitions(partitions)
+                .topicPartitions(ImmutableSet.copyOf(partitions))
                 .txnStartTimestamp(time.milliseconds())
                 .txnLastUpdateTimestamp(time.milliseconds())
                 .build();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManagerTest.java
@@ -21,6 +21,7 @@ import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.AssertJUnit.assertTrue;
 import static org.testng.AssertJUnit.fail;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import io.streamnative.pulsar.handlers.kop.KopProtocolHandlerTestBase;
 import io.streamnative.pulsar.handlers.kop.SystemTopicClient;
@@ -219,7 +220,7 @@ public class TransactionStateManagerTest extends KopProtocolHandlerTestBase {
                         (short) 0,
                         0,
                         TransactionState.COMPLETE_COMMIT,
-                        Collections.emptySet(),
+                        ImmutableSet.of(),
                         now,
                         now);
 
@@ -233,7 +234,7 @@ public class TransactionStateManagerTest extends KopProtocolHandlerTestBase {
                         (short) 0,
                         0,
                         TransactionState.COMPLETE_COMMIT,
-                        Collections.emptySet(),
+                        ImmutableSet.of(),
                         now + txnConfig.getTransactionalIdExpirationMs(),
                         now + txnConfig.getTransactionalIdExpirationMs());
 


### PR DESCRIPTION
### Motivation

https://github.com/apache/kafka/blob/trunk/core/src/main/scala/kafka/coordinator/transaction/TransactionMetadata.scala#L190

The `TxnTransitMetadata.topicPartitions` should be immutable, otherwise it will cause race conditions.

### Modifications

Make TxnTransitMetadata.topicPartitions immutable

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

