### PR TITLE
Do not throw recursive update exception when producer state recovery failed

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLog.java
@@ -180,18 +180,6 @@ public class PartitionLog {
         return initFuture;
     }
 
-    public CompletableFuture<PartitionLog> awaitInitialisation() {
-        return initFuture;
-    }
-
-    public boolean isInitialised() {
-        return initFuture.isDone() && !initFuture.isCompletedExceptionally();
-    }
-
-    public boolean isInitialisationFailed() {
-        return initFuture.isDone() && initFuture.isCompletedExceptionally();
-    }
-
     private CompletableFuture<Void> loadTopicProperties() {
         CompletableFuture<Optional<PersistentTopic>> persistentTopicFuture =
                 kafkaTopicLookupService.getTopic(fullPartitionName, this);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionTest.java
@@ -477,7 +477,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
         for (int i = 0; i < numPartitions; i++) {
             PartitionLog partitionLog = protocolHandler
                     .getReplicaManager()
-                    .getPartitionLog(new TopicPartition(topicName, i), tenant + "/" + namespace);
+                    .getPartitionLog(new TopicPartition(topicName, i), tenant + "/" + namespace).join();
 
             // we can only take the snapshot on the only thread that is allowed to process mutations
             // on the state
@@ -728,7 +728,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
         consumeTxnMessage(topicName, 2, lastMessage, isolation);
     }
 
-    @Test(timeOut = 10000, dataProvider = "takeSnapshotBeforeRecovery")
+    @Test(timeOut = 20000, dataProvider = "takeSnapshotBeforeRecovery")
     public void testPurgeAbortedTx(boolean takeSnapshotBeforeRecovery) throws Exception {
 
         String topicName = "testPurgeAbortedTx_" + takeSnapshotBeforeRecovery;
@@ -760,8 +760,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
 
         PartitionLog partitionLog = protocolHandler
                 .getReplicaManager()
-                .getPartitionLog(topicPartition, namespacePrefix);
-        partitionLog.awaitInitialisation().get();
+                .getPartitionLog(topicPartition, namespacePrefix).join();
         assertEquals(0, partitionLog.fetchOldestAvailableIndexFromTopic().get().longValue());
 
         List<FetchResponse.AbortedTransaction> abortedIndexList =
@@ -795,8 +794,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
 
         partitionLog = protocolHandler
                 .getReplicaManager()
-                .getPartitionLog(topicPartition, namespacePrefix);
-        partitionLog.awaitInitialisation().get();
+                .getPartitionLog(topicPartition, namespacePrefix).join();
         assertEquals(0L, partitionLog.fetchOldestAvailableIndexFromTopic().get().longValue());
 
         abortedIndexList =
@@ -821,8 +819,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
         // validate that the topic has been trimmed
         partitionLog = protocolHandler
                 .getReplicaManager()
-                .getPartitionLog(topicPartition, namespacePrefix);
-        partitionLog.awaitInitialisation().get();
+                .getPartitionLog(topicPartition, namespacePrefix).join();
         assertEquals(0L, partitionLog.fetchOldestAvailableIndexFromTopic().get().longValue());
 
         // all the messages up to here will be trimmed
@@ -832,7 +829,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
 
         assertSame(partitionLog, protocolHandler
                 .getReplicaManager()
-                .getPartitionLog(topicPartition, namespacePrefix));
+                .getPartitionLog(topicPartition, namespacePrefix).join());
 
         assertEquals(7L, partitionLog.fetchOldestAvailableIndexFromTopic().get().longValue());
         abortedIndexList =
@@ -851,8 +848,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
 
         partitionLog = protocolHandler
                 .getReplicaManager()
-                .getPartitionLog(topicPartition, namespacePrefix);
-        partitionLog.awaitInitialisation().get();
+                .getPartitionLog(topicPartition, namespacePrefix).join();
         assertEquals(8L, partitionLog.fetchOldestAvailableIndexFromTopic().get().longValue());
 
         // this TX is aborted and must not be purged
@@ -883,8 +879,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
 
         partitionLog = protocolHandler
                 .getReplicaManager()
-                .getPartitionLog(topicPartition, namespacePrefix);
-        partitionLog.awaitInitialisation().get();
+                .getPartitionLog(topicPartition, namespacePrefix).join();
 
         // verify that we have 2 aborted TX in memory
         assertTrue(partitionLog.getProducerStateManager().hasSomeAbortedTransactions());
@@ -1058,8 +1053,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
                 pulsar.getProtocolHandlers().protocol("kafka");
         PartitionLog partitionLog = protocolHandler
                 .getReplicaManager()
-                .getPartitionLog(topicPartition, namespacePrefix);
-        partitionLog.awaitInitialisation().get();
+                .getPartitionLog(topicPartition, namespacePrefix).join();
         assertEquals(0L, partitionLog.fetchOldestAvailableIndexFromTopic().get().longValue());
 
         // all the messages up to here will be trimmed
@@ -1078,8 +1072,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
 
         partitionLog = protocolHandler
                 .getReplicaManager()
-                .getPartitionLog(topicPartition, namespacePrefix);
-        partitionLog.awaitInitialisation().get();
+                .getPartitionLog(topicPartition, namespacePrefix).join();
         assertEquals(8L, partitionLog.fetchOldestAvailableIndexFromTopic().get().longValue());
 
         // use a new consumer group, it will read from the beginning of the topic


### PR DESCRIPTION
### Motivation

When transaction is enabled, `PartitionLog#initialise` will recover the state from the local snapshot. It's an asynchronous operation that could fail. In this case, an "recursive update" `IllegalStateException` will be thrown, which is unexpected.

```
Suppressed: java.lang.IllegalStateException: Recursive update
    at java.util.concurrent.ConcurrentHashMap.replaceNode(ConcurrentHashMap.java:1167) ~[?:?]
    at java.util.concurrent.ConcurrentHashMap.remove(ConcurrentHashMap.java:1552) ~[?:?]
    at io.streamnative.pulsar.handlers.kop.storage.PartitionLogManager.lambda$getLog$0(PartitionLogManager.java:88) ~[?:?]
```

The reason is that in `PartitionLogManager#getLog`, `logMap.remove` is called in the callback of `whenComplete`, which could be called in the same thread. Then the `remove` method is just called in the 2nd argument of `computeIfAbsent`.

https://github.com/streamnative/kop/blob/3602c9e826d903d97091af1cc608b9d88c1b8cf3/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java#L88

### Modifications

Store the future of `PartitionLog` in `PartitionLogManager`, move the `remove` call out of the `computeIfAbsent` in the `exceptionally` callback of `ReplicaManager#getPartitionLog`.