### PR TITLE
[branch-2.10.4][improve] Pass group ID to authorizer when using OAuth (#1926)

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -313,7 +313,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 : null;
         final boolean authorizationEnabled = pulsarService.getBrokerService().isAuthorizationEnabled();
         this.authorizer = authorizationEnabled && authenticationEnabled
-                ? new SimpleAclAuthorizer(pulsarService)
+                ? new SimpleAclAuthorizer(pulsarService, kafkaConfig)
                 : null;
         this.adminManager = adminManager;
         this.producePurgatory = producePurgatory;
@@ -2625,6 +2625,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                     isAuthorizedFuture = authorizer.canLookupAsync(session.getPrincipal(), resource);
                 } else if (resource.getResourceType() == ResourceType.NAMESPACE) {
                     isAuthorizedFuture = authorizer.canGetTopicList(session.getPrincipal(), resource);
+                } else if (resource.getResourceType() == ResourceType.GROUP) {
+                    isAuthorizedFuture = authorizer.canDescribeConsumerGroup(session.getPrincipal(), resource);
                 }
                 break;
             case CREATE:

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -116,6 +116,13 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
     @FieldContext(
         category = CATEGORY_KOP,
         required = true,
+        doc = "Use to enable/disable Kafka authorization force groupId check."
+    )
+    private boolean kafkaEnableAuthorizationForceGroupIdCheck = false;
+
+    @FieldContext(
+        category = CATEGORY_KOP,
+        required = true,
         doc = "The namespace used for storing Kafka metadata topics"
     )
     private String kafkaMetadataNamespace = "__kafka";

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/PlainSaslServer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/PlainSaslServer.java
@@ -14,6 +14,7 @@
 package io.streamnative.pulsar.handlers.kop.security;
 
 import static io.streamnative.pulsar.handlers.kop.security.SaslAuthenticator.AUTH_DATA_SOURCE_PROP;
+import static io.streamnative.pulsar.handlers.kop.security.SaslAuthenticator.GROUP_ID_PROP;
 import static io.streamnative.pulsar.handlers.kop.security.SaslAuthenticator.USER_NAME_PROP;
 
 import io.streamnative.pulsar.handlers.kop.SaslAuth;
