### PR TITLE
[branch-2.11] Fix failed GroupMetadataManagerTest

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/group/GroupMetadataManagerTest.java
@@ -130,6 +130,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
 
     @BeforeMethod
     protected void setUp() throws PulsarClientException, PulsarAdminException {
+        conf.setOffsetsTopicNumPartitions(numOffsetsPartitions);
         producerBuilder = pulsarClient.newProducer(Schema.BYTEBUFFER);
         readerBuilder = pulsarClient.newReader(Schema.BYTEBUFFER)
                 .startMessageId(MessageId.earliest);
@@ -167,6 +168,7 @@ public class GroupMetadataManagerTest extends KopProtocolHandlerTestBase {
 
     @AfterMethod
     protected void tearDown() throws PulsarClientException {
+        conf.setOffsetsTopicNumPartitions(numOffsetsPartitions);
         if (consumer != null) {
             consumer.close();
         }


### PR DESCRIPTION
### Motivation

When running `GroupMetadataManagerTest`,
`testOffsetWriteAfterGroupRemoved` will be called after `testOffsetTopicNumPartitionsModify`, which changes the `offsetTopicNumPartitions` to 100 so that `consumerGroupPartitionId` will be 74 while `groupPartitionId` is 0, and then the group metadata will be sent to partition 0 while `scheduleLoadGroupAndOffsets` will read from partition 74. Since no group metadata is loaded,

### Modifications

Migrate the fix in https://github.com/streamnative/kop/pull/1759 to reset the `offsetTopicNumPartitions` before and after each method.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

