### PR TITLE
Update Kafka wire protocol to 3.4.0 and implement KIP-699 and KIP-709

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/DelayedFetch.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/DelayedFetch.java
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.requests.FetchRequest;
+import org.apache.kafka.common.message.FetchRequestData;
 
 @Slf4j
 public class DelayedFetch extends DelayedOperation {
@@ -33,7 +33,7 @@ public class DelayedFetch extends DelayedOperation {
     private final long bytesReadable;
     private final int fetchMaxBytes;
     private final boolean readCommitted;
-    private final Map<TopicPartition, FetchRequest.PartitionData> readPartitionInfo;
+    private final Map<TopicPartition, FetchRequestData.FetchPartition> readPartitionInfo;
     private final Map<TopicPartition, PartitionLog.ReadRecordsResult> readRecordsResult;
     private final MessageFetchContext context;
     protected volatile Boolean hasError;
@@ -55,7 +55,7 @@ public class DelayedFetch extends DelayedOperation {
                         final boolean readCommitted,
                         final MessageFetchContext context,
                         final ReplicaManager replicaManager,
-                        final Map<TopicPartition, FetchRequest.PartitionData> readPartitionInfo,
+                        final Map<TopicPartition, FetchRequestData.FetchPartition> readPartitionInfo,
                         final Map<TopicPartition, PartitionLog.ReadRecordsResult> readRecordsResult,
                         final CompletableFuture<Map<TopicPartition, PartitionLog.ReadRecordsResult>> callback) {
         super(delayMs, Optional.empty());

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaCommandDecoder.java
@@ -465,7 +465,14 @@ public abstract class KafkaCommandDecoder extends ChannelInboundHandlerAdapter {
                                 request, response);
                     }
 
-                    final ByteBuf result = responseToByteBuf(response, request, true);
+                    final ByteBuf result;
+                    try {
+                        result = responseToByteBuf(response, request, true);
+                    } catch (Throwable error) {
+                        log.error("[{}] Failed to convert response {} to ByteBuf", channel, response, error);
+                        sendErrorResponse(request, channel, error, true);
+                        return;
+                    }
                     final int resultSize = result.readableBytes();
                     channel.writeAndFlush(result).addListener(future -> {
                         if (response instanceof ResponseCallbackWrapper) {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -17,6 +17,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration.TENANT_ALLNAMESPACES_PLACEHOLDER;
 import static io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration.TENANT_PLACEHOLDER;
+import static io.streamnative.pulsar.handlers.kop.utils.KafkaResponseUtils.buildOffsetFetchResponse;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -58,7 +59,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -116,6 +116,9 @@ import org.apache.kafka.common.message.DescribeConfigsRequestData;
 import org.apache.kafka.common.message.DescribeConfigsResponseData;
 import org.apache.kafka.common.message.EndTxnRequestData;
 import org.apache.kafka.common.message.EndTxnResponseData;
+import org.apache.kafka.common.message.FetchRequestData;
+import org.apache.kafka.common.message.FetchResponseData;
+import org.apache.kafka.common.message.FindCoordinatorResponseData;
 import org.apache.kafka.common.message.InitProducerIdRequestData;
 import org.apache.kafka.common.message.InitProducerIdResponseData;
 import org.apache.kafka.common.message.JoinGroupRequestData;
@@ -134,7 +137,6 @@ import org.apache.kafka.common.record.EndTransactionMarker;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.MutableRecordBatch;
 import org.apache.kafka.common.record.RecordBatch;
-import org.apache.kafka.common.record.Records;
 import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.requests.AbstractResponse;
 import org.apache.kafka.common.requests.AddOffsetsToTxnRequest;
@@ -960,18 +962,53 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         checkArgument(findCoordinator.getRequest() instanceof FindCoordinatorRequest);
         FindCoordinatorRequest request = (FindCoordinatorRequest) findCoordinator.getRequest();
 
+        List<String> coordinatorKeys = request.version() < FindCoordinatorRequest.MIN_BATCHED_VERSION
+                ? Collections.singletonList(request.data().key()) : request.data().coordinatorKeys();
+
+        List<CompletableFuture<FindCoordinatorResponseData.Coordinator>> futures =
+                new ArrayList<>(coordinatorKeys.size());
+        for (String coordinatorKey : coordinatorKeys) {
+            CompletableFuture<FindCoordinatorResponseData.Coordinator> future =
+                    findSingleCoordinator(coordinatorKey, findCoordinator);
+            futures.add(future);
+        }
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                .whenComplete((ignore, ex) -> {
+                    if (ex != null) {
+                        resultFuture.completeExceptionally(ex);
+                        return;
+                    }
+                    List<FindCoordinatorResponseData.Coordinator> coordinators = new ArrayList<>(futures.size());
+                    for (CompletableFuture<FindCoordinatorResponseData.Coordinator> future : futures) {
+                        coordinators.add(future.join());
+                    }
+                    resultFuture.complete(KafkaResponseUtils.newFindCoordinator(coordinators, request.version()));
+                });
+
+    }
+
+    private CompletableFuture<FindCoordinatorResponseData.Coordinator> findSingleCoordinator(
+            String coordinatorKey, KafkaHeaderAndRequest findCoordinator) {
+
+        FindCoordinatorRequest request = (FindCoordinatorRequest) findCoordinator.getRequest();
+        CompletableFuture<FindCoordinatorResponseData.Coordinator> findSingleCoordinatorResult =
+                new CompletableFuture<>();
+
         if (request.data().keyType() == FindCoordinatorRequest.CoordinatorType.TRANSACTION.id()) {
             TransactionCoordinator transactionCoordinator = getTransactionCoordinator();
-            int partition = transactionCoordinator.partitionFor(request.data().key());
+            int partition = transactionCoordinator.partitionFor(coordinatorKey);
             String pulsarTopicName = transactionCoordinator.getTopicPartitionName(partition);
             findBroker(TopicName.get(pulsarTopicName))
                     .whenComplete((KafkaResponseUtils.BrokerLookupResult result, Throwable throwable) -> {
                         if (result.error != Errors.NONE || throwable != null) {
                             log.error("[{}] Request {}: Error while find coordinator.",
                                     ctx.channel(), findCoordinator.getHeader(), throwable);
-
-                            resultFuture.complete(KafkaResponseUtils
-                                    .newFindCoordinator(Errors.LEADER_NOT_AVAILABLE));
+                            findSingleCoordinatorResult.complete(
+                                    new FindCoordinatorResponseData.Coordinator()
+                                            .setErrorCode(Errors.LEADER_NOT_AVAILABLE.code())
+                                            .setErrorMessage(Errors.LEADER_NOT_AVAILABLE.message())
+                                            .setKey(coordinatorKey));
                             return;
                         }
 
@@ -979,7 +1016,14 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                             log.debug("[{}] Found node {} as coordinator for key {} partition {}.",
                                     ctx.channel(), result.node, request.data().key(), partition);
                         }
-                        resultFuture.complete(KafkaResponseUtils.newFindCoordinator(result.node));
+                        findSingleCoordinatorResult.complete(
+                                new FindCoordinatorResponseData.Coordinator()
+                                        .setNodeId(result.node.id())
+                                        .setHost(result.node.host())
+                                        .setPort(result.node.port())
+                                        .setErrorCode(result.error.code())
+                                        .setErrorMessage(result.error.message())
+                                        .setKey(coordinatorKey));
                     });
         } else if (request.data().keyType() == FindCoordinatorRequest.CoordinatorType.GROUP.id()) {
             authorize(AclOperation.DESCRIBE, Resource.of(ResourceType.GROUP, request.data().key()))
@@ -987,27 +1031,33 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                         if (ex != null) {
                             log.error("Describe group authorize failed, group - {}. {}",
                                     request.data().key(), ex.getMessage());
-                            resultFuture.complete(KafkaResponseUtils
-                                    .newFindCoordinator(Errors.GROUP_AUTHORIZATION_FAILED));
+                            findSingleCoordinatorResult.complete(
+                                    new FindCoordinatorResponseData.Coordinator()
+                                            .setErrorCode(Errors.GROUP_AUTHORIZATION_FAILED.code())
+                                            .setErrorMessage(Errors.GROUP_AUTHORIZATION_FAILED.message())
+                                            .setKey(coordinatorKey));
+
                             return;
                         }
                         if (!isAuthorized) {
-                            resultFuture.complete(
-                                    KafkaResponseUtils
-                                            .newFindCoordinator(Errors.GROUP_AUTHORIZATION_FAILED));
+                            findSingleCoordinatorResult.complete(
+                                    new FindCoordinatorResponseData.Coordinator()
+                                            .setErrorCode(Errors.GROUP_AUTHORIZATION_FAILED.code())
+                                            .setErrorMessage(Errors.GROUP_AUTHORIZATION_FAILED.message())
+                                            .setKey(coordinatorKey));
+
                             return;
                         }
                         CompletableFuture<Void> storeGroupIdFuture;
-                        int partition = getGroupCoordinator().partitionFor(request.data().key());
+                        int partition = getGroupCoordinator().partitionFor(coordinatorKey);
                         String pulsarTopicName = getGroupCoordinator().getTopicPartitionName(partition);
                         if (kafkaConfig.isKopEnableGroupLevelConsumerMetrics()) {
-                            String groupId = request.data().key();
                             String groupIdPath = GroupIdUtils.groupIdPathFormat(findCoordinator.getClientHost(),
                                     findCoordinator.getHeader().clientId());
                             currentConnectedClientId.add(findCoordinator.getHeader().clientId());
 
                             // Store group name to metadata store for current client, use to collect consumer metrics.
-                            storeGroupIdFuture = storeGroupId(groupId, groupIdPath);
+                            storeGroupIdFuture = storeGroupId(coordinatorKey, groupIdPath);
                         } else {
                             storeGroupIdFuture = CompletableFuture.completedFuture(null);
                         }
@@ -1023,8 +1073,11 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                             log.error("[{}] Request {}: Error while find coordinator.",
                                                     ctx.channel(), findCoordinator.getHeader(), throwable);
 
-                                            resultFuture.complete(KafkaResponseUtils
-                                                    .newFindCoordinator(Errors.LEADER_NOT_AVAILABLE));
+                                            findSingleCoordinatorResult.complete(
+                                                    new FindCoordinatorResponseData.Coordinator()
+                                                            .setErrorCode(Errors.LEADER_NOT_AVAILABLE.code())
+                                                            .setErrorMessage(Errors.LEADER_NOT_AVAILABLE.message())
+                                                            .setKey(coordinatorKey));
                                             return;
                                         }
 
@@ -1032,14 +1085,23 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                                             log.debug("[{}] Found node {} as coordinator for key {} partition {}.",
                                                     ctx.channel(), result.node, request.data().key(), partition);
                                         }
-                                        resultFuture.complete(KafkaResponseUtils.newFindCoordinator(result.node));
+                                        findSingleCoordinatorResult.complete(
+                                                new FindCoordinatorResponseData.Coordinator()
+                                                        .setNodeId(result.node.id())
+                                                        .setHost(result.node.host())
+                                                        .setPort(result.node.port())
+                                                        .setErrorCode(result.error.code())
+                                                        .setErrorMessage(result.error.message())
+                                                        .setKey(coordinatorKey));
                                     });
                                 });
                     });
         } else {
-            throw new NotImplementedException("FindCoordinatorRequest not support unknown type "
-                + request.data().keyType());
+            findSingleCoordinatorResult.completeExceptionally(
+                    new NotImplementedException("FindCoordinatorRequest not support unknown type "
+                            + request.data().keyType()));
         }
