### PR TITLE
[feat][transaction] Support cleanup aborted txns index data (Part-1)

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -446,6 +446,12 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
             DefaultRemoveExpiredTransactionalIdsIntervalMs;
 
     @FieldContext(
+            category = CATEGORY_KOP_TRANSACTION,
+            doc = "Interval for purging aborted transactions from memory (requires reads from storage)"
+    )
+    private int kafkaTxnPurgeAbortedTxnIntervalSeconds = 60 * 60 * 24;
+
+    @FieldContext(
             category = CATEGORY_KOP,
             doc = "The fully qualified name of a SASL server callback handler class that implements the "
                     + "AuthenticateCallbackHandler interface, which is used for OAuth2 authentication. "

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicLookupService.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicLookupService.java
@@ -37,7 +37,7 @@ public class KafkaTopicLookupService {
      }
 
     // A wrapper of `BrokerService#getTopic` that is to find the topic's associated `PersistentTopic` instance
-    public CompletableFuture<Optional<PersistentTopic>> getTopic(String topicName, Channel channel) {
+    public CompletableFuture<Optional<PersistentTopic>> getTopic(String topicName, Object requestor) {
         CompletableFuture<Optional<PersistentTopic>> topicCompletableFuture = new CompletableFuture<>();
         brokerService.getTopicIfExists(topicName).whenComplete((t2, throwable) -> {
             TopicName topicNameObject = TopicName.get(topicName);
@@ -47,7 +47,7 @@ public class KafkaTopicLookupService {
                 if (topicNameObject.getPartitionIndex() == 0) {
                     log.warn("Get partition-0 error [{}].", throwable.getMessage());
                 } else {
-                    handleGetTopicException(topicName, topicCompletableFuture, throwable, channel);
+                    handleGetTopicException(topicName, topicCompletableFuture, throwable, requestor);
                     return;
                 }
             }
@@ -60,11 +60,11 @@ public class KafkaTopicLookupService {
                 String nonPartitionedTopicName = topicNameObject.getPartitionedTopicName();
                 if (log.isDebugEnabled()) {
                     log.debug("[{}]Try to get non-partitioned topic for name {}",
-                            channel, nonPartitionedTopicName);
+                            requestor, nonPartitionedTopicName);
                 }
                 brokerService.getTopicIfExists(nonPartitionedTopicName).whenComplete((nonPartitionedTopic, ex) -> {
                     if (ex != null) {
-                        handleGetTopicException(nonPartitionedTopicName, topicCompletableFuture, ex, channel);
+                        handleGetTopicException(nonPartitionedTopicName, topicCompletableFuture, ex, requestor);
                         // Failed to getTopic from current broker, remove non-partitioned topic cache,
                         // which added in getTopicBroker.
                         KopBrokerLookupManager.removeTopicManagerCache(nonPartitionedTopicName);
@@ -75,14 +75,14 @@ public class KafkaTopicLookupService {
                         topicCompletableFuture.complete(Optional.of(persistentTopic));
                     } else {
                         log.error("[{}]Get empty non-partitioned topic for name {}",
-                                channel, nonPartitionedTopicName);
+                                requestor, nonPartitionedTopicName);
                         KopBrokerLookupManager.removeTopicManagerCache(nonPartitionedTopicName);
                         topicCompletableFuture.complete(Optional.empty());
                     }
                 });
                 return;
             }
-            log.error("[{}]Get empty topic for name {}", channel, topicName);
+            log.error("[{}]Get empty topic for name {}", requestor, topicName);
             KopBrokerLookupManager.removeTopicManagerCache(topicName);
             topicCompletableFuture.complete(Optional.empty());
         });
@@ -93,15 +93,15 @@ public class KafkaTopicLookupService {
                                          @NonNull
                                          final CompletableFuture<Optional<PersistentTopic>> topicCompletableFuture,
                                          @NonNull final Throwable ex,
-                                         @NonNull final Channel channel) {
+                                         @NonNull final Object requestor) {
         // The ServiceUnitNotReadyException is retryable, so we should print a warning log instead of error log
         if (ex instanceof BrokerServiceException.ServiceUnitNotReadyException) {
             log.warn("[{}] Failed to getTopic {}: {}",
-                    channel, topicName, ex.getMessage());
+                    requestor, topicName, ex.getMessage());
             topicCompletableFuture.complete(Optional.empty());
         } else {
             log.error("[{}] Failed to getTopic {}. exception:",
-                    channel, topicName, ex);
+                    requestor, topicName, ex);
             topicCompletableFuture.completeExceptionally(ex);
         }
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicLookupService.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicLookupService.java
@@ -13,7 +13,6 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
-import io.netty.channel.Channel;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import lombok.NonNull;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -50,7 +50,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.Getter;
 import lombok.ToString;
 import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
@@ -18,12 +18,10 @@ import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import io.streamnative.pulsar.handlers.kop.KafkaTopicLookupService;
 import io.streamnative.pulsar.handlers.kop.RequestStats;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.TopicPartition;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManager.java
@@ -104,6 +104,8 @@ public class ProducerStateManager {
     private final TreeMap<Long, TxnMetadata> ongoingTxns = Maps.newTreeMap();
     private final List<AbortedTxn> abortedIndexList = new ArrayList<>();
 
+    private volatile long abortedTxnsPurgeOffset = -1;
+
     public ProducerStateManager(String topicPartition) {
         this.topicPartition = topicPartition;
     }
@@ -198,6 +200,20 @@ public class ProducerStateManager {
             }
         }
         return abortedTransactions;
+    }
+
+    public boolean hasSomeAbortedTransactions() {
+        return !abortedIndexList.isEmpty();
+    }
+
+    void updateAbortedTxnsPurgeOffset(long abortedTxnsPurgeOffset) {
+        if (log.isDebugEnabled()) {
+            log.debug("{} updateAbortedTxnsPurgeOffset offset={}", topicPartition, abortedTxnsPurgeOffset);
+        }
+        if (abortedTxnsPurgeOffset < 0) {
+            return;
+        }
+        this.abortedTxnsPurgeOffset = abortedTxnsPurgeOffset;
     }
 
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
@@ -17,6 +17,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.streamnative.pulsar.handlers.kop.DelayedFetch;
 import io.streamnative.pulsar.handlers.kop.DelayedProduceAndFetch;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
