### PR TITLE
[refactor] Decoupling the offset topic I/O from GroupMetadataManager

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SystemTopicClient.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/SystemTopicClient.java
@@ -14,6 +14,7 @@
 package io.streamnative.pulsar.handlers.kop;
 
 import java.nio.ByteBuffer;
+import lombok.Getter;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.ProducerBuilder;
@@ -25,6 +26,7 @@ import org.apache.pulsar.client.api.Schema;
  */
 public class SystemTopicClient extends AbstractPulsarClient {
 
+    @Getter
     private final int maxPendingMessages;
 
     public SystemTopicClient(final PulsarService pulsarService, final KafkaServiceConfiguration kafkaConfig) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/CompactedPartitionedTopic.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/CompactedPartitionedTopic.java
@@ -228,5 +228,13 @@ public class CompactedPartitionedTopic<T> implements Closeable {
         return topic + TopicName.PARTITIONED_TOPIC_SUFFIX + partition;
     }
 
-    public record ReadResult(long timeMs, long numMessages) {}
+    public record ReadResult(long timeMs, long numMessages) {
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof ReadResult that)) {
+                return false;
+            }
+            return this.timeMs == that.timeMs && this.numMessages == that.numMessages;
+        }
+    }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/CompactedPartitionedTopic.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/CompactedPartitionedTopic.java
@@ -1,0 +1,232 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.coordinator;
+
+import com.google.common.collect.Sets;
+import io.streamnative.pulsar.handlers.kop.utils.CoreUtils;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerBuilder;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Reader;
+import org.apache.pulsar.client.api.ReaderBuilder;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.naming.TopicName;
+
+/**
+ * The abstraction to read or write a compacted partitioned topic.
+ */
+@Slf4j
+public class CompactedPartitionedTopic<T> implements Closeable {
+
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+    private final Map<Integer, Future<Producer<T>>> producers = new ConcurrentHashMap<>();
+    private final Map<Integer, Future<Reader<T>>> readers = new ConcurrentHashMap<>();
+    private final ProducerBuilder<T> producerBuilder;
+    private final ReaderBuilder<T> readerBuilder;
+    private final String topic;
+    private final Executor executor;
+    // Before this class is introduced, KoP writes an "empty" value to indicate it's the end of the topic, then read
+    // until the message's position. The extra write is unnecessary. To be compatible with the older versions of KoP,
+    // we need to recognize if the message is "empty" and then skip it.
+    private final Function<T, Boolean> valueIsEmpty;
+
+    // Use a separated executor for the creation of producers and readers to avoid deadlock
+    private final ExecutorService createAsyncExecutor;
+
+    public CompactedPartitionedTopic(final PulsarClient client,
+                                     final Schema<T> schema,
+                                     final int maxPendingMessages,
+                                     final String topic,
+                                     final Executor executor,
+                                     final Function<T, Boolean> valueIsEmpty) {
+        this.producerBuilder = client.newProducer(schema)
+                .maxPendingMessages(maxPendingMessages)
+                .blockIfQueueFull(true);
+        this.readerBuilder = client.newReader(schema)
+                .startMessageId(MessageId.earliest)
+                .readCompacted(true);
+        this.topic = topic;
+        this.executor = executor;
+        this.valueIsEmpty = valueIsEmpty;
+        this.createAsyncExecutor = Executors.newSingleThreadExecutor();
+    }
+
+    /**
+     * Send the message asynchronously.
+     */
+    public CompletableFuture<MessageId> sendAsync(int partition, byte[] key, T value, long timestamp) {
+        final Producer<T> producer;
+        try {
+            producer = getProducer(partition);
+        } catch (IOException e) {
+            return CompletableFuture.failedFuture(e.getCause());
+        }
+
+        final var future = new CompletableFuture<MessageId>();
+        producer.newMessage().keyBytes(key).value(value).eventTime(timestamp).sendAsync().whenComplete((msgId, e) -> {
+            if (e == null) {
+                future.complete(msgId);
+            } else {
+                if (e instanceof PulsarClientException.AlreadyClosedException) {
+                    // The producer is already closed, we don't need to close it again.
+                    producers.remove(partition);
+                }
+                future.completeExceptionally(e);
+            }
+        });
+        return future;
+    }
+
+    /**
+     * Read to the latest message of the partition.
+     *
+     * @param partition the partition of `topic` to read
+     * @param messageConsumer the message callback that is guaranteed to be called in the same thread
+     * @return the future of the read result
+     */
+    public CompletableFuture<ReadResult> readToLatest(int partition, Consumer<Message<T>> messageConsumer) {
+        final CompletableFuture<ReadResult> future = new CompletableFuture<>();
+        executor.execute(() -> {
+            try {
+                final Reader<T> reader = getReader(partition);
+                readToLatest(reader, partition, messageConsumer, future, System.currentTimeMillis(), 0);
+            } catch (IOException e) {
+                future.completeExceptionally(e.getCause());
+            }
+        });
+        return future;
+    }
+
+    private void readToLatest(Reader<T> reader, int partition, Consumer<Message<T>> messageConsumer,
+                              CompletableFuture<ReadResult> future, long startTimeMs, long numMessages) {
+        if (closed.get()) {
+            future.complete(new ReadResult(System.currentTimeMillis() - startTimeMs, numMessages));
+            return;
+        }
+        reader.hasMessageAvailableAsync().thenComposeAsync(available -> {
+            if (available && !closed.get()) {
+                return reader.readNextAsync();
+            } else {
+                return CompletableFuture.completedFuture(null);
+            }
+        }, executor).thenAcceptAsync(msg -> {
+            if (msg == null) {
+                future.complete(new ReadResult(System.currentTimeMillis() - startTimeMs, numMessages));
+                return;
+            }
+            long numMessagesProcessed = numMessages;
+            if (!valueIsEmpty.apply(msg.getValue())) {
+                numMessagesProcessed++;
+                messageConsumer.accept(msg);
+            }
+            readToLatest(reader, partition, messageConsumer, future, startTimeMs, numMessagesProcessed);
+        }, executor).exceptionallyAsync(e -> {
+            while (e.getCause() != null) {
+                e = e.getCause();
+            }
+            if (e instanceof PulsarClientException.AlreadyClosedException) {
+                // The producer is already closed, we don't need to close it again.
+                removeAndClose("reader", readers, partition, producer -> CompletableFuture.completedFuture(null));
+                log.warn("Failed to read {}-{} to latest since the reader is closed", topic, partition);
+                future.complete(new ReadResult(System.currentTimeMillis() - startTimeMs, numMessages));
+            } else {
+                removeAndClose("reader", readers, partition, Reader::closeAsync);
+                log.error("Failed to read {}-{} to latest", topic, partition, e);
+                future.completeExceptionally(e);
+            }
+            return null;
+        }, executor);
+    }
+
+    /**
+     * Remove the cached producer and reader of the target partition.
+     */
+    public CompletableFuture<Void> remove(int partition) {
+        return CompletableFuture.allOf(
+                removeAndClose("producer", producers, partition, Producer::closeAsync),
+                removeAndClose("readers", readers, partition, Reader::closeAsync)
+        );
+    }
+
+    @Override
+    public void close() {
+        try {
+            CoreUtils.waitForAll(
+                    Sets.union(producers.keySet(), readers.keySet()).stream().map(this::remove).toList()
+            ).get(3, TimeUnit.SECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            log.warn("Failed to close CompactedPartitionedTopic ({}) in 3 seconds", topic);
+        }
+        createAsyncExecutor.shutdown();
+    }
+
+    private static <T> CompletableFuture<Void> removeAndClose(String name, Map<Integer, Future<T>> cache, int index,
+                                                              Function<T, CompletableFuture<Void>> closeFunc) {
+        final var elem = cache.remove(index);
+        if (elem == null) {
+            return CompletableFuture.completedFuture(null);
+        }
+        try {
+            return closeFunc.apply(elem.get(1, TimeUnit.SECONDS));
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            log.warn("Failed to create {}: {}", name, e.getCause());
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    private Producer<T> getProducer(int partition) throws IOException {
+        try {
+            return producers.computeIfAbsent(partition, __ ->
+                createAsyncExecutor.submit(() -> producerBuilder.clone().topic(getPartition(partition)).create())
+            ).get();
+        } catch (Throwable e) {
+            throw new IOException(e);
+        }
+    }
+
+    private Reader<T> getReader(int partition) throws IOException {
+        try {
+            return readers.computeIfAbsent(partition, __ ->
+                    createAsyncExecutor.submit(() -> readerBuilder.clone().topic(getPartition(partition)).create())
+            ).get();
+        } catch (Throwable e) {
+            throw new IOException(e);
+        }
+    }
+
+    private String getPartition(int partition) {
+        return topic + TopicName.PARTITIONED_TOPIC_SUFFIX + partition;
+    }
+
+    public record ReadResult(long timeMs, long numMessages) {}
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinator.java
@@ -34,7 +34,6 @@ import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperationKey.Gro
 import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperationKey.MemberKey;
 import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperationPurgatory;
 import io.streamnative.pulsar.handlers.kop.utils.timer.Timer;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -45,7 +44,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
@@ -61,8 +59,6 @@ import org.apache.kafka.common.requests.JoinGroupRequest;
 import org.apache.kafka.common.requests.OffsetFetchResponse.PartitionData;
 import org.apache.kafka.common.requests.TransactionResult;
 import org.apache.kafka.common.utils.Time;
-import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.util.FutureUtil;
 
@@ -88,8 +84,7 @@ public class GroupCoordinator {
 
         GroupMetadataManager metadataManager = new GroupMetadataManager(
             offsetConfig,
-            client.newProducerBuilder(),
-            client.newReaderBuilder(),
+            client,
             coordinatorExecutor,
             namespacePrefixForMetadata,
             time
@@ -184,14 +179,6 @@ public class GroupCoordinator {
 
     public String getTopicPartitionName(int partition) {
         return groupManager.getTopicPartitionName(partition);
-    }
-
-    public ConcurrentMap<Integer, CompletableFuture<Producer<ByteBuffer>>> getOffsetsProducers() {
-        return groupManager.getOffsetsProducers();
-    }
-
-    public ConcurrentMap<Integer, CompletableFuture<Reader<ByteBuffer>>> getOffsetsReaders() {
-        return groupManager.getOffsetsReaders();
     }
 
     public GroupMetadataManager getGroupManager() {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataConstants.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataConstants.java
@@ -25,6 +25,7 @@ import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupMetadataManage
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupMetadataManager.GroupMetadataKey;
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupMetadataManager.GroupTopicPartition;
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupMetadataManager.OffsetKey;
+import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupMetadataManager.UnknownKey;
 import io.streamnative.pulsar.handlers.kop.exceptions.KoPTopicException;
 import io.streamnative.pulsar.handlers.kop.offset.OffsetAndMetadata;
 import io.streamnative.pulsar.handlers.kop.utils.KopTopic;
@@ -373,11 +374,12 @@ public final class GroupMetadataConstants {
 
             return new GroupMetadataKey(version, group);
         } else {
-            throw new IllegalStateException("Unknown version " + version + " for group metadata message");
+            return new UnknownKey(version);
         }
     }
 
     public static OffsetAndMetadata readOffsetMessageValue(ByteBuffer buffer) {
+        // TODO: should we check empty buffer?
         if (null == buffer) {
             return null;
         }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/package-info.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/package-info.java
@@ -1,0 +1,17 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Classes for both group and transaction coordinators.
+ */
+package io.streamnative.pulsar.handlers.kop.coordinator;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/CoreUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/CoreUtils.java
@@ -95,6 +95,18 @@ public final class CoreUtils {
         return map.entrySet().stream().map(e -> function.apply(e.getKey(), e.getValue())).collect(Collectors.toList());
     }
 
+    public static <K1, K2, K3, V> Map<K2, Map<K3, V>> groupBy(final Map<K1, V> map,
+                                                              final Function<K1, K2> groupFunction,
+                                                              final Function<K1, K3> keyMapper) {
+        return map.entrySet().stream().collect(Collectors.groupingBy(e -> groupFunction.apply(e.getKey()),
+                Collectors.toMap(e -> keyMapper.apply(e.getKey()), Entry::getValue)));
+    }
+
+    public static <K1, K2, V> Map<K2, Map<K1, V>> groupBy(final Map<K1, V> map,
+                                                          final Function<K1, K2> groupFunction) {
+        return groupBy(map, groupFunction, key -> key);
+    }
+
     public static <T> CompletableFuture<Void> waitForAll(final Collection<CompletableFuture<T>> futures) {
         return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/CompactedPartitionedTopicTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/CompactedPartitionedTopicTest.java
@@ -1,0 +1,154 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.coordinator;
+
+import io.streamnative.pulsar.handlers.kop.KopProtocolHandlerTestBase;
+import io.streamnative.pulsar.handlers.kop.utils.CoreUtils;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.client.admin.LongRunningProcessStatus;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.naming.TopicName;
+import org.awaitility.Awaitility;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class CompactedPartitionedTopicTest extends KopProtocolHandlerTestBase {
+
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    @BeforeClass
+    @Override
+    public void setup() throws Exception {
+        super.internalSetup();
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    public void cleanup() throws Exception {
+        executor.shutdown();
+        super.internalCleanup();
+    }
+
+    @Test(timeOut = 30000)
+    public void testCompaction() throws Exception {
+        final var topic = "test-compaction";
+        final var numPartitions = 3;
+        admin.topics().createPartitionedTopic(topic, numPartitions);
+        @Cleanup final var compactedTopic = new CompactedPartitionedTopic<>(pulsarClient, Schema.STRING,
+                1000, topic, executor, String::isEmpty);
+
+        final var numMessages = 100;
+        final var futures = new ArrayList<CompletableFuture<MessageId>>();
+        for (int i = 0; i < numMessages; i++) {
+            for (int j = 0; j < numPartitions; j++) {
+                futures.add(compactedTopic.sendAsync(j, ("A" + j).getBytes(), "msg-" + i, i + 100));
+                futures.add(compactedTopic.sendAsync(j, ("B" + j).getBytes(), "msg-" + i, i + 100));
+            }
+        }
+        CoreUtils.waitForAll(futures).get();
+
+        Callable<Map<String, List<String>>> readKeyValues = () -> {
+            final var keyValues = new ConcurrentHashMap<String, List<String>>();
+            for (int i = 0; i < numPartitions; i++) {
+                final var readResult = compactedTopic.readToLatest(i, msg -> keyValues.computeIfAbsent(
+                        new String(msg.getKeyBytes()), __ -> new CopyOnWriteArrayList<>()
+                ).add(msg.getValue())).get();
+                log.info("Load from partition {}: {}ms and {} messages",
+                        i, readResult.timeMs(), readResult.numMessages());
+            }
+            return keyValues;
+        };
+        var keyValues = readKeyValues.call();
+        Assert.assertEquals(keyValues.keySet().size(), numPartitions * 2);
+        for (int i = 0; i < numPartitions; i++) {
+            final var values = IntStream.range(0, numMessages).mapToObj(__ -> "msg-" + __).toList();
+            Assert.assertEquals(keyValues.get("A" + i), values);
+            Assert.assertEquals(keyValues.get("B" + i), values);
+        }
+
+        for (int i = 0; i < numPartitions; i++) {
+            final var partition = topic + TopicName.PARTITIONED_TOPIC_SUFFIX + i;
+            admin.topics().triggerCompaction(partition);
+            Awaitility.await().atMost(Duration.ofSeconds(3)).until(() ->
+                    admin.topics().compactionStatus(partition).status == LongRunningProcessStatus.Status.SUCCESS);
+        }
+
+        // Clear the cache of the 1st partition
+        compactedTopic.remove(0);
+        keyValues = readKeyValues.call();
+
+        final var singleMessageList = Collections.singletonList("msg-" + (numMessages - 1));
+        Assert.assertEquals(keyValues.keySet(), new HashSet<>(Arrays.asList("A0", "B0")));
+        Assert.assertEquals(keyValues.get("A0"), singleMessageList);
+        Assert.assertEquals(keyValues.get("B0"), singleMessageList);
+    }
+
+    @Test(timeOut = 30000)
+    public void testSkipEmptyMessages() throws Exception {
+        final var topic = "test-skip-empty-messages";
+        admin.topics().createPartitionedTopic(topic, 1);
+        @Cleanup final var compactedTopic = new CompactedPartitionedTopic<>(pulsarClient, Schema.BYTEBUFFER,
+                1000, topic, executor, buffer -> buffer.limit() == 0);
+        @Cleanup final var producer = pulsarClient.newProducer(Schema.BYTEBUFFER)
+                .topic(topic + TopicName.PARTITIONED_TOPIC_SUFFIX + 0).create();
+        final var numMessages = 3 * 100;
+        for (int i = 0; i < numMessages; i++) {
+            producer.send(ByteBuffer.allocate((i % 3 == 0 ? 0 : 1)));
+        }
+
+        final var numMessagesReceived = new AtomicInteger(0);
+        compactedTopic.readToLatest(0, msg -> numMessagesReceived.incrementAndGet()).get();
+        Assert.assertEquals(numMessagesReceived.get(), numMessages - numMessages / 3);
+    }
+
+    @Test(timeOut = 30000)
+    public void testClose() throws Exception {
+        final var topic = "test-close";
+        admin.topics().createPartitionedTopic(topic, 1);
+        final var compactedTopic = new CompactedPartitionedTopic<>(pulsarClient, Schema.STRING,
+                1000, topic, executor, __ -> false);
+        final var numMessages = 100;
+        for (int i = 0; i < numMessages; i++) {
+            compactedTopic.sendAsync(0, "key".getBytes(), "value", 1).get();
+        }
+        final var numMessagesReceived = new AtomicInteger(0);
+        final var future = compactedTopic.readToLatest(0, msg -> numMessagesReceived.incrementAndGet());
+        compactedTopic.close();
+        final var readResult = future.get();
+        log.info("Load {} messages in {}ms", readResult.timeMs(), readResult.numMessages());
+        Assert.assertEquals(readResult.numMessages(), numMessagesReceived.get());
+        Assert.assertTrue(readResult.numMessages() < numMessages);
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupCoordinatorTest.java
@@ -23,13 +23,13 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.streamnative.pulsar.handlers.kop.KopProtocolHandlerTestBase;
+import io.streamnative.pulsar.handlers.kop.SystemTopicClient;
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupMetadata.GroupOverview;
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupMetadata.GroupSummary;
 import io.streamnative.pulsar.handlers.kop.coordinator.group.MemberMetadata.MemberSummary;
 import io.streamnative.pulsar.handlers.kop.offset.OffsetAndMetadata;
 import io.streamnative.pulsar.handlers.kop.utils.delayed.DelayedOperationPurgatory;
 import io.streamnative.pulsar.handlers.kop.utils.timer.MockTimer;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -49,11 +49,7 @@ import org.apache.kafka.common.requests.OffsetCommitRequest;
 import org.apache.kafka.common.requests.OffsetFetchResponse;
 import org.apache.kafka.common.requests.OffsetFetchResponse.PartitionData;
 import org.apache.kafka.common.requests.TransactionResult;
-import org.apache.pulsar.client.api.MessageId;
-import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.PulsarClientException;
-import org.apache.pulsar.client.api.ReaderBuilder;
-import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
@@ -122,20 +118,13 @@ public class GroupCoordinatorTest extends KopProtocolHandlerTestBase {
         OffsetConfig offsetConfig = OffsetConfig.builder().offsetsTopicName(topicName).build();
 
         timer = new MockTimer();
-
-        ProducerBuilder<ByteBuffer> producerBuilder = pulsarClient.newProducer(Schema.BYTEBUFFER);
-
-        ReaderBuilder<ByteBuffer> readerBuilder = pulsarClient.newReader(Schema.BYTEBUFFER)
-                .startMessageId(MessageId.earliest);
-
         groupPartitionId = 0;
         otherGroupPartitionId = 1;
         otherGroupId = "otherGroup";
         offsetConfig.offsetsTopicNumPartitions(2);
         groupMetadataManager = spy(new GroupMetadataManager(
                 offsetConfig,
-                producerBuilder,
-                readerBuilder,
+                new SystemTopicClient(pulsar, conf),
                 scheduler,
                 "public/default",
                 timer.time()

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
@@ -37,6 +37,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.streamnative.pulsar.handlers.kop.KafkaProtocolHandler;
 import io.streamnative.pulsar.handlers.kop.KopProtocolHandlerTestBase;
+import io.streamnative.pulsar.handlers.kop.SystemTopicClient;
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupMetadata.CommitRecordMetadataAndOffset;
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupMetadataManager.BaseKey;
 import io.streamnative.pulsar.handlers.kop.coordinator.group.GroupMetadataManager.GroupMetadataKey;
@@ -81,7 +82,6 @@ import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
-import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.ReaderBuilder;
@@ -114,6 +114,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
     private ReaderBuilder<ByteBuffer> readerBuilder = null;
     private Consumer<ByteBuffer> consumer;
     private OrderedScheduler scheduler;
+    private SystemTopicClient systemTopicClient;
 
     @BeforeClass
     @Override
@@ -154,10 +155,10 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
                 .name("test-scheduler")
                 .numThreads(1)
                 .build();
+        systemTopicClient = new SystemTopicClient(pulsar, conf);
         groupMetadataManager = new GroupMetadataManager(
                 offsetConfig,
-                producerBuilder,
-                readerBuilder,
+                systemTopicClient,
                 scheduler,
                 "public/default",
                 Time.SYSTEM
@@ -367,12 +368,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         ByteBuffer buffer = newMemoryRecordsBuffer(offsetCommitRecords);
         byte[] key = groupMetadataKey(groupId);
 
-        Producer<ByteBuffer> producer = groupMetadataManager.getOffsetsTopicProducer(groupPartitionId).get();
-        producer.newMessage()
-            .keyBytes(key)
-            .value(buffer)
-            .eventTime(Time.SYSTEM.milliseconds())
-            .send();
+        groupMetadataManager.storeOffsetMessage(groupPartitionId, key, buffer);
 
         CompletableFuture<GroupMetadata> onLoadedFuture = new CompletableFuture<>();
         groupMetadataManager.scheduleLoadGroupAndOffsets(
@@ -418,12 +414,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         ByteBuffer buffer = newMemoryRecordsBuffer(offsetCommitRecords);
         byte[] key = groupMetadataKey(groupId);
 
-        Producer<ByteBuffer> producer = groupMetadataManager.getOffsetsTopicProducer(groupPartitionId).get();
-        producer.newMessage()
-            .keyBytes(key)
-            .value(buffer)
-            .eventTime(Time.SYSTEM.milliseconds())
-            .send();
+        groupMetadataManager.storeOffsetMessage(groupPartitionId, key, buffer);
 
         CompletableFuture<GroupMetadata> onLoadedFuture = new CompletableFuture<>();
         groupMetadataManager.scheduleLoadGroupAndOffsets(
@@ -473,12 +464,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         buffer.flip();
 
         byte[] key = groupMetadataKey(groupId);
-        Producer<ByteBuffer> producer = groupMetadataManager.getOffsetsTopicProducer(groupPartitionId).get();
-        producer.newMessage()
-            .keyBytes(key)
-            .value(buffer)
-            .eventTime(Time.SYSTEM.milliseconds())
-            .send();
+        groupMetadataManager.storeOffsetMessage(groupPartitionId, key, buffer);
 
         CompletableFuture<GroupMetadata> onLoadedFuture = new CompletableFuture<>();
         groupMetadataManager.scheduleLoadGroupAndOffsets(
@@ -521,12 +507,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
 
         byte[] key = groupMetadataKey(groupId);
 
-        Producer<ByteBuffer> producer = groupMetadataManager.getOffsetsTopicProducer(groupPartitionId).get();
-        producer.newMessage()
-            .keyBytes(key)
-            .value(buffer)
-            .eventTime(Time.SYSTEM.milliseconds())
-            .send();
+        groupMetadataManager.storeOffsetMessage(groupPartitionId, key, buffer);
 
         groupMetadataManager.scheduleLoadGroupAndOffsets(
             groupPartitionId,
@@ -558,12 +539,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         byte[] key = groupMetadataKey(groupId);
 
 
-        Producer<ByteBuffer> producer = groupMetadataManager.getOffsetsTopicProducer(groupPartitionId).get();
-        producer.newMessage()
-            .keyBytes(key)
-            .value(buffer)
-            .eventTime(Time.SYSTEM.milliseconds())
-            .send();
+        groupMetadataManager.storeOffsetMessage(groupPartitionId, key, buffer);
 
         CompletableFuture<GroupMetadata> onLoadedFuture = new CompletableFuture<>();
         groupMetadataManager.scheduleLoadGroupAndOffsets(
@@ -618,12 +594,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         byte[] key = groupMetadataKey(groupId);
 
 
-        Producer<ByteBuffer> producer = groupMetadataManager.getOffsetsTopicProducer(groupPartitionId).get();
-        producer.newMessage()
-            .keyBytes(key)
-            .value(buffer)
-            .eventTime(Time.SYSTEM.milliseconds())
-            .send();
+        groupMetadataManager.storeOffsetMessage(groupPartitionId, key, buffer);
 
         CompletableFuture<GroupMetadata> onLoadedFuture = new CompletableFuture<>();
         groupMetadataManager.scheduleLoadGroupAndOffsets(
@@ -693,12 +664,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         byte[] key = groupMetadataKey(groupId);
 
 
-        Producer<ByteBuffer> producer = groupMetadataManager.getOffsetsTopicProducer(groupPartitionId).get();
-        producer.newMessage()
-            .keyBytes(key)
-            .value(buffer)
-            .eventTime(Time.SYSTEM.milliseconds())
-            .send();
+        groupMetadataManager.storeOffsetMessage(groupPartitionId, key, buffer);
 
         CompletableFuture<GroupMetadata> onLoadedFuture = new CompletableFuture<>();
         groupMetadataManager.scheduleLoadGroupAndOffsets(
@@ -779,12 +745,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
 
         byte[] key = groupMetadataKey(groupId);
 
-        Producer<ByteBuffer> producer = groupMetadataManager.getOffsetsTopicProducer(groupPartitionId).get();
-        producer.newMessage()
-            .keyBytes(key)
-            .value(buffer)
-            .eventTime(Time.SYSTEM.milliseconds())
-            .send();
+        groupMetadataManager.storeOffsetMessage(groupPartitionId, key, buffer);
 
         CompletableFuture<GroupMetadata> onLoadedFuture = new CompletableFuture<>();
         groupMetadataManager.scheduleLoadGroupAndOffsets(
@@ -820,7 +781,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
 
     }
 
-    @Test
+    @Test(timeOut = 10000)
     public void testGroupLoadWithConsumerAndTransactionalOffsetCommitsTransactionWins() throws Exception {
         long producerId = 1000L;
         short producerEpoch = 2;
@@ -849,12 +810,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
 
         byte[] key = groupMetadataKey(groupId);
 
-        Producer<ByteBuffer> producer = groupMetadataManager.getOffsetsTopicProducer(groupPartitionId).get();
-        producer.newMessage()
-            .keyBytes(key)
-            .value(buffer)
-            .eventTime(Time.SYSTEM.milliseconds())
-            .send();
+        groupMetadataManager.storeOffsetMessage(groupPartitionId, key, buffer);
 
         CompletableFuture<GroupMetadata> onLoadedFuture = new CompletableFuture<>();
         groupMetadataManager.scheduleLoadGroupAndOffsets(
@@ -886,8 +842,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
     public void testGroupNotExits() {
         groupMetadataManager = new GroupMetadataManager(
             offsetConfig,
-            producerBuilder,
-            readerBuilder,
+            systemTopicClient,
             scheduler,
             NAMESPACE_PREFIX,
             new MockTime()
@@ -935,12 +890,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
 
         byte[] key = groupMetadataKey(groupId);
 
-        Producer<ByteBuffer> producer = groupMetadataManager.getOffsetsTopicProducer(groupPartitionId).get();
-        producer.newMessage()
-            .keyBytes(key)
-            .value(buffer)
-            .eventTime(Time.SYSTEM.milliseconds())
-            .send();
+        groupMetadataManager.storeOffsetMessage(groupPartitionId, key, buffer);
 
         CompletableFuture<GroupMetadata> onLoadedFuture = new CompletableFuture<>();
         groupMetadataManager.scheduleLoadGroupAndOffsets(
@@ -998,12 +948,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
 
         byte[] key = groupMetadataKey(groupId);
 
-        Producer<ByteBuffer> producer = groupMetadataManager.getOffsetsTopicProducer(groupPartitionId).get();
-        producer.newMessage()
-            .keyBytes(key)
-            .value(buffer)
-            .eventTime(Time.SYSTEM.milliseconds())
-            .send();
+        groupMetadataManager.storeOffsetMessage(groupPartitionId, key, buffer);
 
         CompletableFuture<GroupMetadata> onLoadedFuture = new CompletableFuture<>();
         groupMetadataManager.scheduleLoadGroupAndOffsets(
@@ -1059,12 +1004,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
 
         byte[] key = groupMetadataKey(groupId);
 
-        Producer<ByteBuffer> producer = groupMetadataManager.getOffsetsTopicProducer(groupPartitionId).get();
-        producer.newMessage()
-            .keyBytes(key)
-            .value(buffer)
-            .eventTime(Time.SYSTEM.milliseconds())
-            .send();
+        groupMetadataManager.storeOffsetMessage(groupPartitionId, key, buffer);
 
         groupMetadataManager.scheduleLoadGroupAndOffsets(
             groupPartitionId,
@@ -1115,12 +1055,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         byte[] key = groupMetadataKey(groupId);
         int consumerGroupPartitionId =
                 GroupMetadataManager.getPartitionId(groupId, conf.getOffsetsTopicNumPartitions());
-        Producer<ByteBuffer> producer = groupMetadataManager.getOffsetsTopicProducer(consumerGroupPartitionId).get();
-        producer.newMessage()
-            .keyBytes(key)
-            .value(buffer)
-            .eventTime(Time.SYSTEM.milliseconds())
-            .send();
+        groupMetadataManager.storeOffsetMessage(groupPartitionId, key, buffer);
         CompletableFuture<GroupMetadata> onLoadedFuture = new CompletableFuture<>();
         groupMetadataManager.scheduleLoadGroupAndOffsets(consumerGroupPartitionId,
             groupMetadata -> onLoadedFuture.complete(groupMetadata)
@@ -1182,19 +1117,8 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
         ByteBuffer segment2Buffer = newMemoryRecordsBuffer(segment2Records);
 
         byte[] key = groupMetadataKey(groupId);
-
-        Producer<ByteBuffer> producer = groupMetadataManager.getOffsetsTopicProducer(groupPartitionId).get();
-        producer.newMessage()
-            .keyBytes(key)
-            .value(segment1Buffer)
-            .eventTime(Time.SYSTEM.milliseconds())
-            .send();
-
-        producer.newMessage()
-            .keyBytes(key)
-            .value(segment2Buffer)
-            .eventTime(Time.SYSTEM.milliseconds())
-            .send();
+        groupMetadataManager.storeOffsetMessage(groupPartitionId, key, segment1Buffer);
+        groupMetadataManager.storeOffsetMessage(groupPartitionId, key, segment2Buffer);
 
         CompletableFuture<GroupMetadata> onLoadedFuture = new CompletableFuture<>();
         groupMetadataManager.scheduleLoadGroupAndOffsets(
@@ -1232,8 +1156,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
     public void testAddGroup() {
         groupMetadataManager = new GroupMetadataManager(
             offsetConfig,
-            producerBuilder,
-            readerBuilder,
+            systemTopicClient,
             scheduler,
             NAMESPACE_PREFIX,
             new MockTime()
@@ -1511,8 +1434,8 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
                 (CompletableFuture<MessageId>) invocationOnMock.callRealMethod();
             realWriteFutureRef.set(realWriteFuture);
             return writeOffsetMessageFuture;
-        }).when(spyGroupManager).storeOffsetMessage(
-            any(String.class), any(byte[].class), any(ByteBuffer.class), anyLong()
+        }).when(spyGroupManager).storeOffsetMessageAsync(
+            any(Integer.class), any(byte[].class), any(ByteBuffer.class), anyLong()
         );
 
         CompletableFuture<Map<TopicPartition, Errors>> storeFuture = spyGroupManager.storeOffsets(
@@ -1568,8 +1491,8 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
                 (CompletableFuture<MessageId>) invocationOnMock.callRealMethod();
             realWriteFutureRef.set(realWriteFuture);
             return writeOffsetMessageFuture;
-        }).when(spyGroupManager).storeOffsetMessage(
-            any(String.class), any(byte[].class), any(ByteBuffer.class), anyLong()
+        }).when(spyGroupManager).storeOffsetMessageAsync(
+            any(Integer.class), any(byte[].class), any(ByteBuffer.class), anyLong()
         );
 
         CompletableFuture<Map<TopicPartition, Errors>> storeFuture = spyGroupManager.storeOffsets(
@@ -1622,8 +1545,8 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
                 (CompletableFuture<MessageId>) invocationOnMock.callRealMethod();
             realWriteFutureRef.set(realWriteFuture);
             return writeOffsetMessageFuture;
-        }).when(spyGroupManager).storeOffsetMessage(
-            any(String.class), any(byte[].class), any(ByteBuffer.class), anyLong()
+        }).when(spyGroupManager).storeOffsetMessageAsync(
+            any(Integer.class), any(byte[].class), any(ByteBuffer.class), anyLong()
         );
 
         CompletableFuture<Map<TopicPartition, Errors>> storeFuture = spyGroupManager.storeOffsets(


### PR DESCRIPTION
### Motivation

Currently the offset topic I/O operations are deeply coupled with GroupMetadataManager so that the code is hard to maintain.

### Modifications

Add a `CompactedPartitionedTopic` class as the abstraction to read or write a compacted partitioned topic with the following public APIs:
- sendAsync: write a key-value as well as the timestamp to a partition
- readToLatest: read until the latest message of a partition
- remove: remove the cached producer and reader of a partition
- close: close the resources

Then, use this class to replace the existing offset topic I/O logic in `GroupMetadataManager`.

Add a `CompactedPartitionedTopicTest` to simulate sending messages and reading message before or after the compaction.

### Important Changes

Before this PR, when the `GroupMetadataManager` reads the offset topic, it writes an empty `ByteBuffer` first, then get the MessageId to read until the latest message's MessageId reaches this empty message.

After this PR, it reads in a loop until no messages are available. To fix the compatibility issue, the empty messages will be ignored.

Another important change is that this PR don't cache futures of producers and readers and then call `thenXxx` APIs to send messages. Because the `CompletableFuture` stores pending callbacks in a stack.

```java
producerFuture.thenApply(producer -> producer.sendAsync(msg0));
producerFuture.thenApply(producer -> producer.sendAsync(msg1));
producerFuture.thenApply(producer -> producer.sendAsync(msg2));
```

For example, the code above might send `msg2`, `msg1`, `msg0` in order, which is unexpected.
### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

