### PR TITLE
[security] Communications between broker inherit BrokerClient configuration

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ssl/SSLUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/ssl/SSLUtils.java
@@ -302,9 +302,15 @@ public class SSLUtils {
                     break;
                 case SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG:
                     obj = kafkaServiceConfiguration.getKopSslTruststoreLocation();
+                    if (obj == null) {
+                        obj = kafkaServiceConfiguration.getBrokerClientTlsTrustStore();
+                    }
                     break;
                 case SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG:
                     obj = kafkaServiceConfiguration.getKopSslTruststorePassword();
+                    if (obj == null && kafkaServiceConfiguration.getKopSslTruststoreLocation() == null) {
+                        obj = kafkaServiceConfiguration.getBrokerClientTlsTrustStorePassword();
+                    }
                     break;
                 case SslConfigs.SSL_KEYMANAGER_ALGORITHM_CONFIG:
                     obj = kafkaServiceConfiguration.getKopSslKeymanagerAlgorithm();

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/KafkaSSLChannelTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/KafkaSSLChannelTest.java
@@ -57,6 +57,7 @@ public class KafkaSSLChannelTest extends KopProtocolHandlerTestBase {
     private String kopClientTruststoreLocation;
     private String kopClientTruststorePassword;
     private final boolean withCertHost;
+    private final boolean useBrokerClientTrustore;
 
     static {
         final HostnameVerifier defaultHostnameVerifier = javax.net.ssl.HttpsURLConnection.getDefaultHostnameVerifier();
@@ -73,9 +74,10 @@ public class KafkaSSLChannelTest extends KopProtocolHandlerTestBase {
         javax.net.ssl.HttpsURLConnection.setDefaultHostnameVerifier(localhostAcceptedHostnameVerifier);
     }
 
-    public KafkaSSLChannelTest(final String entryFormat, boolean withCertHost) {
+    public KafkaSSLChannelTest(final String entryFormat, boolean withCertHost, boolean useBrokerClientTrustore) {
         super(entryFormat);
         this.withCertHost = withCertHost;
+        this.useBrokerClientTrustore = useBrokerClientTrustore;
         setSslConfigurations(withCertHost);
     }
 
@@ -103,10 +105,12 @@ public class KafkaSSLChannelTest extends KopProtocolHandlerTestBase {
     @Factory
     public static Object[] instances() {
         return new Object[] {
-                new KafkaSSLChannelTest("pulsar", false),
-                new KafkaSSLChannelTest("pulsar", true),
-                new KafkaSSLChannelTest("kafka", false),
-                new KafkaSSLChannelTest("kafka", true)
+                new KafkaSSLChannelTest("pulsar", false, false),
+                new KafkaSSLChannelTest("pulsar", true, false),
+                new KafkaSSLChannelTest("kafka", false, false),
+                new KafkaSSLChannelTest("kafka", true, false),
+                // test rokerClientTlsTrustStore
+                new KafkaSSLChannelTest("kafka", true, true)
         };
     }
 
@@ -116,8 +120,13 @@ public class KafkaSSLChannelTest extends KopProtocolHandlerTestBase {
         conf.setKopSslKeystoreType("JKS");
         conf.setKopSslKeystoreLocation(kopSslKeystoreLocation);
         conf.setKopSslKeystorePassword(kopSslKeystorePassword);
-        conf.setKopSslTruststoreLocation(kopSslTruststoreLocation);
-        conf.setKopSslTruststorePassword(kopSslTruststorePassword);
+        if (useBrokerClientTrustore) {
+            conf.setBrokerClientTlsTrustStore(kopSslTruststoreLocation);
+            conf.setBrokerClientTlsTrustStorePassword(kopSslTruststorePassword);
+        } else {
+            conf.setKopSslTruststoreLocation(kopSslTruststoreLocation);
+            conf.setKopSslTruststorePassword(kopSslTruststorePassword);
+        }
     }
 
     @BeforeMethod


### PR DESCRIPTION
(cherry picked from commit 5ff8b8079c60e6566175faa9640a2312bd95496d)


### Motivation

Communications between broker inherit BrokerClient configuration.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