@@ -149,6 +150,9 @@ public class PlainSaslServer implements SaslServer {
         }
         if (USER_NAME_PROP.equals(propName)) {
             return username;
+        }
+        if (GROUP_ID_PROP.equals(propName)) {
+            return "";
         }
         if (AUTH_DATA_SOURCE_PROP.equals(propName)) {
             return authDataSource;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/SaslAuthenticator.java
@@ -70,6 +70,7 @@ import org.apache.pulsar.client.admin.PulsarAdmin;
 public class SaslAuthenticator {
 
     public static final String USER_NAME_PROP = "username";
+    public static final String GROUP_ID_PROP = "groupId";
     public static final String AUTH_DATA_SOURCE_PROP = "authDataSource";
     public static final String AUTHENTICATION_SERVER_OBJ = "authenticationServerObj";
 
@@ -439,6 +440,7 @@ public class SaslAuthenticator {
                         newSession = new Session(
                                 new KafkaPrincipal(KafkaPrincipal.USER_TYPE, saslServer.getAuthorizationID(),
                                         safeGetProperty(saslServer, USER_NAME_PROP),
+                                        safeGetProperty(saslServer, GROUP_ID_PROP),
                                         safeGetProperty(saslServer, AUTH_DATA_SOURCE_PROP)),
                                 "old-clientId");
                         if (!tenantAccessValidationFunction.apply(newSession)) {
@@ -499,6 +501,7 @@ public class SaslAuthenticator {
                     this.session = new Session(
                             new KafkaPrincipal(KafkaPrincipal.USER_TYPE, pulsarRole,
                                     safeGetProperty(saslServer, USER_NAME_PROP),
+                                    safeGetProperty(saslServer, GROUP_ID_PROP),
                                     safeGetProperty(saslServer, AUTH_DATA_SOURCE_PROP)),
                             header.clientId());
                     if (log.isDebugEnabled()) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/Authorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/Authorizer.java
@@ -114,4 +114,5 @@ public interface Authorizer {
      */
     CompletableFuture<Boolean> canConsumeAsync(KafkaPrincipal principal, Resource resource);
 
+    CompletableFuture<Boolean> canDescribeConsumerGroup(KafkaPrincipal principal, Resource resource);
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/ResourceType.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/ResourceType.java
@@ -46,6 +46,10 @@ public enum ResourceType {
      */
     TENANT((byte) 3),
 
+    /**
+     * A consumer group.
+     */
+    GROUP((byte) 4),
     ;
 
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerSaslServer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerSaslServer.java
@@ -14,11 +14,13 @@
 package io.streamnative.pulsar.handlers.kop.security.oauth;
 
 import static io.streamnative.pulsar.handlers.kop.security.SaslAuthenticator.AUTH_DATA_SOURCE_PROP;
+import static io.streamnative.pulsar.handlers.kop.security.SaslAuthenticator.GROUP_ID_PROP;
 import static io.streamnative.pulsar.handlers.kop.security.SaslAuthenticator.USER_NAME_PROP;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Objects;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
@@ -28,9 +30,16 @@ import javax.security.sasl.SaslServer;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
+import org.apache.kafka.common.security.auth.SaslExtensions;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerExtensionsValidatorCallback;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
 import org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerClientInitialResponse;
+import org.apache.kafka.common.utils.Utils;
 
+/**
+ * Migrate from {@link org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerSaslServer}.
+ */
 @Slf4j
 public class KopOAuthBearerSaslServer implements SaslServer {
 
@@ -46,6 +55,7 @@ public class KopOAuthBearerSaslServer implements SaslServer {
     private boolean complete;
     private KopOAuthBearerToken tokenForNegotiatedProperty = null;
     private String errorMessage = null;
+    private SaslExtensions extensions;
 
     public KopOAuthBearerSaslServer(CallbackHandler callbackHandler, String defaultKafkaMetadataTenant) {
         if (!(Objects.requireNonNull(callbackHandler) instanceof AuthenticateCallbackHandler)) {
@@ -72,7 +82,7 @@ public class KopOAuthBearerSaslServer implements SaslServer {
     @Override
     public byte[] evaluateResponse(byte[] response) throws SaslException, SaslAuthenticationException {
         if (response.length == 1 && response[0] == BYTE_CONTROL_A && errorMessage != null) {
-            if (log.isDebugEnabled()){
+            if (log.isDebugEnabled()) {
                 log.debug("Received %x01 response from client after it received our error");
             }
             throw new SaslAuthenticationException(errorMessage);
@@ -85,7 +95,7 @@ public class KopOAuthBearerSaslServer implements SaslServer {
             log.debug(e.getMessage());
             throw e;
         }
-        return process(clientResponse.tokenValue(), clientResponse.authorizationId());
+        return process(clientResponse.tokenValue(), clientResponse.authorizationId(), clientResponse.extensions());
     }
 
     @Override
@@ -107,6 +117,9 @@ public class KopOAuthBearerSaslServer implements SaslServer {
             throw new IllegalStateException("Authentication exchange has not completed");
         }
 
+        if (NEGOTIATED_PROPERTY_KEY_TOKEN.equals(propName)) {
+            return tokenForNegotiatedProperty;
+        }
         if (AUTH_DATA_SOURCE_PROP.equals(propName)) {
             return tokenForNegotiatedProperty.authDataSource();
         }
@@ -114,9 +127,20 @@ public class KopOAuthBearerSaslServer implements SaslServer {
             if (tokenForNegotiatedProperty.tenant() != null) {
                 return tokenForNegotiatedProperty.tenant();
             }
+            String tenant = extensions.map().get(propName);
+            if (tenant != null) {
+                return tenant;
+            }
             return defaultKafkaMetadataTenant;
         }
-        return NEGOTIATED_PROPERTY_KEY_TOKEN.equals(propName) ? tokenForNegotiatedProperty : null;
+        if (GROUP_ID_PROP.equals(propName)) {
+            String groupId = extensions.map().get(propName);
+            if (groupId != null) {
+                return groupId;
+            }
+            return "";
+        }
+        return extensions.map().get(propName);
     }
 
     @Override
@@ -125,7 +149,7 @@ public class KopOAuthBearerSaslServer implements SaslServer {
     }
 
     @Override
-    public byte[] unwrap(byte[] incoming, int offset, int len) throws SaslException {
+    public byte[] unwrap(byte[] incoming, int offset, int len) {
         if (!complete) {
             throw new IllegalStateException("Authentication exchange has not completed");
         }
@@ -133,7 +157,7 @@ public class KopOAuthBearerSaslServer implements SaslServer {
     }
 
     @Override
-    public byte[] wrap(byte[] outgoing, int offset, int len) throws SaslException {
+    public byte[] wrap(byte[] outgoing, int offset, int len) {
         if (!complete) {
             throw new IllegalStateException("Authentication exchange has not completed");
         }
@@ -141,21 +165,19 @@ public class KopOAuthBearerSaslServer implements SaslServer {
     }
 
     @Override
-    public void dispose() throws SaslException {
+    public void dispose() {
         complete = false;
         tokenForNegotiatedProperty = null;
+        extensions = null;
     }
 
-    private byte[] process(String tokenValue, String authorizationId) throws SaslException {
+    private byte[] process(String tokenValue, String authorizationId, SaslExtensions extensions)
+            throws SaslException {
         KopOAuthBearerValidatorCallback callback = new KopOAuthBearerValidatorCallback(tokenValue);
         try {
-            callbackHandler.handle(new Callback[]{callback});
+            callbackHandler.handle(new Callback[] {callback});
         } catch (IOException | UnsupportedCallbackException e) {
-            String msg = String.format("%s: %s", INTERNAL_ERROR_ON_SERVER, e.getMessage());
-            if (log.isDebugEnabled()) {
-                log.debug(msg, e);
-            }
-            throw new SaslException(msg);
+            handleCallbackError(e);
         }
         KopOAuthBearerToken token = callback.token();
         if (token == null) {
@@ -176,13 +198,39 @@ public class KopOAuthBearerSaslServer implements SaslServer {
                             + "that is different from the token's principal name (%s)",
                     authorizationId, token.principalName()));
         }
+        Map<String, String> validExtensions = processExtensions(token, extensions);
 
         tokenForNegotiatedProperty = token;
+        this.extensions = new SaslExtensions(validExtensions);
         complete = true;
         if (log.isDebugEnabled()) {
             log.debug("Successfully authenticate User={}", token.principalName());
         }
         return new byte[0];
+    }
+
+    private Map<String, String> processExtensions(OAuthBearerToken token, SaslExtensions extensions)
+            throws SaslException {
+        OAuthBearerExtensionsValidatorCallback extensionsCallback =
+                new OAuthBearerExtensionsValidatorCallback(token, extensions);
+        try {
+            callbackHandler.handle(new Callback[] {extensionsCallback});
+        } catch (UnsupportedCallbackException e) {
+            // backwards compatibility - no extensions will be added
+        } catch (IOException e) {
+            handleCallbackError(e);
+        }
+        if (!extensionsCallback.invalidExtensions().isEmpty()) {
+            String errorMessage = String.format("Authentication failed: %d extensions are invalid! They are: %s",
+                    extensionsCallback.invalidExtensions().size(),
+                    Utils.mkString(extensionsCallback.invalidExtensions(), "", "", ": ", "; "));
+            if (log.isDebugEnabled()) {
+                log.debug(errorMessage);
+            }
+            throw new SaslAuthenticationException(errorMessage);
+        }
+
+        return extensionsCallback.validatedExtensions();
     }
 
     private static String jsonErrorResponse(String errorStatus, String errorScope, String errorOpenIDConfiguration) {
@@ -198,4 +246,11 @@ public class KopOAuthBearerSaslServer implements SaslServer {
         return jsonErrorResponse;
     }
 
+    private void handleCallbackError(Exception e) throws SaslException {
+        String msg = String.format("%s: %s", INTERNAL_ERROR_ON_SERVER, e.getMessage());
+        if (log.isDebugEnabled()) {
+            log.debug(msg, e);
+        }
+        throw new SaslException(msg);
+    }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerSaslServer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/KopOAuthBearerSaslServer.java
@@ -201,6 +201,8 @@ public class KopOAuthBearerSaslServer implements SaslServer {
         Map<String, String> validExtensions = processExtensions(token, extensions);
 
         tokenForNegotiatedProperty = token;
+        log.info("Successfully authenticate User={}, validExtensions={}",
+                token.principalName(), validExtensions);
         this.extensions = new SaslExtensions(validExtensions);
         complete = true;
         if (log.isDebugEnabled()) {

--- a/oauth-client/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/ClientInfo.java
+++ b/oauth-client/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/ClientInfo.java
@@ -11,40 +11,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.streamnative.pulsar.handlers.kop.security;
+package io.streamnative.pulsar.handlers.kop.security.oauth;
 
-
-import java.security.Principal;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
-import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 
-
-/**
- * Store client login info.
- */
 @Getter
 @ToString
+@EqualsAndHashCode
+@NoArgsConstructor
 @AllArgsConstructor
-public class KafkaPrincipal implements Principal {
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ClientInfo {
 
-    public static final String USER_TYPE = "User";
+    @JsonProperty("client_id")
+    private String id;
 
-    private final String principalType;
+    @JsonProperty("client_secret")
+    private String secret;
 
-    /**
-     * Pulsar role.
-     */
-    private final String name;
+    @JsonProperty("tenant")
+    private String tenant;
 
-    /**
-     * Pulsar Tenant Specs.
-     * It can be "tenant" or "tenant/namespace"
-     */
-    private final String tenantSpec;
-
-    private final String groupId;
-
-    private final AuthenticationDataSource authenticationData;
+    @JsonProperty("group_id")
+    private String groupId;
 }

--- a/oauth-client/src/test/java/io/streamnative/pulsar/handlers/kop/security/oauth/ClientConfigTest.java
+++ b/oauth-client/src/test/java/io/streamnative/pulsar/handlers/kop/security/oauth/ClientConfigTest.java
@@ -15,6 +15,7 @@ package io.streamnative.pulsar.handlers.kop.security.oauth;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -27,14 +28,34 @@ public class ClientConfigTest {
 
     @Test
     public void testValidConfig() {
+        String credentialsUrl = Objects.requireNonNull(
+                getClass().getClassLoader().getResource("private_key.json")).toString();
         final ClientConfig clientConfig = ClientConfigHelper.create(
                 "https://issuer-url.com",
-                "file:///etc/config/credentials.json",
+                credentialsUrl,
                 "audience"
         );
         Assert.assertEquals(clientConfig.getIssuerUrl().toString(), "https://issuer-url.com");
-        Assert.assertEquals(clientConfig.getCredentialsUrl().toString(), "file:/etc/config/credentials.json");
+        Assert.assertEquals(clientConfig.getCredentialsUrl().toString(), credentialsUrl);
         Assert.assertEquals(clientConfig.getAudience(), "audience");
+        Assert.assertEquals(clientConfig.getClientInfo(),
+                new ClientInfo("my-id", "my-secret", "my-tenant", null));
+    }
+
+    @Test
+    public void testValidConfigWithGroupId() {
+        String credentialsUrl = Objects.requireNonNull(
+                getClass().getClassLoader().getResource("private_key_with_group_id.json")).toString();
+        final ClientConfig clientConfig = ClientConfigHelper.create(
+                "https://issuer-url.com",
+                credentialsUrl,
+                "audience"
+        );
+        Assert.assertEquals(clientConfig.getIssuerUrl().toString(), "https://issuer-url.com");
+        Assert.assertEquals(clientConfig.getCredentialsUrl().toString(), credentialsUrl);
+        Assert.assertEquals(clientConfig.getAudience(), "audience");
+        Assert.assertEquals(clientConfig.getClientInfo(),
+                new ClientInfo("my-id", "my-secret", "my-tenant", "my-group-id"));
     }
 
     @Test

--- a/oauth-client/src/test/java/io/streamnative/pulsar/handlers/kop/security/oauth/ClientCredentialsFlowTest.java
+++ b/oauth-client/src/test/java/io/streamnative/pulsar/handlers/kop/security/oauth/ClientCredentialsFlowTest.java
@@ -35,20 +35,21 @@ public class ClientCredentialsFlowTest {
     public void testFindAuthorizationServer() throws IOException {
         final ClientCredentialsFlow flow = new ClientCredentialsFlow(ClientConfigHelper.create(
                 "http://localhost:4444", // a local OAuth2 server started by init_hydra_oauth_server.sh
-                "file:///tmp/not_exist.json"
+                Objects.requireNonNull(
+                        getClass().getClassLoader().getResource("private_key.json")).toString()
         ));
         final ClientCredentialsFlow.Metadata metadata = flow.findAuthorizationServer();
         Assert.assertEquals(metadata.getTokenEndPoint(), "http://127.0.0.1:4444/oauth2/token");
     }
 
     @Test
-    public void testLoadPrivateKey() throws Exception {
-        final ClientCredentialsFlow flow = new ClientCredentialsFlow(ClientConfigHelper.create(
+    public void testLoadPrivateKey() {
+        ClientConfig clientConfig = ClientConfigHelper.create(
                 "http://localhost:4444",
                 Objects.requireNonNull(
                         getClass().getClassLoader().getResource("private_key.json")).toString()
-        ));
-        final ClientCredentialsFlow.ClientInfo clientInfo = flow.loadPrivateKey();
+        );
+        ClientInfo clientInfo = clientConfig.getClientInfo();
         Assert.assertEquals(clientInfo.getId(), "my-id");
         Assert.assertEquals(clientInfo.getSecret(), "my-secret");
         Assert.assertEquals(clientInfo.getTenant(), "my-tenant");

--- a/oauth-client/src/test/resources/private_key_with_group_id.json
+++ b/oauth-client/src/test/resources/private_key_with_group_id.json
@@ -1,0 +1,6 @@
+{
+  "client_id": "my-id",
+  "client_secret": "my-secret",
+  "tenant": "my-tenant",
+  "group_id": "my-group-id"
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/HydraOAuthUtils.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/HydraOAuthUtils.java
@@ -17,9 +17,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import io.fusionauth.jwks.domain.JSONWebKey;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
+import io.streamnative.pulsar.handlers.kop.security.oauth.ClientInfo;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -41,6 +43,10 @@ public class HydraOAuthUtils {
     private static final String AUDIENCE = "http://example.com/api/v2/";
 
     private static final AdminApi hydraAdmin = new AdminApi();
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static final ObjectWriter CLIENT_INFO_WRITER =
+            OBJECT_MAPPER.writerFor(ClientInfo.class);
 
     private static String publicKey;
 
@@ -87,6 +93,11 @@ public class HydraOAuthUtils {
     }
 
     public static String createOAuthClient(String clientId, String clientSecret, String tenant)
+            throws IOException, ApiException {
+        return createOAuthClient(clientId, clientSecret, tenant, null);
+    }
+
+    public static String createOAuthClient(String clientId, String clientSecret, String tenant, String groupId)
             throws ApiException, IOException {
         final OAuth2Client oAuth2Client = new OAuth2Client()
                 .audience(Collections.singletonList(AUDIENCE))
@@ -102,18 +113,16 @@ public class HydraOAuthUtils {
                 throw e;
             }
         }
-        return writeCredentialsFile(clientId, clientSecret, tenant, clientId + ".json");
+        return writeCredentialsFile(clientId, clientSecret, tenant, groupId, clientId + ".json");
     }
 
     public static String writeCredentialsFile(String clientId,
-                                               String clientSecret,
-                                               String tenant,
-                                               String basename) throws IOException {
-        final String content = "{\n"
-                + "    \"client_id\": \"" + clientId + "\",\n"
-                + "    \"client_secret\": \"" + clientSecret + (tenant != null ? "\",\n" : "\"\n")
-                + (tenant != null ? "    \"tenant\": \"" + tenant + "\"\n" : "")
-                + "}\n";
+                                              String clientSecret,
+                                              String tenant,
+                                              String groupId,
+                                              String basename) throws IOException {
+        ClientInfo clientInfo = new ClientInfo(clientId, clientSecret, tenant, groupId);
+        final String content = CLIENT_INFO_WRITER.writeValueAsString(clientInfo);
 
         File file = File.createTempFile("oauth-credentials-", basename);
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOAuthKopHandlersTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOAuthKopHandlersTest.java
@@ -197,7 +197,7 @@ public class SaslOAuthKopHandlersTest extends SaslOAuthBearerTestBase {
     public void testWrongSecret() throws IOException {
         final Properties producerProps = newKafkaProducerProperties();
         internalConfigureOAuth2(producerProps, HydraOAuthUtils
-                .writeCredentialsFile(ADMIN_USER, ADMIN_SECRET + "-wrong", null, "test-wrong-secret.json"));
+                .writeCredentialsFile(ADMIN_USER, ADMIN_SECRET + "-wrong", null, null, "test-wrong-secret.json"));
         try {
             new KafkaProducer<>(producerProps);
         } catch (Exception e) {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOAuthKopHandlersWithGroupIdTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOAuthKopHandlersWithGroupIdTest.java
@@ -1,0 +1,203 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import com.google.common.collect.Sets;
+import io.streamnative.pulsar.handlers.kop.security.oauth.OauthLoginCallbackHandler;
+import io.streamnative.pulsar.handlers.kop.security.oauth.OauthValidatorCallbackHandler;
+import java.io.IOException;
+import java.net.URL;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Properties;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.errors.GroupAuthorizationException;
+import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
+import org.apache.pulsar.broker.authentication.AuthenticationProviderToken;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationFactoryOAuth2;
+import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2;
+import org.apache.pulsar.common.policies.data.AuthAction;
+import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import sh.ory.hydra.ApiException;
+
+@Slf4j
+public class SaslOAuthKopHandlersWithGroupIdTest extends SaslOAuthBearerTestBase {
+
+    private static final String ADMIN_USER = "simple_client_id";
+    private static final String ADMIN_SECRET = "admin_secret";
+    private static final String ISSUER_URL = "http://localhost:4444";
+    private static final String AUDIENCE = "http://example.com/api/v2/";
+    private static final String DEFAULT_GROUP_ID = "my-group-id";
+
+    private String adminCredentialPath = null;
+
+    private String tenant = "my-tenant";
+
+    @BeforeClass(timeOut = 20000)
+    @Override
+    protected void setup() throws Exception {
+        String tokenPublicKey = HydraOAuthUtils.getPublicKeyStr();
+        adminCredentialPath = HydraOAuthUtils.createOAuthClient(ADMIN_USER, ADMIN_SECRET);
+        super.resetConfig();
+        // Broker's config
+        conf.setAuthenticationEnabled(true);
+        conf.setAuthorizationEnabled(true);
+        conf.setKafkaEnableMultiTenantMetadata(true);
+        conf.setAuthorizationProvider(SaslOAuthKopHandlersTest.OAuthMockAuthorizationProvider.class.getName());
+        conf.setAuthenticationProviders(Sets.newHashSet(AuthenticationProviderToken.class.getName()));
+        conf.setBrokerClientAuthenticationPlugin(AuthenticationOAuth2.class.getName());
+        conf.setBrokerClientAuthenticationParameters(String.format("{\"type\":\"client_credentials\","
+                        + "\"privateKey\":\"%s\",\"issuerUrl\":\"%s\",\"audience\":\"%s\"}",
+                adminCredentialPath, ISSUER_URL, AUDIENCE));
+        conf.setKafkaEnableAuthorizationForceGroupIdCheck(true);
+        final Properties properties = new Properties();
+        properties.setProperty("tokenPublicKey", tokenPublicKey);
+        conf.setProperties(properties);
+
+        // KoP's config
+        conf.setSaslAllowedMechanisms(Sets.newHashSet("OAUTHBEARER"));
+        conf.setKopOauth2AuthenticateCallbackHandler(OauthValidatorCallbackHandler.class.getName());
+        conf.setKopOauth2ConfigFile("src/test/resources/kop-handler-oauth2.properties");
+
+        super.internalSetup();
+
+        admin.tenants().createTenant(tenant,
+                TenantInfo.builder()
+                        .adminRoles(Collections.singleton(ADMIN_USER))
+                        .allowedClusters(Collections.singleton(configClusterName))
+                        .build());
+        TenantInfo tenantInfo = admin.tenants().getTenantInfo(tenant);
+        log.info("TenantInfo for {} {} in test", tenant, tenantInfo);
+        assertNotNull(tenantInfo);
+    }
+
+    @AfterClass
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Override
+    protected void createAdmin() throws Exception {
+        super.admin = PulsarAdmin.builder()
+                .serviceHttpUrl(brokerUrl.toString())
+                .authentication(
+                        AuthenticationFactoryOAuth2.clientCredentials(
+                                new URL(ISSUER_URL), new URL(adminCredentialPath), AUDIENCE))
+                .build();
+    }
+
+    @Test(timeOut = 30000)
+    public void testGrantAndRevokePermissionWithGroupId() throws Exception {
+        SaslOAuthKopHandlersTest.OAuthMockAuthorizationProvider.NULL_ROLE_STACKS.clear();
+
+        final String namespace = tenant + "/" + "test-grant-and-revoke-permission-with-group-id-ns";
+        admin.namespaces().createNamespace(namespace);
+        final String topic = "persistent://" + namespace + "/test-grant-and-revoke-permission-with-group-id";
+        final String role = "normal-role-" + System.currentTimeMillis();
+        final String clientCredentialPath = HydraOAuthUtils.createOAuthClient(role, "secret", tenant);
+
+        admin.namespaces().grantPermissionOnNamespace(namespace, role, Collections.singleton(AuthAction.produce));
+
+        final Properties consumerProps = newKafkaConsumerProperties();
+        internalConfigureOAuth2(consumerProps, clientCredentialPath);
+        final KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consumerProps);
+        consumer.subscribe(Collections.singleton(topic));
+
+        admin.namespaces().grantPermissionOnNamespace(namespace, role, Sets.newHashSet(AuthAction.consume));
+        // Only have consume permission, can't consume without subscription permission.
+        Assert.assertThrows(GroupAuthorizationException.class, () -> consumer.poll(Duration.ofSeconds(5)));
+
+        consumer.close();
+
+        // Pass subscription permission, can consume now.
+        final String roleWithGroupId = "role-with-groupId" + System.currentTimeMillis();
+        final String clientCredentialPathWithGroupId =
+                HydraOAuthUtils.createOAuthClient(roleWithGroupId, "secret", tenant, DEFAULT_GROUP_ID);
+        final Properties consumerPropsWithGroupId = newKafkaConsumerProperties();
+        internalConfigureOAuth2(consumerPropsWithGroupId, clientCredentialPathWithGroupId);
+        final KafkaConsumer<String, String> consumer2 = new KafkaConsumer<>(consumerPropsWithGroupId);
+        consumer2.subscribe(Collections.singleton(topic));
+
+        admin.namespaces().grantPermissionOnNamespace(namespace, roleWithGroupId, Sets.newHashSet(AuthAction.consume));
+        admin.namespaces().grantPermissionOnSubscription(namespace, DEFAULT_GROUP_ID, Sets.newHashSet(roleWithGroupId));
+
+        consumer2.poll(Duration.ofSeconds(5));
+
+        assertEquals(SaslOAuthKopHandlersTest.OAuthMockAuthorizationProvider.NULL_ROLE_STACKS.size(), 0);
+    }
+
+    @Test(timeOut = 30000, expectedExceptions = org.apache.kafka.common.errors.GroupAuthorizationException.class)
+    public void testDifferentGroupId() throws PulsarAdminException, IOException, ApiException {
+        SaslOAuthKopHandlersTest.OAuthMockAuthorizationProvider.NULL_ROLE_STACKS.clear();
+
+        final String namespace = tenant + "/" + "test-different-group-id-ns";
+        admin.namespaces().createNamespace(namespace);
+        final String topic = "persistent://" + namespace + "/test-grant-and-revoke-permission";
+        // Pass subscription permission, can consume now.
+        final String roleWithGroupId = "role-with-groupId" + System.currentTimeMillis();
+        final String clientCredentialPathWithGroupId =
+                HydraOAuthUtils.createOAuthClient(roleWithGroupId, "secret", tenant, DEFAULT_GROUP_ID);
+        admin.namespaces().grantPermissionOnNamespace(namespace, roleWithGroupId, Sets.newHashSet(AuthAction.consume));
+        admin.namespaces().grantPermissionOnSubscription(namespace, DEFAULT_GROUP_ID, Sets.newHashSet(roleWithGroupId));
+
+        final Properties consumerPropsWithGroupId = newKafkaConsumerProperties();
+        internalConfigureOAuth2(consumerPropsWithGroupId, clientCredentialPathWithGroupId);
+        consumerPropsWithGroupId.put(ConsumerConfig.GROUP_ID_CONFIG, "different-group-id");
+        final KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consumerPropsWithGroupId);
+        consumer.subscribe(Collections.singleton(topic));
+
+        consumer.poll(Duration.ofSeconds(5));
+
+        assertEquals(SaslOAuthKopHandlersTest.OAuthMockAuthorizationProvider.NULL_ROLE_STACKS.size(), 0);
+    }
+
+    private void internalConfigureOAuth2(final Properties props, final String credentialPath,
+                                         Class<? extends AuthenticateCallbackHandler> callbackHandler) {
+        props.setProperty("sasl.login.callback.handler.class", callbackHandler.getName());
+        props.setProperty("security.protocol", "SASL_PLAINTEXT");
+        props.setProperty("sasl.mechanism", "OAUTHBEARER");
+
+        final String jaasTemplate = "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required"
+                + " oauth.issuer.url=\"%s\""
+                + " oauth.credentials.url=\"%s\""
+                + " oauth.audience=\"%s\";";
+        props.setProperty("sasl.jaas.config", String.format(jaasTemplate,
+                ISSUER_URL,
+                credentialPath,
+                AUDIENCE
+        ));
+    }
+
+    private void internalConfigureOAuth2(final Properties props, final String credentialPath) {
+        internalConfigureOAuth2(props, credentialPath, OauthLoginCallbackHandler.class);
+    }
+
+    @Override
+    protected void configureOAuth2(final Properties props) {
+        internalConfigureOAuth2(props, adminCredentialPath);
+    }
+
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOAuthKopHandlersWithGroupIdTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/SaslOAuthKopHandlersWithGroupIdTest.java
@@ -49,7 +49,7 @@ public class SaslOAuthKopHandlersWithGroupIdTest extends SaslOAuthBearerTestBase
     private static final String ADMIN_SECRET = "admin_secret";
     private static final String ISSUER_URL = "http://localhost:4444";
     private static final String AUDIENCE = "http://example.com/api/v2/";
-    private static final String DEFAULT_GROUP_ID = "my-group-id";
+    private static final String DEFAULT_GROUP_ID = "my-group";
 
     private String adminCredentialPath = null;
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizerTest.java
@@ -112,7 +112,7 @@ public class SimpleAclAuthorizerTest extends KopProtocolHandlerTestBase {
         admin.namespaces().grantPermissionOnNamespace(TENANT + "/" + NAMESPACE, CONSUMER_USER,
                 Sets.newHashSet(AuthAction.consume));
 
-        simpleAclAuthorizer = new SimpleAclAuthorizer(pulsar);
+        simpleAclAuthorizer = new SimpleAclAuthorizer(pulsar, conf);
     }
 
     @Override
@@ -131,37 +131,37 @@ public class SimpleAclAuthorizerTest extends KopProtocolHandlerTestBase {
     @Test
     public void testAuthorizeProduce() throws ExecutionException, InterruptedException {
         Boolean isAuthorized = simpleAclAuthorizer.canProduceAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER, null,
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER, null, null,
                         new AuthenticationDataCommand(SIMPLE_USER)),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertTrue(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canProduceAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, PRODUCE_USER, null,
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, PRODUCE_USER, null, null,
                         new AuthenticationDataCommand(PRODUCE_USER)),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertTrue(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canProduceAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, CONSUMER_USER, null,
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, CONSUMER_USER, null, null,
                     new AuthenticationDataCommand(CONSUMER_USER)),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertFalse(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canProduceAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ANOTHER_USER, null,
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ANOTHER_USER, null, null,
                         new AuthenticationDataCommand(ANOTHER_USER)),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertFalse(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canProduceAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER, null,
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER, null, null,
                         new AuthenticationDataCommand(SIMPLE_USER)),
                 Resource.of(ResourceType.TOPIC, NOT_EXISTS_TENANT_TOPIC)).get();
         assertFalse(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canProduceAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ADMIN_USER, null,
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ADMIN_USER, null, null,
                         new AuthenticationDataCommand(ADMIN_USER)),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertTrue(isAuthorized);
@@ -170,31 +170,31 @@ public class SimpleAclAuthorizerTest extends KopProtocolHandlerTestBase {
     @Test
     public void testAuthorizeConsume() throws ExecutionException, InterruptedException {
         Boolean isAuthorized = simpleAclAuthorizer.canConsumeAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER, null,
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER, null, null,
                         new AuthenticationDataCommand(SIMPLE_USER)),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertTrue(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canConsumeAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, PRODUCE_USER, null,
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, PRODUCE_USER, null, null,
                         new AuthenticationDataCommand(PRODUCE_USER)),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertFalse(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canConsumeAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, CONSUMER_USER, null,
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, CONSUMER_USER, null, null,
                         new AuthenticationDataCommand(CONSUMER_USER)),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertTrue(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canConsumeAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ANOTHER_USER, null,
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ANOTHER_USER, null, null,
                         new AuthenticationDataCommand(ANOTHER_USER)),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertFalse(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canConsumeAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER, null,
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER, null, null,
                         new AuthenticationDataCommand(SIMPLE_USER)),
                 Resource.of(ResourceType.TOPIC, NOT_EXISTS_TENANT_TOPIC)).get();
         assertFalse(isAuthorized);
@@ -203,31 +203,31 @@ public class SimpleAclAuthorizerTest extends KopProtocolHandlerTestBase {
     @Test
     public void testAuthorizeLookup() throws ExecutionException, InterruptedException {
         Boolean isAuthorized = simpleAclAuthorizer.canLookupAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER, null,
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER, null, null,
                         new AuthenticationDataCommand(SIMPLE_USER)),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertTrue(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canLookupAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, PRODUCE_USER, null,
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, PRODUCE_USER, null, null,
                         new AuthenticationDataCommand(PRODUCE_USER)),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertTrue(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canLookupAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, CONSUMER_USER, null,
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, CONSUMER_USER, null, null,
                         new AuthenticationDataCommand(CONSUMER_USER)),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertTrue(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canLookupAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ANOTHER_USER, null,
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ANOTHER_USER, null, null,
                         new AuthenticationDataCommand(ANOTHER_USER)),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertFalse(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canLookupAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER, null,
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, SIMPLE_USER, null, null,
                         new AuthenticationDataCommand(SIMPLE_USER)),
                 Resource.of(ResourceType.TOPIC, NOT_EXISTS_TENANT_TOPIC)).get();
         assertFalse(isAuthorized);
@@ -239,28 +239,28 @@ public class SimpleAclAuthorizerTest extends KopProtocolHandlerTestBase {
         // TENANT_ADMIN_USER can't produce don't exist tenant's topic,
         // because tenant admin depend on exist tenant.
         Boolean isAuthorized = simpleAclAuthorizer.canProduceAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TENANT_ADMIN_USER, null,
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TENANT_ADMIN_USER, null, null,
                         new AuthenticationDataCommand(TENANT_ADMIN_USER)),
                 Resource.of(ResourceType.TOPIC, NOT_EXISTS_TENANT_TOPIC)).get();
         assertFalse(isAuthorized);
 
         // ADMIN_USER can produce don't exist tenant's topic, because is superuser.
         isAuthorized = simpleAclAuthorizer.canProduceAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ADMIN_USER, null,
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, ADMIN_USER, null, null,
                         new AuthenticationDataCommand(ADMIN_USER)),
                 Resource.of(ResourceType.TOPIC, NOT_EXISTS_TENANT_TOPIC)).get();
         assertTrue(isAuthorized);
 
         // TENANT_ADMIN_USER can produce.
         isAuthorized = simpleAclAuthorizer.canProduceAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TENANT_ADMIN_USER, null,
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TENANT_ADMIN_USER, null, null,
                         new AuthenticationDataCommand(TENANT_ADMIN_USER)),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertFalse(isAuthorized);
 
         // TENANT_ADMIN_USER can create or delete Topic
         isAuthorized = simpleAclAuthorizer.canManageTenantAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TENANT_ADMIN_USER, null,
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TENANT_ADMIN_USER, null, null,
                         new AuthenticationDataCommand(TENANT_ADMIN_USER)),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertTrue(isAuthorized);
@@ -273,25 +273,25 @@ public class SimpleAclAuthorizerTest extends KopProtocolHandlerTestBase {
         admin.topics().grantPermission(topic, TOPIC_LEVEL_PERMISSIONS_USER, Sets.newHashSet(AuthAction.produce));
 
         Boolean isAuthorized = simpleAclAuthorizer.canLookupAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TOPIC_LEVEL_PERMISSIONS_USER, null,
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TOPIC_LEVEL_PERMISSIONS_USER, null, null,
                         new AuthenticationDataCommand(TOPIC_LEVEL_PERMISSIONS_USER)),
                 Resource.of(ResourceType.TOPIC, topic)).get();
         assertTrue(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canProduceAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TOPIC_LEVEL_PERMISSIONS_USER, null,
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TOPIC_LEVEL_PERMISSIONS_USER, null, null,
                         new AuthenticationDataCommand(TOPIC_LEVEL_PERMISSIONS_USER)),
                 Resource.of(ResourceType.TOPIC, topic)).get();
         assertTrue(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canConsumeAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TOPIC_LEVEL_PERMISSIONS_USER, null,
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TOPIC_LEVEL_PERMISSIONS_USER, null, null,
                         new AuthenticationDataCommand(TOPIC_LEVEL_PERMISSIONS_USER)),
                 Resource.of(ResourceType.TOPIC, topic)).get();
         assertFalse(isAuthorized);
 
         isAuthorized = simpleAclAuthorizer.canProduceAsync(
-                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TOPIC_LEVEL_PERMISSIONS_USER, null,
+                new KafkaPrincipal(KafkaPrincipal.USER_TYPE, TOPIC_LEVEL_PERMISSIONS_USER, null, null,
                         new AuthenticationDataCommand(TOPIC_LEVEL_PERMISSIONS_USER)),
                 Resource.of(ResourceType.TOPIC, TOPIC)).get();
         assertFalse(isAuthorized);


### PR DESCRIPTION
### Motivation
Currently, the KoP only supports checking the topic permission when doing the consume authorization, but Kafka support checking the topic and group ID permission.

Before introducing this change, let's understand why KoP can't check group ID permission.

When Kafka does the consume authorization check, it will first check the group ID permission in `handleJoinGroupRequest` method, then it will check the topic permission in the `handleFetchRequest` method.

However, Pulsar is using another way to check consume permission. See the
`org.apache.pulsar.broker.authorization.AuthorizationService#canConsumeAsync` method, it requires passing the topic name and subscription to check both permissions in the same place, and the topic name is required param.
```
public CompletableFuture<Boolean> canConsumeAsync(TopicName topicName, String role, AuthenticationDataSource authenticationData,String subscription)
```

If we follow the Kafka way to check the consumer permission, we can't get the topic name when joining a group since the join group request does not contain the topic name. So we have to authorize permission in the fetch request.

However, to authorization consume permission in the fetch request, we can only get the topic name in this request. In this case, we can't authorize the group ID.

### Modifications
Since we can't get group ID when handling fetch requests, we need to find a way to pass through group ID when doing the authentication.

In OAuth, we have a `credentials_file.json` file that needs to be config, for example:
```
{
	"client_id": "my-id",
	"client_secret": "my-secret",
	"tenant": "my-tenant"
}
```
Here we can add a new parameter into the config:
```
{
	"client_id": "my-id",
	"client_secret": "my-secret",
	"tenant": "my-tenant",
        "group_id": "my-group-id"
}
```
Then we can add these parameters to `SaslExtensions`, and send it to the broker.

(cherry picked from commit e108e44621decef8221b44f37322c59f8b674be5)


### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

