### PR TITLE
[improvements] Use the TopicEventListener API

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -57,7 +57,6 @@ import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.utils.Time;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.ServiceConfiguration;
-import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.protocol.ProtocolHandler;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.client.admin.PulsarAdmin;
@@ -103,6 +102,8 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     @Getter
     private KopEventManager kopEventManager;
     private OrderedScheduler sendResponseScheduler;
+    @VisibleForTesting
+    @Getter
     private NamespaceBundleOwnershipListenerImpl bundleListener;
     @VisibleForTesting
     @Getter
@@ -218,20 +219,31 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
             throw new IllegalStateException(ex);
         }
 
-        final NamespaceService namespaceService = brokerService.pulsar().getNamespaceService();
-        bundleListener = new NamespaceBundleOwnershipListenerImpl(namespaceService,
-                brokerService.pulsar().getBrokerServiceUrl());
         // Listener for invalidating the global Broker ownership cache
+        bundleListener = new NamespaceBundleOwnershipListenerImpl(brokerService);
+
         bundleListener.addTopicOwnershipListener(new TopicOwnershipListener() {
-            @Override
-            public void whenLoad(TopicName topicName) {
-                invalidateBundleCache(topicName);
-            }
 
             @Override
             public void whenUnload(TopicName topicName) {
                 invalidateBundleCache(topicName);
                 invalidatePartitionLog(topicName);
+            }
+
+            @Override
+            public void whenDelete(TopicName topicName) {
+                invalidateBundleCache(topicName);
+                invalidatePartitionLog(topicName);
+            }
+
+            @Override
+            public boolean interestedInEvent(NamespaceName namespaceName, EventType event) {
+                switch (event) {
+                    case UNLOAD:
+                    case DELETE:
+                        return true;
+                }
+                return false;
             }
 
             @Override
@@ -254,7 +266,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 }
             }
         });
-        namespaceService.addNamespaceBundleOwnershipListener(bundleListener);
+        bundleListener.register();
 
         if (kafkaConfig.isKafkaManageSystemNamespaces()) {
             // initialize default Group Coordinator
@@ -319,8 +331,14 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 }
 
                 @Override
-                public boolean test(NamespaceName namespaceName) {
-                    return namespaceName.equals(kafkaMetaNs);
+                public boolean interestedInEvent(NamespaceName namespaceName, EventType event) {
+                    switch (event) {
+                        case LOAD:
+                        case UNLOAD:
+                            return namespaceName.equals(kafkaMetaNs);
+                        default:
+                            return false;
+                    }
                 }
             });
             return transactionCoordinator;
@@ -371,9 +389,16 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 }
 
                 @Override
