### PR TITLE
[transaction] Use the config's metadata tenant when disable multi-tenant metadata

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaProtocolHandler.java
@@ -470,12 +470,16 @@ public class KafkaProtocolHandler implements ProtocolHandler, TenantContextManag
             if (!kafkaConfig.isKafkaTransactionCoordinatorEnabled()) {
                 return new MemoryProducerStateManagerSnapshotBuffer();
             }
-            return getTransactionCoordinator(tenant)
+            if (kafkaConfig.isKafkaEnableMultiTenantMetadata()) {
+                return getTransactionCoordinator(tenant)
+                        .getProducerStateManagerSnapshotBuffer();
+            }
+            return getTransactionCoordinator(kafkaConfig.getKafkaMetadataTenant())
                     .getProducerStateManagerSnapshotBuffer();
         }
     }
 
-    private Function<String, ProducerStateManagerSnapshotBuffer> getProducerStateManagerSnapshotBufferByTenant =
+    protected final Function<String, ProducerStateManagerSnapshotBuffer> getProducerStateManagerSnapshotBufferByTenant =
             new ProducerStateManagerSnapshotProvider();
 
     // this is called after initialize, and with kafkaConfig, brokerService all set.


### PR DESCRIPTION
### Motivation

When users disable the `KafkaEnableMultiTenantMetadata`, we should use the config's metadata tenant as the `PulsarTopicProducerStateManagerSnapshotBuffer` topic tenant.

### Modifications

Use the config's metadata tenant when disable multi-tenant metadata

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

