### PR TITLE
[feature][transaction] Support turn off txn state recovery

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -123,7 +123,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     private final Map<String, GroupCoordinator> groupCoordinatorsByTenant = new ConcurrentHashMap<>();
     private final Map<String, TransactionCoordinator> transactionCoordinatorByTenant = new ConcurrentHashMap<>();
 
-
+    @Getter
     private OrderedExecutor recoveryExecutor;
 
     @Override

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -682,7 +682,8 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                         .name("transaction-log-manager-" + tenant)
                         .numThreads(1)
                         .build(),
-                Time.SYSTEM);
+                Time.SYSTEM,
+                recoveryExecutor);
 
         transactionCoordinator.startup(kafkaConfig.isKafkaTransactionalIdExpirationEnable()).get();
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -124,6 +124,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     private final Map<String, TransactionCoordinator> transactionCoordinatorByTenant = new ConcurrentHashMap<>();
 
     @Getter
+    @VisibleForTesting
     private OrderedExecutor recoveryExecutor;
 
     @Override

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfiguration.java
@@ -429,6 +429,12 @@ public class KafkaServiceConfiguration extends ServiceConfiguration {
 
     @FieldContext(
             category = CATEGORY_KOP_TRANSACTION,
+            doc = "Flag to enable disable producer state recovery"
+    )
+    private boolean kafkaTransactionStateProducerRecoveryEnabled = true;
+
+    @FieldContext(
+            category = CATEGORY_KOP_TRANSACTION,
             doc = "Number of partitions for the transaction log topic"
     )
     private int kafkaTxnLogTopicNumPartitions = DefaultTxnLogTopicNumPartitions;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -157,7 +157,7 @@ public class TransactionCoordinator {
                 namespacePrefixForMetadata,
                 namespacePrefixForUserTopics,
                 (config) -> new PulsarTopicProducerStateManagerSnapshotBuffer(
-                        config.getTransactionProducerStateSnapshotTopicName(), txnTopicClient)
+                        config.getTransactionProducerStateSnapshotTopicName(), txnTopicClient, scheduler)
                 );
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -35,6 +35,7 @@ import io.streamnative.pulsar.handlers.kop.utils.ProducerIdAndEpoch;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -133,7 +134,8 @@ public class TransactionCoordinator {
                                             MetadataStoreExtended metadataStore,
                                             KopBrokerLookupManager kopBrokerLookupManager,
                                             ScheduledExecutorService scheduler,
-                                            Time time) throws Exception {
+                                            Time time,
+                                            Executor recoveryExecutor) throws Exception {
         String namespacePrefixForMetadata = MetadataUtils.constructMetadataNamespace(tenant, kafkaConfig);
         String namespacePrefixForUserTopics = MetadataUtils.constructUserTopicsNamespace(tenant, kafkaConfig);
         TransactionStateManager transactionStateManager =
@@ -157,7 +159,7 @@ public class TransactionCoordinator {
                 namespacePrefixForMetadata,
                 namespacePrefixForUserTopics,
                 (config) -> new PulsarTopicProducerStateManagerSnapshotBuffer(
-                        config.getTransactionProducerStateSnapshotTopicName(), txnTopicClient, scheduler)
+                        config.getTransactionProducerStateSnapshotTopicName(), txnTopicClient, recoveryExecutor)
                 );
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -165,7 +165,8 @@ public class PartitionLog {
                 initFuture.completeExceptionally(errorLoadTopic);
                 return;
             }
