### PR TITLE
[docs] Add docs for OAuth credentials

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -173,6 +173,16 @@ This section lists configurations about the authentication.
 | saslAllowedMechanisms                | A set of supported SASL mechanisms exposed by the broker.     | PLAIN,<br>OAUTHBEARER |         |
 | kopOauth2AuthenticateCallbackHandler | The fully qualified name of a SASL server callback handler class that implements the <br>AuthenticateCallbackHandler interface, which is used for OAuth2 authentication. <br>If it is not set, the class will be Kafka's default server callback handler for <br>OAUTHBEARER mechanism: OAuthBearerUnsecuredValidatorCallbackHandler. |                       |         |
 
+
+## Authorization
+
+This section lists configurations about the authorization.
+
+| Name                                      | Description                                                                                            | Range       | Default |
+|-------------------------------------------|--------------------------------------------------------------------------------------------------------|-------------|---------|
+| kafkaEnableAuthorizationForceGroupIdCheck | Whether to enable authorization force group ID check. Note: It only support for OAuth2 authentication. | true, false | false   |
+
+
 ## SSL encryption
 
 |Name|Description|Default|

--- a/docs/security.md
+++ b/docs/security.md
@@ -253,15 +253,27 @@ If you want to enable the authentication feature for KoP using the `OAUTHBEARER`
         </tbody>
     </table>
 
-```properties
-sasl.login.callback.handler.class=io.streamnative.pulsar.handlers.kop.security.oauth.OauthLoginCallbackHandler
-security.protocol=SASL_PLAINTEXT  # or security.protocol=SASL_SSL if SSL connection is used
-sasl.mechanism=OAUTHBEARER
-sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule \
-   required oauth.issuer.url="https://accounts.google.com"\
-   oauth.credentials.url="file:///path/to/credentials_file.json"\
-   oauth.audience="https://broker.example.com";
-```
+   ```properties
+   sasl.login.callback.handler.class=io.streamnative.pulsar.handlers.kop.security.oauth.OauthLoginCallbackHandler
+   security.protocol=SASL_PLAINTEXT  # or security.protocol=SASL_SSL if SSL connection is used
+   sasl.mechanism=OAUTHBEARER
+   sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule \
+        required oauth.issuer.url="https://accounts.google.com"\
+        oauth.credentials.url="file:///path/to/credentials_file.json"\
+        oauth.audience="https://broker.example.com";
+   ```
+
+   (4) Config the credentials_file.json.
+    The `client_id` and `client_secret` is required fields. And the `tenant` and `group_id` is optional fields. 
+    When use `group_id` field and set `kafkaEnableAuthorizationForceGroupIdCheck=true`, then the client will only able to use this group id to consumer.
+   ```json
+    {
+      "client_id": "my-id",
+      "client_secret": "my-secret",
+      "tenant": "my-tenant",
+      "group_id": "my-group-id"
+    }
+   ```
 
 ### Authentication for the Schema Registry
 


### PR DESCRIPTION
### Motivation
https://github.com/streamnative/kop/pull/1728 Introduced tenant for OAuth, and https://github.com/streamnative/kop/pull/1926 introduced group ID for OAuth, we should add docs.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [x] `doc` 
  
  (If this PR contains doc changes)

