### PR TITLE
Optimize authorization by caching authorization results

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -181,6 +181,8 @@ This section lists configurations about the authorization.
 | Name                                      | Description                                                                                            | Range       | Default |
 |-------------------------------------------|--------------------------------------------------------------------------------------------------------|-------------|---------|
 | kafkaEnableAuthorizationForceGroupIdCheck | Whether to enable authorization force group ID check. Note: It only support for OAuth2 authentication. | true, false | false   |
+| kopAuthorizationCacheRefreshMs | If it's configured with a positive value N, each connection will cache the authorization results of PRODUCE and FETCH requests for at least N ms.<br>It could help improve the performance when authorization is enabled, but the permission revoke will also take N ms to take effect. | 1 .. 2147483647 | 30000 |
+| kopAuthorizationCacheMaxCountPerConnection | If it's configured with a positive value N, each connection will cache at most N entries for PRODUCE or FETCH requests.<br>If it's non-positive, the cache size will be the default value. | 1 .. 2147483647 | 100 |
 
 
 ## SSL encryption

--- a/kafka-impl/pom.xml
+++ b/kafka-impl/pom.xml
@@ -117,6 +117,12 @@
       <artifactId>test-listener</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/security/auth/SimpleAclAuthorizer.java
@@ -13,6 +13,7 @@
  */
 package io.streamnative.pulsar.handlers.kop.security.auth;
 
+import com.github.benmanes.caffeine.cache.CacheLoader;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
@@ -32,6 +33,7 @@ import org.apache.pulsar.common.policies.data.NamespaceOperation;
 import org.apache.pulsar.common.policies.data.PolicyName;
 import org.apache.pulsar.common.policies.data.PolicyOperation;
 import org.apache.pulsar.common.policies.data.TopicOperation;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Simple acl authorizer.
