### PR TITLE
[fix] not respone for PRODUCE when acks=0

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -15,6 +15,7 @@ package io.streamnative.pulsar.handlers.kop;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.kafka.common.protocol.ApiKeys.API_VERSIONS;
+import static org.apache.kafka.common.protocol.ApiKeys.PRODUCE;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -45,6 +46,7 @@ import org.apache.kafka.common.requests.AbstractResponse;
 import org.apache.kafka.common.requests.ApiVersionsRequest;
 import org.apache.kafka.common.requests.KopResponseUtils;
 import org.apache.kafka.common.requests.ListOffsetRequestV0;
+import org.apache.kafka.common.requests.ProduceRequest;
 import org.apache.kafka.common.requests.RequestHeader;
 import org.apache.kafka.common.requests.ResponseCallbackWrapper;
 import org.apache.kafka.common.requests.ResponseHeader;
@@ -382,6 +384,16 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
             if (responseAndRequest == null) {
                 // requestQueue is empty
                 break;
+            }
+
+            if (PRODUCE.equals(responseAndRequest.request.getHeader().apiKey()) ) {
+                ProduceRequest produceRequest = (ProduceRequest) responseAndRequest.request.getRequest();
+                if (produceRequest.acks() == 0) {
+                    if (requestQueue.remove(responseAndRequest)) {
+                        RequestStats.REQUEST_QUEUE_SIZE_INSTANCE.decrementAndGet();
+                    }
+                    continue;
+                }
             }
 
             final CompletableFuture<AbstractResponse> responseFuture = responseAndRequest.getResponseFuture();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -386,7 +386,7 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
                 break;
             }
 
