### PR TITLE
[transactions] Prevent NullPointerException due to Recycled object used in different threads

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/AppendRecordsContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/AppendRecordsContext.java
@@ -34,7 +34,7 @@ public class AppendRecordsContext {
     };
 
     private final Recycler.Handle<AppendRecordsContext> recyclerHandle;
-    private KafkaTopicManager topicManager;
+    private volatile KafkaTopicManager topicManager;
     private Consumer<Integer> startSendOperationForThrottling;
     private Consumer<Integer> completeSendOperationForThrottling;
     private Map<TopicPartition, PendingTopicFutures> pendingTopicFuturesMap;
@@ -51,21 +51,21 @@ public class AppendRecordsContext {
                                            final Map<TopicPartition, PendingTopicFutures> pendingTopicFuturesMap,
                                            final ChannelHandlerContext ctx) {
         AppendRecordsContext context = RECYCLER.get();
-        context.topicManager = topicManager;
         context.startSendOperationForThrottling = startSendOperationForThrottling;
         context.completeSendOperationForThrottling = completeSendOperationForThrottling;
         context.pendingTopicFuturesMap = pendingTopicFuturesMap;
+        context.topicManager = topicManager;
         context.ctx = ctx;
 
         return context;
     }
 
     public void recycle() {
-        topicManager = null;
         startSendOperationForThrottling = null;
         completeSendOperationForThrottling = null;
         pendingTopicFuturesMap = null;
         recyclerHandle.recycle(this);
+        topicManager = null;
         ctx = null;
     }
 


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->


### Motivation

Cherry pick changes in https://github.com/datastax/starlight-for-kafka/commit/e85e4c2f66b291764d286e9648e9c811f2ac6f3c

### Modifications

- Prevent NullPointerException due to Recycled object used in different threads by make it volatile

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