-            if (kafkaConfig.isKafkaTransactionCoordinatorEnabled()) {
+            if (kafkaConfig.isKafkaTransactionCoordinatorEnabled()
+                    && kafkaConfig.isKafkaTransactionStateProducerRecoveryEnabled()) {
                 producerStateManager
                         .recover(this, recoveryExecutor)
                         .thenRun(() -> initFuture.complete(this))
@@ -833,7 +834,7 @@ public class PartitionLog {
 
             @Override
             public void readEntriesFailed(ManagedLedgerException exception, Object ctx) {
-                log.error("Error read entry for topic: {}", fullPartitionName);
+                log.error("Error read entry for topic: {}", fullPartitionName, exception);
                 if (exception instanceof ManagedLedgerException.ManagedLedgerFencedException) {
                     invalidateCacheOnTopic.accept(fullPartitionName);
                 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarPartitionedTopicProducerStateManagerSnapshotBuffer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarPartitionedTopicProducerStateManagerSnapshotBuffer.java
@@ -18,6 +18,7 @@ import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCo
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.common.naming.TopicName;
 
@@ -42,13 +43,15 @@ public class PulsarPartitionedTopicProducerStateManagerSnapshotBuffer implements
 
     public PulsarPartitionedTopicProducerStateManagerSnapshotBuffer(String topicName,
                                                                     SystemTopicClient pulsarClient,
+                                                                    Executor executor,
                                                                     int numPartitions) {
         TopicName fullName = TopicName.get(topicName);
         for (int i = 0; i < numPartitions; i++) {
             PulsarTopicProducerStateManagerSnapshotBuffer partition =
                     new PulsarTopicProducerStateManagerSnapshotBuffer(
                             fullName.getPartition(i).toString(),
-                            pulsarClient);
+                            pulsarClient,
+                            executor);
             partitions.add(partition);
         }
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBuffer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBuffer.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.errors.NotLeaderOrFollowerException;
 import org.apache.pulsar.client.api.Message;
@@ -45,6 +46,7 @@ public class PulsarTopicProducerStateManagerSnapshotBuffer implements ProducerSt
     private final Map<String, ProducerStateManagerSnapshot> latestSnapshots = new ConcurrentHashMap<>();
     private final String topic;
     private final SystemTopicClient pulsarClient;
+    private final Executor executor;
     private CompletableFuture<Reader<ByteBuffer>> reader;
 
     private CompletableFuture<Producer<ByteBuffer>> producer;
@@ -82,10 +84,10 @@ public class PulsarTopicProducerStateManagerSnapshotBuffer implements ProducerSt
                         return CompletableFuture.completedFuture(null);
                     } else {
                         CompletableFuture<Message<ByteBuffer>> opMessage = reader.readNextAsync();
-                        return opMessage.thenCompose(msg -> {
+                        return opMessage.thenComposeAsync(msg -> {
                             processMessage(msg);
                             return readNextMessageIfAvailable(reader);
-                        });
+                        }, executor);
                     }
                 });
     }
@@ -323,9 +325,12 @@ public class PulsarTopicProducerStateManagerSnapshotBuffer implements ProducerSt
         });
     }
 
-    public PulsarTopicProducerStateManagerSnapshotBuffer(String topicName, SystemTopicClient pulsarClient) {
+    public PulsarTopicProducerStateManagerSnapshotBuffer(String topicName,
+            SystemTopicClient pulsarClient,
+            Executor executor) {
         this.topic = topicName;
         this.pulsarClient = pulsarClient;
+        this.executor = executor;
     }
 
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
@@ -113,6 +113,7 @@ public class ReplicaManager {
             // add the topicPartition with timeout error if it's not existed in responseMap
             entriesPerPartition.keySet().forEach(topicPartition -> {
                 if (!responseMap.containsKey(topicPartition)) {
+                    log.error("Adding dummy REQUEST_TIMED_OUT to produce response for {}", topicPartition);
                     responseMap.put(topicPartition, new ProduceResponse.PartitionResponse(Errors.REQUEST_TIMED_OUT));
                 }
             });

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/PulsarPartitionedTopicProducerStateManagerSnapshotBufferTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/PulsarPartitionedTopicProducerStateManagerSnapshotBufferTest.java
@@ -25,7 +25,8 @@ public class PulsarPartitionedTopicProducerStateManagerSnapshotBufferTest
 
     @Override
     protected ProducerStateManagerSnapshotBuffer createProducerStateManagerSnapshotBuffer(String topic) {
-        return new PulsarPartitionedTopicProducerStateManagerSnapshotBuffer(topic, systemTopicClient, NUM_PARTITIONS);
+        return new PulsarPartitionedTopicProducerStateManagerSnapshotBuffer(
+                topic, systemTopicClient, getProtocolHandler().getRecoveryExecutor(), NUM_PARTITIONS);
     }
 
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBufferTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBufferTest.java
@@ -39,7 +39,8 @@ public class PulsarTopicProducerStateManagerSnapshotBufferTest extends ProducerS
 
     @Override
     protected ProducerStateManagerSnapshotBuffer createProducerStateManagerSnapshotBuffer(String topic) {
-        return new PulsarTopicProducerStateManagerSnapshotBuffer(topic, systemTopicClient);
+        return new PulsarTopicProducerStateManagerSnapshotBuffer(
+                topic, systemTopicClient, getProtocolHandler().getRecoveryExecutor());
     }
 
     @Test


### PR DESCRIPTION
### Motivation

Support turn off txn state recovery.

### Modifications

Add a configuration to control whether kafkaTransactionStateProducer recovery.
Use recovery executor to complete ProducerStateManagerSnapshot reads.


### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

