### PR TITLE
[Transaction] Fix initTransaction might wait until request timeout

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/KafkaRequestHandler.java
@@ -2178,10 +2178,6 @@ public class KafkaRequestHandler extends KafkaCommandDecoder {
                             .setErrorCode(resp.getError().code())
                             .setProducerId(resp.getProducerId())
                             .setProducerEpoch(resp.getProducerEpoch());
-                    if (resp.getError() == Errors.COORDINATOR_LOAD_IN_PROGRESS
-                        || resp.getError() == Errors.CONCURRENT_TRANSACTIONS) {
-                        responseData.setThrottleTimeMs(1000);
-                    }
                     response.complete(new InitProducerIdResponse(responseData));
                 });
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionTest.java
@@ -1153,7 +1153,6 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
         producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, getKafkaServerAdder());
         producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class.getName());
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-        producerProps.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 1000 * 10);
         producerProps.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId);
         if (txTimeout > 0) {
             producerProps.put(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, txTimeout);
@@ -1172,7 +1171,6 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
         consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, getKafkaServerAdder());
         consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, IntegerDeserializer.class.getName());
         consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
-        consumerProps.put(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG, 1000 * 10);
         consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
         consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         consumerProps.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, isolation);
@@ -1187,7 +1185,6 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
         producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, getKafkaServerAdder());
         producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, IntegerSerializer.class.getName());
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-        producerProps.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 1000 * 10);
         producerProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
 
         addCustomizeProps(producerProps);
@@ -1323,6 +1320,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
         // beginTransaction doesn't do anything
         producer1.beginTransaction();
 
+        producer1.commitTransaction(); // avoid close() being blocked for request timeout
         producer1.close();
         producer2.close();
     }


### PR DESCRIPTION
### Motivation

Most of the tests in `TransactionTest` take at least 10 seconds because the `request.timeout.ms` config is 10000. See
https://github.com/streamnative/kop/blob/1fd3bdb9158fd944c2fb7a241c0d8dca923367ab/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionTest.java#L1150

It's because KoP loads the metadata topic lazily, unlike Kafka, which loads the metadata topic when started. KoP adopts this way because KoP starts before the Pulsar broker finishes the start, in this case there might be some problems with the topic lookup.

Therefore, when the Kafka producer sends the 1st INIT_PRODUCER_ID request, it will receive `COORDINATOR_LOAD_IN_PROGRESS` error, and the request will reenqueue [1], then the request will expire after `request.timeout.ms` milliseconds.

```java
} else if (error != Errors.NOT_COORDINATOR && error != Errors.COORDINATOR_NOT_AVAILABLE) {
    if (error != Errors.COORDINATOR_LOAD_IN_PROGRESS && error != Errors.CONCURRENT_TRANSACTIONS) {
       /* ... */
    } else {
        this.reenqueue(); // [1]
    }
} else { // [2]
    TransactionManager.this.lookupCoordinator(CoordinatorType.TRANSACTION, TransactionManager.this.transactionalId);
    this.reenqueue();
}
```

### Modifications

Return `COORDINATOR_NOT_AVAILABLE` instead of
`COORDINATOR_LOAD_IN_PROGRESS` when the transaction metadata topic is loading. It's different with Kafka's behavior but it can avoid waiting 30 seconds by default for `initTransaction` in KoP.

In addition, configure the request timeout with 3 seconds for some cases that `initTransaction` might expire so that the test time could be reduced.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