-                public boolean test(NamespaceName namespaceName) {
-                    return namespaceName.equals(kafkaMetaNs);
+                public boolean interestedInEvent(NamespaceName namespaceName, EventType event) {
+                    switch (event) {
+                        case LOAD:
+                        case UNLOAD:
+                            return namespaceName.equals(kafkaMetaNs);
+                        default:
+                            return false;
+                    }
                 }
+
             });
         } catch (Exception e) {
             log.error("Failed to create offset metadata", e);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManager.java
@@ -137,7 +137,8 @@ public class KafkaTopicConsumerManager implements Closeable {
     // each success remove should have a following add.
     public CompletableFuture<Pair<ManagedCursor, Long>> removeCursorFuture(long offset) {
         if (closed.get()) {
-            return null;
+            return CompletableFuture.failedFuture(new Exception("Current managedLedger for "
+                    + topic.getName() + " has been closed."));
         }
 
         lastAccessTimes.remove(offset);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/NamespaceBundleOwnershipListenerImpl.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/NamespaceBundleOwnershipListenerImpl.java
@@ -21,6 +21,7 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.namespace.NamespaceBundleOwnershipListener;
 import org.apache.pulsar.broker.namespace.NamespaceService;
+import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicDomain;
@@ -28,11 +29,35 @@ import org.apache.pulsar.common.naming.TopicName;
 
 @AllArgsConstructor
 @Slf4j
-public class NamespaceBundleOwnershipListenerImpl implements NamespaceBundleOwnershipListener {
+public class NamespaceBundleOwnershipListenerImpl {
+
+    private static final boolean USE_TOPIC_EVENT_LISTENER;
+    static {
+        boolean isTopicEventsListenerAvailable = false;
+        try {
+            Class.forName("org.apache.pulsar.broker.service.TopicEventsListener",
+                    true, BrokerService.class.getClassLoader());
+            log.info("Detected TopicEventsListener API");
+            isTopicEventsListenerAvailable = true;
+        } catch (ClassNotFoundException legacyPulsarVersion) {
+            log.info("TopicEventsListener API is not available on this version of Pulsar");
+        }
+        USE_TOPIC_EVENT_LISTENER = isTopicEventsListenerAvailable;
+    }
 
     private final List<TopicOwnershipListener> topicOwnershipListeners = new CopyOnWriteArrayList<>();
     private final NamespaceService namespaceService;
+    private final BrokerService brokerService;
     private final String brokerUrl;
+
+    private final InnerNamespaceBundleOwnershipListener bundleBasedImpl = new InnerNamespaceBundleOwnershipListener();
+
+    public NamespaceBundleOwnershipListenerImpl(BrokerService brokerService) {
+        this.brokerService = brokerService;
+        this.brokerUrl =
+                brokerService.pulsar().getBrokerServiceUrl();
+        this.namespaceService = brokerService.pulsar().getNamespaceService();
+    }
 
     /**
      * @implNote Like {@link NamespaceService#addNamespaceBundleOwnershipListener}, when a new listener is added, the
@@ -40,77 +65,155 @@ public class NamespaceBundleOwnershipListenerImpl implements NamespaceBundleOwne
      */
     public void addTopicOwnershipListener(final TopicOwnershipListener listener) {
         topicOwnershipListeners.add(listener);
-        namespaceService.getOwnedServiceUnits().stream().filter(this).forEach(this::onLoad);
+        namespaceService.getOwnedServiceUnits()
+                .stream()
+                .filter(bundleBasedImpl).forEach(bundleBasedImpl::onLoad);
     }
 
-    @Override
-    public void onLoad(NamespaceBundle bundle) {
-        log.info("[{}] Load bundle: {}", brokerUrl, bundle);
-        getOwnedPersistentTopicList(bundle).thenAccept(topics -> {
-            topicOwnershipListeners.forEach(listener -> {
-                if (!listener.test(bundle.getNamespaceObject())) {
-                    return;
+    private boolean anyListenerInterestedInEvent(NamespaceName namespaceName, TopicOwnershipListener.EventType event) {
+        return topicOwnershipListeners
+                .stream()
+                .anyMatch(l -> l.interestedInEvent(namespaceName, event));
+    }
+
+    private class InnerNamespaceBundleOwnershipListener implements NamespaceBundleOwnershipListener {
+
+        @Override
+        public void onLoad(NamespaceBundle bundle) {
+
+            NamespaceName namespaceObject = bundle.getNamespaceObject();
+            if (!anyListenerInterestedInEvent(namespaceObject, TopicOwnershipListener.EventType.LOAD)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] Load bundle: {} - NO LISTENER INTERESTED", brokerUrl, bundle);
                 }
-                topics.forEach(topic -> {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}][{}] Trigger load callback for {}", brokerUrl, listener.name(), topic);
-                    }
-                    listener.whenLoad(TopicName.get(topic));
-                });
-            });
-        }).exceptionally(ex -> {
-            log.error("[{}] Failed to get owned topic list of {}", brokerUrl, bundle, ex);
-            return null;
-        });
-    }
-
-    @Override
-    public void unLoad(NamespaceBundle bundle) {
-        log.info("[{}] Unload bundle: {}", brokerUrl, bundle);
-        getOwnedPersistentTopicList(bundle).thenAccept(topics -> {
-            topicOwnershipListeners.forEach(listener -> {
-                if (!listener.test(bundle.getNamespaceObject())) {
-                    return;
-                }
-                topics.forEach(topic -> {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}][{}] Trigger unload callback for {}", brokerUrl, listener.name(), topic);
-                    }
-                    listener.whenUnload(TopicName.get(topic));
-                });
-            });
-        }).exceptionally(ex -> {
-            log.error("[{}] Failed to get owned topic list of {}", brokerUrl, bundle, ex);
-            return null;
-        });
-    }
-
-    @Override
-    public boolean test(NamespaceBundle bundle) {
-        return true;
-    }
-
-    // Kafka topics are always persistent so there is no need to get owned non-persistent topics.
-    // However, `NamespaceService#getOwnedTopicListForNamespaceBundle` calls `getFullListTopics`, which always calls
-    // `getListOfNonPersistentTopics`. So this method is a supplement to the existing NamespaceService API.
-    private CompletableFuture<List<String>> getOwnedPersistentTopicList(final NamespaceBundle bundle) {
-        final NamespaceName namespaceName = bundle.getNamespaceObject();
-        final CompletableFuture<List<String>> topicsFuture = namespaceService.getListOfPersistentTopics(namespaceName)
-                .thenApply(topics -> topics.stream()
-                        .filter(topic -> bundle.includes(TopicName.get(topic)))
-                        .collect(Collectors.toList()));
-        final CompletableFuture<List<String>> partitionsFuture =
-                namespaceService.getPartitions(namespaceName, TopicDomain.persistent)
-                        .thenApply(topics -> topics.stream()
-                                .filter(topic -> bundle.includes(TopicName.get(topic)))
-                                .collect(Collectors.toList()));
-        return topicsFuture.thenCombine(partitionsFuture, (topics, partitions) -> {
-            for (String partition : partitions) {
-                if (!topics.contains(partition)) {
-                    topics.add(partition);
-                }
+                return;
             }
-            return topics;
+            log.info("[{}] Load bundle: {}", brokerUrl, bundle);
+
+            // We have to eagerly list all the topics in the bundle even if they are not LOADED yet,
+            // this is necessary in order to eagerly bootstrap the GroupCoordinator and the TransactionCoordinator
+            // services.
+            getOwnedPersistentTopicList(bundle).thenAccept(topics -> {
+                notifyLoadTopics(namespaceObject, topics);
+            }).exceptionally(ex -> {
+                log.error("[{}] Failed to get owned topic list of {}", brokerUrl, bundle, ex);
+                return null;
+            });
+        }
+
+        @Override
+        public void unLoad(NamespaceBundle bundle) {
+            if (USE_TOPIC_EVENT_LISTENER) {
+                // Unload events hard dispatched in a better way using the TopicEventListener API.
+                return;
+            }
+            // We have to eagerly list all the topics in the bundle, even if they are not LOADED yet
+            NamespaceName namespaceObject = bundle.getNamespaceObject();
+            if (!anyListenerInterestedInEvent(namespaceObject, TopicOwnershipListener.EventType.UNLOAD)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] Unload bundle: {} - NO LISTENER INTERESTED", brokerUrl, bundle);
+                }
+                return;
+            }
+            log.info("[{}] Unload bundle: {}", brokerUrl, bundle);
+            getOwnedPersistentTopicList(bundle).thenAccept(topics -> {
+                notifyUnloadTopics(namespaceObject, topics);
+            }).exceptionally(ex -> {
+                log.error("[{}] Failed to get owned topic list of {}", brokerUrl, bundle, ex);
+                return null;
+            });
+        }
+
+        @Override
+        public boolean test(NamespaceBundle bundle) {
+            return true;
+        }
+
+        // Kafka topics are always persistent so there is no need to get owned non-persistent topics.
+        // However, `NamespaceService#getOwnedTopicListForNamespaceBundle` calls `getFullListTopics`, which always calls
+        // `getListOfNonPersistentTopics`. So this method is a supplement to the existing NamespaceService API.
+        private CompletableFuture<List<TopicName>> getOwnedPersistentTopicList(final NamespaceBundle bundle) {
+            final NamespaceName namespaceName = bundle.getNamespaceObject();
+            final CompletableFuture<List<TopicName>> topicsFuture =
+                    namespaceService.getListOfPersistentTopics(namespaceName)
+                            .thenApply(topics -> topics.stream()
+                                    .map(TopicName::get)
+                                    .filter(topic -> bundle.includes(topic))
+                                    .collect(Collectors.toList()));
+            final CompletableFuture<List<TopicName>> partitionsFuture =
+                    namespaceService.getPartitions(namespaceName, TopicDomain.persistent)
+                            .thenApply(topics -> topics.stream()
+                                    .map(TopicName::get)
+                                    .filter(topic -> bundle.includes(topic))
+                                    .collect(Collectors.toList()));
+            return topicsFuture.thenCombine(partitionsFuture, (topics, partitions) -> {
+                for (TopicName partition : partitions) {
+                    if (!topics.contains(partition)) {
+                        topics.add(partition);
+                    }
+                }
+                return topics;
+            });
+        }
+    }
+
+    void notifyUnloadTopic(NamespaceName namespaceObject, TopicName topic) {
+        topicOwnershipListeners.forEach(listener -> {
+            if (!listener.interestedInEvent(namespaceObject, TopicOwnershipListener.EventType.UNLOAD)) {
+                return;
+            }
+            if (log.isDebugEnabled()) {
+                log.debug("[{}][{}] Trigger unload callback for {}", brokerUrl, listener.name(), topic);
+            }
+            listener.whenUnload(topic);
         });
     }
