### PR TITLE
[improvement] Do not use a static LOOKUP_CACHE

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaChannelInitializer.java
@@ -50,6 +50,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
     private final KopBrokerLookupManager kopBrokerLookupManager;
     @Getter
     private final KafkaTopicManagerSharedState kafkaTopicManagerSharedState;
+    private final KafkaTopicLookupService kafkaTopicLookupService;
     private final LookupClient lookupClient;
 
     private final AdminManager adminManager;
@@ -82,6 +83,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
                                    RequestStats requestStats,
                                    OrderedScheduler sendResponseScheduler,
                                    KafkaTopicManagerSharedState kafkaTopicManagerSharedState,
+                                   KafkaTopicLookupService kafkaTopicLookupService,
                                    LookupClient lookupClient) {
         super();
         this.pulsarService = pulsarService;
@@ -105,6 +107,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
         this.sendResponseScheduler = sendResponseScheduler;
         this.kafkaTopicManagerSharedState = kafkaTopicManagerSharedState;
         this.lengthFieldPrepender = new LengthFieldPrepender(4);
+        this.kafkaTopicLookupService = kafkaTopicLookupService;
     }
 
     @Override
@@ -130,7 +133,7 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
                 tenantContextManager, replicaManager, kopBrokerLookupManager, adminManager,
                 producePurgatory, fetchPurgatory,
                 enableTls, advertisedEndPoint, skipMessagesWithoutIndex, requestStats, sendResponseScheduler,
-                kafkaTopicManagerSharedState, lookupClient);
+                kafkaTopicManagerSharedState, kafkaTopicLookupService, lookupClient);
     }
 
     @VisibleForTesting
@@ -141,6 +144,6 @@ public class KafkaChannelInitializer extends ChannelInitializer<SocketChannel> {
                 enableTls, advertisedEndPoint, skipMessagesWithoutIndex,
                 requestStats,
                 sendResponseScheduler,
-                kafkaTopicManagerSharedState, lookupClient);
+                kafkaTopicManagerSharedState, kafkaTopicLookupService, lookupClient);
     }
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -322,6 +322,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                RequestStats requestStats,
                                OrderedScheduler sendResponseScheduler,
                                KafkaTopicManagerSharedState kafkaTopicManagerSharedState,
