### PR TITLE
[transactions] Do not use a partitioned Reader

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -123,7 +123,8 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
     private final Map<String, GroupCoordinator> groupCoordinatorsByTenant = new ConcurrentHashMap<>();
     private final Map<String, TransactionCoordinator> transactionCoordinatorByTenant = new ConcurrentHashMap<>();
 
-
+    @VisibleForTesting
+    @Getter
     private OrderedExecutor recoveryExecutor;
 
     @Override
@@ -661,6 +662,7 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                 .transactionProducerIdTopicName(MetadataUtils.constructTxnProducerIdTopicBaseName(tenant, kafkaConfig))
                 .transactionProducerStateSnapshotTopicName(MetadataUtils.constructTxProducerStateTopicBaseName(tenant,
                         kafkaConfig))
+                .producerStateTopicNumPartitions(kafkaConfig.getKafkaTxnProducerStateTopicNumPartitions())
                 .abortTimedOutTransactionsIntervalMs(kafkaConfig.getKafkaTxnAbortTimedOutTransactionCleanupIntervalMs())
                 .transactionalIdExpirationMs(kafkaConfig.getKafkaTransactionalIdExpirationMs())
                 .removeExpiredTransactionalIdsIntervalMs(
@@ -682,7 +684,8 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
                         .name("transaction-log-manager-" + tenant)
                         .numThreads(1)
                         .build(),
-                Time.SYSTEM);
+                Time.SYSTEM,
+                recoveryExecutor);
 
         transactionCoordinator.startup(kafkaConfig.isKafkaTransactionalIdExpirationEnable()).get();
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionConfig.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionConfig.java
@@ -35,6 +35,7 @@ public class TransactionConfig {
     public static final int DefaultTransactionCoordinatorSchedulerNum = 1;
     public static final int DefaultTransactionStateManagerSchedulerNum = 1;
     public static final int DefaultTransactionLogNumPartitions = 8;
+    public static final int DefaultTransactionStateNumPartitions = 8;
 
     @Default
     private int brokerId = 1;
@@ -50,6 +51,8 @@ public class TransactionConfig {
     private long transactionalIdExpirationMs = DefaultTransactionalIdExpirationMs;
     @Default
     private int transactionLogNumPartitions = DefaultTransactionLogNumPartitions;
+    @Default
+    private int producerStateTopicNumPartitions = DefaultTransactionStateNumPartitions;
     @Default
     private long abortTimedOutTransactionsIntervalMs = DefaultAbortTimedOutTransactionsIntervalMs;
     @Default

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionCoordinator.java
@@ -29,12 +29,13 @@ import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionMe
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionStateManager.CoordinatorEpochAndTxnMetadata;
 import io.streamnative.pulsar.handlers.kop.scala.Either;
 import io.streamnative.pulsar.handlers.kop.storage.ProducerStateManagerSnapshotBuffer;
-import io.streamnative.pulsar.handlers.kop.storage.PulsarTopicProducerStateManagerSnapshotBuffer;
+import io.streamnative.pulsar.handlers.kop.storage.PulsarPartitionedTopicProducerStateManagerSnapshotBuffer;
 import io.streamnative.pulsar.handlers.kop.utils.MetadataUtils;
 import io.streamnative.pulsar.handlers.kop.utils.ProducerIdAndEpoch;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -133,7 +134,8 @@ public class TransactionCoordinator {
                                             MetadataStoreExtended metadataStore,
                                             KopBrokerLookupManager kopBrokerLookupManager,
                                             ScheduledExecutorService scheduler,
-                                            Time time) throws Exception {
+                                            Time time,
+                                            Executor recoveryExecutor) throws Exception {
         String namespacePrefixForMetadata = MetadataUtils.constructMetadataNamespace(tenant, kafkaConfig);
         String namespacePrefixForUserTopics = MetadataUtils.constructUserTopicsNamespace(tenant, kafkaConfig);
         TransactionStateManager transactionStateManager =
@@ -156,8 +158,9 @@ public class TransactionCoordinator {
                 time,
                 namespacePrefixForMetadata,
                 namespacePrefixForUserTopics,
-                (config) -> new PulsarTopicProducerStateManagerSnapshotBuffer(
-                        config.getTransactionProducerStateSnapshotTopicName(), txnTopicClient)
+                (config) -> new PulsarPartitionedTopicProducerStateManagerSnapshotBuffer(
+                        config.getTransactionProducerStateSnapshotTopicName(), txnTopicClient, recoveryExecutor,
+                        config.getProducerStateTopicNumPartitions())
                 );
     }
 

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -833,7 +833,7 @@ public class PartitionLog {
 
             @Override
             public void readEntriesFailed(ManagedLedgerException exception, Object ctx) {
-                log.error("Error read entry for topic: {}", fullPartitionName);
+                log.error("Error read entry for topic: {}", fullPartitionName, exception);
                 if (exception instanceof ManagedLedgerException.ManagedLedgerFencedException) {
                     invalidateCacheOnTopic.accept(fullPartitionName);
                 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarPartitionedTopicProducerStateManagerSnapshotBuffer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PulsarPartitionedTopicProducerStateManagerSnapshotBuffer.java
@@ -18,6 +18,7 @@ import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCo
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.common.naming.TopicName;
 
@@ -42,13 +43,15 @@ public class PulsarPartitionedTopicProducerStateManagerSnapshotBuffer implements
 
     public PulsarPartitionedTopicProducerStateManagerSnapshotBuffer(String topicName,
                                                                     SystemTopicClient pulsarClient,
+                                                                    Executor executor,
                                                                     int numPartitions) {
         TopicName fullName = TopicName.get(topicName);
         for (int i = 0; i < numPartitions; i++) {
             PulsarTopicProducerStateManagerSnapshotBuffer partition =
                     new PulsarTopicProducerStateManagerSnapshotBuffer(
                             fullName.getPartition(i).toString(),
-                            pulsarClient);
+                            pulsarClient,
+                            executor);
             partitions.add(partition);
         }
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
@@ -113,6 +113,7 @@ public class ReplicaManager {
             // add the topicPartition with timeout error if it's not existed in responseMap
             entriesPerPartition.keySet().forEach(topicPartition -> {
                 if (!responseMap.containsKey(topicPartition)) {
+                    log.error("Adding dummy REQUEST_TIMED_OUT to produce response for {}", topicPartition);
                     responseMap.put(topicPartition, new ProduceResponse.PartitionResponse(Errors.REQUEST_TIMED_OUT));
                 }
             });

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/PulsarPartitionedTopicProducerStateManagerSnapshotBufferTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/PulsarPartitionedTopicProducerStateManagerSnapshotBufferTest.java
@@ -25,7 +25,8 @@ public class PulsarPartitionedTopicProducerStateManagerSnapshotBufferTest
 
     @Override
     protected ProducerStateManagerSnapshotBuffer createProducerStateManagerSnapshotBuffer(String topic) {
-        return new PulsarPartitionedTopicProducerStateManagerSnapshotBuffer(topic, systemTopicClient, NUM_PARTITIONS);
+        return new PulsarPartitionedTopicProducerStateManagerSnapshotBuffer(
+                topic, systemTopicClient, getProtocolHandler().getRecoveryExecutor(), NUM_PARTITIONS);
     }
 
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBufferTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/PulsarTopicProducerStateManagerSnapshotBufferTest.java
@@ -39,7 +39,8 @@ public class PulsarTopicProducerStateManagerSnapshotBufferTest extends ProducerS
 
     @Override
     protected ProducerStateManagerSnapshotBuffer createProducerStateManagerSnapshotBuffer(String topic) {
-        return new PulsarTopicProducerStateManagerSnapshotBuffer(topic, systemTopicClient);
+        return new PulsarTopicProducerStateManagerSnapshotBuffer(
+                topic, systemTopicClient, getProtocolHandler().getRecoveryExecutor());
     }
 
     @Test


### PR DESCRIPTION
(cherry picked from commit 0e0d235a1fff2882ecdf56e01f80469c1f1ff414)

### Modifications

Use `PulsarPartitionedTopicProducerStateManagerSnapshotBuffer` instead of `PulsarTopicProducerStateManagerSnapshotBuffer`.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

