### PR TITLE
[transactions] Throttle clients on certain error during handleInitProducerId

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -2151,6 +2151,10 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                             .setErrorCode(resp.getError().code())
                             .setProducerId(resp.getProducerId())
                             .setProducerEpoch(resp.getProducerEpoch());
+                    if (resp.getError() == Errors.COORDINATOR_LOAD_IN_PROGRESS
+                        || resp.getError() == Errors.CONCURRENT_TRANSACTIONS) {
+                        responseData.setThrottleTimeMs(1000);
+                    }
                     response.complete(new InitProducerIdResponse(responseData));
                 });
     }


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation

Cherry pick https://github.com/datastax/starlight-for-kafka/commit/152625d62e80c33785862bf949be66d44ea1e74f

### Modifications

Add throttling for COORDINATOR_LOAD_IN_PROGRESS and CONCURRENT_TRANSACTIONS during handleInitProducerId

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.


### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

