### PR TITLE
[transaction] Use a dedicated timeout for writing transaction marker

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -211,6 +211,12 @@ import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 @Getter
 public class KafkaRequestHandler extends KafkaCommandDecoder {
     private static final int THROTTLE_TIME_MS = 10;
+    /**
+     * Request timeout for writes of the TXMARKERS
+     * Writing the TXMARKERS require recovery of the
+     * transactions on the PartitionLog at it may take much time.
+     */
+    private static final int WRITE_TXN_MARKERS_TIMEOUT = 120000;
     private static final String POLICY_ROOT = "/admin/policies/";
 
     private final PulsarService pulsarService;
@@ -2441,7 +2447,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                     this.pendingTopicFuturesMap,
                     ctx);
             getReplicaManager().appendRecords(
-                    kafkaConfig.getRequestTimeoutMs(),
+                    WRITE_TXN_MARKERS_TIMEOUT,
                     (short) 1,
                     true,
                     currentNamespacePrefix(),


### PR DESCRIPTION
(cherry picked from commit e1e4562a035cba0d31f699e55002d073dd99e60d)

### Modifications

Use a dedicated timeout for writing transaction marker

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

