### PR TITLE
[improve] Get size from byteBuf earlier to prevent unnecessary retention

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -853,11 +853,12 @@ public class PartitionLog {
 
         final int numMessages = encodeResult.getNumMessages();
         final ByteBuf byteBuf = encodeResult.getEncodedByteBuf();
+        final int byteBufSize = byteBuf.readableBytes();
         final long beforePublish = time.nanoseconds();
 
         publishMessage(persistentTopic, byteBuf, appendInfo)
                 .whenComplete((offset, e) -> {
-            appendRecordsContext.getCompleteSendOperationForThrottling().accept(byteBuf.readableBytes());
+            appendRecordsContext.getCompleteSendOperationForThrottling().accept(byteBufSize);
 
             if (e == null) {
                 requestStats.getMessagePublishStats().registerSuccessfulEvent(


### PR DESCRIPTION
### Motivation

Get size from byteBuf earlier to prevent unnecessary retention


### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

