### PR TITLE
[perf][improvement] Improvements for PulsarEntryFormatter

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/PulsarEntryFormatter.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/format/PulsarEntryFormatter.java
@@ -20,7 +20,6 @@ import io.netty.buffer.ByteBuf;
 import io.streamnative.pulsar.handlers.kop.utils.PulsarMessageBuilder;
 import java.nio.ByteBuffer;
 import java.util.List;
-import java.util.stream.StreamSupport;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.common.util.MathUtils;
 import org.apache.bookkeeper.mledger.Entry;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/PulsarMessageBuilder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/PulsarMessageBuilder.java
@@ -68,7 +68,7 @@ public class PulsarMessageBuilder {
             metadata.setNullValue(true);
             return this;
         }
-        this.content = ByteBuffer.wrap(SCHEMA.encode(value));
+        this.content = value;
         return this;
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/PulsarMessageBuilder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/PulsarMessageBuilder.java
@@ -29,7 +29,7 @@ import org.apache.pulsar.common.api.proto.MessageMetadata;
  */
 public class PulsarMessageBuilder {
     private static final ByteBuffer EMPTY_CONTENT = ByteBuffer.allocate(0);
-    private static final Schema<byte[]> SCHEMA = Schema.BYTES;
+    private static final Schema<ByteBuffer> SCHEMA = Schema.BYTEBUFFER;
 
     private final transient MessageMetadata metadata;
     private transient ByteBuffer content;
@@ -63,7 +63,7 @@ public class PulsarMessageBuilder {
         return this;
     }
 
-    public PulsarMessageBuilder value(byte[] value) {
+    public PulsarMessageBuilder value(ByteBuffer value) {
         if (value == null) {
             metadata.setNullValue(true);
             return this;
@@ -103,7 +103,7 @@ public class PulsarMessageBuilder {
         return this;
     }
 
-    public Message<byte[]> getMessage() {
+    public Message<ByteBuffer> getMessage() {
         return MessageImpl.create(metadata, content, SCHEMA, null);
     }
 


### PR DESCRIPTION
This PR is used to cherry-pick these commits.
https://github.com/datastax/starlight-for-kafka/commit/760f213c2c78156138a9e5cb9a93b43b29090655
https://github.com/datastax/starlight-for-kafka/commit/f7f6b7f47329d247446567984cd8c8651fd84ffa
https://github.com/datastax/starlight-for-kafka/commit/2c7c24ef54520cd753fe1ad5e347924ab50dfdcd
https://github.com/datastax/starlight-for-kafka/commit/76c386c1499e3fda8cf0e2b26cdfbeb7f181e6f0

### Motivation

1. Optimize encoding by reducing context switching.
2. Don't copy the value to a byte[] while formatting in Pulsar format.
3. Do not perform an additional memory copy

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

