### PR TITLE
[improvement] hide scary InterruptedException in KopEventManager during broker shutdown

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KopEventManager.java
@@ -141,12 +141,12 @@ public class KopEventManager {
                 registerEventQueuedLatency(eventWrapper);
 
                 if (eventWrapper.kopEvent instanceof ShutdownEventThread) {
-                    log.info("Shutting down KopEventThread.");
+                    log.debug("Shutting down KopEventThread.");
                 } else {
                     eventWrapper.kopEvent.process(registerEventLatency, MathUtils.nowInNano());
                 }
             } catch (InterruptedException e) {
-                log.error("Error processing event {}", eventWrapper, e);
+                log.debug("Error processing event {}", eventWrapper, e);
             }
         }
 


### PR DESCRIPTION
### Motivation

The following error log is useless, we can change it to debug level.
```
2023-05-31T04:10:01,281+0000 [kop-event-thread] ERROR io.streamnative.pulsar.handlers.kop.KopEventManager - Error processing event null
java.lang.InterruptedException: null
	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1638) ~[?:?]
	at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435) ~[?:?]
	at io.streamnative.pulsar.handlers.kop.KopEventManager$KopEventThread.doWork(KopEventManager.java:140) ~[ewqichUs9Q6h6lSbSYgTKg/:?]
	at io.streamnative.pulsar.handlers.kop.utils.ShutdownableThread.run(ShutdownableThread.java:108) ~[ewqichUs9Q6h6lSbSYgTKg/:?]
```


### Modifications

* Hide scary `InterruptedException` in KopEventManager during broker shutdown

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