@@ -50,13 +52,23 @@ public class SimpleAclAuthorizer implements Authorizer {
             .maximumSize(10000)
             .expireAfterWrite(Duration.ofMinutes(5))
             .refreshAfterWrite(Duration.ofMinutes(1))
-            .build(__ -> null);
+            .build(new CacheLoader<>() {
+                @Override
+                public @Nullable Boolean load(Pair<TopicName, String> topicNameStringPair) {
+                    return null;
+                }
+            });
     // key is (topic, role, group)
     private final LoadingCache<Triple<TopicName, String, String>, Boolean> fetchCache = Caffeine.newBuilder()
             .maximumSize(10000)
             .expireAfterWrite(Duration.ofMinutes(5))
             .refreshAfterWrite(Duration.ofMinutes(1))
-            .build(__ -> null);
+            .build(new CacheLoader<>() {
+                @Override
+                public @Nullable Boolean load(Triple<TopicName, String, String> topicNameStringStringTriple) {
+                    return null;
+                }
+            });
 
     public SimpleAclAuthorizer(PulsarService pulsarService, KafkaServiceConfiguration config) {
         this.pulsarService = pulsarService;

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/KafkaServiceConfigurationTest.java
@@ -295,7 +295,7 @@ public class KafkaServiceConfigurationTest {
     @Test(timeOut = 10000)
     public void testKopAuthorizationCache() throws InterruptedException {
         KafkaServiceConfiguration configuration = new KafkaServiceConfiguration();
-        configuration.setKopAuthorizationCacheRefreshMs(100);
+        configuration.setKopAuthorizationCacheRefreshMs(500);
         configuration.setKopAuthorizationCacheMaxCountPerConnection(5);
         LoadingCache<Integer, Integer> cache = configuration.getAuthorizationCacheBuilder().build(new CacheLoader<>() {
             @Override
@@ -309,12 +309,12 @@ public class KafkaServiceConfigurationTest {
         for (int i = 0; i < 10; i++) {
             cache.put(i, i + 100);
         }
-        Awaitility.await().atMost(Duration.ofMillis(10)).pollInterval(Duration.ofMillis(1))
+        Awaitility.await().atMost(Duration.ofMillis(100)).pollInterval(Duration.ofMillis(1))
                 .until(() -> IntStream.range(0, 10).mapToObj(cache::get).filter(Objects::nonNull).count() <= 5);
         IntStream.range(0, 10).mapToObj(cache::get).filter(Objects::nonNull).map(i -> i - 100).forEach(key ->
                 assertEquals(cache.get(key).intValue(), key + 100));
 
-        Thread.sleep(200); // wait until the cache expired
+        Thread.sleep(600); // wait until the cache expired
         for (int i = 0; i < 10; i++) {
             assertNull(cache.get(i));
         }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/KafkaAuthorizationMockTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/KafkaAuthorizationMockTest.java
@@ -13,130 +13,25 @@
  */
 package io.streamnative.pulsar.handlers.kop.security.auth;
 
-import static org.mockito.Mockito.spy;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-
-import com.google.common.collect.Sets;
-import io.jsonwebtoken.SignatureAlgorithm;
-import io.streamnative.pulsar.handlers.kop.KopProtocolHandlerTestBase;
-import java.time.Duration;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Properties;
-import javax.crypto.SecretKey;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.PartitionInfo;
-import org.apache.pulsar.broker.authentication.AuthenticationProviderToken;
-import org.apache.pulsar.broker.authentication.utils.AuthTokenUtils;
-import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
-import org.apache.pulsar.client.impl.auth.AuthenticationToken;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-/**
- * Unit test for Authorization with `entryFormat=pulsar`.
- */
-public class KafkaAuthorizationMockTest extends KopProtocolHandlerTestBase {
-
-    protected static final String TENANT = "KafkaAuthorizationTest";
-    protected static final String NAMESPACE = "ns1";
-    private static final SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
-
-    protected static final String ADMIN_USER = "pass.pass";
+public class KafkaAuthorizationMockTest extends KafkaAuthorizationMockTestBase {
 
     @BeforeClass
-    @Override
-    protected void setup() throws Exception {
-        Properties properties = new Properties();
-        properties.setProperty("tokenSecretKey", AuthTokenUtils.encodeKeyBase64(secretKey));
-
-        String adminToken = AuthTokenUtils.createToken(secretKey, ADMIN_USER, Optional.empty());
-
-        conf.setSaslAllowedMechanisms(Sets.newHashSet("PLAIN"));
-        conf.setKafkaMetadataTenant("internal");
-        conf.setKafkaMetadataNamespace("__kafka");
-        conf.setKafkaTenant(TENANT);
-        conf.setKafkaNamespace(NAMESPACE);
-
-        conf.setClusterName(super.configClusterName);
-        conf.setAuthorizationEnabled(true);
-        conf.setAuthenticationEnabled(true);
-        conf.setAuthorizationAllowWildcardsMatching(true);
-        conf.setAuthorizationProvider(KafkaMockAuthorizationProvider.class.getName());
-        conf.setAuthenticationProviders(
-                Sets.newHashSet(AuthenticationProviderToken.class.getName()));
-        conf.setBrokerClientAuthenticationPlugin(AuthenticationToken.class.getName());
-        conf.setBrokerClientAuthenticationParameters("token:" + adminToken);
-        conf.setProperties(properties);
-
-        super.internalSetup();
+    public void setup() throws Exception {
+        super.setup();
     }
 
-    @AfterClass
-    @Override
-    protected void cleanup() throws Exception {
-        super.admin = spy(PulsarAdmin.builder().serviceHttpUrl(brokerUrl.toString())
-                .authentication(this.conf.getBrokerClientAuthenticationPlugin(),
-                        this.conf.getBrokerClientAuthenticationParameters()).build());
+    @AfterClass(alwaysRun = true)
+    public void cleanup() throws Exception {
+        super.cleanup();
     }
 
-    @Override
-    protected void createAdmin() throws Exception {
-        super.admin = spy(PulsarAdmin.builder().serviceHttpUrl(brokerUrl.toString())
-                .authentication(this.conf.getBrokerClientAuthenticationPlugin(),
-                        this.conf.getBrokerClientAuthenticationParameters()).build());
-    }
-
-
-    @Test(timeOut = 30 * 1000)
+    @Test(timeOut = 30000)
     public void testSuperUserProduceAndConsume() throws PulsarAdminException {
-        String superUserToken = AuthTokenUtils.createToken(secretKey, "pass.pass", Optional.empty());
-        String topic = "testSuperUserProduceAndConsumeTopic";
-        String fullNewTopicName = "persistent://" + TENANT + "/" + NAMESPACE + "/" + topic;
-        KProducer kProducer = new KProducer(topic, false, "localhost", getKafkaBrokerPort(),
-                TENANT + "/" + NAMESPACE, "token:" + superUserToken);
-        int totalMsgs = 10;
-        String messageStrPrefix = topic + "_message_";
-
-        for (int i = 0; i < totalMsgs; i++) {
-            String messageStr = messageStrPrefix + i;
-            kProducer.getProducer().send(new ProducerRecord<>(topic, i, messageStr));
-        }
-        KConsumer kConsumer = new KConsumer(topic, "localhost", getKafkaBrokerPort(), false,
-                TENANT + "/" + NAMESPACE, "token:" + superUserToken, "DemoKafkaOnPulsarConsumer");
-        kConsumer.getConsumer().subscribe(Collections.singleton(topic));
-
-        int i = 0;
-        while (i < totalMsgs) {
-            ConsumerRecords<Integer, String> records = kConsumer.getConsumer().poll(Duration.ofSeconds(1));
-            for (ConsumerRecord<Integer, String> record : records) {
-                Integer key = record.key();
-                assertEquals(messageStrPrefix + key.toString(), record.value());
-                i++;
-            }
-        }
-        assertEquals(i, totalMsgs);
-
-        // no more records
-        ConsumerRecords<Integer, String> records = kConsumer.getConsumer().poll(Duration.ofMillis(200));
-        assertTrue(records.isEmpty());
-
-        // ensure that we can list the topic
-        Map<String, List<PartitionInfo>> result = kConsumer.getConsumer().listTopics(Duration.ofSeconds(1));
-        assertEquals(result.size(), 1);
-        assertTrue(result.containsKey(topic),
-                "list of topics " + result.keySet() + "  does not contains " + topic);
-
-        // Cleanup
-        kProducer.close();
-        kConsumer.close();
-        admin.topics().deletePartitionedTopic(fullNewTopicName);
+        super.testSuperUserProduceAndConsume();
     }
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/KafkaAuthorizationMockTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/KafkaAuthorizationMockTestBase.java
@@ -1,0 +1,136 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.security.auth;
+
+import static org.mockito.Mockito.spy;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.google.common.collect.Sets;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.streamnative.pulsar.handlers.kop.KopProtocolHandlerTestBase;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import javax.crypto.SecretKey;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.pulsar.broker.authentication.AuthenticationProviderToken;
+import org.apache.pulsar.broker.authentication.utils.AuthTokenUtils;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.impl.auth.AuthenticationToken;
+
+/**
+ * Unit test for Authorization with `entryFormat=pulsar`.
+ */
+public class KafkaAuthorizationMockTestBase extends KopProtocolHandlerTestBase {
+
+    protected static final String TENANT = "KafkaAuthorizationTest";
+    protected static final String NAMESPACE = "ns1";
+    protected static final SecretKey SECRET_KEY = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
+
+    protected static final String ADMIN_USER = "pass.pass";
+    protected String authorizationProviderClassName = KafkaMockAuthorizationProvider.class.getName();
+
+    @Override
+    protected void setup() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty("tokenSecretKey", AuthTokenUtils.encodeKeyBase64(SECRET_KEY));
+
+        String adminToken = AuthTokenUtils.createToken(SECRET_KEY, ADMIN_USER, Optional.empty());
+
+        conf.setSaslAllowedMechanisms(Sets.newHashSet("PLAIN"));
+        conf.setKafkaMetadataTenant("internal");
+        conf.setKafkaMetadataNamespace("__kafka");
+        conf.setKafkaTenant(TENANT);
+        conf.setKafkaNamespace(NAMESPACE);
+
+        conf.setClusterName(super.configClusterName);
+        conf.setAuthorizationEnabled(true);
+        conf.setAuthenticationEnabled(true);
+        conf.setAuthorizationAllowWildcardsMatching(true);
+        conf.setAuthorizationProvider(authorizationProviderClassName);
+        conf.setAuthenticationProviders(
+                Sets.newHashSet(AuthenticationProviderToken.class.getName()));
+        conf.setBrokerClientAuthenticationPlugin(AuthenticationToken.class.getName());
+        conf.setBrokerClientAuthenticationParameters("token:" + adminToken);
+        conf.setProperties(properties);
+
+        super.internalSetup();
+    }
+
+    @Override
+    protected void cleanup() throws Exception {
+        super.admin = spy(PulsarAdmin.builder().serviceHttpUrl(brokerUrl.toString())
+                .authentication(this.conf.getBrokerClientAuthenticationPlugin(),
+                        this.conf.getBrokerClientAuthenticationParameters()).build());
+    }
+
+    @Override
+    protected void createAdmin() throws Exception {
+        super.admin = spy(PulsarAdmin.builder().serviceHttpUrl(brokerUrl.toString())
+                .authentication(this.conf.getBrokerClientAuthenticationPlugin(),
+                        this.conf.getBrokerClientAuthenticationParameters()).build());
+    }
+
+    public void testSuperUserProduceAndConsume() throws PulsarAdminException {
+        String superUserToken = AuthTokenUtils.createToken(SECRET_KEY, "pass.pass", Optional.empty());
+        String topic = "testSuperUserProduceAndConsumeTopic";
+        String fullNewTopicName = "persistent://" + TENANT + "/" + NAMESPACE + "/" + topic;
+        KProducer kProducer = new KProducer(topic, false, "localhost", getKafkaBrokerPort(),
+                TENANT + "/" + NAMESPACE, "token:" + superUserToken);
+        int totalMsgs = 10;
+        String messageStrPrefix = topic + "_message_";
+
+        for (int i = 0; i < totalMsgs; i++) {
+            String messageStr = messageStrPrefix + i;
+            kProducer.getProducer().send(new ProducerRecord<>(topic, i, messageStr));
+        }
+        KConsumer kConsumer = new KConsumer(topic, "localhost", getKafkaBrokerPort(), false,
+                TENANT + "/" + NAMESPACE, "token:" + superUserToken, "DemoKafkaOnPulsarConsumer");
+        kConsumer.getConsumer().subscribe(Collections.singleton(topic));
+
+        int i = 0;
+        while (i < totalMsgs) {
+            ConsumerRecords<Integer, String> records = kConsumer.getConsumer().poll(Duration.ofSeconds(1));
+            for (ConsumerRecord<Integer, String> record : records) {
+                Integer key = record.key();
+                assertEquals(messageStrPrefix + key.toString(), record.value());
+                i++;
+            }
+        }
+        assertEquals(i, totalMsgs);
+
+        // no more records
+        ConsumerRecords<Integer, String> records = kConsumer.getConsumer().poll(Duration.ofMillis(200));
+        assertTrue(records.isEmpty());
+
+        // ensure that we can list the topic
+        Map<String, List<PartitionInfo>> result = kConsumer.getConsumer().listTopics(Duration.ofSeconds(1));
+        assertEquals(result.size(), 1);
+        assertTrue(result.containsKey(topic),
+                "list of topics " + result.keySet() + "  does not contains " + topic);
+
+        // Cleanup
+        kProducer.close();
+        kConsumer.close();
+        admin.topics().deletePartitionedTopic(fullNewTopicName);
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/SlowAuthorizationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/auth/SlowAuthorizationTest.java
@@ -1,0 +1,112 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.kop.security.auth;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
+import org.apache.pulsar.broker.authentication.utils.AuthTokenUtils;
+import org.apache.pulsar.common.naming.TopicName;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class SlowAuthorizationTest extends KafkaAuthorizationMockTestBase {
+
+    @BeforeClass
+    public void setup() throws Exception {
+        super.authorizationProviderClassName = SlowMockAuthorizationProvider.class.getName();
+        super.setup();
+    }
+
+    @AfterClass
+    public void cleanup() throws Exception {
+        super.cleanup();
+    }
+
+    @Test(timeOut = 60000)
+    public void testManyMessages() throws Exception {
+        String superUserToken = AuthTokenUtils.createToken(SECRET_KEY, "normal-user", Optional.empty());
+        final String topic = "test-many-messages";
+        @Cleanup
+        final KProducer kProducer = new KProducer(topic, false, "localhost", getKafkaBrokerPort(),
+                TENANT + "/" + NAMESPACE, "token:" + superUserToken);
+        long start = System.currentTimeMillis();
+        log.info("Before send");
+        for (int i = 0; i < 1000; i++) {
+            kProducer.getProducer().send(new ProducerRecord(topic, "msg-" + i)).get();
+        }
+        log.info("After send ({} ms)", System.currentTimeMillis() - start);
+        @Cleanup
+        KConsumer kConsumer = new KConsumer(topic, "localhost", getKafkaBrokerPort(), false,
+                TENANT + "/" + NAMESPACE, "token:" + superUserToken, "DemoKafkaOnPulsarConsumer");
+        kConsumer.getConsumer().subscribe(Collections.singleton(topic));
+        int i = 0;
+        start = System.currentTimeMillis();
+        log.info("Before poll");
+        while (i < 1000) {
+            final ConsumerRecords<Integer, String> records = kConsumer.getConsumer().poll(Duration.ofSeconds(1));
+            i += records.count();
+        }
+        log.info("After poll ({} ms)", System.currentTimeMillis() - start);
+    }
+
+    public static class SlowMockAuthorizationProvider extends KafkaMockAuthorizationProvider {
+
+        @Override
+        public CompletableFuture<Boolean> isSuperUser(String role, ServiceConfiguration serviceConfiguration) {
+            return CompletableFuture.completedFuture(role.equals("pass.pass"));
+        }
+
+        @Override
+        public CompletableFuture<Boolean> isSuperUser(String role, AuthenticationDataSource authenticationData,
+                                                      ServiceConfiguration serviceConfiguration) {
+            return CompletableFuture.completedFuture(role.equals("pass.pass"));
+        }
+
+        @Override
+        public CompletableFuture<Boolean> canProduceAsync(TopicName topicName, String role,
+                                                          AuthenticationDataSource authenticationData) {
+            return authorizeSlowly();
+        }
+
+        @Override
+        public CompletableFuture<Boolean> canConsumeAsync(
+                TopicName topicName, String role, AuthenticationDataSource authenticationData, String subscription) {
+            return authorizeSlowly();
+        }
+
+        private static CompletableFuture<Boolean> authorizeSlowly() {
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            return CompletableFuture.completedFuture(true);
+        }
+
+        @Override
+        CompletableFuture<Boolean> roleAuthorizedAsync(String role) {
+            return CompletableFuture.completedFuture(true);
+        }
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/oauth/SaslOAuthKopHandlersTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/oauth/SaslOAuthKopHandlersTest.java
@@ -103,6 +103,7 @@ public class SaslOAuthKopHandlersTest extends SaslOAuthBearerTestBase {
         conf.setSaslAllowedMechanisms(Sets.newHashSet("OAUTHBEARER"));
         conf.setKopOauth2AuthenticateCallbackHandler(OauthValidatorCallbackHandler.class.getName());
         conf.setKopOauth2ConfigFile("src/test/resources/kop-handler-oauth2.properties");
+        conf.setKopAuthorizationCacheRefreshMs(0);
 
         super.internalSetup();
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/oauth/SaslOAuthKopHandlersWithMultiTenantTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/security/oauth/SaslOAuthKopHandlersWithMultiTenantTest.java
@@ -75,6 +75,7 @@ public class SaslOAuthKopHandlersWithMultiTenantTest extends SaslOAuthBearerTest
         conf.setSaslAllowedMechanisms(Sets.newHashSet("OAUTHBEARER"));
         conf.setKopOauth2AuthenticateCallbackHandler(OauthValidatorCallbackHandler.class.getName());
         conf.setKopOauth2ConfigFile("src/test/resources/kop-handler-oauth2.properties");
+        conf.setKopAuthorizationCacheRefreshMs(0);
 
         super.internalSetup();
     }


### PR DESCRIPTION
### Motivation

To follow Kafka's behavior, KoP also performs authorization for each PRODUCE or FETCH request. If the custom authorization provider is slow to authorize produce or consume permissions, the performance will be impacted.

### Modifications

Introduce caches for authorization:
- PRODUCE: (topic, role) -> result
- FETCH: (topic, role, group) -> result;

Add `SlowAuthorizationTest` to verify the producer and consumer won't be affected significantly by slow authorization.

Introduce two configs to configure the cache policy so that revoke permission can work:
- kopAuthorizationCacheRefreshMs: the refresh timeout
- kopAuthorizationCacheMaxCountPerConnection: the max cache size

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

