### PR TITLE
Reduce the offset commit timeout to 5 seconds and make it configurable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -147,6 +147,7 @@ This section lists configurations about the group coordinator and the `__consume
 |offsetsMessageTTL| The offsets message TTL in seconds. | 259200 |
 |offsetsRetentionCheckIntervalMs| The frequency at which to check for stale offsets.  |600000|
 |offsetsTopicNumPartitions| The number of partitions for the offsets topic.  |50|
+|offsetCommitTimeoutMs | Offset commit will be delayed until the offset metadata be persisted or this timeout is reached |5000|
 |systemTopicRetentionSizeInMB| The system topic retention size in mb. | -1 |
 
 ## Transaction

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -545,6 +545,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
             .maxMetadataSize(kafkaConfig.getOffsetMetadataMaxSize())
             .offsetsRetentionCheckIntervalMs(kafkaConfig.getOffsetsRetentionCheckIntervalMs())
             .offsetsRetentionMs(TimeUnit.MINUTES.toMillis(kafkaConfig.getOffsetsRetentionMinutes()))
+            .offsetCommitTimeoutMs(kafkaConfig.getOffsetCommitTimeoutMs())
             .build();
 
         GroupCoordinator groupCoordinator = GroupCoordinator.of(

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -196,6 +196,12 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
 
     @FieldContext(
             category = CATEGORY_KOP,
+            doc = "Offset commit will be delayed until the offset metadata be persisted or this timeout is reached"
+    )
+    private int offsetCommitTimeoutMs = 5000;
+
+    @FieldContext(
+            category = CATEGORY_KOP,
             doc = "send queue size of system client to produce system topic."
     )
     private int kafkaMetaMaxPendingMessages = 10000;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/OffsetConfig.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/group/OffsetConfig.java
@@ -33,6 +33,7 @@ public class OffsetConfig {
     public static final long DefaultOffsetsRetentionCheckIntervalMs = 600000L;
     public static final String DefaultOffsetsTopicName = "public/__kafka/__consumer_offsets";
     public static final int DefaultOffsetsNumPartitions = KafkaServiceConfiguration.DefaultOffsetsTopicNumPartitions;
+    public static final int DefaultOffsetCommitTimeoutMs = 5000;
 
     @Default
     private String offsetsTopicName = DefaultOffsetsTopicName;
@@ -46,4 +47,6 @@ public class OffsetConfig {
     private long offsetsRetentionCheckIntervalMs = DefaultOffsetsRetentionCheckIntervalMs;
     @Default
     private int offsetsTopicNumPartitions = DefaultOffsetsNumPartitions;
+    @Default
+    private int offsetCommitTimeoutMs = DefaultOffsetCommitTimeoutMs;
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -86,6 +86,7 @@ import org.testng.Assert;
 @Slf4j
 public abstract class KopProtocolHandlerTestBase {
 
+    protected static final String DEFAULT_GROUP_ID = "my-group";
     protected KafkaServiceConfiguration conf;
     protected PulsarService pulsar;
     protected PulsarAdmin admin;
@@ -770,7 +771,7 @@ public abstract class KopProtocolHandlerTestBase {
     protected Properties newKafkaConsumerProperties() {
         final Properties props = new Properties();
         props.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getClientPort());
-        props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "my-group");
+        props.setProperty(ConsumerConfig.GROUP_ID_CONFIG, DEFAULT_GROUP_ID);
         props.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         props.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         props.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/OffsetTopicWriteTimeoutTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/OffsetTopicWriteTimeoutTest.java
@@ -1,0 +1,134 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import static io.streamnative.pulsar.handlers.kop.KafkaCommonTestUtils.buildRequest;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.message.JoinGroupRequestData;
+import org.apache.kafka.common.message.OffsetCommitRequestData;
+import org.apache.kafka.common.message.SyncGroupRequestData;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.AbstractResponse;
+import org.apache.kafka.common.requests.JoinGroupRequest;
+import org.apache.kafka.common.requests.JoinGroupResponse;
+import org.apache.kafka.common.requests.OffsetCommitRequest;
+import org.apache.kafka.common.requests.OffsetCommitResponse;
+import org.apache.kafka.common.requests.SyncGroupRequest;
+import org.apache.kafka.common.requests.SyncGroupResponse;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class OffsetTopicWriteTimeoutTest extends KopProtocolHandlerTestBase {
+
+    private KafkaRequestHandler handler;
+    private InetSocketAddress serviceAddress;
+
+
+    @BeforeClass(timeOut = 30000)
+    @Override
+    protected void setup() throws Exception {
+        // Any request that writes to the offset topic will time out with such a low timeout
+        conf.setOffsetCommitTimeoutMs(1);
+        super.internalSetup();
+        handler = newRequestHandler();
+        ChannelHandlerContext mockCtx = mock(ChannelHandlerContext.class);
+        Channel mockChannel = mock(Channel.class);
+        doReturn(mockChannel).when(mockCtx).channel();
+        handler.channelActive(mockCtx);
+        serviceAddress = new InetSocketAddress(pulsar.getBindAddress(), kafkaBrokerPort);
+        KafkaConsumer<String, String> consumer = new KafkaConsumer<>(newKafkaConsumerProperties());
+        final var rebalanced = new AtomicBoolean(false);
+        consumer.subscribe(Collections.singleton("my-topic"), new ConsumerRebalanceListener() {
+            @Override
+            public void onPartitionsRevoked(Collection<TopicPartition> collection) {
+                // No ops
+            }
+
+            @Override
+            public void onPartitionsAssigned(Collection<TopicPartition> collection) {
+                rebalanced.set(true);
+            }
+        });
+        for (int i = 0; !rebalanced.get() && i < 100; i++) {
+            consumer.poll(Duration.ofMillis(50));
+        }
+        Assert.assertTrue(rebalanced.get());
+        consumer.close();
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test(timeOut = 30000)
+    public void testSyncGroup() throws Exception {
+        final var protocols = new JoinGroupRequestData.JoinGroupRequestProtocolCollection();
+        protocols.add(new JoinGroupRequestData.JoinGroupRequestProtocol().setName("range").setMetadata("".getBytes()));
+        final var joinGroupRequest = buildRequest(new JoinGroupRequest.Builder(
+                new JoinGroupRequestData().setGroupId(DEFAULT_GROUP_ID).setMemberId("")
+                        .setSessionTimeoutMs(conf.getGroupMinSessionTimeoutMs())
+                        .setProtocolType("consumer").setProtocols(protocols)
+        ), serviceAddress);
+        final var joinGroupFuture = new CompletableFuture<AbstractResponse>();
+        handler.handleJoinGroupRequest(joinGroupRequest, joinGroupFuture);
+        final var joinGroupResponse = (JoinGroupResponse) joinGroupFuture.get();
+        Assert.assertEquals(joinGroupResponse.error(), Errors.NONE);
+
+        final var syncGroupRequest = buildRequest(new SyncGroupRequest.Builder(
+                new SyncGroupRequestData().setGroupId(DEFAULT_GROUP_ID)
+                        .setMemberId(joinGroupResponse.data().memberId())
+                        .setGenerationId(joinGroupResponse.data().generationId())), serviceAddress);
+        var syncGroupFuture = new CompletableFuture<AbstractResponse>();
+
+        handler.handleSyncGroupRequest(syncGroupRequest, syncGroupFuture);
+        final var syncGroupResponse = (SyncGroupResponse) syncGroupFuture.get();
+        Assert.assertEquals(syncGroupResponse.errorCounts().keySet(),
+                Collections.singleton(Errors.REBALANCE_IN_PROGRESS));
+    }
+
+    @Test(timeOut = 30000)
+    public void testOffsetCommit() throws Exception {
+        final var offsetCommit = new OffsetCommitRequest.Builder(new OffsetCommitRequestData()
+                .setGroupId(DEFAULT_GROUP_ID)
+                .setTopics(Collections.singletonList(KafkaCommonTestUtils.newOffsetCommitRequestPartitionData(
+                        new TopicPartition("my-topic", 0),
+                        0,
+                        ""
+                ))));
+        final var request = buildRequest(offsetCommit, serviceAddress);
+        final var future = new CompletableFuture<AbstractResponse>();
+        handler.handleOffsetCommitRequest(request, future);
+        final var response = (OffsetCommitResponse) future.get();
+        Assert.assertEquals(response.errorCounts().keySet(), Collections.singleton(Errors.REQUEST_TIMED_OUT));
+    }
+}


### PR DESCRIPTION
### Motivation

When Kafka writes to offset topics, the default timeout is 5 seconds and it's configurable by the `offsets.commit.timeout.ms` config, while the timeout of KoP is 30 seconds, which could be too long.

### Modifications

- Add an `offsetCommitTimeoutMs` config to configure the offset commit timeout whose default value is 5000.
- Handle the write error in a correct way:
  - For already closed exception, return `NOT_COORDINATOR` to tell the Kafka client to retry committing.
  - For timeout excepetion, return
    - `REBALANCE_IN_PROGRESS` for group messages
    - `REQUEST_TIMED_OUT` for offset messages
  - For other errors, return `UNKNOWN_SERVER_ERROR` to avoid retrying
- Add `OffsetTopicWriteTimeoutTest` to protect the changes


### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [x] `doc` 
  
  (If this PR contains doc changes)

