### PR TITLE
[fix] Memory leak of the map in ThreadLocalAccessor

### DIFF
--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/MessageFetchContext.java
@@ -15,6 +15,7 @@ package io.streamnative.pulsar.handlers.kop;
 
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
+import io.netty.util.concurrent.EventExecutor;
 import io.streamnative.pulsar.handlers.kop.KafkaCommandDecoder.KafkaHeaderAndRequest;
 import io.streamnative.pulsar.handlers.kop.coordinator.transaction.TransactionCoordinator;
 import io.streamnative.pulsar.handlers.kop.utils.GroupIdUtils;
@@ -45,6 +46,7 @@ public final class MessageFetchContext {
     private volatile KafkaTopicManager topicManager;
     private volatile RequestStats statsLogger;
     private volatile TransactionCoordinator tc;
+    private volatile EventExecutor eventExecutor;
     private volatile String clientHost;
     private volatile String namespacePrefix;
     private volatile int maxReadEntriesNum;
@@ -64,6 +66,7 @@ public final class MessageFetchContext {
                                           KafkaHeaderAndRequest kafkaHeaderAndRequest) {
         MessageFetchContext context = RECYCLER.get();
         context.requestHandler = requestHandler;
+        context.eventExecutor = requestHandler.ctx.executor();
         context.sharedState = sharedState;
         context.decodeExecutor = decodeExecutor;
         context.topicManager = requestHandler.getTopicManager();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/PendingTopicFutures.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/PendingTopicFutures.java
@@ -17,11 +17,9 @@ import com.google.common.annotations.VisibleForTesting;
 import io.streamnative.pulsar.handlers.kop.storage.PartitionLog;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import lombok.Getter;
 import lombok.NonNull;
-import org.apache.bookkeeper.common.util.MathUtils;
 
 /**
  * Pending futures of PersistentTopic.
@@ -29,27 +27,10 @@ import org.apache.bookkeeper.common.util.MathUtils;
  */
 public class PendingTopicFutures {
 
-    private final RequestStats requestStats;
-    private final long enqueueTimestamp;
     private int count = 0;
     private CompletableFuture<TopicThrowablePair> currentTopicFuture;
 
-    public PendingTopicFutures(RequestStats requestStats) {
-        this.requestStats = requestStats;
-        this.enqueueTimestamp = MathUtils.nowInNano();
-    }
-
-    private void registerQueueLatency(boolean success) {
-        if (requestStats != null) {
-            if (success) {
-                requestStats.getMessageQueuedLatencyStats().registerSuccessfulEvent(
-                        MathUtils.elapsedNanos(enqueueTimestamp), TimeUnit.NANOSECONDS);
-            } else {
-                requestStats.getMessageQueuedLatencyStats().registerFailedEvent(
-                        MathUtils.elapsedNanos(enqueueTimestamp), TimeUnit.NANOSECONDS);
-            }
-        }
-    }
+    public PendingTopicFutures() {}
 
     private synchronized void decrementCount() {
         count--;
@@ -62,12 +43,10 @@ public class PendingTopicFutures {
             count = 1;
             // The first pending future comes
             currentTopicFuture = topicFuture.thenApply(persistentTopic -> {
-                registerQueueLatency(true);
                 persistentTopicConsumer.accept(persistentTopic);
                 decrementCount();
                 return TopicThrowablePair.withTopic(persistentTopic);
             }).exceptionally(e -> {
-                registerQueueLatency(false);
                 exceptionConsumer.accept(e.getCause());
                 decrementCount();
                 return TopicThrowablePair.withThrowable(e.getCause());
@@ -77,16 +56,13 @@ public class PendingTopicFutures {
             // The next pending future reuses the completed result of the previous topic future
             currentTopicFuture = currentTopicFuture.thenApply(topicThrowablePair -> {
                 if (topicThrowablePair.getThrowable() == null) {
-                    registerQueueLatency(true);
                     persistentTopicConsumer.accept(topicThrowablePair.getPersistentTopicOpt());
                 } else {
-                    registerQueueLatency(false);
                     exceptionConsumer.accept(topicThrowablePair.getThrowable());
                 }
                 decrementCount();
                 return topicThrowablePair;
             }).exceptionally(e -> {
-                registerQueueLatency(false);
                 exceptionConsumer.accept(e.getCause());
                 decrementCount();
                 return TopicThrowablePair.withThrowable(e.getCause());

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/AppendRecordsContext.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/AppendRecordsContext.java
@@ -14,6 +14,7 @@
 package io.streamnative.pulsar.handlers.kop.storage;
 
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.concurrent.EventExecutor;
 import io.streamnative.pulsar.handlers.kop.KafkaTopicManager;
 import io.streamnative.pulsar.handlers.kop.PendingTopicFutures;
 import java.util.Map;
@@ -35,6 +36,7 @@ public class AppendRecordsContext {
     private Consumer<Integer> completeSendOperationForThrottling;
     private Map<TopicPartition, PendingTopicFutures> pendingTopicFuturesMap;
     private ChannelHandlerContext ctx;
+    private EventExecutor eventExecutor;
 
     // recycler and get for this object
     public static AppendRecordsContext get(final KafkaTopicManager topicManager,
@@ -46,7 +48,8 @@ public class AppendRecordsContext {
                 startSendOperationForThrottling,
                 completeSendOperationForThrottling,
                 pendingTopicFuturesMap,
-                ctx);
+                ctx,
+                ctx.executor());
     }
 
 }

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogManager.java
@@ -14,6 +14,7 @@
 package io.streamnative.pulsar.handlers.kop.storage;
 
 import com.google.common.collect.Maps;
+import io.netty.util.concurrent.EventExecutor;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import io.streamnative.pulsar.handlers.kop.KafkaTopicLookupService;
 import io.streamnative.pulsar.handlers.kop.RequestStats;
@@ -68,7 +69,7 @@ public class PartitionLogManager {
         this.recoveryExecutor = recoveryExecutor;
     }
 
-    public PartitionLog getLog(TopicPartition topicPartition, String namespacePrefix) {
+    public PartitionLog getLog(TopicPartition topicPartition, String namespacePrefix, EventExecutor eventExecutor) {
         String kopTopic = KopTopic.toString(topicPartition, namespacePrefix);
         String tenant = TopicName.get(kopTopic).getTenant();
         ProducerStateManagerSnapshotBuffer prodPerTenant = producerStateManagerSnapshotBuffer.apply(tenant);
@@ -76,7 +77,7 @@ public class PartitionLogManager {
             PartitionLog partitionLog = new PartitionLog(kafkaConfig, requestStats,
                     time, topicPartition, key, entryFilters,
                     kafkaTopicLookupService,
-                    prodPerTenant, recoveryExecutor);
+                    prodPerTenant, recoveryExecutor, eventExecutor);
 
             CompletableFuture<PartitionLog> initialiseResult = partitionLog
                     .initialise();

--- a/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
+++ b/kafka-impl/src/main/java/io/streamnative/pulsar/handlers/kop/storage/ReplicaManager.java
@@ -14,6 +14,7 @@
 package io.streamnative.pulsar.handlers.kop.storage;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.netty.util.concurrent.EventExecutor;
 import io.streamnative.pulsar.handlers.kop.DelayedFetch;
 import io.streamnative.pulsar.handlers.kop.DelayedProduceAndFetch;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
@@ -82,8 +83,9 @@ public class ReplicaManager {
     }
 
     public PartitionLog getPartitionLog(TopicPartition topicPartition,
-                                        String namespacePrefix) {
-        return logManager.getLog(topicPartition, namespacePrefix);
+                                        String namespacePrefix,
+                                        EventExecutor eventExecutor) {
+        return logManager.getLog(topicPartition, namespacePrefix, eventExecutor);
     }
 
     public void removePartitionLog(String topicName) {
@@ -172,7 +174,10 @@ public class ReplicaManager {
                             Errors.forException(new InvalidTopicException(
                                     String.format("Cannot append to internal topic %s", topicPartition.topic())))));
                 } else {
-                    PartitionLog partitionLog = getPartitionLog(topicPartition, namespacePrefix);
+                    PartitionLog partitionLog = getPartitionLog(
+                            topicPartition,
+                            namespacePrefix,
+                            appendRecordsContext.getEventExecutor());
                     if (requiredAcks == 0) {
                         partitionLog.appendRecords(memoryRecords, origin, appendRecordsContext);
                         return;
@@ -303,7 +308,7 @@ public class ReplicaManager {
             }
         };
         readPartitionInfo.forEach((tp, fetchInfo) -> {
-            getPartitionLog(tp, context.getNamespacePrefix())
+            getPartitionLog(tp, context.getNamespacePrefix(), context.getEventExecutor())
                     .awaitInitialisation()
                     .whenComplete((partitionLog, failed) ->{
                         if (failed != null) {

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/PendingTopicFuturesTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/PendingTopicFuturesTest.java
@@ -62,7 +62,7 @@ public class PendingTopicFuturesTest {
 
     @Test(timeOut = 10000)
     void testNormalComplete() throws ExecutionException, InterruptedException {
-        final PendingTopicFutures pendingTopicFutures = new PendingTopicFutures(null);
+        final PendingTopicFutures pendingTopicFutures = new PendingTopicFutures();
         final CompletableFuture<PartitionLog> topicFuture = new CompletableFuture<>();
         final List<Integer> completedIndexes = new ArrayList<>();
         final List<Integer> changesOfPendingCount = new ArrayList<>();
@@ -95,7 +95,7 @@ public class PendingTopicFuturesTest {
 
     @Test(timeOut = 10000)
     void testExceptionalComplete() throws ExecutionException, InterruptedException {
-        final PendingTopicFutures pendingTopicFutures = new PendingTopicFutures(null);
+        final PendingTopicFutures pendingTopicFutures = new PendingTopicFutures();
         final CompletableFuture<PartitionLog> topicFuture = new CompletableFuture<>();
         final List<String> exceptionMessages = new ArrayList<>();
         final List<Integer> changesOfPendingCount = new ArrayList<>();
@@ -129,7 +129,7 @@ public class PendingTopicFuturesTest {
 
     @Test(timeOut = 10000)
     void testParallelAccess() throws ExecutionException, InterruptedException {
-        final PendingTopicFutures pendingTopicFutures = new PendingTopicFutures(null);
+        final PendingTopicFutures pendingTopicFutures = new PendingTopicFutures();
         final CompletableFuture<PartitionLog> topicFuture = new CompletableFuture<>();
         final List<Integer> completedIndexes = new CopyOnWriteArrayList<>();
         int randomNum = ThreadLocalRandom.current().nextInt(0, 9);

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EncodePerformanceTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EncodePerformanceTest.java
@@ -15,6 +15,7 @@ package io.streamnative.pulsar.handlers.kop.format;
 
 import static org.mockito.Mockito.mock;
 
+import io.netty.util.concurrent.EventExecutor;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import io.streamnative.pulsar.handlers.kop.KafkaTopicLookupService;
 import io.streamnative.pulsar.handlers.kop.storage.MemoryProducerStateManagerSnapshotBuffer;
@@ -53,7 +54,8 @@ public class EncodePerformanceTest {
             null,
             mock(KafkaTopicLookupService.class),
             new MemoryProducerStateManagerSnapshotBuffer(),
-            mock(OrderedExecutor.class));
+            mock(OrderedExecutor.class),
+            mock(EventExecutor.class));
 
     public static void main(String[] args) {
         pulsarServiceConfiguration.setEntryFormat("pulsar");

--- a/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterTest.java
+++ b/kafka-impl/src/test/java/io/streamnative/pulsar/handlers/kop/format/EntryFormatterTest.java
@@ -18,6 +18,7 @@ import static org.apache.kafka.common.record.LegacyRecord.RECORD_OVERHEAD_V1;
 import static org.apache.kafka.common.record.Records.LOG_OVERHEAD;
 import static org.mockito.Mockito.mock;
 
+import io.netty.util.concurrent.EventExecutor;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import io.streamnative.pulsar.handlers.kop.KafkaTopicLookupService;
 import io.streamnative.pulsar.handlers.kop.storage.MemoryProducerStateManagerSnapshotBuffer;
@@ -83,7 +84,8 @@ public class EntryFormatterTest {
             null,
             mock(KafkaTopicLookupService.class),
             new MemoryProducerStateManagerSnapshotBuffer(),
-            mock(OrderedExecutor.class));
+            mock(OrderedExecutor.class),
+            mock(EventExecutor.class));
 
     private void init() {
         pulsarServiceConfiguration.setEntryFormat("pulsar");

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/coordinator/transaction/TransactionTest.java
@@ -16,6 +16,7 @@ package io.streamnative.pulsar.handlers.kop.coordinator.transaction;
 import static org.apache.kafka.clients.CommonClientConfigs.CLIENT_ID_CONFIG;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -26,6 +27,7 @@ import static org.testng.Assert.expectThrows;
 import static org.testng.Assert.fail;
 
 import com.google.common.collect.ImmutableMap;
+import io.netty.util.concurrent.EventExecutor;
 import io.streamnative.pulsar.handlers.kop.KafkaProtocolHandler;
 import io.streamnative.pulsar.handlers.kop.KopProtocolHandlerTestBase;
 import io.streamnative.pulsar.handlers.kop.scala.Either;
@@ -82,6 +84,8 @@ import org.testng.annotations.Test;
  */
 @Slf4j
 public class TransactionTest extends KopProtocolHandlerTestBase {
+
+    private final EventExecutor eventExecutor = mock(EventExecutor.class);
 
     protected void setupTransactions() {
         this.conf.setDefaultNumberOfNamespaceBundles(4);
@@ -483,7 +487,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
         for (int i = 0; i < numPartitions; i++) {
             PartitionLog partitionLog = protocolHandler
                     .getReplicaManager()
-                    .getPartitionLog(new TopicPartition(topicName, i), tenant + "/" + namespace);
+                    .getPartitionLog(new TopicPartition(topicName, i), tenant + "/" + namespace, eventExecutor);
 
             // we can only take the snapshot on the only thread that is allowed to process mutations
             // on the state
@@ -766,7 +770,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
 
         PartitionLog partitionLog = protocolHandler
                 .getReplicaManager()
-                .getPartitionLog(topicPartition, namespacePrefix);
+                .getPartitionLog(topicPartition, namespacePrefix, eventExecutor);
         partitionLog.awaitInitialisation().get();
         assertEquals(0, partitionLog.fetchOldestAvailableIndexFromTopic().get().longValue());
 
@@ -801,7 +805,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
 
         partitionLog = protocolHandler
                 .getReplicaManager()
-                .getPartitionLog(topicPartition, namespacePrefix);
+                .getPartitionLog(topicPartition, namespacePrefix, eventExecutor);
         partitionLog.awaitInitialisation().get();
         assertEquals(0L, partitionLog.fetchOldestAvailableIndexFromTopic().get().longValue());
 
@@ -827,7 +831,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
         // validate that the topic has been trimmed
         partitionLog = protocolHandler
                 .getReplicaManager()
-                .getPartitionLog(topicPartition, namespacePrefix);
+                .getPartitionLog(topicPartition, namespacePrefix, eventExecutor);
         partitionLog.awaitInitialisation().get();
         assertEquals(0L, partitionLog.fetchOldestAvailableIndexFromTopic().get().longValue());
 
@@ -838,7 +842,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
 
         assertSame(partitionLog, protocolHandler
                 .getReplicaManager()
-                .getPartitionLog(topicPartition, namespacePrefix));
+                .getPartitionLog(topicPartition, namespacePrefix, eventExecutor));
 
         assertEquals(7L, partitionLog.fetchOldestAvailableIndexFromTopic().get().longValue());
         abortedIndexList =
@@ -857,7 +861,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
 
         partitionLog = protocolHandler
                 .getReplicaManager()
-                .getPartitionLog(topicPartition, namespacePrefix);
+                .getPartitionLog(topicPartition, namespacePrefix, eventExecutor);
         partitionLog.awaitInitialisation().get();
         assertEquals(8L, partitionLog.fetchOldestAvailableIndexFromTopic().get().longValue());
 
@@ -889,7 +893,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
 
         partitionLog = protocolHandler
                 .getReplicaManager()
-                .getPartitionLog(topicPartition, namespacePrefix);
+                .getPartitionLog(topicPartition, namespacePrefix, eventExecutor);
         partitionLog.awaitInitialisation().get();
 
         // verify that we have 2 aborted TX in memory
@@ -1064,7 +1068,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
                 pulsar.getProtocolHandlers().protocol("kafka");
         PartitionLog partitionLog = protocolHandler
                 .getReplicaManager()
-                .getPartitionLog(topicPartition, namespacePrefix);
+                .getPartitionLog(topicPartition, namespacePrefix, eventExecutor);
         partitionLog.awaitInitialisation().get();
         assertEquals(0L, partitionLog.fetchOldestAvailableIndexFromTopic().get().longValue());
 
@@ -1084,7 +1088,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
 
         partitionLog = protocolHandler
                 .getReplicaManager()
-                .getPartitionLog(topicPartition, namespacePrefix);
+                .getPartitionLog(topicPartition, namespacePrefix, eventExecutor);
         partitionLog.awaitInitialisation().get();
         assertEquals(8L, partitionLog.fetchOldestAvailableIndexFromTopic().get().longValue());
 
@@ -1425,7 +1429,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
 
             PartitionLog partitionLog = protocolHandler
                     .getReplicaManager()
-                    .getPartitionLog(topicPartition, namespacePrefix);
+                    .getPartitionLog(topicPartition, namespacePrefix, eventExecutor);
             partitionLog.awaitInitialisation().get();
 
             List<FetchResponseData.AbortedTransaction> abortedIndexList =
@@ -1451,7 +1455,7 @@ public class TransactionTest extends KopProtocolHandlerTestBase {
 
             partitionLog = protocolHandler
                     .getReplicaManager()
-                    .getPartitionLog(topicPartition, namespacePrefix);
+                    .getPartitionLog(topicPartition, namespacePrefix, eventExecutor);
             partitionLog.awaitInitialisation().get();
             assertEquals(5, partitionLog.fetchOldestAvailableIndexFromTopic().get().longValue());
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/kop/storage/PartitionLogTest.java
@@ -15,6 +15,7 @@ package io.streamnative.pulsar.handlers.kop.storage;
 
 import static org.mockito.Mockito.mock;
 
+import io.netty.util.concurrent.EventExecutor;
 import io.streamnative.pulsar.handlers.kop.KafkaServiceConfiguration;
 import io.streamnative.pulsar.handlers.kop.KafkaTopicLookupService;
 import java.nio.ByteBuffer;
@@ -52,7 +53,8 @@ public class PartitionLogTest {
             null,
             mock(KafkaTopicLookupService.class),
             new MemoryProducerStateManagerSnapshotBuffer(),
-            mock(OrderedExecutor.class));
+            mock(OrderedExecutor.class),
+            mock(EventExecutor.class));
 
     @DataProvider(name = "compressionTypes")
     Object[] allCompressionTypes() {


### PR DESCRIPTION
Fix: https://github.com/streamnative/kop/issues/1956

### Modifications
Update stats on the netty threads to fix the stats memory leak issue.

The root cause is we can only use `DataSketchesOpStatsLogger` in the netty thread. When used in other threads, it will cause memory leak, since the `FastThreadLocal` can't remove the map if the thread is not netty thread.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