+                               KafkaTopicLookupService kafkaTopicLookupService,
                                LookupClient lookupClient) throws Exception {
         super(requestStats, kafkaConfig, sendResponseScheduler);
         this.pulsarService = pulsarService;
@@ -348,7 +349,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         this.tlsEnabled = tlsEnabled;
         this.advertisedEndPoint = advertisedEndPoint;
         this.skipMessagesWithoutIndex = skipMessagesWithoutIndex;
-        this.topicManager = new KafkaTopicManager(this);
+        this.topicManager = new KafkaTopicManager(this, kafkaTopicLookupService);
         this.defaultNumPartitions = kafkaConfig.getDefaultNumPartitions();
         this.maxReadEntriesNum = kafkaConfig.getMaxReadEntriesNum();
         this.currentConnectedGroup = new ConcurrentHashMap<>();
@@ -702,7 +703,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         // Because in version 0, an empty topic list indicates "request metadata for all topics."
         if ((request.topics() == null) || (request.topics().isEmpty() && request.version() == 0)) {
             // clean all cache when get all metadata for librdkafka(<1.0.0).
-            KopBrokerLookupManager.clear();
+            kopBrokerLookupManager.clear();
             return expandAllowedNamespaces(kafkaConfig.getKopAllowedNamespaces())
                     .thenCompose(namespaces -> authorizeNamespacesAsync(namespaces, AclOperation.DESCRIBE))
                     .thenCompose(this::listAllTopicsFromNamespacesAsync)

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicLookupService.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicLookupService.java
@@ -30,9 +30,12 @@ import org.apache.pulsar.common.naming.TopicName;
 @Slf4j
 public class KafkaTopicLookupService {
     private final BrokerService brokerService;
+    private final KopBrokerLookupManager kopBrokerLookupManager;
 
-    public KafkaTopicLookupService(BrokerService brokerService) {
+    public KafkaTopicLookupService(BrokerService brokerService,
+            KopBrokerLookupManager kopBrokerLookupManager) {
         this.brokerService = brokerService;
+        this.kopBrokerLookupManager = kopBrokerLookupManager;
      }
 
     // A wrapper of `BrokerService#getTopic` that is to find the topic's associated `PersistentTopic` instance
@@ -42,7 +45,7 @@ public class KafkaTopicLookupService {
             TopicName topicNameObject = TopicName.get(topicName);
             if (throwable != null) {
                 // Failed to getTopic from current broker, remove cache, which added in getTopicBroker.
-                KopBrokerLookupManager.removeTopicManagerCache(topicName);
+                kopBrokerLookupManager.removeTopicManagerCache(topicName);
                 if (topicNameObject.getPartitionIndex() == 0) {
                     log.warn("Get partition-0 error [{}].", throwable.getMessage());
                 } else {
@@ -66,7 +69,7 @@ public class KafkaTopicLookupService {
                         handleGetTopicException(nonPartitionedTopicName, topicCompletableFuture, ex, requestor);
                         // Failed to getTopic from current broker, remove non-partitioned topic cache,
                         // which added in getTopicBroker.
-                        KopBrokerLookupManager.removeTopicManagerCache(nonPartitionedTopicName);
+                        kopBrokerLookupManager.removeTopicManagerCache(nonPartitionedTopicName);
                         return;
                     }
                     if (nonPartitionedTopic.isPresent()) {
@@ -75,14 +78,14 @@ public class KafkaTopicLookupService {
                     } else {
                         log.error("[{}]Get empty non-partitioned topic for name {}",
                                 requestor, nonPartitionedTopicName);
-                        KopBrokerLookupManager.removeTopicManagerCache(nonPartitionedTopicName);
+                        kopBrokerLookupManager.removeTopicManagerCache(nonPartitionedTopicName);
                         topicCompletableFuture.complete(Optional.empty());
                     }
                 });
                 return;
             }
             log.error("[{}]Get empty topic for name {}", requestor, topicName);
-            KopBrokerLookupManager.removeTopicManagerCache(topicName);
+            kopBrokerLookupManager.removeTopicManagerCache(topicName);
             topicCompletableFuture.complete(Optional.empty());
         });
         return topicCompletableFuture;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManager.java
@@ -41,13 +41,13 @@ public class KafkaTopicManager {
 
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
-    KafkaTopicManager(KafkaRequestHandler kafkaRequestHandler) {
+    KafkaTopicManager(KafkaRequestHandler kafkaRequestHandler, KafkaTopicLookupService kafkaTopicLookupService) {
         this.requestHandler = kafkaRequestHandler;
         PulsarService pulsarService = kafkaRequestHandler.getPulsarService();
         this.brokerService = pulsarService.getBrokerService();
         this.internalServerCnx = new InternalServerCnx(requestHandler);
         this.lookupClient = kafkaRequestHandler.getLookupClient();
-        this.kafkaTopicLookupService = new KafkaTopicLookupService(pulsarService.getBrokerService());
+        this.kafkaTopicLookupService = kafkaTopicLookupService;
      }
 
     // update Ctx information, since at internalServerCnx create time there is no ctx passed into kafkaRequestHandler.

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManagerSharedState.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaTopicManagerSharedState.java
@@ -45,6 +45,8 @@ public final class KafkaTopicManagerSharedState {
     private final ConcurrentHashMap<ProducerKey, Producer>
             references = new ConcurrentHashMap<>();
 
+    private final KopBrokerLookupManager kopBrokerLookupManager;
+
     @AllArgsConstructor
     @EqualsAndHashCode
     private static final class ProducerKey {
@@ -52,7 +54,9 @@ public final class KafkaTopicManagerSharedState {
         final KafkaRequestHandler requestHandler;
     }
 
-    public KafkaTopicManagerSharedState(BrokerService brokerService) {
+    public KafkaTopicManagerSharedState(BrokerService brokerService,
+                                        KopBrokerLookupManager kopBrokerLookupManager) {
+        this.kopBrokerLookupManager = kopBrokerLookupManager;
         initializeCursorExpireTask(brokerService.executor());
     }
 
@@ -125,7 +129,7 @@ public final class KafkaTopicManagerSharedState {
 
     public void deReference(String topicName) {
         try {
-            KopBrokerLookupManager.removeTopicManagerCache(topicName);
+            kopBrokerLookupManager.removeTopicManagerCache(topicName);
             kafkaTopicConsumerManagerCache.removeAndCloseByTopic(topicName);
         } catch (Exception e) {
             log.error("Failed to close reference for individual topic {}. exception:", topicName, e);

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerChannelManager.java
@@ -519,14 +519,30 @@ public class TransactionMarkerChannelManager {
             txnMarkerQueue.forEachTxnTopicPartition((__, queue) -> queue.drainTo(txnIdAndMarkerEntriesForMarker));
             if (!txnIdAndMarkerEntriesForMarker.isEmpty()) {
                 getChannel(txnMarkerQueue.address).whenComplete((channelHandler, throwable) -> {
-
-                    List<TxnMarkerEntry> sendEntries = new ArrayList<>();
-                    for (TxnIdAndMarkerEntry txnIdAndMarkerEntry : txnIdAndMarkerEntriesForMarker) {
-                        sendEntries.add(txnIdAndMarkerEntry.entry);
+                    if (throwable != null) {
+                        log.error("Get channel for {} failed, re-enqueing {} txnIdAndMarkerEntriesForMarker",
+                                txnMarkerQueue.address, txnIdAndMarkerEntriesForMarker.size());
+                        // put back
+                        txnIdAndMarkerEntriesForMarker.forEach(txnIdAndMarkerEntry -> {
+                            log.error("Re-enqueueing {}", txnIdAndMarkerEntry);
+                            addTxnMarkersToBrokerQueue(txnIdAndMarkerEntry.getTransactionalId(),
+                                    txnIdAndMarkerEntry.getEntry().producerId(),
+                                    txnIdAndMarkerEntry.getEntry().producerEpoch(),
+                                    txnIdAndMarkerEntry.getEntry().transactionResult(),
+                                    txnIdAndMarkerEntry.getEntry().coordinatorEpoch(),
+                                    new HashSet<>(txnIdAndMarkerEntry.getEntry().partitions()),
+                                    namespacePrefixForUserTopics);
+                        });
+                    } else {
+                        List<TxnMarkerEntry> sendEntries = new ArrayList<>();
+                        for (TxnIdAndMarkerEntry txnIdAndMarkerEntry : txnIdAndMarkerEntriesForMarker) {
+                            sendEntries.add(txnIdAndMarkerEntry.entry);
+                        }
+                        channelHandler.enqueueWriteTxnMarkers(sendEntries,
+                                new TransactionMarkerRequestCompletionHandler(txnStateManager, this,
+                                        kopBrokerLookupManager,
+                                        txnIdAndMarkerEntriesForMarker, namespacePrefixForUserTopics));
                     }
-                    channelHandler.enqueueWriteTxnMarkers(sendEntries,
-                            new TransactionMarkerRequestCompletionHandler(txnStateManager, this,
-                                    txnIdAndMarkerEntriesForMarker, namespacePrefixForUserTopics));
                 });
             }
         }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerRequestCompletionHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionMarkerRequestCompletionHandler.java
@@ -39,6 +39,7 @@ public class TransactionMarkerRequestCompletionHandler implements Consumer<Respo
 
     private final TransactionStateManager txnStateManager;
     private final TransactionMarkerChannelManager txnMarkerChannelManager;
+    private final KopBrokerLookupManager kopBrokerLookupManager;
     private final List<TransactionMarkerChannelManager.TxnIdAndMarkerEntry> txnIdAndMarkerEntries;
     private final String namespacePrefixForUserTopics;
 
@@ -183,7 +184,7 @@ public class TransactionMarkerRequestCompletionHandler implements Consumer<Respo
                                             + "retrying with current coordinator epoch {} and invalidating cache",
                                     transactionalId, topicPartition,
                                     error.exceptionName(), epochAndMetadata.getCoordinatorEpoch());
-                            KopBrokerLookupManager.removeTopicManagerCache(
+                            kopBrokerLookupManager.removeTopicManagerCache(
                                     KopTopic.toString(topicPartition, namespacePrefixForUserTopics));
                             abortSendingAndRetryPartitions.retryPartitions.add(topicPartition);
                             break;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CacheInvalidatorTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/CacheInvalidatorTest.java
@@ -19,12 +19,14 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
+import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
@@ -82,10 +84,11 @@ public class CacheInvalidatorTest extends KopProtocolHandlerTestBase {
             assertEquals("value", record.value());
         }
 
-        assertFalse(KopBrokerLookupManager.LOOKUP_CACHE.isEmpty());
+        ConcurrentHashMap<String, CompletableFuture<InetSocketAddress>> lookupCache =
+                getProtocolHandler().getKopBrokerLookupManager().getLocalBrokerTopics();
+        assertFalse(lookupCache.isEmpty());
         log.info("Before unload, ReplicaManager log size: {}", getProtocolHandler().getReplicaManager().size());
 
-        log.info("Before unload, LOOKUP_CACHE is {}", KopBrokerLookupManager.LOOKUP_CACHE);
         String namespace = conf.getKafkaTenant() + "/" + conf.getKafkaNamespace();
         BundlesData bundles = pulsar.getAdminClient().namespaces().getBundles(namespace);
         List<String> boundaries = bundles.getBoundaries();
@@ -102,7 +105,8 @@ public class CacheInvalidatorTest extends KopProtocolHandlerTestBase {
         }
 
         Awaitility.await().untilAsserted(() -> {
-            assertTrue(KopBrokerLookupManager.LOOKUP_CACHE.isEmpty());
+            log.info("LOOKUP_CACHE {}", lookupCache);
+            assertTrue(lookupCache.isEmpty());
         });
 
         Awaitility.await().untilAsserted(() -> {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaTopicConsumerManagerTest.java
@@ -87,7 +87,8 @@ public class KafkaTopicConsumerManagerTest extends KopProtocolHandlerTestBase {
         doReturn(mockChannel).when(mockCtx).channel();
         kafkaRequestHandler.ctx = mockCtx;
 
-        kafkaTopicManager = new KafkaTopicManager(kafkaRequestHandler);
+        kafkaTopicManager = new KafkaTopicManager(kafkaRequestHandler,
+                new KafkaTopicLookupService(pulsar.getBrokerService(), mock(KopBrokerLookupManager.class)));
         kafkaTopicManager.setRemoteAddress(InternalServerCnx.MOCKED_REMOTE_ADDRESS);
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -15,6 +15,7 @@ package io.streamnative.pulsar.handlers.kop;
 
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.testng.Assert.assertTrue;
 
@@ -858,8 +859,8 @@ public abstract class KopProtocolHandlerTestBase {
             admin.namespaces().setRetention(namespace, new RetentionPolicies(0, 0));
             admin.namespaces().setDeduplicationStatus(namespace, false);
 
-
-            KafkaTopicLookupService lookupService = new KafkaTopicLookupService(pulsar.getBrokerService());
+            KafkaTopicLookupService lookupService = new KafkaTopicLookupService(pulsar.getBrokerService(),
+                    mock(KopBrokerLookupManager.class));
             PersistentTopic topicHandle = lookupService.getTopic(topic, "test").get().get();
 
             Awaitility.await().untilAsserted(() -> {


### PR DESCRIPTION
(cherry picked from commit f6e7e823159fcb1ac1a1d9201fb6b45172601a24)

### Motivation

Do not use a static LOOKUP_CACHE.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