+
+    void notifyDeleteTopic(NamespaceName namespaceObject, TopicName topic) {
+        topicOwnershipListeners.forEach(listener -> {
+            if (!listener.interestedInEvent(namespaceObject, TopicOwnershipListener.EventType.DELETE)) {
+                return;
+            }
+            if (log.isDebugEnabled()) {
+                log.debug("[{}][{}] Trigger delete callback for {}", brokerUrl, listener.name(), topic);
+            }
+            listener.whenDelete(topic);
+        });
+    }
+
+    void notifyUnloadTopics(NamespaceName namespaceObject, List<TopicName> topics) {
+        topicOwnershipListeners.forEach(listener -> {
+            if (!listener.interestedInEvent(namespaceObject, TopicOwnershipListener.EventType.UNLOAD)) {
+                return;
+            }
+            topics.forEach(topic -> {
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}][{}] Trigger unload callback for {}", brokerUrl, listener.name(), topic);
+                }
+                listener.whenUnload(topic);
+            });
+        });
+    }
+
+    private void notifyLoadTopics(NamespaceName namespaceObject, List<TopicName> topics) {
+        topicOwnershipListeners.forEach(listener -> {
+            if (!listener.interestedInEvent(namespaceObject, TopicOwnershipListener.EventType.LOAD)) {
+                return;
+            }
+            topics.forEach(topic -> {
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}][{}] Trigger load callback for {}", brokerUrl, listener.name(), topic);
+                }
+                listener.whenLoad(topic);
+            });
+        });
+    }
+
+    public void register() {
+        namespaceService.addNamespaceBundleOwnershipListener(bundleBasedImpl);
+        if (USE_TOPIC_EVENT_LISTENER) {
+            brokerService.addTopicEventListener(new TopicEventListenerImpl(this));
+        }
+    }
+
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/TopicEventListenerImpl.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/TopicEventListenerImpl.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.service.TopicEventsListener;
+import org.apache.pulsar.common.naming.TopicName;
+
+/**
+ * This is a listener to receive notifications about UNLOAD and DELETE events.
+ * The TopicEventsListener API is available only since Pulsar 3.0.0
+ * and Luna Streaming 2.10.3.3. This is the reason why this class is not an innerclass
+ * of {@link NamespaceBundleOwnershipListenerImpl}, because we don't want to load it and
+ * cause errors on older versions of Pulsar.
+ *
+ * Please note that we are not interested in LOAD events because they are handled
+ * in {@link NamespaceBundleOwnershipListenerImpl} in a different way.
+ */
+@Slf4j
+class TopicEventListenerImpl implements TopicEventsListener {
+
+    final NamespaceBundleOwnershipListenerImpl parent;
+
+    public TopicEventListenerImpl(NamespaceBundleOwnershipListenerImpl parent) {
+        this.parent = parent;
+    }
+
+    @Override
+    public void handleEvent(String topicName, TopicEvent event, EventStage stage, Throwable t) {
+        if (stage == EventStage.SUCCESS || stage == EventStage.FAILURE) {
+            if (log.isDebugEnabled()) {
+                log.debug("handleEvent {} {} on {}", event, stage, topicName);
+            }
+            TopicName topicName1 = TopicName.get(topicName);
+            switch (event) {
+                case UNLOAD:
+                    parent.notifyUnloadTopic(topicName1.getNamespaceObject(), topicName1);
+                    break;
+                case DELETE:
+                    parent.notifyDeleteTopic(topicName1.getNamespaceObject(), topicName1);
+                    break;
+                default:
+                    if (log.isDebugEnabled()) {
+                        log.debug("Ignore event {} {} on {}", event, stage, topicName);
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/TopicOwnershipListener.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/TopicOwnershipListener.java
@@ -13,33 +13,49 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
-import java.util.function.Predicate;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 
 /**
  * Listener that is triggered when a topic's ownership changed via load or unload.
  */
-public interface TopicOwnershipListener extends Predicate<NamespaceName> {
+public interface TopicOwnershipListener  {
+
+    enum EventType {
+        LOAD,
+        UNLOAD,
+        DELETE
+    }
 
     /**
      * It's triggered when the topic is loaded by a broker.
      *
      * @param topicName
      */
-    void whenLoad(TopicName topicName);
+    default void whenLoad(TopicName topicName) {
+    }
 
     /**
      * It's triggered when the topic is unloaded by a broker.
      *
      * @param topicName
      */
-    void whenUnload(TopicName topicName);
+    default void whenUnload(TopicName topicName) {
+    }
+
+    /**
+     * It's triggered when the topic is deleted by a broker.
+     *
+     * @param topicName
+     */
+    default void whenDelete(TopicName topicName) {
+    }
 
     /** Returns the name of the listener. */
     String name();
 
-    default boolean test(NamespaceName namespaceName) {
-        return true;
+    default boolean interestedInEvent(NamespaceName namespaceName, EventType event) {
+        return false;
     }
+
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CacheInvalidatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CacheInvalidatorTest.java
@@ -243,6 +243,7 @@ public class CacheInvalidatorTest extends KopProtocolHandlerTestBase {
     @Override
     protected void setup() throws Exception {
         conf.setKafkaTransactionCoordinatorEnabled(true);
+        conf.setTopicLevelPoliciesEnabled(false);
         super.internalSetup();
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CacheInvalidatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CacheInvalidatorTest.java
@@ -22,7 +22,12 @@ import static org.testng.Assert.assertTrue;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -31,10 +36,13 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.BundlesData;
 import org.awaitility.Awaitility;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
@@ -100,6 +108,134 @@ public class CacheInvalidatorTest extends KopProtocolHandlerTestBase {
         Awaitility.await().untilAsserted(() -> {
             assertEquals(getProtocolHandler().getReplicaManager().size(), 0);
         });
+
+    }
+
+    @DataProvider(name = "testEvents")
+    protected static Object[][] testEvents() {
+        // isBatch
+        return new Object[][]{
+                {List.of(TopicOwnershipListener.EventType.LOAD), false, false,
+                        List.of(TopicOwnershipListener.EventType.LOAD)},
+                {List.of(TopicOwnershipListener.EventType.UNLOAD), true, false,
+                        List.of(TopicOwnershipListener.EventType.UNLOAD)},
+                {List.of(TopicOwnershipListener.EventType.UNLOAD), false, true,
+                        List.of()},
+                {List.of(TopicOwnershipListener.EventType.UNLOAD), true, true,
+                        List.of(TopicOwnershipListener.EventType.UNLOAD)},
+                {List.of(TopicOwnershipListener.EventType.DELETE), true, true,
+                        List.of(TopicOwnershipListener.EventType.DELETE)},
+                {List.of(TopicOwnershipListener.EventType.DELETE), false, true,
+                        List.of(TopicOwnershipListener.EventType.DELETE)},
+                // PartitionLog listener
+                {List.of(TopicOwnershipListener.EventType.UNLOAD, TopicOwnershipListener.EventType.DELETE),
+                        false, true,
+                        List.of(TopicOwnershipListener.EventType.DELETE)},
+                {List.of(TopicOwnershipListener.EventType.UNLOAD, TopicOwnershipListener.EventType.DELETE),
+                        true, true,
+                        List.of(TopicOwnershipListener.EventType.UNLOAD, TopicOwnershipListener.EventType.DELETE)},
+                {List.of(TopicOwnershipListener.EventType.UNLOAD, TopicOwnershipListener.EventType.DELETE),
+                        true, false,
+                        List.of(TopicOwnershipListener.EventType.UNLOAD)},
+                {List.of(TopicOwnershipListener.EventType.UNLOAD, TopicOwnershipListener.EventType.DELETE),
+                        false, false,
+                        List.of()},
+                // Group and TransactionCoordinators
+                {List.of(TopicOwnershipListener.EventType.LOAD,
+                        TopicOwnershipListener.EventType.UNLOAD), true, true,
+                        List.of(TopicOwnershipListener.EventType.LOAD,
+                        TopicOwnershipListener.EventType.UNLOAD)},
+                {List.of(TopicOwnershipListener.EventType.LOAD,
+                        TopicOwnershipListener.EventType.UNLOAD), false, true,
+                        List.of(TopicOwnershipListener.EventType.LOAD)},
+                {List.of(TopicOwnershipListener.EventType.LOAD,
+                        TopicOwnershipListener.EventType.UNLOAD), true, false,
+                        List.of(TopicOwnershipListener.EventType.LOAD,
+                        TopicOwnershipListener.EventType.UNLOAD)},
+                {List.of(TopicOwnershipListener.EventType.LOAD,
+                        TopicOwnershipListener.EventType.UNLOAD), false, false,
+                        List.of(TopicOwnershipListener.EventType.LOAD)}
+        };
+    }
+
+    @Test(dataProvider = "testEvents")
+    public void testEvents(List<TopicOwnershipListener.EventType> eventTypes, boolean unload, boolean delete,
+                           List<TopicOwnershipListener.EventType> exepctedEventTypes)
+            throws Exception {
+
+        KafkaProtocolHandler protocolHandler = getProtocolHandler();
+
+        NamespaceBundleOwnershipListenerImpl bundleListener = protocolHandler.getBundleListener();
+
+        String namespace = tenant + "/" + "my-namespace_test_" + UUID.randomUUID();
+        admin.namespaces().createNamespace(namespace, 10);
+        NamespaceName namespaceName = NamespaceName.get(namespace);
+
+        Map<TopicOwnershipListener.EventType, List<TopicName>> events = new ConcurrentHashMap<>();
+
+        bundleListener.addTopicOwnershipListener(new TopicOwnershipListener() {
+            @Override
+            public String name() {
+                return "tester";
+            }
+
+            @Override
+            public void whenLoad(TopicName topicName) {
+                log.info("whenLoad {}", topicName);
+                events.computeIfAbsent(EventType.LOAD, e -> new CopyOnWriteArrayList<>())
+                        .add(topicName);
+            }
+
+            @Override
+            public void whenUnload(TopicName topicName) {
+                log.info("whenUnload {}", topicName);
+                events.computeIfAbsent(EventType.UNLOAD, e -> new CopyOnWriteArrayList<>())
+                        .add(topicName);
+            }
+
+            @Override
+            public void whenDelete(TopicName topicName) {
+                log.info("whenDelete {}", topicName);
+                events.computeIfAbsent(EventType.DELETE, e -> new CopyOnWriteArrayList<>())
+                        .add(topicName);
+            }
+
+            @Override
+            public boolean interestedInEvent(NamespaceName theNamespaceName, EventType event) {
+                log.info("interestedInEvent {} {}", theNamespaceName, event);
+                return namespaceName.equals(theNamespaceName) && eventTypes.contains(event);
+            }
+        });
+
+        int numPartitions = 10;
+        String topicName = namespace + "/test-topic-" + UUID.randomUUID();
+        admin.topics().createPartitionedTopic(topicName, numPartitions);
+        admin.lookups().lookupPartitionedTopic(topicName);
+
+        if (unload) {
+            admin.topics().unload(topicName);
+        }
+
+        if (delete) {
+            // DELETE triggers also UNLOAD so we do delete only
+            admin.topics().deletePartitionedTopic(topicName);
+        }
+        if (exepctedEventTypes.isEmpty()) {
+            Awaitility.await().during(5, TimeUnit.SECONDS).untilAsserted(() -> {
+                log.info("Events {}", events);
+                assertTrue(events.isEmpty());
+            });
+        } else {
+            Awaitility.await().untilAsserted(() -> {
+                log.info("Events {}", events);
+                assertEquals(events.size(), exepctedEventTypes.size());
+                for (TopicOwnershipListener.EventType eventType : exepctedEventTypes) {
+                    assertEquals(events.get(eventType).size(), numPartitions);
+                }
+            });
+        }
+
+        admin.namespaces().deleteNamespace(namespace, true);
 
     }
 


### PR DESCRIPTION
Cherry-pick: https://github.com/datastax/starlight-for-kafka/pull/67 

### Motivation
The new TopicEventListener API allows a ProtocolHandler to be notified about the lifecycle of single topics.
Previously we could rely only on Bundle level notifications: loadBundle and unloadBundle.
The old approach had some limitations:

* it didn't support single topic unload (pulsar-admin topics unload TOPIC)
* it didn't support clearing caches in case of topic deletion
* for each bundle we had to eagerly force listing all the topics in the "onLoad" event (this also happened for all the system namespaces in the broker)
* for each bundle we eagerly forced listing of all the topics even in the case of "unload" events
Benefits:

* we will be able to react to single topic events
* we won't need to list all the topics in case of "unload" events
* we won't need to trigger the listing of all the topics in case of "load/unload" events (we do that in the case of "load" and only for the system kafka namespaces that contain __consumer_offsets and __transaction_state)
* the overall impact on the broker and on the metadata services will be reduced a lot in case of brokers with many topics per bundle


### Modifications
* detect the availability of the TopicEventListener API
* use the TopicEventListener API for UNLOAD and DELETE events
* narrow down the listing of topics in case of Namespace Bundle load/unload events
* update the tests in order to leverage the new capabilities (single topic unload and deletion)
* add new tests

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

