### PR TITLE
[transactions] Better handling of network exceptions while sending TX markers

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -2195,9 +2195,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                             responseData.results().add(topicResult);
                                             topicPartitionErrorsMap.forEach((TopicPartition tp, Errors error) -> {
                                                 if (tp.topic().equals(topicName)) {
-                                                    if (log.isDebugEnabled() && error != Errors.NONE) {
-                                                        log.info("Error {} for {}", error, tp);
-                                                    }
                                                     topicResult.results()
                                                         .add(new AddPartitionsToTxnResponseData
                                                                 .AddPartitionsToTxnPartitionResult()

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -2195,6 +2195,9 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                             responseData.results().add(topicResult);
                                             topicPartitionErrorsMap.forEach((TopicPartition tp, Errors error) -> {
                                                 if (tp.topic().equals(topicName)) {
+                                                    if (log.isDebugEnabled() && error != Errors.NONE) {
+                                                        log.info("Error {} for {}", error, tp);
+                                                    }
                                                     topicResult.results()
                                                         .add(new AddPartitionsToTxnResponseData
                                                                 .AddPartitionsToTxnPartitionResult()

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/PendingRequest.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/PendingRequest.java
@@ -57,6 +57,10 @@ public class PendingRequest {
         return requestHeader.correlationId();
     }
 
+    public AbstractResponse createErrorResponse(Throwable error) {
+        return request.getErrorResponse(error);
+    }
+
     public void complete(final ResponseContext responseContext) {
         responseConsumerHandler.accept(responseContext);
         sendFuture.complete(responseContext.getResponse());

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerRequestCompletionHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerRequestCompletionHandler.java
@@ -169,6 +169,7 @@ public class TransactionMarkerRequestCompletionHandler implements Consumer<Respo
                         case NOT_ENOUGH_REPLICAS:
                         case NOT_ENOUGH_REPLICAS_AFTER_APPEND:
                         case REQUEST_TIMED_OUT:
+                        case NETWORK_EXCEPTION:
                         case UNKNOWN_SERVER_ERROR:
                         case KAFKA_STORAGE_ERROR: // these are retriable errors
                             log.info("Sending {}'s transaction marker for partition {} has failed with error {}, "

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManager.java
@@ -775,6 +775,10 @@ public class TransactionStateManager {
     public void removeTransactionsForTxnTopicPartition(int partition) {
         TopicPartition topicPartition =
                 new TopicPartition(transactionConfig.getTransactionMetadataTopicName(), partition);
+        if (scheduler.isShutdown()) {
+            log.info("Skip unloading transaction metadata from {} as broker is stopping", topicPartition);
+            return;
+        }
         log.info("Scheduling unloading transaction metadata from {}", topicPartition);
 
         CoreUtils.inWriteLock(stateLock, () -> {


### PR DESCRIPTION
This PR is cherry-picking from https://github.com/datastax/starlight-for-kafka/commit/e0636995

### Motivation

Complete the pending request features when the channel is Inactive, or the exception caught.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

