### PR TITLE
Add Time based metric exipration.

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/stats/DataSketchesOpStatsLogger.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/stats/DataSketchesOpStatsLogger.java
@@ -101,7 +101,7 @@ public class DataSketchesOpStatsLogger implements OpStatsLogger {
         throw new UnsupportedOperationException();
     }
 
-    public void rotateLatencyCollection() {
+    public void rotateLatencyCollection(long expiredTimeSeconds) {
         // Swap current with replacement
         ThreadLocalAccessor local = current;
         current = replacement;
@@ -109,7 +109,7 @@ public class DataSketchesOpStatsLogger implements OpStatsLogger {
 
         final DoublesUnion aggregateSuccess = new DoublesUnionBuilder().build();
         final DoublesUnion aggregateFail = new DoublesUnionBuilder().build();
-        local.record(aggregateSuccess, aggregateFail);
+        local.recordAndCheckStatsExpire(aggregateSuccess, aggregateFail, expiredTimeSeconds);
         successResult = aggregateSuccess.getResultAndReset();
         failResult = aggregateFail.getResultAndReset();
     }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/stats/ThreadLocalAccessor.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/stats/ThreadLocalAccessor.java
@@ -36,7 +36,9 @@ public class ThreadLocalAccessor {
         }
     };
 
-    public void recordAndCheckStatsExpire(DoublesUnion aggregateSuccess, DoublesUnion aggregateFail, long expireTimeMs) {
+    public void recordAndCheckStatsExpire(DoublesUnion aggregateSuccess,
+                                          DoublesUnion aggregateFail,
+                                          long expireTimeMs) {
         long currentTime = System.currentTimeMillis();
 
         map.keySet().forEach(key -> {

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/stats/ThreadLocalAccessor.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/stats/ThreadLocalAccessor.java
@@ -36,8 +36,18 @@ public class ThreadLocalAccessor {
         }
     };
 
-    public void record(DoublesUnion aggregateSuccess, DoublesUnion aggregateFail) {
-        map.keySet().forEach(key -> key.record(aggregateSuccess, aggregateFail));
+    public void recordAndCheckStatsExpire(DoublesUnion aggregateSuccess, DoublesUnion aggregateFail, long expireTimeMs) {
+        long currentTime = System.currentTimeMillis();
+
+        map.keySet().forEach(key -> {
+            // update stats
+            key.record(aggregateSuccess, aggregateFail);
+
+            // check if record expired.
+            if (currentTime - key.lastHasRecordTime() > expireTimeMs) {
+                map.remove(key);
+            }
+        });
     }
 
     public LocalData getLocalData() {


### PR DESCRIPTION
Fixes #1956

### Motivation
FastThreadLocal wont cleanup until thread exit. so we can just check if the stats is not recorded a long time if expired just remove from threadlocal


### Modifications
add time check logic if long time have no record just remove the stats.

### Verifying this change


### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

