### PR TITLE
[feat][transaction] Support cleanup aborted txns index data (Part-2)

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -446,6 +446,12 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
             DefaultRemoveExpiredTransactionalIdsIntervalMs;
 
     @FieldContext(
+            category = CATEGORY_KOP_TRANSACTION,
+            doc = "Interval for purging aborted transactions from memory (requires reads from storage)"
+    )
+    private int kafkaTxnPurgeAbortedTxnIntervalSeconds = 60 * 60 * 24;
+
+    @FieldContext(
             category = CATEGORY_KOP,
             doc = "The fully qualified name of a SASL server callback handler class that implements the "
                     + "AuthenticateCallbackHandler interface, which is used for OAuth2 authentication. "

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -888,6 +888,8 @@ public class PartitionLog {
             producerStateManager.update(producerAppendInfo);
         });
         analyzeResult.completedTxns().forEach(completedTxn -> {
+            // update to real last offset
+            completedTxn.lastOffset(lastOffset - 1);
             long lastStableOffset = producerStateManager.lastStableOffset(completedTxn);
             producerStateManager.updateTxnIndex(completedTxn, lastStableOffset);
             producerStateManager.completeTxn(completedTxn);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
@@ -52,7 +52,7 @@ public class PartitionLogManager {
 
         return logMap.computeIfAbsent(kopTopic, key -> {
                 return new PartitionLog(kafkaConfig, requestStats, time, topicPartition, kopTopic, entryFilters,
-                        new ProducerStateManager(kopTopic));
+                        new ProducerStateManager(kopTopic, kafkaConfig.getKafkaTxnPurgeAbortedTxnIntervalSeconds()));
         });
     }
 

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EncodePerformanceTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EncodePerformanceTest.java
@@ -48,7 +48,8 @@ public class EncodePerformanceTest {
             new TopicPartition("test", 1),
             "test",
             null,
-            new ProducerStateManager("test"));
+            new ProducerStateManager("test",
+                    kafkaMixedServiceConfiguration.getKafkaTxnPurgeAbortedTxnIntervalSeconds()));
 
     public static void main(String[] args) {
         pulsarServiceConfiguration.setEntryFormat("pulsar");

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterTest.java
@@ -79,7 +79,8 @@ public class EntryFormatterTest {
             new TopicPartition("test", 1),
             "test",
             null,
-            new ProducerStateManager("test"));
+            new ProducerStateManager("test",
+                    kafkaMixedServiceConfiguration.getKafkaTxnPurgeAbortedTxnIntervalSeconds()));
 
     private void init() {
         pulsarServiceConfiguration.setEntryFormat("pulsar");

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogTest.java
@@ -46,7 +46,7 @@ public class PartitionLogTest {
             new TopicPartition("test", 1),
             "test",
             null,
-            new ProducerStateManager("test"));
+            new ProducerStateManager("test", kafkaConfig.getKafkaTxnPurgeAbortedTxnIntervalSeconds()));
 
     @DataProvider(name = "compressionTypes")
     Object[] allCompressionTypes() {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManagerTest.java
@@ -59,7 +59,7 @@ public class ProducerStateManagerTest extends KopProtocolHandlerTestBase {
 
     @BeforeMethod
     protected void setUp() {
-        stateManager = new ProducerStateManager(partition.toString());
+        stateManager = new ProducerStateManager(partition.toString(), conf.getKafkaTxnPurgeAbortedTxnIntervalSeconds());
     }
 
     @AfterMethod
@@ -208,7 +208,7 @@ public class ProducerStateManagerTest extends KopProtocolHandlerTestBase {
     @Test(timeOut = defaultTestTimeout)
     public void testSequenceNotValidatedForGroupMetadataTopic() {
         TopicPartition partition = new TopicPartition(Topic.GROUP_METADATA_TOPIC_NAME, 0);
-        stateManager = new ProducerStateManager(partition.toString());
+        stateManager = new ProducerStateManager(partition.toString(), conf.getKafkaTxnPurgeAbortedTxnIntervalSeconds());
         short epoch = 0;
         append(stateManager, producerId, epoch, 99L, time.milliseconds(),
                 true, PartitionLog.AppendOrigin.Coordinator);


### PR DESCRIPTION
This is a migration for commit https://github.com/datastax/starlight-for-kafka/commit/2b3ed4170af8233ae00804eb8adbed3e831862ea, but they are not exactly the same, because there are some new changes after this commit.

### Motivation

This is a part of cleaning up useless aborted transaction data in memory, supporting removing aborted transaction index data which last offset less than the oldest offset of the topic.

### Modifications

Remove aborted transaction index data while publishing messages.

### Verifying this change

No test yet, I'll add tests for cleaning up aborted txns after all codes are merged.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