+import io.streamnative.pulsar.handlers.kop.KafkaTopicLookupService;
 import io.streamnative.pulsar.handlers.kop.MessageFetchContext;
 import io.streamnative.pulsar.handlers.kop.RequestStats;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
@@ -61,8 +62,10 @@ public class ReplicaManager {
                           Time time,
                           List<EntryFilter> entryFilters,
                           DelayedOperationPurgatory<DelayedOperation> producePurgatory,
-                          DelayedOperationPurgatory<DelayedOperation> fetchPurgatory) {
-        this.logManager = new PartitionLogManager(kafkaConfig, requestStats, entryFilters, time);
+                          DelayedOperationPurgatory<DelayedOperation> fetchPurgatory,
+                          KafkaTopicLookupService kafkaTopicLookupService) {
+        this.logManager = new PartitionLogManager(
+                kafkaConfig, requestStats, entryFilters, time, kafkaTopicLookupService);
         this.producePurgatory = producePurgatory;
         this.fetchPurgatory = fetchPurgatory;
         this.metadataNamespace = kafkaConfig.getKafkaMetadataNamespace();
@@ -268,6 +271,10 @@ public class ReplicaManager {
         if (log.isDebugEnabled()) {
             log.debug("Request key {} unblocked {} fetch requests.", key.keyLabel(), completed);
         }
+    }
+
+    public CompletableFuture<?> updatePurgeAbortedTxnsOffsets() {
+        return logManager.updatePurgeAbortedTxnsOffsets();
     }
 
 }

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EncodePerformanceTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EncodePerformanceTest.java
@@ -13,7 +13,10 @@
  */
 package io.streamnative.pulsar.handlers.kop.format;
 
+import static org.mockito.Mockito.mock;
+
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
+import io.streamnative.pulsar.handlers.kop.KafkaTopicLookupService;
 import io.streamnative.pulsar.handlers.kop.storage.PartitionLog;
 import io.streamnative.pulsar.handlers.kop.storage.ProducerStateManager;
 import java.nio.ByteBuffer;
@@ -48,7 +51,8 @@ public class EncodePerformanceTest {
             new TopicPartition("test", 1),
             "test",
             null,
-            new ProducerStateManager("test"));
+            new ProducerStateManager("test"),
+            mock(KafkaTopicLookupService.class));
 
     public static void main(String[] args) {
         pulsarServiceConfiguration.setEntryFormat("pulsar");

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterTest.java
@@ -19,6 +19,7 @@ import static org.apache.kafka.common.record.Records.LOG_OVERHEAD;
 import static org.mockito.Mockito.mock;
 
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
+import io.streamnative.pulsar.handlers.kop.KafkaTopicLookupService;
 import io.streamnative.pulsar.handlers.kop.storage.PartitionLog;
 import io.streamnative.pulsar.handlers.kop.storage.ProducerStateManager;
 import java.io.DataOutputStream;
@@ -79,7 +80,8 @@ public class EntryFormatterTest {
             new TopicPartition("test", 1),
             "test",
             null,
-            new ProducerStateManager("test"));
+            new ProducerStateManager("test"),
+            mock(KafkaTopicLookupService.class));
 
     private void init() {
         pulsarServiceConfiguration.setEntryFormat("pulsar");

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogTest.java
@@ -13,7 +13,10 @@
  */
 package io.streamnative.pulsar.handlers.kop.storage;
 
+import static org.mockito.Mockito.mock;
+
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
+import io.streamnative.pulsar.handlers.kop.KafkaTopicLookupService;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
@@ -46,7 +49,8 @@ public class PartitionLogTest {
             new TopicPartition("test", 1),
             "test",
             null,
-            new ProducerStateManager("test"));
+            new ProducerStateManager("test"),
+            mock(KafkaTopicLookupService.class));
 
     @DataProvider(name = "compressionTypes")
     Object[] allCompressionTypes() {


### PR DESCRIPTION
This is a migration for commit https://github.com/datastax/starlight-for-kafka/commit/2b3ed4170af8233ae00804eb8adbed3e831862ea, but they are not exactly the same, because there are some new changes after this commit.

### Motivation

This is a part of cleaning up useless aborted transaction data in memory, supporting the timed fetching of the oldest offset of the topic, aborted transactions which last offset less than the oldest offset will be removed.

### Modifications

1. Add a new configuration `kafkaTxnPurgeAbortedTxnIntervalSeconds` to control how often to fetch the oldest offset of the topic.
2. Start a timer task to fetch the oldest offset of the topic while starting the protocol handler.

### Verifying this change

No test yet, I'll add tests for cleaning up aborted txns after all codes are merged.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