+        return findSingleCoordinatorResult;
     }
 
     @VisibleForTesting
@@ -1083,6 +1145,57 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         checkState(getGroupCoordinator() != null,
             "Group Coordinator not started");
 
+        List<CompletableFuture<KafkaResponseUtils.OffsetFetchResponseGroupData>> futures = new ArrayList<>();
+        if (request.version() >= 8) {
+            request.data().groups().forEach(group -> {
+                String groupId = group.groupId();
+                List<TopicPartition> partitions = new ArrayList<>();
+                // null topics means no partitions specified, so we should fetch all partitions
+                if (group.topics() != null) {
+                    group
+                        .topics()
+                        .forEach(topic -> {
+                            topic.partitionIndexes()
+                                    .forEach(partition -> partitions.add(new TopicPartition(topic.name(), partition)));
+                        });
+                }
+                futures.add(getOffsetFetchForGroup(groupId, partitions));
+            });
+
+        } else {
+            // old clients
+            String groupId = request.data().groupId();
+            List<TopicPartition> partitions = new ArrayList<>();
+            request.data().topics().forEach(topic -> {
+                topic
+                        .partitionIndexes()
+                        .forEach(partition -> partitions.add(new TopicPartition(topic.name(), partition)));
+            });
+            futures.add(getOffsetFetchForGroup(groupId, partitions));
+        }
+
+        FutureUtil.waitForAll(futures).whenComplete((___, error) -> {
+            if (error != null) {
+                resultFuture.complete(request.getErrorResponse(error));
+                return;
+            }
+            List<KafkaResponseUtils.OffsetFetchResponseGroupData> partitionsResponses = new ArrayList<>();
+            futures.forEach(f -> {
+                partitionsResponses.add(f.join());
+            });
+
+            resultFuture.complete(buildOffsetFetchResponse(partitionsResponses, request.version()));
+        });
+
+    }
+
+    protected CompletableFuture<KafkaResponseUtils.OffsetFetchResponseGroupData> getOffsetFetchForGroup(
+            String groupId,
+            List<TopicPartition> partitions
+            ) {
+
+        CompletableFuture<KafkaResponseUtils.OffsetFetchResponseGroupData> resultFuture = new CompletableFuture<>();
+
         CompletableFuture<List<TopicPartition>> authorizeFuture = new CompletableFuture<>();
 
         // replace
@@ -1094,10 +1207,11 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         Map<TopicPartition, OffsetFetchResponse.PartitionData> unknownPartitionData =
                 Maps.newConcurrentMap();
 
-        if (request.partitions() == null || request.partitions().isEmpty()) {
+        if (partitions == null || partitions.isEmpty()) {
+            // fetch all partitions
             authorizeFuture.complete(null);
         } else {
-            AtomicInteger partitionCount = new AtomicInteger(request.partitions().size());
+            AtomicInteger partitionCount = new AtomicInteger(partitions.size());
 
             Runnable completeOneAuthorization = () -> {
                 if (partitionCount.decrementAndGet() == 0) {
@@ -1105,7 +1219,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 }
             };
             final String namespacePrefix = currentNamespacePrefix();
-            request.partitions().forEach(tp -> {
+            partitions.forEach(tp -> {
                 try {
                     String fullName =  new KopTopic(tp.topic(), namespacePrefix).getFullName();
                     authorize(AclOperation.DESCRIBE, Resource.of(ResourceType.TOPIC, fullName))
@@ -1138,7 +1252,7 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         authorizeFuture.whenComplete((partitionList, ex) -> {
             KeyValue<Errors, Map<TopicPartition, OffsetFetchResponse.PartitionData>> keyValue =
                     getGroupCoordinator().handleFetchOffsets(
-                            request.groupId(),
+                            groupId,
                             Optional.ofNullable(partitionList)
                     );
             if (log.isDebugEnabled()) {
@@ -1154,13 +1268,20 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
             }
 
             // recover to original topic name
-            replaceTopicPartition(keyValue.getValue(), replacingIndex);
-            keyValue.getValue().putAll(unauthorizedPartitionData);
-            keyValue.getValue().putAll(unknownPartitionData);
+            Map<TopicPartition, OffsetFetchResponse.PartitionData> partitionsResponses = keyValue.getValue();
+            replaceTopicPartition(partitionsResponses, replacingIndex);
+            partitionsResponses.putAll(unauthorizedPartitionData);
+            partitionsResponses.putAll(unknownPartitionData);
 
-            resultFuture.complete(new OffsetFetchResponse(keyValue.getKey(), keyValue.getValue()));
+            Errors errors = keyValue.getKey();
+            resultFuture.complete(new KafkaResponseUtils.OffsetFetchResponseGroupData(groupId, errors,
+                    partitionsResponses));
         });
+
+        return resultFuture;
     }
+
+
 
     private CompletableFuture<Pair<Errors, Long>> fetchOffset(String topicName, long timestamp) {
         CompletableFuture<Pair<Errors, Long>> partitionData = new CompletableFuture<>();
@@ -1632,30 +1753,31 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         checkArgument(fetch.getRequest() instanceof FetchRequest);
         FetchRequest request = (FetchRequest) fetch.getRequest();
 
+        FetchRequestData data = request.data();
         if (log.isDebugEnabled()) {
             log.debug("[{}] Request {} Fetch request. Size: {}. Each item: ",
-                ctx.channel(), fetch.getHeader(), request.fetchData().size());
+                ctx.channel(), fetch.getHeader(), data.topics().size());
 
-            request.fetchData().forEach((topic, data) -> {
-                log.debug("Fetch request topic:{} data:{}.", topic, data.toString());
+            data.topics().forEach((topicData) -> {
+                log.debug("Fetch request topic: data:{}.", topicData.toString());
             });
         }
 
-        if (request.fetchData().isEmpty()) {
-            resultFuture.complete(new FetchResponse<>(
-                    Errors.NONE,
-                    new LinkedHashMap<>(),
-                    THROTTLE_TIME_MS,
-                    request.metadata().sessionId()));
+        int numPartitions = data.topics().stream().mapToInt(topic -> topic.partitions().size()).sum();
+        if (numPartitions == 0) {
+            resultFuture.complete(new FetchResponse(new FetchResponseData()
+                    .setErrorCode(Errors.NONE.code())
+                    .setSessionId(request.metadata().sessionId())
+                    .setResponses(new ArrayList<>())));
             return;
         }
 
-        ConcurrentHashMap<TopicPartition, FetchResponse.PartitionData<Records>> erroneous =
+        ConcurrentHashMap<TopicPartition, FetchResponseData.PartitionData> erroneous =
                 new ConcurrentHashMap<>();
-        ConcurrentHashMap<TopicPartition, FetchRequest.PartitionData> interesting =
+        ConcurrentHashMap<TopicPartition, FetchRequestData.FetchPartition> interesting =
                 new ConcurrentHashMap<>();
 
-        AtomicInteger unfinishedAuthorizationCount = new AtomicInteger(request.fetchData().size());
+        AtomicInteger unfinishedAuthorizationCount = new AtomicInteger(numPartitions);
         Runnable completeOne = () -> {
             if (unfinishedAuthorizationCount.decrementAndGet() == 0) {
                 TransactionCoordinator transactionCoordinator = null;
@@ -1668,13 +1790,12 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 int fetchMinBytes = Math.min(request.minBytes(), fetchMaxBytes);
                 if (interesting.isEmpty()) {
                     if (log.isDebugEnabled()) {
-                        log.debug("Fetch interesting is empty. Partitions: [{}]", request.fetchData());
+                        log.debug("Fetch interesting is empty. Partitions: [{}]", data.topics());
                     }
-                    resultFuture.complete(new FetchResponse<>(
-                            Errors.NONE,
-                            new LinkedHashMap<>(erroneous),
-                            THROTTLE_TIME_MS,
-                            request.metadata().sessionId()));
+                    resultFuture.complete(new FetchResponse(new FetchResponseData()
+                            .setErrorCode(Errors.NONE.code())
+                            .setSessionId(request.metadata().sessionId())
+                            .setResponses(buildFetchResponses(erroneous))));
                 } else {
                     MessageFetchContext context = MessageFetchContext
                             .get(this, transactionCoordinator, maxReadEntriesNum, namespacePrefix,
@@ -1687,18 +1808,17 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                             request.isolationLevel(),
                             context
                     ).thenAccept(resultMap -> {
-                        LinkedHashMap<TopicPartition, FetchResponse.PartitionData<Records>> partitions =
-                                new LinkedHashMap<>();
-                        resultMap.forEach((tp, data) -> {
-                            partitions.put(tp, data.toPartitionData());
+                        Map<TopicPartition, FetchResponseData.PartitionData> all = new HashMap<>();
+                        resultMap.forEach((tp, results) -> {
+                            all.put(tp, results.toPartitionData());
                         });
-                        partitions.putAll(erroneous);
+                        all.putAll(erroneous);
                         boolean triggeredCompletion = resultFuture.complete(new ResponseCallbackWrapper(
-                                new FetchResponse<>(
-                                    Errors.NONE,
-                                    partitions,
-                                    0,
-                                    request.metadata().sessionId()),
+                                new FetchResponse(new FetchResponseData()
+                                        .setErrorCode(Errors.NONE.code())
+                                        .setThrottleTimeMs(0)
+                                        .setSessionId(request.metadata().sessionId())
+                                        .setResponses(buildFetchResponses(all))),
                                 () -> resultMap.forEach((__, readRecordsResult) -> {
                                     readRecordsResult.recycle();
                                 })
@@ -1715,36 +1835,72 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
         };
 
         // Regular Kafka consumers need READ permission on each partition they are fetching.
-        request.fetchData().forEach((topicPartition, partitionData) -> {
-            final String fullTopicName = KopTopic.toString(topicPartition, this.currentNamespacePrefix());
-            authorize(AclOperation.READ, Resource.of(ResourceType.TOPIC, fullTopicName))
-                    .whenComplete((isAuthorized, ex) -> {
-                        if (ex != null) {
-                            log.error("Read topic authorize failed, topic - {}. {}",
-                                    fullTopicName, ex.getMessage());
-                            erroneous.put(topicPartition, errorResponse(Errors.TOPIC_AUTHORIZATION_FAILED));
+        data.topics().forEach(topicData -> {
+            topicData.partitions().forEach((partitionData) -> {
+                TopicPartition topicPartition = new TopicPartition(topicData.topic(), partitionData.partition());
+                final String fullTopicName = KopTopic.toString(topicPartition, this.currentNamespacePrefix());
+                authorize(AclOperation.READ, Resource.of(ResourceType.TOPIC, fullTopicName))
+                        .whenComplete((isAuthorized, ex) -> {
+                            if (ex != null) {
+                                log.error("Read topic authorize failed, topic - {}. {}",
+                                        fullTopicName, ex.getMessage());
+                                erroneous.put(topicPartition, errorResponse(Errors.TOPIC_AUTHORIZATION_FAILED));
+                                completeOne.run();
+                                return;
+                            }
+                            if (!isAuthorized) {
+                                erroneous.put(topicPartition, errorResponse(Errors.TOPIC_AUTHORIZATION_FAILED));
+                                completeOne.run();
+                                return;
+                            }
+                            interesting.put(topicPartition, partitionData);
                             completeOne.run();
-                            return;
-                        }
-                        if (!isAuthorized) {
-                            erroneous.put(topicPartition, errorResponse(Errors.TOPIC_AUTHORIZATION_FAILED));
-                            completeOne.run();
-                            return;
-                        }
-                        interesting.put(topicPartition, partitionData);
-                        completeOne.run();
-                    });
+                        });
+            });
         });
 
 
 
     }
 
-    private static FetchResponse.PartitionData<Records> errorResponse(Errors error) {
-        return new FetchResponse.PartitionData<>(error,
-                FetchResponse.INVALID_HIGHWATERMARK,
-                FetchResponse.INVALID_LAST_STABLE_OFFSET,
-                FetchResponse.INVALID_LOG_START_OFFSET, null, MemoryRecords.EMPTY);
+    public static List<FetchResponseData.FetchableTopicResponse> buildFetchResponses(
+            Map<TopicPartition, FetchResponseData.PartitionData> partitionData) {
+        List<FetchResponseData.FetchableTopicResponse> result = new ArrayList<>();
+        partitionData.keySet()
+                .stream()
+                .map(topicPartition -> topicPartition.topic())
+                .distinct()
+                        .forEach(topic -> {
+                            FetchResponseData.FetchableTopicResponse fetchableTopicResponse =
+                                    new FetchResponseData.FetchableTopicResponse()
+                                    .setTopic(topic)
+                                    .setPartitions(new ArrayList<>());
+                            result.add(fetchableTopicResponse);
+
+                            partitionData.forEach((tp, data) -> {
+                                if (tp.topic().equals(topic)) {
+                                    fetchableTopicResponse.partitions().add(new FetchResponseData.PartitionData()
+                                                    .setPartitionIndex(tp.partition())
+                                                    .setErrorCode(data.errorCode())
+                                                    .setHighWatermark(data.highWatermark())
+                                                    .setLastStableOffset(data.lastStableOffset())
+                                                    .setLogStartOffset(data.logStartOffset())
+                                                    .setAbortedTransactions(data.abortedTransactions())
+                                                    .setPreferredReadReplica(data.preferredReadReplica())
+                                                    .setRecords(data.records()));
+                                }
+                            });
+                        });
+        return result;
+    }
+
+    private static FetchResponseData.PartitionData errorResponse(Errors error) {
+        return new FetchResponseData.PartitionData()
+                .setErrorCode(error.code())
+                .setHighWatermark(FetchResponse.INVALID_HIGH_WATERMARK)
+                .setLastStableOffset(FetchResponse.INVALID_LAST_STABLE_OFFSET)
+                .setLogStartOffset(FetchResponse.INVALID_LOG_START_OFFSET)
+                .setRecords(MemoryRecords.EMPTY);
     }
 
     @Override
@@ -1780,7 +1936,8 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                 joinGroupResult.getProtocolType(),
                 joinGroupResult.getMemberId(),
                 joinGroupResult.getLeaderId(),
-                members
+                members,
+                request.version()
             );
             if (log.isTraceEnabled()) {
                 log.trace("Sending join group response {} for correlation id {} to client {}.",

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/exceptions/KoPTopicInitializeException.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/exceptions/KoPTopicInitializeException.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.exceptions;
+
+import java.io.Serial;
+
+/**
+ * KoP topic load exception.
+ */
+public class KoPTopicInitializeException extends KoPBaseException {
+
+    @Serial
+    private static final long serialVersionUID = 0L;
+
+    public KoPTopicInitializeException(Throwable throwable) {
+        super(throwable);
+    }
+
+}

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -1199,8 +1199,7 @@ public class PartitionLog {
     public CompletableFuture<Long> recoverTxEntries(
             long offset,
             Executor executor) {
-        if (!kafkaConfig.isKafkaTransactionCoordinatorEnabled()
-                || !MessageMetadataUtils.isInterceptorConfigured(persistentTopic.getManagedLedger())) {
+        if (!kafkaConfig.isKafkaTransactionCoordinatorEnabled()) {
             // no need to scan the topic, because transactions are disabled
             return CompletableFuture.completedFuture(Long.valueOf(0));
         }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -76,12 +76,12 @@ import org.apache.kafka.common.errors.KafkaStorageException;
 import org.apache.kafka.common.errors.NotLeaderOrFollowerException;
 import org.apache.kafka.common.errors.RecordTooLargeException;
 import org.apache.kafka.common.errors.UnknownServerException;
+import org.apache.kafka.common.message.FetchRequestData;
+import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.RecordBatch;
-import org.apache.kafka.common.record.Records;
-import org.apache.kafka.common.requests.FetchRequest;
 import org.apache.kafka.common.requests.FetchResponse;
 import org.apache.kafka.common.utils.Time;
 import org.apache.pulsar.broker.service.Topic;
@@ -291,7 +291,7 @@ public class PartitionLog {
         private final Recycler.Handle<ReadRecordsResult> recyclerHandle;
 
         private DecodeResult decodeResult;
-        private List<FetchResponse.AbortedTransaction> abortedTransactions;
+        private List<FetchResponseData.AbortedTransaction> abortedTransactions;
         private long highWatermark;
         private long lastStableOffset;
         private Position lastPosition;
@@ -308,7 +308,7 @@ public class PartitionLog {
         }
 
         public static ReadRecordsResult get(DecodeResult decodeResult,
-                                            List<FetchResponse.AbortedTransaction> abortedTransactions,
+                                            List<FetchResponseData.AbortedTransaction> abortedTransactions,
                                             long highWatermark,
                                             long lastStableOffset,
                                             Position lastPosition,
@@ -324,7 +324,7 @@ public class PartitionLog {
         }
 
         public static ReadRecordsResult get(DecodeResult decodeResult,
-                                            List<FetchResponse.AbortedTransaction> abortedTransactions,
+                                            List<FetchResponseData.AbortedTransaction> abortedTransactions,
                                             long highWatermark,
                                             long lastStableOffset,
                                             Position lastPosition,
@@ -368,7 +368,7 @@ public class PartitionLog {
                     partitionLog);
         }
 
-        public FetchResponse.PartitionData<Records> toPartitionData() {
+        public FetchResponseData.PartitionData toPartitionData() {
 
             // There are three cases:
             //
@@ -379,21 +379,20 @@ public class PartitionLog {
             // 3. errors == Others error :
             //        Get errors.
             if (errors != null) {
-                return new FetchResponse.PartitionData<>(
-                        errors,
-                        FetchResponse.INVALID_HIGHWATERMARK,
-                        FetchResponse.INVALID_LAST_STABLE_OFFSET,
-                        FetchResponse.INVALID_LOG_START_OFFSET,
-                        null,
-                        MemoryRecords.EMPTY);
+                return new FetchResponseData.PartitionData()
+                        .setErrorCode(errors.code())
+                        .setHighWatermark(FetchResponse.INVALID_HIGH_WATERMARK)
+                        .setLastStableOffset(FetchResponse.INVALID_LAST_STABLE_OFFSET)
+                        .setLogStartOffset(FetchResponse.INVALID_LOG_START_OFFSET)
+                        .setRecords(MemoryRecords.EMPTY);
             }
-            return new FetchResponse.PartitionData<>(
-                    Errors.NONE,
-                    highWatermark,
-                    lastStableOffset,
-                    highWatermark, // TODO: should it be changed to the logStartOffset?
-                    abortedTransactions,
-                    decodeResult.getRecords());
+            return new FetchResponseData.PartitionData()
+                    .setErrorCode(Errors.NONE.code())
+                    .setHighWatermark(highWatermark)
+                    .setLastStableOffset(lastStableOffset)
+                    .setHighWatermark(highWatermark) // TODO: should it be changed to the logStartOffset?
+                    .setAbortedTransactions(abortedTransactions)
+                    .setRecords(decodeResult.getRecords());
         }
 
         public void recycle() {
@@ -460,7 +459,7 @@ public class PartitionLog {
         return producerStateManager.firstUndecidedOffset();
     }
 
-    public List<FetchResponse.AbortedTransaction> getAbortedIndexList(long fetchOffset) {
+    public List<FetchResponseData.AbortedTransaction> getAbortedIndexList(long fetchOffset) {
         return producerStateManager.getAbortedIndexList(fetchOffset);
     }
 
@@ -537,14 +536,14 @@ public class PartitionLog {
         return persistentTopic.getLastPosition();
     }
 
-    public CompletableFuture<ReadRecordsResult> readRecords(final FetchRequest.PartitionData partitionData,
+    public CompletableFuture<ReadRecordsResult> readRecords(final FetchRequestData.FetchPartition partitionData,
                                                             final boolean readCommitted,
                                                             final AtomicLong limitBytes,
                                                             final int maxReadEntriesNum,
                                                             final MessageFetchContext context) {
         final long startPrepareMetadataNanos = MathUtils.nowInNano();
         final CompletableFuture<ReadRecordsResult> future = new CompletableFuture<>();
-        final long offset = partitionData.fetchOffset;
+        final long offset = partitionData.fetchOffset();
         KafkaTopicManager topicManager = context.getTopicManager();
         // The future that is returned by getTopicConsumerManager is always completed normally
         topicManager.getTopicConsumerManager(fullPartitionName).thenAccept(tcm -> {
@@ -592,7 +591,7 @@ public class PartitionLog {
 
                 requestStats.getPrepareMetadataStats().registerSuccessfulEvent(
                         MathUtils.elapsedNanos(startPrepareMetadataNanos), TimeUnit.NANOSECONDS);
-                long adjustedMaxBytes = Math.min(partitionData.maxBytes, limitBytes.get());
+                long adjustedMaxBytes = Math.min(partitionData.partitionMaxBytes(), limitBytes.get());
                 if (readCommitted) {
                     long firstUndecidedOffset = producerStateManager.firstUndecidedOffset().orElse(-1L);
                     if (firstUndecidedOffset >= 0 && firstUndecidedOffset <= offset) {
@@ -674,7 +673,7 @@ public class PartitionLog {
 
     private void handleEntries(final CompletableFuture<ReadRecordsResult> future,
                                final List<Entry> entries,
-                               final FetchRequest.PartitionData partitionData,
+                               final FetchRequestData.FetchPartition partitionData,
                                final KafkaTopicConsumerManager tcm,
                                final ManagedCursor cursor,
                                final boolean readCommitted,
@@ -716,9 +715,9 @@ public class PartitionLog {
 
             // collect consumer metrics
             decodeResult.updateConsumerStats(topicPartition, committedEntries.size(), groupName, requestStats);
-            List<FetchResponse.AbortedTransaction> abortedTransactions = null;
+            List<FetchResponseData.AbortedTransaction> abortedTransactions = null;
             if (readCommitted) {
-                abortedTransactions = this.getAbortedIndexList(partitionData.fetchOffset);
+                abortedTransactions = this.getAbortedIndexList(partitionData.fetchOffset());
             }
             if (log.isDebugEnabled()) {
                 log.debug("Partition {} read entry completed in {} ns",
@@ -1133,7 +1132,15 @@ public class PartitionLog {
         // look for the first entry with data
         PositionImpl nextValidPosition = managedLedger.getNextValidPosition(firstPosition);
 
-        managedLedger.asyncReadEntry(nextValidPosition, new AsyncCallbacks.ReadEntryCallback() {
+        fetchOldestAvailableIndexFromTopicReadNext(future, managedLedger, nextValidPosition);
+
+        return future;
+
+    }
+
+    private void fetchOldestAvailableIndexFromTopicReadNext(CompletableFuture<Long> future,
+                                                            ManagedLedgerImpl managedLedger, PositionImpl position) {
+        managedLedger.asyncReadEntry(position, new AsyncCallbacks.ReadEntryCallback() {
             @Override
             public void readEntryComplete(Entry entry, Object ctx) {
                 try {
@@ -1141,6 +1148,13 @@ public class PartitionLog {
                     log.info("First offset for topic {} is {} - position {}", fullPartitionName,
                             startOffset, entry.getPosition());
                     future.complete(startOffset);
+                } catch (MetadataCorruptedException.NoBrokerEntryMetadata noBrokerEntryMetadata) {
+                    long currentOffset = MessageMetadataUtils.getCurrentOffset(managedLedger);
+                    log.info("Legacy entry for topic {} - position {} - returning current offset {}",
+                            fullPartitionName,
+                            entry.getPosition(),
+                            currentOffset);
+                    future.complete(currentOffset);
                 } catch (Exception err) {
                     future.completeExceptionally(err);
                 } finally {
@@ -1153,9 +1167,6 @@ public class PartitionLog {
                 future.completeExceptionally(exception);
             }
         }, null);
-
-        return future;
-
     }
 
     @VisibleForTesting
@@ -1187,7 +1198,8 @@ public class PartitionLog {
     public CompletableFuture<Long> recoverTxEntries(
             long offset,
             Executor executor) {
-        if (!kafkaConfig.isKafkaTransactionCoordinatorEnabled()) {
+        if (!kafkaConfig.isKafkaTransactionCoordinatorEnabled()
+                || !MessageMetadataUtils.isInterceptorConfigured(persistentTopic.getManagedLedger())) {
             // no need to scan the topic, because transactions are disabled
             return CompletableFuture.completedFuture(Long.valueOf(0));
         }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -26,6 +26,7 @@ import io.streamnative.pulsar.handlers.kop.MessageFetchContext;
 import io.streamnative.pulsar.handlers.kop.MessagePublishContext;
 import io.streamnative.pulsar.handlers.kop.PendingTopicFutures;
 import io.streamnative.pulsar.handlers.kop.RequestStats;
+import io.streamnative.pulsar.handlers.kop.exceptions.KoPTopicInitializeException;
 import io.streamnative.pulsar.handlers.kop.exceptions.MetadataCorruptedException;
 import io.streamnative.pulsar.handlers.kop.format.DecodeResult;
 import io.streamnative.pulsar.handlers.kop.format.EncodeRequest;
@@ -165,7 +166,7 @@ public class PartitionLog {
     public CompletableFuture<PartitionLog> initialise() {
         loadTopicProperties().whenComplete((___, errorLoadTopic) -> {
             if (errorLoadTopic != null) {
-                initFuture.completeExceptionally(errorLoadTopic);
+                initFuture.completeExceptionally(new KoPTopicInitializeException(errorLoadTopic));
                 return;
             }
             if (kafkaConfig.isKafkaTransactionCoordinatorEnabled()) {
@@ -173,7 +174,7 @@ public class PartitionLog {
                         .recover(this, recoveryExecutor)
                         .thenRun(() -> initFuture.complete(this))
                         .exceptionally(error -> {
-                            initFuture.completeExceptionally(error);
+                            initFuture.completeExceptionally(new KoPTopicInitializeException(error));
                             return null;
                         });
             } else {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManager.java
@@ -363,8 +363,7 @@ public class ProducerStateManager {
         if (snapshotOffset < minOffset) {
             log.info("{} handleMissingDataBeforeRecovery mapEndOffset {} snapshotOffset "
                             + "{} minOffset {} RESETTING STATE",
-                    topicPartition,
-                    mapEndOffset, minOffset);
+                    topicPartition, mapEndOffset, snapshotOffset, minOffset);
             // topic was not empty (mapEndOffset has some value)
             // but there is no more data on the topic (trimmed?)
             ongoingTxns.clear();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ProducerStateManager.java
@@ -27,8 +27,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.util.SafeRunnable;
+import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.record.RecordBatch;
-import org.apache.kafka.common.requests.FetchResponse;
 
 /**
  * Producer state manager.
@@ -339,13 +339,15 @@ public class ProducerStateManager {
         return count.get();
     }
 
-    public List<FetchResponse.AbortedTransaction> getAbortedIndexList(long fetchOffset) {
+    public List<FetchResponseData.AbortedTransaction> getAbortedIndexList(long fetchOffset) {
         synchronized (abortedIndexList) {
-            List<FetchResponse.AbortedTransaction> abortedTransactions = new ArrayList<>();
+            List<FetchResponseData.AbortedTransaction> abortedTransactions = new ArrayList<>();
             for (AbortedTxn abortedTxn : abortedIndexList) {
                 if (abortedTxn.lastOffset() >= fetchOffset) {
                     abortedTransactions.add(
-                            new FetchResponse.AbortedTransaction(abortedTxn.producerId(), abortedTxn.firstOffset()));
+                            new FetchResponseData.AbortedTransaction()
+                                    .setProducerId(abortedTxn.producerId())
+                                    .setFirstOffset(abortedTxn.firstOffset()));
                 }
             }
             return abortedTransactions;

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
@@ -42,9 +42,9 @@ import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.InvalidTopicException;
 import org.apache.kafka.common.errors.NotLeaderOrFollowerException;
+import org.apache.kafka.common.message.FetchRequestData;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.record.MemoryRecords;
-import org.apache.kafka.common.requests.FetchRequest;
 import org.apache.kafka.common.requests.ProduceResponse;
 import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
@@ -240,7 +240,7 @@ public class ReplicaManager {
             final long timeout,
             final int fetchMinBytes,
             final int fetchMaxBytes,
-            final ConcurrentHashMap<TopicPartition, FetchRequest.PartitionData> fetchInfos,
+            final ConcurrentHashMap<TopicPartition, FetchRequestData.FetchPartition> fetchInfos,
             final IsolationLevel isolationLevel,
             final MessageFetchContext context) {
         CompletableFuture<Map<TopicPartition, PartitionLog.ReadRecordsResult>> future =
@@ -294,7 +294,7 @@ public class ReplicaManager {
             final boolean readCommitted,
             final int fetchMaxBytes,
             final int maxReadEntriesNum,
-            final Map<TopicPartition, FetchRequest.PartitionData> readPartitionInfo,
+            final Map<TopicPartition, FetchRequestData.FetchPartition> readPartitionInfo,
             final MessageFetchContext context) {
         AtomicLong limitBytes = new AtomicLong(fetchMaxBytes);
         CompletableFuture<Map<TopicPartition, PartitionLog.ReadRecordsResult>> resultFuture = new CompletableFuture<>();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KafkaResponseUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/KafkaResponseUtils.java
@@ -188,31 +188,22 @@ public class KafkaResponseUtils {
         return new DescribeGroupsResponse(data);
     }
 
-    public static FindCoordinatorResponse newFindCoordinator(List<String> coordinatorKeys,
-                                                             Node node,
-                                                             int version) {
-        FindCoordinatorResponseData data = new FindCoordinatorResponseData();
-        if (version < FindCoordinatorRequest.MIN_BATCHED_VERSION) {
-            data.setErrorMessage(Errors.NONE.message())
-                    .setErrorCode(Errors.NONE.code())
-                    .setPort(node.port())
-                    .setHost(node.host())
-                    .setNodeId(node.id());
-        } else {
-            // for new clients
-            data.setCoordinators(coordinatorKeys
-                    .stream()
-                    .map(key -> new FindCoordinatorResponseData.Coordinator()
-                            .setErrorCode(Errors.NONE.code())
-                            .setErrorMessage(Errors.NONE.message())
-                            .setHost(node.host())
-                            .setPort(node.port())
-                            .setNodeId(node.id())
-                            .setKey(key))
-                    .collect(Collectors.toList()));
+    public static FindCoordinatorResponseData.Coordinator newCoordinator(Errors errors,
+                                                                         Node node,
+                                                                         String coordinatorKey) {
+        if (errors != Errors.NONE) {
+            return new FindCoordinatorResponseData.Coordinator()
+                    .setErrorCode(errors.code())
+                    .setErrorMessage(errors.message())
+                    .setKey(coordinatorKey);
         }
-
-        return new FindCoordinatorResponse(data);
+        return new FindCoordinatorResponseData.Coordinator()
+                .setNodeId(node.id())
+                .setHost(node.host())
+                .setPort(node.port())
+                .setErrorCode(Errors.NONE.code())
+                .setErrorMessage(Errors.NONE.message())
+                .setKey(coordinatorKey);
     }
 
     public static FindCoordinatorResponse newFindCoordinator(List<FindCoordinatorResponseData.Coordinator> coordinators,

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MessageMetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MessageMetadataUtils.java
@@ -38,6 +38,10 @@ import org.apache.pulsar.common.protocol.Commands;
 @Slf4j
 public class MessageMetadataUtils {
 
+    public static boolean isInterceptorConfigured(ManagedLedger managedLedger) {
+        return managedLedger.getManagedLedgerInterceptor() instanceof ManagedLedgerInterceptorImpl;
+    }
+
     public static long getCurrentOffset(ManagedLedger managedLedger) {
         return ((ManagedLedgerInterceptorImpl) managedLedger.getManagedLedgerInterceptor()).getIndex();
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MessageMetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MessageMetadataUtils.java
@@ -14,6 +14,7 @@
 package io.streamnative.pulsar.handlers.kop.utils;
 
 import com.google.common.base.Predicate;
+import io.jsonwebtoken.lang.Collections;
 import io.netty.buffer.ByteBuf;
 import io.streamnative.pulsar.handlers.kop.exceptions.MetadataCorruptedException;
 import java.util.concurrent.CompletableFuture;
@@ -28,8 +29,11 @@ import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.intercept.ManagedLedgerInterceptorImpl;
+import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.common.api.proto.BrokerEntryMetadata;
 import org.apache.pulsar.common.api.proto.MessageMetadata;
+import org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor;
+import org.apache.pulsar.common.intercept.BrokerEntryMetadataInterceptor;
 import org.apache.pulsar.common.protocol.Commands;
 
 /**
@@ -37,6 +41,18 @@ import org.apache.pulsar.common.protocol.Commands;
  */
 @Slf4j
 public class MessageMetadataUtils {
+
+    public static boolean isBrokerIndexMetadataInterceptorConfigured(BrokerService brokerService) {
+        if (Collections.isEmpty(brokerService.getBrokerEntryMetadataInterceptors())) {
+            return false;
+        }
+        for (BrokerEntryMetadataInterceptor interceptor : brokerService.getBrokerEntryMetadataInterceptors()) {
+            if (interceptor instanceof AppendIndexMetadataInterceptor) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     public static long getCurrentOffset(ManagedLedger managedLedger) {
         return ((ManagedLedgerInterceptorImpl) managedLedger.getManagedLedgerInterceptor()).getIndex();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MessageMetadataUtils.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/utils/MessageMetadataUtils.java
@@ -38,10 +38,6 @@ import org.apache.pulsar.common.protocol.Commands;
 @Slf4j
 public class MessageMetadataUtils {
 
-    public static boolean isInterceptorConfigured(ManagedLedger managedLedger) {
-        return managedLedger.getManagedLedgerInterceptor() instanceof ManagedLedgerInterceptorImpl;
-    }
-
     public static long getCurrentOffset(ManagedLedger managedLedger) {
         return ((ManagedLedgerInterceptorImpl) managedLedger.getManagedLedgerInterceptor()).getIndex();
     }

--- a/kafka-impl/src/main/java/org/apache/kafka/common/requests/ResponseCallbackWrapper.java
+++ b/kafka-impl/src/main/java/org/apache/kafka/common/requests/ResponseCallbackWrapper.java
@@ -56,4 +56,9 @@ public class ResponseCallbackWrapper extends AbstractResponse {
     public ApiMessage data() {
         return abstractResponse.data();
     }
+
+    @Override
+    public void maybeSetThrottleTimeMs(int i) {
+        abstractResponse.maybeSetThrottleTimeMs(i);
+    }
 }

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterTest.java
@@ -339,15 +339,15 @@ public class EntryFormatterTest {
         }
 
         @Override
-        public Long appendWithOffset(long offset, SimpleRecord record) {
-            return appendWithOffset(offset,
+        public void appendWithOffset(long offset, SimpleRecord record) {
+            appendWithOffset(offset,
                     record.timestamp(),
                     record.key(),
                     record.value(),
                     record.headers());
         }
 
-        public Long appendWithOffset(long offset,
+        public void appendWithOffset(long offset,
                                      long timestamp,
                                      ByteBuffer key,
                                      ByteBuffer value,
@@ -359,9 +359,9 @@ public class EntryFormatterTest {
 
                 if (magic > RecordBatch.MAGIC_VALUE_V1) {
                     appendDefaultRecord(offset, timestamp, key, value, headers);
-                    return null;
+
                 } else {
-                    return appendLegacyRecord(offset, timestamp, key, value);
+                    appendLegacyRecord(offset, timestamp, key, value);
                 }
             } catch (IOException e) {
                 throw new KafkaException("I/O exception when writing to the append stream, closing", e);

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <!-- dependencies -->
     <jackson.version>2.14.2</jackson.version>
     <jackson-databind.version>2.14.2</jackson-databind.version>
-    <kafka.version>2.8.0</kafka.version>
+    <kafka.version>3.4.0</kafka.version>
     <lombok.version>1.18.24</lombok.version>
     <mockito.version>4.11.0</mockito.version>
     <wiremock.version>3.0.0-beta-2</wiremock.version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <!-- dependencies -->
     <jackson.version>2.14.2</jackson.version>
     <jackson-databind.version>2.14.2</jackson-databind.version>
-    <kafka.version>3.4.0</kafka.version>
+    <kafka.version>3.4.1</kafka.version>
     <lombok.version>1.18.24</lombok.version>
     <mockito.version>4.11.0</mockito.version>
     <wiremock.version>3.0.0-beta-2</wiremock.version>

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/EntryPublishTimeKafkaFormatTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/EntryPublishTimeKafkaFormatTest.java
@@ -92,7 +92,7 @@ public class EntryPublishTimeKafkaFormatTest extends EntryPublishTimeTest {
 
         // time before first message
         ListOffsetsRequest.Builder builder = ListOffsetsRequest.Builder
-                .forConsumer(true, IsolationLevel.READ_UNCOMMITTED)
+                .forConsumer(true, IsolationLevel.READ_UNCOMMITTED, false)
                 .setTargetTimes(KafkaCommonTestUtils.newListOffsetTargetTimes(tp, startTime));
 
         KafkaCommandDecoder.KafkaHeaderAndRequest request = buildRequest(builder);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaCommonTestUtils.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaCommonTestUtils.java
@@ -13,6 +13,8 @@
  */
 package io.streamnative.pulsar.handlers.kop;
 
+import static org.testng.Assert.assertEquals;
+
 import io.netty.buffer.ByteBuf;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
@@ -48,7 +50,7 @@ public class KafkaCommonTestUtils {
     public static FetchRequest.PartitionData newFetchRequestPartitionData(long fetchOffset,
                                                                           long logStartOffset,
                                                                           int maxBytes) {
-        return new FetchRequest.PartitionData(fetchOffset,
+        return new FetchRequest.PartitionData(null, fetchOffset,
                 logStartOffset,
                 maxBytes,
                 Optional.empty()
@@ -110,7 +112,12 @@ public class KafkaCommonTestUtils {
 
     public static KafkaCommandDecoder.KafkaHeaderAndRequest buildRequest(AbstractRequest.Builder builder,
                                                                   SocketAddress serviceAddress) {
-        AbstractRequest request = builder.build(builder.apiKey().latestVersion());
+        return buildRequest(builder, serviceAddress, builder.latestAllowedVersion());
+    }
+    public static KafkaCommandDecoder.KafkaHeaderAndRequest buildRequest(AbstractRequest.Builder builder,
+                SocketAddress serviceAddress, short version) {
+        AbstractRequest request = builder.build(version);
+        assertEquals(version, request.version());
         RequestHeader mockHeader = new RequestHeader(builder.apiKey(), request.version(), "dummy", 1233);
 
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandlerTest.java
@@ -639,7 +639,7 @@ public class KafkaRequestHandlerTest extends KopProtocolHandlerTestBase {
         final RequestHeader header =
                 new RequestHeader(ApiKeys.LIST_OFFSETS, ApiKeys.LIST_OFFSETS.latestVersion(), "client", 0);
         final ListOffsetsRequest request =
-                ListOffsetsRequest.Builder.forConsumer(true, IsolationLevel.READ_UNCOMMITTED)
+                ListOffsetsRequest.Builder.forConsumer(true, IsolationLevel.READ_UNCOMMITTED, false)
                         .setTargetTimes(KafkaCommonTestUtils
                                 .newListOffsetTargetTimes(topicPartition, ListOffsetsRequest.EARLIEST_TIMESTAMP))
                         .build(ApiKeys.LIST_OFFSETS.latestVersion());

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -312,7 +312,6 @@ public abstract class KopProtocolHandlerTestBase {
             createClient();
 
             MetadataUtils.createOffsetMetadataIfMissing(conf.getKafkaMetadataTenant(), admin, clusterData, this.conf);
-
             if (conf.isKafkaTransactionCoordinatorEnabled()) {
                 MetadataUtils.createTxnMetadataIfMissing(conf.getKafkaMetadataTenant(), admin, clusterData, this.conf);
             }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/KopProtocolHandlerTestBase.java
@@ -192,7 +192,8 @@ public abstract class KopProtocolHandlerTestBase {
         // kafka related settings.
         kafkaConfig.setOffsetsTopicNumPartitions(1);
 
-        kafkaConfig.setKafkaTransactionCoordinatorEnabled(false);
+        // kafka 3.1.x clients init the producerId by default, so we need to enable it.
+        kafkaConfig.setKafkaTransactionCoordinatorEnabled(true);
         kafkaConfig.setKafkaTxnLogTopicNumPartitions(1);
 
         kafkaConfig.setKafkaListeners(
@@ -311,6 +312,7 @@ public abstract class KopProtocolHandlerTestBase {
             createClient();
 
             MetadataUtils.createOffsetMetadataIfMissing(conf.getKafkaMetadataTenant(), admin, clusterData, this.conf);
+
             if (conf.isKafkaTransactionCoordinatorEnabled()) {
                 MetadataUtils.createTxnMetadataIfMissing(conf.getKafkaMetadataTenant(), admin, clusterData, this.conf);
             }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/admin/KafkaAdminTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/admin/KafkaAdminTest.java
@@ -76,6 +76,7 @@ import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.util.Murmur3_32Hash;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
 
@@ -552,6 +553,8 @@ public class KafkaAdminTest extends KopProtocolHandlerTestBase {
         admin.topics().deletePartitionedTopic(topic, true);
     }
 
+    @Ignore("\"org.apache.kafka.common.errors.UnsupportedVersionException: "
+            + "The version of API is not supported.\" in testAlterClientQuotas")
     @Test(timeOut = 30000)
     public void testAlterClientQuotas() throws ExecutionException, InterruptedException {
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManagerTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionStateManagerTest.java
@@ -107,6 +107,8 @@ public class TransactionStateManagerTest extends KopProtocolHandlerTestBase {
     @BeforeClass
     @Override
     protected void setup() throws Exception {
+        // we need to disable the kafka transaction coordinator to avoid the conflict
+        this.conf.setKafkaTransactionCoordinatorEnabled(false);
         this.conf.setKafkaTxnLogTopicNumPartitions(numPartitions);
         internalSetup();
         MetadataUtils.createTxnMetadataIfMissing(conf.getKafkaMetadataTenant(), admin, clusterData, this.conf);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionTest.java
@@ -63,8 +63,8 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.requests.FetchResponse;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -770,12 +770,12 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
         partitionLog.awaitInitialisation().get();
         assertEquals(0, partitionLog.fetchOldestAvailableIndexFromTopic().get().longValue());
 
-        List<FetchResponse.AbortedTransaction> abortedIndexList =
+        List<FetchResponseData.AbortedTransaction> abortedIndexList =
                 partitionLog.getProducerStateManager().getAbortedIndexList(Long.MIN_VALUE);
         abortedIndexList.forEach(tx -> {
             log.info("TX {}", tx);
         });
-        assertEquals(0, abortedIndexList.get(0).firstOffset);
+        assertEquals(0, abortedIndexList.get(0).firstOffset());
 
         producer.beginTransaction();
         String lastMessage = "msg1b";
@@ -810,7 +810,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
         abortedIndexList.forEach(tx -> {
             log.info("TX {}", tx);
         });
-        assertEquals(0, abortedIndexList.get(0).firstOffset);
+        assertEquals(0, abortedIndexList.get(0).firstOffset());
         assertEquals(1, abortedIndexList.size());
 
         waitForTransactionsToBeInStableState(transactionalId);
@@ -848,7 +848,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
         });
 
         assertEquals(1, abortedIndexList.size());
-        assertEquals(0, abortedIndexList.get(0).firstOffset);
+        assertEquals(0, abortedIndexList.get(0).firstOffset());
 
         producer.beginTransaction();
         producer.send(new ProducerRecord<>(topicName, 0, "msg4")).get(); // OFFSET 8
@@ -875,8 +875,8 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
             log.info("TX {}", tx);
         });
 
-        assertEquals(0, abortedIndexList.get(0).firstOffset);
-        assertEquals(11, abortedIndexList.get(1).firstOffset);
+        assertEquals(0, abortedIndexList.get(0).firstOffset());
+        assertEquals(11, abortedIndexList.get(1).firstOffset());
         assertEquals(2, abortedIndexList.size());
 
         producer.beginTransaction();
@@ -900,8 +900,8 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
             log.info("TX {}", tx);
         });
 
-        assertEquals(0, abortedIndexList.get(0).firstOffset);
-        assertEquals(11, abortedIndexList.get(1).firstOffset);
+        assertEquals(0, abortedIndexList.get(0).firstOffset());
+        assertEquals(11, abortedIndexList.get(1).firstOffset());
         assertEquals(2, abortedIndexList.size());
 
 
@@ -916,7 +916,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
             log.info("TX {}", tx);
         });
         assertEquals(1, abortedIndexList.size());
-        assertEquals(11, abortedIndexList.get(0).firstOffset);
+        assertEquals(11, abortedIndexList.get(0).firstOffset());
 
         // use a new consumer group, it will read from the beginning of the topic
         assertEquals(

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionTest.java
@@ -1430,12 +1430,12 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
                     .getPartitionLog(topicPartition, namespacePrefix);
             partitionLog.awaitInitialisation().get();
 
-            List<FetchResponse.AbortedTransaction> abortedIndexList =
+            List<FetchResponseData.AbortedTransaction> abortedIndexList =
                     partitionLog.getProducerStateManager().getAbortedIndexList(Long.MIN_VALUE);
             assertEquals(2, abortedIndexList.size());
             assertEquals(2, abortedIndexList.size());
-            assertEquals(0, abortedIndexList.get(0).firstOffset);
-            assertEquals(3, abortedIndexList.get(1).firstOffset);
+            assertEquals(0, abortedIndexList.get(0).firstOffset());
+            assertEquals(3, abortedIndexList.get(1).firstOffset());
 
             takeSnapshot(topicName);
 
@@ -1460,8 +1460,8 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
             abortedIndexList =
                     partitionLog.getProducerStateManager().getAbortedIndexList(Long.MIN_VALUE);
             assertEquals(2, abortedIndexList.size());
-            assertEquals(0, abortedIndexList.get(0).firstOffset);
-            assertEquals(3, abortedIndexList.get(1).firstOffset);
+            assertEquals(0, abortedIndexList.get(0).firstOffset());
+            assertEquals(3, abortedIndexList.get(1).firstOffset());
 
             // force reading the minimum valid offset
             // the timer is not started by the PH because
@@ -1480,7 +1480,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
             assertEquals(1, abortedIndexList.size());
             // the second TX cannot be purged because the lastOffset is 5, that is the boundary of the
             // trimmed portion of the topic
-            assertEquals(3, abortedIndexList.get(0).firstOffset);
+            assertEquals(3, abortedIndexList.get(0).firstOffset());
 
             producer1.close();
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/e2e/DistributedClusterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/e2e/DistributedClusterTest.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -393,7 +394,7 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
     @Test(timeOut = 30000)
     public void testMultiBrokerUnloadReload() throws Exception {
         int partitionNumber = 10;
-        String kafkaTopicName = "kopMultiBrokerUnloadReload" + partitionNumber;
+        String kafkaTopicName = "kopMultiBrokerUnloadReload-" + partitionNumber + "-" + UUID.randomUUID();
         String pulsarTopicName = "persistent://public/default/" + kafkaTopicName;
         String kopNamespace = "public/default";
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/e2e/DistributedClusterTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/e2e/DistributedClusterTest.java
@@ -86,6 +86,7 @@ public class DistributedClusterTest extends KopProtocolHandlerTestBase {
         kConfig.setOffsetsTopicNumPartitions(offsetsTopicNumPartitions);
 
         kConfig.setAdvertisedAddress("localhost");
+        kConfig.setKafkaTransactionCoordinatorEnabled(true);
         kConfig.setClusterName(configClusterName);
         kConfig.setManagedLedgerCacheSizeMB(8);
         kConfig.setActiveConsumerFailoverDelayTimeMillis(0);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/metrics/MetricsProviderTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/metrics/MetricsProviderTest.java
@@ -127,7 +127,7 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase {
         }
 
         Assert.assertEquals(getApiKeysSet(), new TreeSet<>(
-                Arrays.asList(ApiKeys.API_VERSIONS, ApiKeys.METADATA, ApiKeys.PRODUCE)));
+                Arrays.asList(ApiKeys.API_VERSIONS, ApiKeys.METADATA, ApiKeys.PRODUCE, ApiKeys.INIT_PRODUCER_ID)));
 
         // 2. consume messages with Kafka consumer
         @Cleanup
@@ -154,14 +154,14 @@ public class MetricsProviderTest extends KopProtocolHandlerTestBase {
 
         Assert.assertEquals(getApiKeysSet(), new TreeSet<>(Arrays.asList(
                 ApiKeys.API_VERSIONS, ApiKeys.METADATA, ApiKeys.PRODUCE, ApiKeys.FIND_COORDINATOR, ApiKeys.LIST_OFFSETS,
-                ApiKeys.OFFSET_FETCH, ApiKeys.FETCH
+                ApiKeys.OFFSET_FETCH, ApiKeys.FETCH, ApiKeys.INIT_PRODUCER_ID
         )));
 
         // commit offsets
         kConsumer.getConsumer().commitSync(Duration.ofSeconds(5));
         Assert.assertEquals(getApiKeysSet(), new TreeSet<>(Arrays.asList(
                 ApiKeys.API_VERSIONS, ApiKeys.METADATA, ApiKeys.PRODUCE, ApiKeys.FIND_COORDINATOR, ApiKeys.LIST_OFFSETS,
-                ApiKeys.OFFSET_FETCH, ApiKeys.FETCH, ApiKeys.OFFSET_COMMIT
+                ApiKeys.OFFSET_FETCH, ApiKeys.FETCH, ApiKeys.OFFSET_COMMIT, ApiKeys.INIT_PRODUCER_ID
         )));
 
         try {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/GlobalKTableTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/GlobalKTableTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.ForeachAction;
@@ -109,7 +110,8 @@ public class GlobalKTableTest extends KafkaStreamsTestBase {
         produceGlobalTableValues();
 
         final ReadOnlyKeyValueStore<Long, String> replicatedStore =
-                kafkaStreams.store(globalStore, QueryableStoreTypes.keyValueStore());
+                kafkaStreams.store(
+                        StoreQueryParameters.fromNameAndType(globalStore, QueryableStoreTypes.keyValueStore()));
 
         TestUtils.waitForCondition(() -> "J".equals(replicatedStore.get(5L)),
                 30000, "waiting for data in replicated store");
@@ -143,7 +145,9 @@ public class GlobalKTableTest extends KafkaStreamsTestBase {
         produceGlobalTableValues();
 
         final ReadOnlyKeyValueStore<Long, String> replicatedStore =
-                kafkaStreams.store(globalStore, QueryableStoreTypes.<Long, String>keyValueStore());
+                kafkaStreams.store(
+                        StoreQueryParameters
+                                .fromNameAndType(globalStore, QueryableStoreTypes.<Long, String>keyValueStore()));
 
         TestUtils.waitForCondition(() -> "J".equals(replicatedStore.get(5L)),
                 30000, "waiting for data in replicated store");
@@ -173,13 +177,15 @@ public class GlobalKTableTest extends KafkaStreamsTestBase {
         Thread.sleep(1000); // NOTE: it may take a few milliseconds to wait streams started
 
         ReadOnlyKeyValueStore<Long, String> store =
-                kafkaStreams.store(globalStore, QueryableStoreTypes.keyValueStore());
+                kafkaStreams.store(
+                        StoreQueryParameters.fromNameAndType(globalStore, QueryableStoreTypes.keyValueStore()));
         assertEquals(store.approximateNumEntries(), 4L);
         kafkaStreams.close();
 
         startStreams();
         Thread.sleep(1000); // NOTE: it may take a few milliseconds to wait streams started
-        store = kafkaStreams.store(globalStore, QueryableStoreTypes.keyValueStore());
+        store = kafkaStreams.store(
+                StoreQueryParameters.fromNameAndType(globalStore, QueryableStoreTypes.keyValueStore()));
         assertEquals(store.approximateNumEntries(), 4L);
     }
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/KTableTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/KTableTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.kstream.Consumed;
@@ -115,14 +116,16 @@ public class KTableTest extends KafkaStreamsTestBase {
         startStreams();
         Thread.sleep(1000); // NOTE: it may take a few milliseconds to wait streams started
         final ReadOnlyKeyValueStore<Long, String> store =
-                kafkaStreams.store(this.store, QueryableStoreTypes.keyValueStore());
+                kafkaStreams.store(
+                        StoreQueryParameters.fromNameAndType(this.store, QueryableStoreTypes.keyValueStore()));
         TestUtils.waitForCondition(() -> store.approximateNumEntries() == 4L, 30000L, "waiting for values");
         kafkaStreams.close();
 
         startStreams();
         Thread.sleep(1000); // NOTE: it may take a few milliseconds to wait streams started
         final ReadOnlyKeyValueStore<Long, String> recoveredStore =
-                kafkaStreams.store(this.store, QueryableStoreTypes.keyValueStore());
+                kafkaStreams.store(
+                        StoreQueryParameters.fromNameAndType(this.store, QueryableStoreTypes.keyValueStore()));
         TestUtils.waitForCondition(() -> {
                          try {
                              return recoveredStore.approximateNumEntries() == 4L;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/KafkaStreamsTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/streams/KafkaStreamsTestBase.java
@@ -15,8 +15,8 @@ package io.streamnative.pulsar.handlers.kop.streams;
 
 import io.streamnative.pulsar.handlers.kop.KopProtocolHandlerTestBase;
 import io.streamnative.pulsar.handlers.kop.utils.timer.MockTime;
+import java.time.Duration;
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 import lombok.Getter;
 import lombok.NonNull;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -83,7 +83,7 @@ public abstract class KafkaStreamsTestBase extends KopProtocolHandlerTestBase {
     @AfterMethod
     protected void cleanupTestCase() throws Exception {
         if (kafkaStreams != null) {
-            kafkaStreams.close(3, TimeUnit.SECONDS);
+            kafkaStreams.close(Duration.ofSeconds(3));
             TestUtils.purgeLocalStreamsState(streamsConfiguration);
         }
     }


### PR DESCRIPTION
(cherry picked from commit 71b77b2fd65fd1a2d481ed7067939fab3c0ad002)

### Motivation

Update Kafka wire protocol to 3.4.0 and implement KIP-699 and KIP-709.

### Modifications

*Describe the modifications you've done.*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

