### PR TITLE
[improvement] Remove expensive useless String.format() in canConsumeAsync

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
@@ -70,9 +70,7 @@ public class SimpleAclAuthorizer implements Authorizer {
 
     @Override
     public CompletableFuture<Boolean> canAccessTenantAsync(KafkaPrincipal principal, Resource resource) {
-        checkArgument(resource.getResourceType() == ResourceType.TENANT,
-                String.format("Expected resource type is TENANT, but have [%s]", resource.getResourceType()));
-
+        checkResourceType(resource, ResourceType.TENANT);
         CompletableFuture<Boolean> canAccessFuture = new CompletableFuture<>();
         authorizeTenantPermission(principal, resource).whenComplete((hasPermission, ex) -> {
                 if (ex != null) {
@@ -92,9 +90,7 @@ public class SimpleAclAuthorizer implements Authorizer {
 
     @Override
     public CompletableFuture<Boolean> canCreateTopicAsync(KafkaPrincipal principal, Resource resource) {
-        checkArgument(resource.getResourceType() == ResourceType.TOPIC,
-                String.format("Expected resource type is TOPIC, but have [%s]", resource.getResourceType()));
-
+        checkResourceType(resource, ResourceType.TOPIC);
         TopicName topicName = TopicName.get(resource.getName());
         return authorizationService.allowNamespaceOperationAsync(
                 topicName.getNamespaceObject(),
@@ -105,9 +101,7 @@ public class SimpleAclAuthorizer implements Authorizer {
 
     @Override
     public CompletableFuture<Boolean> canDeleteTopicAsync(KafkaPrincipal principal, Resource resource) {
-        checkArgument(resource.getResourceType() == ResourceType.TOPIC,
-                String.format("Expected resource type is TOPIC, but have [%s]", resource.getResourceType()));
-
+        checkResourceType(resource, ResourceType.TOPIC);
         TopicName topicName = TopicName.get(resource.getName());
         return authorizationService.allowNamespaceOperationAsync(
                 topicName.getNamespaceObject(),
@@ -118,9 +112,7 @@ public class SimpleAclAuthorizer implements Authorizer {
 
     @Override
     public CompletableFuture<Boolean> canAlterTopicAsync(KafkaPrincipal principal, Resource resource) {
-        checkArgument(resource.getResourceType() == ResourceType.TOPIC,
-                String.format("Expected resource type is TOPIC, but have [%s]", resource.getResourceType()));
-
+        checkResourceType(resource, ResourceType.TOPIC);
         TopicName topicName = TopicName.get(resource.getName());
         return authorizationService.allowTopicPolicyOperationAsync(
                 topicName, PolicyName.PARTITION, PolicyOperation.WRITE,
@@ -129,9 +121,7 @@ public class SimpleAclAuthorizer implements Authorizer {
 
     @Override
     public CompletableFuture<Boolean> canManageTenantAsync(KafkaPrincipal principal, Resource resource) {
-        checkArgument(resource.getResourceType() == ResourceType.TOPIC,
-                String.format("Expected resource type is TOPIC, but have [%s]", resource.getResourceType()));
-
+        checkResourceType(resource, ResourceType.TOPIC);
         TopicName topicName = TopicName.get(resource.getName());
         return authorizationService.allowTopicOperationAsync(
                 topicName, TopicOperation.LOOKUP, principal.getName(), principal.getAuthenticationData());
@@ -139,16 +129,14 @@ public class SimpleAclAuthorizer implements Authorizer {
 
     @Override
     public CompletableFuture<Boolean> canLookupAsync(KafkaPrincipal principal, Resource resource) {
-        checkArgument(resource.getResourceType() == ResourceType.TOPIC,
-                String.format("Expected resource type is TOPIC, but have [%s]", resource.getResourceType()));
+        checkResourceType(resource, ResourceType.TOPIC);
         TopicName topicName = TopicName.get(resource.getName());
         return authorizationService.canLookupAsync(topicName, principal.getName(), principal.getAuthenticationData());
     }
 
     @Override
     public CompletableFuture<Boolean> canGetTopicList(KafkaPrincipal principal, Resource resource) {
-        checkArgument(resource.getResourceType() == ResourceType.NAMESPACE,
-                String.format("Expected resource type is NAMESPACE, but have [%s]", resource.getResourceType()));
+        checkResourceType(resource, ResourceType.NAMESPACE);
         return authorizationService.allowNamespaceOperationAsync(
                 NamespaceName.get(resource.getName()),
                 NamespaceOperation.GET_TOPICS,
@@ -158,18 +146,25 @@ public class SimpleAclAuthorizer implements Authorizer {
 
     @Override
     public CompletableFuture<Boolean> canProduceAsync(KafkaPrincipal principal, Resource resource) {
-        checkArgument(resource.getResourceType() == ResourceType.TOPIC,
-                String.format("Expected resource type is TOPIC, but have [%s]", resource.getResourceType()));
+        checkResourceType(resource, ResourceType.TOPIC);
         TopicName topicName = TopicName.get(resource.getName());
         return authorizationService.canProduceAsync(topicName, principal.getName(), principal.getAuthenticationData());
     }
 
     @Override
     public CompletableFuture<Boolean> canConsumeAsync(KafkaPrincipal principal, Resource resource) {
-        checkArgument(resource.getResourceType() == ResourceType.TOPIC);
+        checkResourceType(resource, ResourceType.TOPIC);
         TopicName topicName = TopicName.get(resource.getName());
         return authorizationService.canConsumeAsync(
                 topicName, principal.getName(), principal.getAuthenticationData(), "");
+    }
+
+    private void checkResourceType(Resource resource, ResourceType expectedResourceType) {
+        if (resource.getResourceType() != expectedResourceType) {
+            throw new IllegalArgumentException(
+                    String.format("Expected resource type is [%s], but have [%s]",
+                            expectedResourceType, resource.getResourceType()));
+        }
     }
 
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
@@ -156,11 +156,11 @@ public class SimpleAclAuthorizer implements Authorizer {
                 topicName, principal.getName(), principal.getAuthenticationData(), "");
     }
 
-    private void checkResourceType(Resource resource, ResourceType expectedResourceType) {
-        if (resource.getResourceType() != expectedResourceType) {
+    private void checkResourceType(Resource actual, ResourceType expected) {
+        if (actual.getResourceType() != expected) {
             throw new IllegalArgumentException(
                     String.format("Expected resource type is [%s], but have [%s]",
-                            expectedResourceType, resource.getResourceType()));
+                            expected, actual.getResourceType()));
         }
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
@@ -13,9 +13,6 @@
  */
 package io.streamnative.pulsar.handlers.kop.security.auth;
 
-
-import static com.google.common.base.Preconditions.checkArgument;
-
 import io.streamnative.pulsar.handlers.kop.security.KafkaPrincipal;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
@@ -166,8 +166,7 @@ public class SimpleAclAuthorizer implements Authorizer {
 
     @Override
     public CompletableFuture<Boolean> canConsumeAsync(KafkaPrincipal principal, Resource resource) {
-        checkArgument(resource.getResourceType() == ResourceType.TOPIC,
-                String.format("Expected resource type is TOPIC, but have [%s]", resource.getResourceType()));
+        checkArgument(resource.getResourceType() == ResourceType.TOPIC);
         TopicName topicName = TopicName.get(resource.getName());
         return authorizationService.canConsumeAsync(
                 topicName, principal.getName(), principal.getAuthenticationData(), "");


### PR DESCRIPTION
(cherry picked from commit fa63a4ab278012ae83319ba2690e201013f2245b)

This PR is used to cherry-pick the commit https://github.com/datastax/starlight-for-kafka/commit/fa63a4ab278012ae83319ba2690e201013f2245b.

### Motivation

The String.format() is an expensive operation in the method canConsumeAsync.

### Modifications

Remove the String.format() operation.


### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

