### PR TITLE
[improve][oauthclient] Support decode base64 format credentials URL

### DIFF
--- a/oauth-client/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/url/DataURLStreamHandler.java
+++ b/oauth-client/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/url/DataURLStreamHandler.java
@@ -1,0 +1,125 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.security.oauth.url;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Extension of the {@code URLStreamHandler} class to handle all stream protocol handlers.
+ */
+public class DataURLStreamHandler extends URLStreamHandler {
+
+    /**
+     * Representation of a communications link between the application and a URL.
+     */
+    static class DataURLConnection extends URLConnection {
+        private boolean parsed = false;
+        private String contentType;
+        private byte[] data;
+        private URI uri;
+
+        private static final Pattern pattern = Pattern.compile(
+              "(?<mimeType>[^;,]+)?(;(?<charset>charset=[^;,]+))?(;(?<base64>base64))?,(?<data>.+)", Pattern.DOTALL);
+
+        protected DataURLConnection(URL url) {
+            super(url);
+            try {
+                this.uri = this.url.toURI();
+            } catch (URISyntaxException e) {
+                this.uri = null;
+            }
+        }
+
+        @Override
+        public void connect() throws IOException {
+            if (this.parsed) {
+                return;
+            }
+
+            if (this.uri == null) {
+                throw new IOException();
+            }
+
+            Matcher matcher = pattern.matcher(this.uri.getSchemeSpecificPart());
+            if (matcher.matches()) {
+                this.contentType = matcher.group("mimeType");
+                if (contentType == null) {
+                    this.contentType = "application/data";
+                }
+
+                if (matcher.group("base64") == null) {
+                    // Support Urlencode but not decode here because already decoded by URI class.
+                    this.data = matcher.group("data").getBytes(StandardCharsets.UTF_8);
+                } else {
+                    this.data = Base64.getDecoder().decode(matcher.group("data"));
+                }
+            } else {
+                throw new MalformedURLException();
+            }
+            parsed = true;
+        }
+
+        @Override
+        public long getContentLengthLong() {
+            long length;
+            try {
+                this.connect();
+                length = this.data.length;
+            } catch (IOException e) {
+                length = -1;
+            }
+            return length;
+        }
+
+        @Override
+        public String getContentType() {
+            String contentType;
+            try {
+                this.connect();
+                contentType = this.contentType;
+            } catch (IOException e) {
+                contentType = null;
+            }
+            return contentType;
+        }
+
+        @Override
+        public String getContentEncoding() {
+            return "identity";
+        }
+
+        public InputStream getInputStream() throws IOException {
+            this.connect();
+            return new ByteArrayInputStream(this.data);
+        }
+    }
+
+    @Override
+    protected URLConnection openConnection(URL u) throws IOException {
+        return new DataURLConnection(u);
+    }
+
+}

--- a/oauth-client/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/url/PulsarURLStreamHandlerFactory.java
+++ b/oauth-client/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/url/PulsarURLStreamHandlerFactory.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.security.oauth.url;
+
+import java.lang.reflect.InvocationTargetException;
+import java.net.URLStreamHandler;
+import java.net.URLStreamHandlerFactory;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class defines a factory for {@code URL} stream
+ * protocol handlers.
+ */
+public class PulsarURLStreamHandlerFactory implements URLStreamHandlerFactory {
+    private static final Map<String, Class<? extends URLStreamHandler>> handlers;
+    static {
+        handlers = new HashMap<>();
+        handlers.put("data", DataURLStreamHandler.class);
+    }
+
+    @Override
+    public URLStreamHandler createURLStreamHandler(String protocol) {
+        URLStreamHandler urlStreamHandler;
+        try {
+            Class<? extends URLStreamHandler> handler = handlers.get(protocol);
+            if (handler != null) {
+                urlStreamHandler = handler.getDeclaredConstructor().newInstance();
+            } else {
+                urlStreamHandler = null;
+            }
+        } catch (InstantiationException | IllegalAccessException
+                | InvocationTargetException | NoSuchMethodException e) {
+            urlStreamHandler = null;
+        }
+        return urlStreamHandler;
+    }
+
+}

--- a/oauth-client/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/url/URL.java
+++ b/oauth-client/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/url/URL.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.security.oauth.url;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLConnection;
+import java.net.URLStreamHandlerFactory;
+
+/**
+ * Wrapper around {@code java.net.URL} to improve usability.
+ */
+public class URL {
+    private static final URLStreamHandlerFactory urlStreamHandlerFactory = new PulsarURLStreamHandlerFactory();
+    private final java.net.URL url;
+
+    public URL(String spec)
+            throws MalformedURLException, URISyntaxException, InstantiationException, IllegalAccessException {
+        String scheme = new URI(spec).getScheme();
+        if (scheme == null) {
+            this.url = new java.net.URL(null, "file:" + spec);
+        } else {
+            this.url = new java.net.URL(null, spec, urlStreamHandlerFactory.createURLStreamHandler(scheme));
+        }
+    }
+
+    /**
+     * Creates java.net.URL with data protocol support.
+     *
+     * @param spec the input URL as String
+     * @return java.net.URL instance
+     */
+    public static final java.net.URL createURL(String spec)
+            throws MalformedURLException, URISyntaxException, InstantiationException, IllegalAccessException {
+        return new URL(spec).url;
+    }
+
+    public URLConnection openConnection() throws IOException {
+        return this.url.openConnection();
+    }
+
+    public Object getContent() throws IOException {
+        return this.url.getContent();
+    }
+
+    public Object getContent(Class<?>[] classes) throws IOException {
+        return this.url.getContent(classes);
+    }
+
+    @Override
+    public String toString() {
+        return url.toString();
+    }
+}

--- a/oauth-client/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/url/package-info.java
+++ b/oauth-client/src/main/java/io/streamnative/pulsar/handlers/kop/security/oauth/url/package-info.java
@@ -1,0 +1,17 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Classes to work with URLs.
+ */
+package io.streamnative.pulsar.handlers.kop.security.oauth.url;


### PR DESCRIPTION
### Motivation

The KoP documentation shows the `auth.credentials.url` support decoding base64 format string: `data:application/json;base64,[base64-encoded value]`, but it unsupported yet. 

### Modifications

Support decode base64 format credentials URL

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