-            if (PRODUCE.equals(responseAndRequest.request.getHeader().apiKey()) ) {
+            if (PRODUCE.equals(responseAndRequest.request.getHeader().apiKey())) {
                 ProduceRequest produceRequest = (ProduceRequest) responseAndRequest.request.getRequest();
                 if (produceRequest.acks() == 0) {
                     if (requestQueue.remove(responseAndRequest)) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -2411,7 +2411,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                     ctx);
             getReplicaManager().appendRecords(
                     kafkaConfig.getRequestTimeoutMs(),
-                    kafkaConfig.getRequiredAcks(),
+                    (short) 1,
                     true,
                     currentNamespacePrefix(),
                     controlRecords,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -849,6 +849,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         final Map<TopicPartition, PartitionResponse> invalidRequestResponses = new HashMap<>();
         final Map<TopicPartition, MemoryRecords> authorizedRequestInfo = new ConcurrentHashMap<>();
         int timeoutMs = produceRequest.timeout();
+        short requiredAcks = produceRequest.acks();
         String namespacePrefix = currentNamespacePrefix();
         final AtomicInteger unfinishedAuthorizationCount = new AtomicInteger(numPartitions);
         Runnable completeOne = () -> {
@@ -867,6 +868,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 ReplicaManager replicaManager = getReplicaManager();
                 replicaManager.appendRecords(
                         timeoutMs,
+                        requiredAcks,
                         false,
                         namespacePrefix,
                         authorizedRequestInfo,
@@ -2409,6 +2411,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                     ctx);
             getReplicaManager().appendRecords(
                     kafkaConfig.getRequestTimeoutMs(),
+                    kafkaConfig.getRequiredAcks(),
                     true,
                     currentNamespacePrefix(),
                     controlRecords,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -259,13 +259,6 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
     private int requestTimeoutMs = 30000;
 
     @FieldContext(
-        category = CATEGORY_KOP,
-        doc = "controls the criteria under which requests are considered complete, \n"
-            + "like acks in kafka\n"
-    )
-    private short requiredAcks = 1;
-
-    @FieldContext(
             category = CATEGORY_KOP,
             doc = "Idle connections timeout: the server handler close the connections that idle more than this, \n"
                     + "like connections.max.idle.ms in kafka server."

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -259,6 +259,13 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
     private int requestTimeoutMs = 30000;
 
     @FieldContext(
+        category = CATEGORY_KOP,
+        doc = "controls the criteria under which requests are considered complete, \n"
+            + "like acks in kafka\n"
+    )
+    private short requiredAcks = 1;
+
+    @FieldContext(
             category = CATEGORY_KOP,
             doc = "Idle connections timeout: the server handler close the connections that idle more than this, \n"
                     + "like connections.max.idle.ms in kafka server."

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
@@ -1040,6 +1040,28 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
     }
 
     @Test(timeOut = 20000)
+    public void testNoAcksProduce() throws Exception {
+        final String topic = "testAcks";
+        admin.topics().createPartitionedTopic(topic, 1);
+
+        final TopicPartition topicPartition = new TopicPartition(topic, 0);
+
+        Properties producerNoAckProperties = newKafkaProducerProperties();
+        producerNoAckProperties.put(ProducerConfig.ACKS_CONFIG, "1");
+        @Cleanup
+        final KafkaProducer<String, String> producerNoAck = new KafkaProducer<>(producerNoAckProperties);
+        RecordMetadata noAckMetadata = producerNoAck.send(new ProducerRecord<>(topic, "test")).get();
+        assertEquals(noAckMetadata.offset(), 0);
+
+        Properties producerAckProperties = newKafkaProducerProperties();
+        producerAckProperties.put(ProducerConfig.ACKS_CONFIG, "0");
+        @Cleanup
+        final KafkaProducer<String, String> producerAck = new KafkaProducer<>(producerAckProperties);
+        RecordMetadata ackMetadata = producerAck.send(new ProducerRecord<>(topic, "test")).get();
+        assertEquals(ackMetadata.offset(), -1);
+    }
+
+    @Test(timeOut = 20000)
     public void testIllegalManagedLedger() throws Exception {
         final String topic = "testIllegalManagedLedger";
         admin.topics().createPartitionedTopic(topic, 1);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaApisTest.java
@@ -56,6 +56,7 @@ import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -107,6 +108,7 @@ import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.util.netty.EventLoopUtil;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Ignore;
@@ -1041,24 +1043,61 @@ public class KafkaApisTest extends KopProtocolHandlerTestBase {
 
     @Test(timeOut = 20000)
     public void testNoAcksProduce() throws Exception {
-        final String topic = "testAcks";
+        final String topic = "testNoAcks";
         admin.topics().createPartitionedTopic(topic, 1);
 
         final TopicPartition topicPartition = new TopicPartition(topic, 0);
 
         Properties producerNoAckProperties = newKafkaProducerProperties();
-        producerNoAckProperties.put(ProducerConfig.ACKS_CONFIG, "1");
+        producerNoAckProperties.put(ProducerConfig.ACKS_CONFIG, "0");
         @Cleanup
         final KafkaProducer<String, String> producerNoAck = new KafkaProducer<>(producerNoAckProperties);
+        for (int numRecords = 0; numRecords < 2000; numRecords++) {
+            producerNoAck.send(new ProducerRecord<>(topic, "test"));
+        }
         RecordMetadata noAckMetadata = producerNoAck.send(new ProducerRecord<>(topic, "test")).get();
-        assertEquals(noAckMetadata.offset(), 0);
+        assertEquals(noAckMetadata.offset(), -1);
+
+        verifySendMessageWithoutAcks(topicPartition, newNormalRecords());
+    }
+
+    private void verifySendMessageWithoutAcks(final TopicPartition topicPartition,
+        final MemoryRecords records)
+        throws ExecutionException, InterruptedException {
+        ProduceRequestData produceRequestData = new ProduceRequestData()
+            .setTimeoutMs(30000)
+            .setAcks((short) 0);
+        produceRequestData.topicData().add(new ProduceRequestData.TopicProduceData()
+            .setName(topicPartition.topic())
+            .setPartitionData(Collections.singletonList(new ProduceRequestData.PartitionProduceData()
+                .setIndex(topicPartition.partition())
+                .setRecords(records)))
+        );
+        final KafkaHeaderAndRequest request = buildRequest(new ProduceRequest.Builder(ApiKeys.PRODUCE.latestVersion(),
+            ApiKeys.PRODUCE.latestVersion(), produceRequestData));
+        final CompletableFuture<AbstractResponse> future = new CompletableFuture<>();
+        kafkaRequestHandler.handleProduceRequest(request, future);
+
+        Assert.expectThrows(TimeoutException.class, () -> {
+            future.get(1000, TimeUnit.MILLISECONDS);
+        });
+    }
+
+    @Test(timeOut = 20000)
+    public void testAcksProduce() throws Exception {
+        final String topic = "testAcks";
+        admin.topics().createPartitionedTopic(topic, 1);
+
+        final TopicPartition topicPartition = new TopicPartition(topic, 0);
 
         Properties producerAckProperties = newKafkaProducerProperties();
-        producerAckProperties.put(ProducerConfig.ACKS_CONFIG, "0");
+        producerAckProperties.put(ProducerConfig.ACKS_CONFIG, "1");
         @Cleanup
         final KafkaProducer<String, String> producerAck = new KafkaProducer<>(producerAckProperties);
         RecordMetadata ackMetadata = producerAck.send(new ProducerRecord<>(topic, "test")).get();
-        assertEquals(ackMetadata.offset(), -1);
+        assertEquals(ackMetadata.offset(), 0);
+
+        verifySendMessageToPartition(topicPartition, newNormalRecords(), Errors.NONE, 1L);
     }
 
     @Test(timeOut = 20000)


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #1875

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation


When the Kafka Producer sets acks=0 to send messages to KoP, an error will be throw

### Modifications


not respone for PRODUCE when acks=0

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

